### PR TITLE
Rename ssh subcommand to shell, add --session flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Isolated VM environment for running Claude Code — Firecracker on Linux, Lima o
 
 ## Architecture
 
-Rust CLI that orchestrates VM lifecycle: setup, start, ssh, stop, destroy, status, logs.
+Rust CLI that orchestrates VM lifecycle: setup, start, shell, stop, destroy, status, logs.
 
 Two backends, auto-detected by platform:
 - **Linux**: Firecracker microVMs with KVM. Cross-compiled from arm64 macOS (`x86_64-unknown-linux-musl` via `musl-cross`).
@@ -54,7 +54,7 @@ You can also run the test script directly if you already have a binary:
 ./tests/integration.sh --binary /path/to/coop --full
 ```
 
-When adding new features, consider whether they should be covered by the integration test. The test exercises the full VM lifecycle (setup → start → status → ssh → guest environment → docker → stop → destroy). New commands or guest-visible changes are good candidates for new test phases.
+When adding new features, consider whether they should be covered by the integration test. The test exercises the full VM lifecycle (setup → start → status → shell → guest environment → docker → stop → destroy). New commands or guest-visible changes are good candidates for new test phases.
 
 ## Known workarounds (revisit later)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ That gives you a Claude Code session running inside an isolated VM with your pro
 | `start` | Launch a new VM instance |
 | `stop` | Stop a running VM (preserves disk) |
 | `destroy` | Stop and remove a VM instance |
-| `ssh` | Interactive SSH session to a running VM |
+| `shell` | Interactive shell session in a running VM |
 | `claude` | Launch Claude Code inside the VM |
 | `exec` | Run a command in the VM non-interactively |
 | `push` | Sync local directory into the VM |

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -146,7 +146,7 @@ Both backends support the same CLI commands and guest capabilities:
 | `coop destroy` | `limactl delete --force` | Kill process, remove TAP, delete instance dir |
 | `coop status` | Queries `limactl list --json` | Reads PID file, queries guest via SSH |
 | `coop logs` | Reads Lima's `serial.log` | Reads Firecracker log file |
-| `coop ssh` | SSH to localhost on Lima-assigned port | SSH to guest IP on configured port |
+| `coop shell` | SSH to localhost on Lima-assigned port | SSH to guest IP on configured port |
 | `coop resize` | Truncates Lima diffdisk | Truncates + resize2fs on rootfs |
 | Resource monitoring | SSH query to guest | SSH query to guest |
 | Docker in guest | Works (full kernel) | Works (with iptables-legacy workaround) |

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -58,7 +58,7 @@ Every field is optional. An empty `[claude]` section (or omitting it entirely) s
 
 ### API key forwarding
 
-coop forwards `ANTHROPIC_API_KEY` to the guest via SSH `SendEnv` on every session: `coop claude`, `coop ssh`, and `coop exec` alike. The key is never written to disk inside the guest.
+coop forwards `ANTHROPIC_API_KEY` to the guest via SSH `SendEnv` on every session: `coop claude`, `coop shell`, and `coop exec` alike. The key is never written to disk inside the guest.
 
 Resolution order:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -94,26 +94,30 @@ coop start --image ml-dev --no-claude
 coop start --mount ~/data:/mnt/data
 ```
 
-### `ssh`
+### `shell`
 
-Open an interactive SSH session to a running VM, or run a single command.
+Open an interactive shell in the VM, or run a single command non-interactively.
 
 ```
-coop ssh [NAME] [FLAGS] [-- COMMAND...]
+coop shell [NAME] [FLAGS] [-- COMMAND...]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `NAME` | Instance name (required if multiple instances exist) |
-| `--no-tmux` | Skip tmux session persistence (raw SSH) |
+| `--session <name>` | tmux session name (default: `main`) |
+| `--no-tmux` | Skip tmux session persistence (raw SSH connection) |
 | `-- COMMAND...` | Command to run non-interactively (no PTY allocated) |
 
-Without a trailing command, `ssh` drops you into a tmux session named `main`. With a trailing command, it executes the command and returns its exit code.
+Without a trailing command, `shell` drops you into a tmux session named `main` (or the name given by `--session`). With a trailing command, it executes the command and returns its exit code.
+
+`--session` and `--no-tmux` are mutually exclusive.
 
 ```
