### PR TITLE
Bump version to 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "coop"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coop"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
 


### PR DESCRIPTION
## Summary
- Version bump for v0.2.5 release (v0.2.4 release workflow failed due to missing CI permissions)