### PR TITLE
Error when restart would silently ignore creation-time flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -477,6 +477,23 @@ fn cmd_start(
     opts: &StartOpts<'_>,
 ) -> Result<()> {
     if let Some(inst) = find_stopped_instance(be, cfg, opts.name)? {
+        let has_ignored_flags = !opts.mounts.is_empty()
+            || opts.workspace_dir.is_some()
+            || opts.git_repo.is_some()
+            || opts.disk.is_some();
+
+        if has_ignored_flags {
+            bail!(
+                "Instance '{}' already exists (stopped). The flags \
+                 --mount, --workspace, --git-repo, and --disk are only \
+                 applied at creation time and would be silently ignored \
+                 on restart.\n\
+                 To apply new options, destroy the instance first:\n  \
+                 coop destroy {0}\n  coop start {0} [options]",
+                inst.name,
+            );
+        }
+
         return restart_instance(be, cfg, &inst, opts.no_claude);
     }
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1051,8 +1051,58 @@ test_restart_stopped() {
         fail "rejects start of already-running instance" "should have failed"
     fi
 
+    # Stop again for subsequent phases
+    coop stop "$INSTANCE" || true
+}
+
+test_restart_rejects_ignored_flags() {
+    echo ""
+    echo "=== Phase: restart rejects ignored flags ==="
+
+    # Instance is stopped from previous phase. Restarting with creation-time
+    # flags (--mount, --workspace, --git-repo, --disk) should fail with a
+    # clear error instead of silently ignoring them.
+
+    local mount_dir
+    mount_dir=$(mktemp -d)
+
+    if moat_fails start "$INSTANCE" --no-claude --mount "$mount_dir"; then
+        pass "restart with --mount rejected"
+    else
+        fail "restart with --mount rejected" "should have failed"
+        coop stop "$INSTANCE" 2>/dev/null || true
+    fi
+
+    if echo "$HARNESS_ERR" | grep -qi "already exists\|ignored on restart\|destroy"; then
+        pass "error message suggests destroy first"
+    else
+        fail "error message suggests destroy first" "stderr: $HARNESS_ERR"
+    fi
+
+    if moat_fails start "$INSTANCE" --no-claude --workspace "$mount_dir"; then
+        pass "restart with --workspace rejected"
+    else
+        fail "restart with --workspace rejected" "should have failed"
+        coop stop "$INSTANCE" 2>/dev/null || true
+    fi
+
+    if moat_fails start "$INSTANCE" --no-claude --disk 20; then
+        pass "restart with --disk rejected"
+    else
+        fail "restart with --disk rejected" "should have failed"
+        coop stop "$INSTANCE" 2>/dev/null || true
+    fi
+
+    # Plain restart (no conflicting flags) should still work
+    if coop start "$INSTANCE" --no-claude; then
+        pass "restart without flags still works"
+    else
+        fail "restart without flags still works" "exit code: $?"
+    fi
+
     # Stop again for the destroy phase
     coop stop "$INSTANCE" || true
+    rm -rf "$mount_dir"
 }
 
 test_destroy() {
@@ -2212,6 +2262,7 @@ main() {
     test_status_stopped
     test_resize_status
     test_restart_stopped
+    test_restart_rejects_ignored_flags
     test_destroy
     test_auto_resolve_no_instances
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -496,7 +496,7 @@ except ImportError:
 try:
     with open('$cfg_path', 'rb') as f:
         cfg = tomllib.load(f)
-    print(cfg.get('claude', {}).get('github', 'off'))
+    print(cfg.get('github', 'off'))
 except Exception:
     print('off')
 " 2>/dev/null || echo "off")


### PR DESCRIPTION
## Summary

- When restarting a stopped instance with `--mount`, `--workspace`, `--git-repo`, or `--disk`, bail with a clear error suggesting `coop destroy` first. Previously these flags were silently dropped on the restart path.
- Add integration test covering all three flag types plus the positive case (plain restart still works).
- Fix pre-existing bug in `test_github_token_forwarding`: the test read `github` from `[claude]` instead of the top level, causing a false failure when `github = "auto"`.

Closes #23

## Test plan

- [x] `cargo clippy` / `cargo test` pass
- [x] macOS integration tests: 76 passed, 0 failed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)