-coop ssh
-coop ssh my-project --no-tmux
-coop ssh my-project -- cat /etc/os-release
+coop shell
+coop shell my-project --no-tmux
+coop shell my-project --session work
+coop shell my-project -- cat /etc/os-release
 ```
 
 ### `claude`
@@ -128,10 +132,11 @@ coop claude [NAME] [FLAGS] [ARGS...]
 |------|-------------|
 | `NAME` | Instance name (required if multiple instances exist) |
 | `--ask` | Prompt for permissions instead of skipping them |
-| `--no-tmux` | Skip tmux session persistence (raw SSH) |
+| `--session <name>` | tmux session name (default: `claude`) |
+| `--no-tmux` | Skip tmux session persistence (raw SSH connection) |
 | `ARGS...` | Extra arguments passed through to `claude` |
 
-The session runs inside tmux under the name `claude`.
+The session runs inside tmux under the name `claude` (or the name given by `--session`). `--session` and `--no-tmux` are mutually exclusive.
 
 ```
 coop claude
@@ -141,7 +146,7 @@ coop claude my-project -- --model sonnet
 
 ### `exec`
 
-Run a command in the VM and print its output. No PTY is allocated and stdin is not forwarded; use `ssh` for interactive work.
+Run a command in the VM and print its output. No PTY is allocated and stdin is not forwarded; use `shell` for interactive work.
 
 ```
 coop exec [--name NAME] COMMAND...

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,18 +171,18 @@ Pass extra arguments through to `claude`:
 coop claude -- --model opus
 ```
 
-**SSH into the VM:**
+**Open a shell in the VM:**
 
 ```
-coop ssh
+coop shell
 ```
 
-Both `coop ssh` and `coop claude` attach to a persistent tmux session. Use `--no-tmux` for a raw SSH connection.
+Both `coop shell` and `coop claude` attach to a persistent tmux session. Use `--no-tmux` for a raw SSH connection, or `--session <name>` to pick a named session.
 
 **Run a command non-interactively:**
 
 ```
-coop ssh -- ls /workspace
+coop shell -- ls /workspace
 coop exec -- docker ps
 ```
 

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -35,15 +35,15 @@ Most commands accept an optional instance name. Resolution follows three cases:
 
 ```
 # With one instance, these are equivalent:
-coop ssh
-coop ssh my-project
+coop shell
+coop shell my-project
 
 # With multiple instances, you must specify:
-coop ssh my-project
-coop ssh another-project
+coop shell my-project
+coop shell another-project
 ```
 
