### PR TITLE
Fix release workflow CI permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   ci:
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
 
   build:


### PR DESCRIPTION
## Summary
- Grant `contents: read` to the reusable CI job in the release workflow
- Without this, the `ci` job inherits `permissions: {}` from the caller, causing startup failure

Fixes the v0.2.4 release build failure.