-This applies to `ssh`, `stop`, `destroy`, `status <name>`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`, and `claude`.
+This applies to `shell`, `stop`, `destroy`, `status <name>`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`, and `claude`.
 
 ## Checking status
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -39,7 +39,7 @@ If GUEST_PATH is omitted, defaults to `/workspace`. Conflicts with `--workspace`
 ### Manual via SSH
 
 ```bash
-coop ssh
+coop shell
 # then use git clone, scp, or any other tool inside the guest
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,27 @@ struct Cli {
     command: Commands,
 }
 
+#[derive(clap::Args)]
+struct SessionArgs {
+    /// Instance name (required if multiple instances exist)
+    name: Option<String>,
+    /// tmux session name
+    #[arg(long, conflicts_with = "no_tmux")]
+    session: Option<String>,
+    /// Skip tmux session persistence (raw SSH connection)
+    #[arg(long)]
+    no_tmux: bool,
+}
+
+impl SessionArgs {
+    fn tmux_session<'a>(&'a self, default: &'a str) -> Option<&'a str> {
+        if self.no_tmux {
+            return None;
+        }
+        Some(self.session.as_deref().unwrap_or(default))
+    }
+}
+
 #[derive(Subcommand)]
 enum Commands {
     /// Check prerequisites, install Firecracker, fetch kernel and build template rootfs
@@ -118,27 +139,22 @@ enum Commands {
         #[arg(long, default_value = config::DEFAULT_IMAGE)]
         image: String,
     },
-    /// SSH into running VM (or run a command non-interactively)
-    Ssh {
-        /// Instance name (required if multiple instances exist)
-        name: Option<String>,
-        /// Skip tmux session persistence (raw SSH)
-        #[arg(long)]
-        no_tmux: bool,
+    /// Open an interactive shell in the VM (or run a command non-interactively)
+    #[command(alias = "ssh")]
+    Shell {
+        #[command(flatten)]
+        session: SessionArgs,
         /// Command to run (non-interactive, no PTY)
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true, last = true)]
+        #[arg(allow_hyphen_values = true, last = true)]
         command: Vec<String>,
     },
     /// Launch Claude Code inside the VM (skips permissions by default)
     Claude {
-        /// Instance name (required if multiple instances exist)
-        name: Option<String>,
+        #[command(flatten)]
+        session: SessionArgs,
         /// Prompt for permissions instead of skipping them
         #[arg(long)]
         ask: bool,
-        /// Skip tmux session persistence (raw SSH)
-        #[arg(long)]
-        no_tmux: bool,
         /// Extra arguments passed to `claude`
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -328,28 +344,26 @@ fn main() -> Result<()> {
                 },
             )
         }
-        Commands::Ssh {
-            name,
-            no_tmux,
-            command,
-        } => cmd_ssh(&be, &cfg, name.as_deref(), &command, no_tmux),
+        Commands::Shell { session, command } => {
+            let tmux = session.tmux_session("main");
+            cmd_shell(&be, &cfg, session.name.as_deref(), &command, tmux)
+        }
         Commands::Claude {
-            name,
+            session,
             ask,
-            no_tmux,
             mut args,
         } => {
-            let running = resolve_running(&be, &cfg, name.as_deref())?;
+            let running = resolve_running(&be, &cfg, session.name.as_deref())?;
             let env_vars = backend::prepare_env_forwarding(&cfg);
-            let session = backend::SshSession {
+            let sess = backend::SshSession {
                 target: &running.target,
                 env: &env_vars,
             };
             if !ask {
                 args.insert(0, "--dangerously-skip-permissions".to_string());
             }
-            let tmux = if no_tmux { None } else { Some("claude") };
-            ssh::run_interactive(&session, crate::guest::CLAUDE_BIN, &args, tmux)
+            let tmux = session.tmux_session("claude");
+            ssh::run_interactive(&sess, crate::guest::CLAUDE_BIN, &args, tmux)
         }
         Commands::Stop { name } => {
             let inst = cfg.resolve_instance(name.as_deref())?;
@@ -537,7 +551,7 @@ fn find_stopped_instance(
         if be.is_running(&inst) {
             bail!(
                 "Instance '{name}' is already running.\n\
-                 Use `coop ssh {name}` to connect, or \
+                 Use `coop shell {name}` to connect, or \
                  `coop stop {name}` first."
             );
         }
@@ -760,12 +774,12 @@ fn resolve_running(
     }
 }
 
-fn cmd_ssh(
+fn cmd_shell(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
     name: Option<&str>,
     command: &[String],
-    no_tmux: bool,
+    tmux_session: Option<&str>,
 ) -> Result<()> {
     let running = resolve_running(be, cfg, name)?;
     let env_vars = backend::prepare_env_forwarding(cfg);
@@ -774,8 +788,7 @@ fn cmd_ssh(
         env: &env_vars,
     };
     if command.is_empty() {
-        let tmux = if no_tmux { None } else { Some("main") };
-        ssh::connect(&session, tmux)
+        ssh::connect(&session, tmux_session)
     } else {
         ssh::run_command(&session, command)
     }
@@ -984,4 +997,97 @@ fn dir_size_display(dir: &std::path::Path) -> String {
     #[expect(clippy::cast_precision_loss, reason = "file sizes fit in f64")]
     let gib = total as f64 / (1024.0 * 1024.0 * 1024.0);
     format!("{gib:.1} GiB")
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "tests use panic for unreachable branches")]
+mod tests {
+    use clap::Parser;
+
+    use super::Cli;
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::parse_from(std::iter::once("coop").chain(args.iter().copied()))
+    }
+
+    fn parse_err(args: &[&str]) -> clap::Error {
+        match Cli::try_parse_from(std::iter::once("coop").chain(args.iter().copied())) {
+            Err(e) => e,
+            Ok(_) => panic!("expected parse failure"),
+        }
+    }
+
+    #[test]
+    fn shell_subcommand_parses() {
+        let cli = parse(&["shell"]);
+        assert!(matches!(cli.command, super::Commands::Shell { .. }));
+    }
+
+    #[test]
+    fn ssh_alias_parses_as_shell() {
+        let cli = parse(&["ssh"]);
+        assert!(matches!(cli.command, super::Commands::Shell { .. }));
+    }
+
+    #[test]
+    fn shell_session_flag_parses() {
+        let cli = parse(&["shell", "--session", "work"]);
+        let super::Commands::Shell { session, .. } = cli.command else {
+            panic!("expected Shell variant");
+        };
+        assert_eq!(session.session.as_deref(), Some("work"));
+        assert_eq!(session.tmux_session("main"), Some("work"));
+    }
+
+    #[test]
+    fn shell_default_no_session() {
+        let cli = parse(&["shell"]);
+        let super::Commands::Shell { session, .. } = cli.command else {
+            panic!("expected Shell variant");
+        };
+        assert!(session.session.is_none());
+        assert_eq!(session.tmux_session("main"), Some("main"));
+    }
+
+    #[test]
+    fn shell_session_and_no_tmux_conflict() {
+        let err = parse_err(&["shell", "--session", "x", "--no-tmux"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn claude_session_flag_parses() {
+        let cli = parse(&["claude", "--session", "dev"]);
+        let super::Commands::Claude { session, .. } = cli.command else {
+            panic!("expected Claude variant");
+        };
+        assert_eq!(session.session.as_deref(), Some("dev"));
+        assert_eq!(session.tmux_session("claude"), Some("dev"));
+    }
+
+    #[test]
+    fn claude_session_and_no_tmux_conflict() {
+        let err = parse_err(&["claude", "--session", "x", "--no-tmux"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn claude_name_and_trailing_args_parse() {
+        let cli = parse(&["claude", "myvm", "--", "--model", "opus"]);
+        let super::Commands::Claude { session, args, .. } = cli.command else {
+            panic!("expected Claude variant");
+        };
+        assert_eq!(session.name.as_deref(), Some("myvm"));
+        assert_eq!(args, vec!["--model", "opus"]);
+    }
+
+    #[test]
+    fn shell_no_tmux_without_session() {
+        let cli = parse(&["shell", "--no-tmux"]);
+        let super::Commands::Shell { session, .. } = cli.command else {
+            panic!("expected Shell variant");
+        };
+        assert!(session.no_tmux);
+        assert!(session.tmux_session("main").is_none());
+    }
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -115,11 +115,11 @@ moat_fails() {
     fi
 }
 
-# Run a command in the guest VM via `coop ssh -- <cmd>`.
+# Run a command in the guest VM via `coop shell -- <cmd>`.
 # RUST_LOG=off suppresses tracing output that would mix with command output.
 guest_exec() {
     local inst="${GUEST_INSTANCE:-$INSTANCE}"
-    RUST_LOG=off "$BINARY" ssh "$inst" -- "$@" 2>/dev/null
+    RUST_LOG=off "$BINARY" shell "$inst" -- "$@" 2>/dev/null
 }
 
 # Run the exec subcommand (captures stdout, propagates exit code).
@@ -346,22 +346,22 @@ test_auto_resolve_running() {
     running_count=$(RUST_LOG=off "$BINARY" status 2>/dev/null | grep -c "running" || true)
 
     if [[ "$running_count" -ne 1 ]]; then
-        skip "ssh auto-resolves single running instance" "$running_count running (need exactly 1)"
+        skip "shell auto-resolves single running instance" "$running_count running (need exactly 1)"
         skip "exec auto-resolves single running instance" "skipped (need exactly 1 running)"
         return
     fi
 
-    # ssh without name should auto-select the single running instance
+    # shell without name should auto-select the single running instance
     local output
-    if output=$(RUST_LOG=off "$BINARY" ssh -- echo "auto-resolve-works" 2>/dev/null); then
-        pass "ssh auto-resolves single running instance"
+    if output=$(RUST_LOG=off "$BINARY" shell -- echo "auto-resolve-works" 2>/dev/null); then
+        pass "shell auto-resolves single running instance"
         if echo "$output" | grep -q "auto-resolve-works"; then
-            pass "ssh auto-resolve returns correct output"
+            pass "shell auto-resolve returns correct output"
         else
-            fail "ssh auto-resolve returns correct output" "got: $output"
+            fail "shell auto-resolve returns correct output" "got: $output"
         fi
     else
-        fail "ssh auto-resolves single running instance" "exit code: $?"
+        fail "shell auto-resolves single running instance" "exit code: $?"
     fi
 
     # exec without --name should also auto-select
@@ -377,22 +377,55 @@ test_auto_resolve_running() {
     fi
 }
 
-test_ssh_connectivity() {
+test_shell_connectivity() {
     echo ""
-    echo "=== Phase: ssh connectivity ==="
+    echo "=== Phase: shell connectivity ==="
 
     local output
     if output=$(guest_exec echo "hello-from-guest" 2>/dev/null); then
-        pass "ssh connects to guest"
+        pass "shell connects to guest"
     else
-        fail "ssh connects to guest"
+        fail "shell connects to guest"
         return
     fi
 
     if echo "$output" | grep -q "hello-from-guest"; then
-        pass "ssh command output correct"
+        pass "shell command output correct"
     else
-        fail "ssh command output correct" "got: $output"
+        fail "shell command output correct" "got: $output"
+    fi
+}
+
+test_ssh_alias() {
+    echo ""
+    echo "=== Phase: ssh alias (backward compat) ==="
+
+    local output
+    if output=$(RUST_LOG=off "$BINARY" ssh "$INSTANCE" -- echo "alias-ok" 2>/dev/null); then
+        if echo "$output" | grep -q "alias-ok"; then
+            pass "ssh alias works as shell"
+        else
+            fail "ssh alias works as shell" "got: $output"
+        fi
+    else
+        fail "ssh alias works as shell" "exit code: $?"
+    fi
+}
+
+test_session_conflict() {
+    echo ""
+    echo "=== Phase: --session / --no-tmux conflict ==="
+
+    if moat_fails shell "$INSTANCE" --session main --no-tmux -- echo nope; then
+        pass "--session and --no-tmux conflict (shell)"
+    else
+        fail "--session and --no-tmux conflict (shell)" "should have failed"
+    fi
+
+    if moat_fails claude "$INSTANCE" --session main --no-tmux; then
+        pass "--session and --no-tmux conflict (claude)"
+    else
+        fail "--session and --no-tmux conflict (claude)" "should have failed"
     fi
 }
 
@@ -529,7 +562,7 @@ test_term_handling() {
     # Modern terminals (Ghostty, Kitty) set TERM values that don't exist
     # in a stock Ubuntu install. The guest_term() function in ssh.rs remaps
     # unknown TERM values to xterm-256color for interactive sessions
-    # (coop ssh, coop claude). Non-interactive SSH (-- cmd) doesn't
+    # (coop shell, coop claude). Non-interactive SSH (-- cmd) doesn't
     # allocate a PTY, so TERM doesn't matter there.
     #
     # This test verifies:
@@ -537,7 +570,7 @@ test_term_handling() {
     # 2. The coop binary doesn't crash or reject exotic TERM values
     local output
     if output=$(env TERM=xterm-ghostty RUST_LOG=off \
-        "$BINARY" ssh "$INSTANCE" -- echo term-ok 2>/dev/null); then
+        "$BINARY" shell "$INSTANCE" -- echo term-ok 2>/dev/null); then
         if echo "$output" | grep -q "term-ok"; then
             pass "SSH works with TERM=xterm-ghostty"
         else
@@ -919,19 +952,19 @@ test_auto_resolve_stopped() {
     running_count=$(RUST_LOG=off "$BINARY" status 2>/dev/null | grep -c "running" || true)
 
     if [[ "$running_count" -gt 0 ]]; then
-        skip "ssh rejects when only stopped instances exist" "$running_count still running"
+        skip "shell rejects when only stopped instances exist" "$running_count still running"
         return
     fi
 
-    if moat_fails ssh -- echo "should-not-work"; then
-        pass "ssh rejects when only stopped instances exist"
+    if moat_fails shell -- echo "should-not-work"; then
+        pass "shell rejects when only stopped instances exist"
         if echo "$HARNESS_ERR" | grep -qi "stopped"; then
-            pass "ssh error mentions instance is stopped"
+            pass "shell error mentions instance is stopped"
         else
-            fail "ssh error mentions instance is stopped" "stderr: $HARNESS_ERR"
+            fail "shell error mentions instance is stopped" "stderr: $HARNESS_ERR"
         fi
     else
-        fail "ssh rejects when only stopped instances exist" "should have failed"
+        fail "shell rejects when only stopped instances exist" "should have failed"
     fi
 }
 
@@ -1140,19 +1173,19 @@ test_auto_resolve_no_instances() {
     instance_count=$(RUST_LOG=off "$BINARY" status 2>/dev/null | grep -cE "running|stopped" || true)
 
     if [[ "$instance_count" -gt 0 ]]; then
-        skip "ssh rejects when no instances exist" "$instance_count instances still present"
+        skip "shell rejects when no instances exist" "$instance_count instances still present"
         return
     fi
 
-    if moat_fails ssh -- echo "should-not-work"; then
-        pass "ssh rejects when no instances exist"
+    if moat_fails shell -- echo "should-not-work"; then
+        pass "shell rejects when no instances exist"
         if echo "$HARNESS_ERR" | grep -qi "no instances"; then
-            pass "ssh error mentions no instances"
+            pass "shell error mentions no instances"
         else
-            fail "ssh error mentions no instances" "stderr: $HARNESS_ERR"
+            fail "shell error mentions no instances" "stderr: $HARNESS_ERR"
         fi
     else
-        fail "ssh rejects when no instances exist" "should have failed"
+        fail "shell rejects when no instances exist" "should have failed"
     fi
 }
 
@@ -1351,22 +1384,22 @@ test_multi_instance() {
     fi
 
     # Auto-resolve should fail when multiple instances are running
-    if moat_fails ssh -- echo "should-not-work"; then
-        pass "ssh rejects auto-resolve with multiple running"
+    if moat_fails shell -- echo "should-not-work"; then
+        pass "shell rejects auto-resolve with multiple running"
         if echo "$HARNESS_ERR" | grep -qi "multiple"; then
             pass "error mentions multiple running instances"
         else
             fail "error mentions multiple running instances" "stderr: $HARNESS_ERR"
         fi
     else
-        fail "ssh rejects auto-resolve with multiple running" "should have failed"
+        fail "shell rejects auto-resolve with multiple running" "should have failed"
     fi
 
     # Explicit name should still work with multiple instances
-    if RUST_LOG=off "$BINARY" ssh "$inst_a" -- echo "explicit-ok" 2>/dev/null | grep -q "explicit-ok"; then
-        pass "ssh with explicit name works among multiple"
+    if RUST_LOG=off "$BINARY" shell "$inst_a" -- echo "explicit-ok" 2>/dev/null | grep -q "explicit-ok"; then
+        pass "shell with explicit name works among multiple"
     else
-        fail "ssh with explicit name works among multiple"
+        fail "shell with explicit name works among multiple"
     fi
 
     # Both should be independently accessible via SSH
@@ -2242,7 +2275,9 @@ main() {
     test_duplicate_name
     test_status_running
     test_auto_resolve_running
-    test_ssh_connectivity
+    test_shell_connectivity
+    test_ssh_alias
+    test_session_conflict
     test_exec
     test_claude_bin_path
     test_github_token_forwarding


### PR DESCRIPTION
## Summary

- Rename `ssh` subcommand to `shell` (with hidden `ssh` alias for backward compat) to describe the feature rather than the transport
- Add `--session <name>` flag to both `shell` and `claude` for named tmux sessions, enabling parallel interactive sessions against the same VM
- Extract shared args into `SessionArgs` struct with `#[command(flatten)]` to keep `shell` and `claude` in sync

## Test plan

- [x] Unit tests: subcommand parsing, alias, `--session` flag, `--session`/`--no-tmux` conflict, `claude` name vs trailing args
- [x] Integration tests: `shell` connectivity, `ssh` alias backward compat, `--session`/`--no-tmux` conflict (151 passed, 0 failed)
- [x] All pre-commit hooks pass (fmt, clippy, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)