### PR TITLE
Add `coop profiles list` and `coop profiles show` commands

### DIFF
--- a/src/guest.rs
+++ b/src/guest.rs
@@ -71,7 +71,23 @@ pub struct ProfileDef {
     pub plugins: Vec<String>,
 }
 
-const BUILTIN_PROFILES: &[&str] = &["python", "node", "c", "fuzz", "rust", "go", "full"];
+/// Single source of truth for builtin profile names and descriptions.
+/// `lookup_builtin` must have a matching arm for every non-"full" entry;
+/// the `builtin_profile_entries_match_lookup` test enforces this.
+const BUILTIN_PROFILES: &[(&str, &str)] = &[
+    ("python", "Python 3 with pip and venv"),
+    ("node", "Node.js 22 via NodeSource"),
+    ("c", "Clang, LLVM, GDB, Valgrind, CMake"),
+    ("fuzz", "Clang, LLVM, AFL++, lcov"),
+    ("rust", "Rust via rustup"),
+    ("go", "Go"),
+    ("full", "python + node + c + fuzz + rust + go"),
+];
+
+/// Returns `(name, description)` for each builtin profile.
+pub fn builtin_profile_entries() -> &'static [(&'static str, &'static str)] {
+    BUILTIN_PROFILES
+}
 
 fn lookup_builtin(name: &str) -> Option<ProfileDef> {
     match name {
@@ -193,7 +209,7 @@ pub fn lookup_profile(name: &str, custom: &HashMap<String, CustomProfile>) -> Re
         return Ok(def);
     }
 
-    let mut available: Vec<&str> = BUILTIN_PROFILES.to_vec();
+    let mut available: Vec<&str> = BUILTIN_PROFILES.iter().map(|(n, _)| *n).collect();
     let mut custom_names: Vec<&str> = custom.keys().map(String::as_str).collect();
     custom_names.sort_unstable();
     available.extend(custom_names);
@@ -226,4 +242,36 @@ pub fn collect_baked_lists(
     plugins.dedup();
 
     Ok((marketplaces, plugins))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_profile_entries_lists_all() {
+        let entries = builtin_profile_entries();
+        let names: Vec<&str> = entries.iter().map(|(n, _)| *n).collect();
+        assert_eq!(
+            names,
+            vec!["python", "node", "c", "fuzz", "rust", "go", "full"]
+        );
+        for &(name, desc) in entries {
+            assert!(
+                !desc.is_empty(),
+                "builtin profile '{name}' has empty description"
+            );
+        }
+    }
+
+    #[test]
+    fn builtin_profile_entries_match_lookup() {
+        let custom = HashMap::new();
+        for &(name, _) in builtin_profile_entries() {
+            assert!(
+                lookup_profile(name, &custom).is_ok(),
+                "builtin_profile_entries lists '{name}' but lookup_profile rejects it"
+            );
+        }
+    }
 }

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -63,6 +63,20 @@ pub const DOCKER_PACKAGES: &[&str] = &[
 
 // ── Profile definitions ───────────────────────────────────────
 
+/// Compile-time profile definition. Single source of truth for all
+/// builtin profiles — name, packages, scripts, and plugins are
+/// colocated in `BUILTIN_PROFILES`.
+pub struct BuiltinProfile {
+    pub name: &'static str,
+    pub apt_packages: &'static [&'static str],
+    pub pre_install: Option<&'static str>,
+    pub post_install: Option<&'static str>,
+    pub marketplaces: &'static [&'static str],
+    pub plugins: &'static [&'static str],
+}
+
+/// Owned profile definition produced by `lookup_profile`. Handles both
+/// builtin (converted from static data) and custom (cloned from config).
 pub struct ProfileDef {
     pub apt_packages: Vec<String>,
     pub pre_install: Option<String>,
@@ -71,86 +85,75 @@ pub struct ProfileDef {
     pub plugins: Vec<String>,
 }
 
-/// Single source of truth for builtin profile names and descriptions.
-/// `lookup_builtin` must have a matching arm for every non-"full" entry;
-/// the `builtin_profile_entries_match_lookup` test enforces this.
-const BUILTIN_PROFILES: &[(&str, &str)] = &[
-    ("python", "Python 3 with pip and venv"),
-    ("node", "Node.js 22 via NodeSource"),
-    ("c", "Clang, LLVM, GDB, Valgrind, CMake"),
-    ("fuzz", "Clang, LLVM, AFL++, lcov"),
-    ("rust", "Rust via rustup"),
-    ("go", "Go"),
-    ("full", "python + node + c + fuzz + rust + go"),
-];
-
-/// Returns `(name, description)` for each builtin profile.
-pub fn builtin_profile_entries() -> &'static [(&'static str, &'static str)] {
-    BUILTIN_PROFILES
-}
-
-fn lookup_builtin(name: &str) -> Option<ProfileDef> {
-    match name {
-        "python" => Some(ProfileDef {
-            apt_packages: vec![
-                "python3".into(),
-                "python3-pip".into(),
-                "python3-venv".into(),
-            ],
-            pre_install: None,
-            post_install: None,
-            marketplaces: vec![],
-            plugins: vec![],
-        }),
-        "node" => Some(ProfileDef {
-            apt_packages: vec!["nodejs".into()],
-            pre_install: Some(include_str!("../scripts/guest/profiles/node-pre.sh").into()),
-            post_install: None,
-            marketplaces: vec![],
-            plugins: vec![],
-        }),
-        "c" => Some(ProfileDef {
-            apt_packages: vec![
-                "clang".into(),
-                "llvm".into(),
-                "gdb".into(),
-                "valgrind".into(),
-                "cmake".into(),
-            ],
-            pre_install: None,
-            post_install: None,
-            marketplaces: vec![],
-            plugins: vec!["clangd-lsp@claude-plugins-official".into()],
-        }),
-        "fuzz" => Some(ProfileDef {
-            apt_packages: vec!["clang".into(), "llvm".into(), "afl++".into(), "lcov".into()],
-            pre_install: None,
-            post_install: None,
-            marketplaces: vec![],
-            plugins: vec![],
-        }),
-        "rust" => Some(ProfileDef {
-            apt_packages: vec![],
-            pre_install: None,
-            post_install: Some(include_str!("../scripts/guest/profiles/rust-post.sh").into()),
-            marketplaces: vec![],
-            plugins: vec!["rust-analyzer-lsp@claude-plugins-official".into()],
-        }),
-        "go" => Some(ProfileDef {
-            apt_packages: vec!["golang".into()],
-            pre_install: None,
-            post_install: None,
-            marketplaces: vec![],
-            plugins: vec![],
-        }),
-        _ => None,
+impl From<&BuiltinProfile> for ProfileDef {
+    fn from(bp: &BuiltinProfile) -> Self {
+        Self {
+            apt_packages: bp.apt_packages.iter().map(|s| (*s).to_owned()).collect(),
+            pre_install: bp.pre_install.map(str::to_owned),
+            post_install: bp.post_install.map(str::to_owned),
+            marketplaces: bp.marketplaces.iter().map(|s| (*s).to_owned()).collect(),
+            plugins: bp.plugins.iter().map(|s| (*s).to_owned()).collect(),
+        }
     }
 }
 
-/// Look up a profile by name. Checks custom profiles first, then
-/// built-in ones. The `full` meta-profile expands all built-in profiles.
+pub const BUILTIN_PROFILES: &[BuiltinProfile] = &[
+    BuiltinProfile {
+        name: "python",
+        apt_packages: &["python3", "python3-pip", "python3-venv"],
+        pre_install: None,
+        post_install: None,
+        marketplaces: &[],
+        plugins: &[],
+    },
+    BuiltinProfile {
+        name: "node",
+        apt_packages: &["nodejs"],
+        pre_install: Some(include_str!("../scripts/guest/profiles/node-pre.sh")),
+        post_install: None,
+        marketplaces: &[],
+        plugins: &[],
+    },
+    BuiltinProfile {
+        name: "c",
+        apt_packages: &["clang", "llvm", "gdb", "valgrind", "cmake"],
+        pre_install: None,
+        post_install: None,
+        marketplaces: &[],
+        plugins: &["clangd-lsp@claude-plugins-official"],
+    },
+    BuiltinProfile {
+        name: "fuzz",
+        apt_packages: &["clang", "llvm", "afl++", "lcov"],
+        pre_install: None,
+        post_install: None,
+        marketplaces: &[],
+        plugins: &[],
+    },
+    BuiltinProfile {
+        name: "rust",
+        apt_packages: &[],
+        pre_install: None,
+        post_install: Some(include_str!("../scripts/guest/profiles/rust-post.sh")),
+        marketplaces: &[],
+        plugins: &["rust-analyzer-lsp@claude-plugins-official"],
+    },
+    BuiltinProfile {
+        name: "go",
+        apt_packages: &["golang"],
+        pre_install: None,
+        post_install: None,
+        marketplaces: &[],
+        plugins: &[],
+    },
+];
+
+fn lookup_builtin(name: &str) -> Option<&'static BuiltinProfile> {
+    BUILTIN_PROFILES.iter().find(|bp| bp.name == name)
+}
+
+/// Look up a profile by name. Checks custom profiles first, then builtins.
 pub fn lookup_profile(name: &str, custom: &HashMap<String, CustomProfile>) -> Result<ProfileDef> {
-    // Custom profiles take precedence
     if let Some(cp) = custom.get(name) {
         return Ok(ProfileDef {
             apt_packages: cp.apt_packages.clone(),
@@ -161,55 +164,11 @@ pub fn lookup_profile(name: &str, custom: &HashMap<String, CustomProfile>) -> Re
         });
     }
 
-    if name == "full" {
-        let all = ["python", "node", "c", "fuzz", "rust", "go"];
-        let mut apt_packages = Vec::new();
-        let mut pre_parts = Vec::new();
-        let mut post_parts = Vec::new();
-        let mut marketplaces = Vec::new();
-        let mut plugins = Vec::new();
-        for sub in all {
-            let Some(def) = lookup_builtin(sub) else {
-                bail!("BUG: built-in profile '{sub}' missing from full expansion");
-            };
-            apt_packages.extend(def.apt_packages);
-            if let Some(s) = def.pre_install {
-                pre_parts.push(s);
-            }
-            if let Some(s) = def.post_install {
-                post_parts.push(s);
-            }
-            marketplaces.extend(def.marketplaces);
-            plugins.extend(def.plugins);
-        }
-        apt_packages.sort_unstable();
-        apt_packages.dedup();
-        marketplaces.sort_unstable();
-        marketplaces.dedup();
-        plugins.sort_unstable();
-        plugins.dedup();
-        return Ok(ProfileDef {
-            apt_packages,
-            pre_install: if pre_parts.is_empty() {
-                None
-            } else {
-                Some(pre_parts.join("\n"))
-            },
-            post_install: if post_parts.is_empty() {
-                None
-            } else {
-                Some(post_parts.join("\n"))
-            },
-            marketplaces,
-            plugins,
-        });
+    if let Some(bp) = lookup_builtin(name) {
+        return Ok(ProfileDef::from(bp));
     }
 
-    if let Some(def) = lookup_builtin(name) {
-        return Ok(def);
-    }
-
-    let mut available: Vec<&str> = BUILTIN_PROFILES.iter().map(|(n, _)| *n).collect();
+    let mut available: Vec<&str> = BUILTIN_PROFILES.iter().map(|bp| bp.name).collect();
     let mut custom_names: Vec<&str> = custom.keys().map(String::as_str).collect();
     custom_names.sort_unstable();
     available.extend(custom_names);
@@ -245,33 +204,41 @@ pub fn collect_baked_lists(
 }
 
 #[cfg(test)]
+#[expect(clippy::panic, reason = "tests use panic for assertion failures")]
+#[expect(clippy::unwrap_used, reason = "tests use unwrap for brevity")]
 mod tests {
     use super::*;
 
     #[test]
-    fn builtin_profile_entries_lists_all() {
-        let entries = builtin_profile_entries();
-        let names: Vec<&str> = entries.iter().map(|(n, _)| *n).collect();
-        assert_eq!(
-            names,
-            vec!["python", "node", "c", "fuzz", "rust", "go", "full"]
-        );
-        for &(name, desc) in entries {
-            assert!(
-                !desc.is_empty(),
-                "builtin profile '{name}' has empty description"
-            );
+    fn all_builtins_resolve() {
+        let custom = HashMap::new();
+        for bp in BUILTIN_PROFILES {
+            let def = lookup_profile(bp.name, &custom)
+                .unwrap_or_else(|_| panic!("builtin '{}' failed to resolve", bp.name));
+            assert_eq!(def.apt_packages.len(), bp.apt_packages.len());
         }
     }
 
     #[test]
-    fn builtin_profile_entries_match_lookup() {
+    fn unknown_profile_fails() {
         let custom = HashMap::new();
-        for &(name, _) in builtin_profile_entries() {
-            assert!(
-                lookup_profile(name, &custom).is_ok(),
-                "builtin_profile_entries lists '{name}' but lookup_profile rejects it"
-            );
-        }
+        assert!(lookup_profile("nonexistent", &custom).is_err());
+    }
+
+    #[test]
+    fn custom_overrides_builtin() {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "python".to_owned(),
+            CustomProfile {
+                apt_packages: vec!["custom-python".to_owned()],
+                pre_install: None,
+                post_install: None,
+                marketplaces: vec![],
+                plugins: vec![],
+            },
+        );
+        let def = lookup_profile("python", &custom).unwrap();
+        assert_eq!(def.apt_packages, vec!["custom-python"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,10 +244,26 @@ enum Commands {
         #[arg(long, required = true)]
         size: String,
     },
+    /// List or inspect available profiles
+    Profiles {
+        #[command(subcommand)]
+        action: Option<ProfilesAction>,
+    },
     /// Validate configuration and check prerequisites
     Validate,
     /// Generate a starter config file at ~/.coop/config.toml
     Init,
+}
+
+#[derive(Subcommand)]
+enum ProfilesAction {
+    /// List all available profiles (builtin and custom)
+    List,
+    /// Show the full definition of a profile
+    Show {
+        /// Profile name to inspect
+        name: String,
+    },
 }
 
 fn init_tracing(verbosity: u8) {
@@ -409,6 +425,9 @@ fn main() -> Result<()> {
         }
         Commands::Images { delete } => cmd_images(&be, &cfg, delete.as_deref()),
         Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_deref(), &size),
+        Commands::Profiles { action } => {
+            cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
+        }
         Commands::Validate => cmd_validate(&cfg, &be),
         Commands::Init => unreachable!("handled before config loading"),
     }
@@ -942,6 +961,141 @@ fn current_disk_gib(be: &backend::PlatformBackend, inst: &config::Instance) -> R
     Ok(gib)
 }
 
+fn cmd_profiles(cfg: &config::CoopConfig, action: &ProfilesAction) -> Result<()> {
+    let out = &mut std::io::stdout();
+    let write_result = match action {
+        ProfilesAction::List => write_profiles_list(out, cfg),
+        ProfilesAction::Show { name } => {
+            let def = guest::lookup_profile(name, &cfg.profiles)?;
+            write_profile_show(out, cfg, name, &def)
+        }
+    };
+    write_result.context("failed to write profile output")
+}
+
+fn write_profiles_list(
+    out: &mut impl std::io::Write,
+    cfg: &config::CoopConfig,
+) -> std::io::Result<()> {
+    let builtin = guest::builtin_profile_entries();
+    let mut custom_names: Vec<&str> = cfg.profiles.keys().map(String::as_str).collect();
+    custom_names.sort_unstable();
+
+    let width = builtin
+        .iter()
+        .map(|(n, _)| n.len())
+        .chain(custom_names.iter().map(|n| n.len()))
+        .max()
+        .unwrap_or(0);
+
+    writeln!(out, "Builtin:")?;
+    for (name, desc) in builtin {
+        writeln!(out, "  {name:<width$} {desc}")?;
+    }
+
+    if !custom_names.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "Custom:")?;
+        for name in custom_names {
+            let cp = &cfg.profiles[name];
+            let detail = format_custom_summary(cp);
+            writeln!(out, "  {name:<width$} {detail}")?;
+        }
+    }
+    Ok(())
+}
+
+fn write_profile_show(
+    out: &mut impl std::io::Write,
+    cfg: &config::CoopConfig,
+    name: &str,
+    def: &guest::ProfileDef,
+) -> std::io::Result<()> {
+    let origin = if cfg.profiles.contains_key(name) {
+        "custom"
+    } else {
+        "builtin"
+    };
+    writeln!(out, "Profile: {name} ({origin})")?;
+    writeln!(
+        out,
+        "  apt_packages: {}",
+        if def.apt_packages.is_empty() {
+            "(none)".to_string()
+        } else {
+            def.apt_packages.join(", ")
+        }
+    )?;
+    writeln!(
+        out,
+        "  pre_install:  {}",
+        script_summary(def.pre_install.as_deref())
+    )?;
+    writeln!(
+        out,
+        "  post_install: {}",
+        script_summary(def.post_install.as_deref())
+    )?;
+    writeln!(
+        out,
+        "  marketplaces: {}",
+        if def.marketplaces.is_empty() {
+            "(none)".to_string()
+        } else {
+            def.marketplaces.join(", ")
+        }
+    )?;
+    writeln!(
+        out,
+        "  plugins:      {}",
+        if def.plugins.is_empty() {
+            "(none)".to_string()
+        } else {
+            def.plugins.join(", ")
+        }
+    )?;
+    Ok(())
+}
+
+fn format_custom_summary(cp: &config::CustomProfile) -> String {
+    let mut parts = Vec::new();
+    if !cp.apt_packages.is_empty() {
+        parts.push(format!("{} apt packages", cp.apt_packages.len()));
+    }
+    if cp.pre_install.is_some() {
+        parts.push("pre-install script".to_string());
+    }
+    if cp.post_install.is_some() {
+        parts.push("post-install script".to_string());
+    }
+    if !cp.marketplaces.is_empty() {
+        parts.push(format!("{} marketplaces", cp.marketplaces.len()));
+    }
+    if !cp.plugins.is_empty() {
+        parts.push(format!("{} plugins", cp.plugins.len()));
+    }
+    if parts.is_empty() {
+        "(empty)".to_string()
+    } else {
+        format!("({})", parts.join(", "))
+    }
+}
+
+fn script_summary(script: Option<&str>) -> String {
+    match script {
+        None | Some("") => "(none)".to_string(),
+        Some(s) => {
+            let lines = s.lines().count();
+            let first = s.lines().next().unwrap_or("");
+            if lines <= 1 {
+                first.to_string()
+            } else {
+                format!("{first} ... ({lines} lines)")
+            }
+        }
+    }
+}
+
 fn cmd_images(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
@@ -1089,5 +1243,44 @@ mod tests {
         };
         assert!(session.no_tmux);
         assert!(session.tmux_session("main").is_none());
+    }
+
+    #[test]
+    fn profiles_list_parses() {
+        let cli = parse(&["profiles", "list"]);
+        let super::Commands::Profiles { action } = cli.command else {
+            panic!("expected Profiles variant");
+        };
+        assert!(matches!(action, Some(super::ProfilesAction::List)));
+    }
+
+    #[test]
+    fn profiles_bare_defaults_to_list() {
+        let cli = parse(&["profiles"]);
+        let super::Commands::Profiles { action } = cli.command else {
+            panic!("expected Profiles variant");
+        };
+        assert!(
+            action.is_none(),
+            "bare `profiles` should have no action (defaults to List at dispatch)"
+        );
+    }
+
+    #[test]
+    fn profiles_show_parses() {
+        let cli = parse(&["profiles", "show", "rust"]);
+        let super::Commands::Profiles { action } = cli.command else {
+            panic!("expected Profiles variant");
+        };
+        let Some(super::ProfilesAction::Show { name }) = action else {
+            panic!("expected Show variant");
+        };
+        assert_eq!(name, "rust");
+    }
+
+    #[test]
+    fn profiles_show_requires_name() {
+        let err = parse_err(&["profiles", "show"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -977,20 +977,20 @@ fn write_profiles_list(
     out: &mut impl std::io::Write,
     cfg: &config::CoopConfig,
 ) -> std::io::Result<()> {
-    let builtin = guest::builtin_profile_entries();
     let mut custom_names: Vec<&str> = cfg.profiles.keys().map(String::as_str).collect();
     custom_names.sort_unstable();
 
-    let width = builtin
+    let width = guest::BUILTIN_PROFILES
         .iter()
-        .map(|(n, _)| n.len())
+        .map(|bp| bp.name.len())
         .chain(custom_names.iter().map(|n| n.len()))
         .max()
         .unwrap_or(0);
 
     writeln!(out, "Builtin:")?;
-    for (name, desc) in builtin {
-        writeln!(out, "  {name:<width$} {desc}")?;
+    for bp in guest::BUILTIN_PROFILES {
+        let summary = builtin_summary(bp);
+        writeln!(out, "  {:<width$} {summary}", bp.name)?;
     }
 
     if !custom_names.is_empty() {
@@ -1003,6 +1003,27 @@ fn write_profiles_list(
         }
     }
     Ok(())
+}
+
+fn builtin_summary(bp: &guest::BuiltinProfile) -> String {
+    let mut parts = Vec::new();
+    if !bp.apt_packages.is_empty() {
+        parts.push(bp.apt_packages.join(", "));
+    }
+    if bp.pre_install.is_some() {
+        parts.push("pre-install script".to_owned());
+    }
+    if bp.post_install.is_some() {
+        parts.push("post-install script".to_owned());
+    }
+    if !bp.plugins.is_empty() {
+        parts.push(format!("plugins: {}", bp.plugins.join(", ")));
+    }
+    if parts.is_empty() {
+        "(empty)".to_owned()
+    } else {
+        parts.join("; ")
+    }
 }
 
 fn write_profile_show(

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -219,6 +219,69 @@ test_invalid_names() {
     fi
 }
 
+# ── Profiles list/show ────────────────────────────────────────
+
+test_profiles_cli() {
+    echo ""
+    echo "=== Phase: profiles list/show ==="
+
+    # `profiles list` exits 0 and includes builtin names
+    if coop profiles list; then
+        pass "profiles list exits 0"
+    else
+        fail "profiles list exits 0" "exit code: $?"
+    fi
+
+    for name in python node c fuzz rust go full; do
+        if echo "$HARNESS_OUT" | grep -q "$name"; then
+            pass "profiles list includes $name"
+        else
+            fail "profiles list includes $name" "output: $HARNESS_OUT"
+        fi
+    done
+
+    # Bare `profiles` defaults to list
+    if coop profiles; then
+        pass "bare profiles exits 0"
+    else
+        fail "bare profiles exits 0" "exit code: $?"
+    fi
+
+    if echo "$HARNESS_OUT" | grep -q "Builtin:"; then
+        pass "bare profiles shows Builtin header"
+    else
+        fail "bare profiles shows Builtin header" "output: $HARNESS_OUT"
+    fi
+
+    # `profiles show <name>` exits 0 and prints profile details
+    if coop profiles show rust; then
+        pass "profiles show rust exits 0"
+    else
+        fail "profiles show rust exits 0" "exit code: $?"
+    fi
+
+    if echo "$HARNESS_OUT" | grep -q "Profile: rust (builtin)"; then
+        pass "profiles show rust reports builtin origin"
+    else
+        fail "profiles show rust reports builtin origin" "output: $HARNESS_OUT"
+    fi
+
+    for field in apt_packages pre_install post_install marketplaces plugins; do
+        if echo "$HARNESS_OUT" | grep -q "$field"; then
+            pass "profiles show rust includes $field"
+        else
+            fail "profiles show rust includes $field" "output: $HARNESS_OUT"
+        fi
+    done
+
+    # `profiles show <unknown>` fails
+    if moat_fails profiles show nonexistent-profile; then
+        pass "profiles show rejects unknown profile"
+    else
+        fail "profiles show rejects unknown profile" "should have failed"
+    fi
+}
+
 # ── Setup ─────────────────────────────────────────────────────
 
 test_setup() {
@@ -2338,6 +2401,7 @@ main() {
     # Pre-VM tests
     test_validate
     test_invalid_names
+    test_profiles_cli
 
     # Setup + primary instance
     test_setup

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -232,7 +232,7 @@ test_profiles_cli() {
         fail "profiles list exits 0" "exit code: $?"
     fi
 
-    for name in python node c fuzz rust go full; do
+    for name in python node c fuzz rust go; do
         if echo "$HARNESS_OUT" | grep -q "$name"; then
             pass "profiles list includes $name"
         else


### PR DESCRIPTION
## Summary

- Add `coop profiles list` and `coop profiles show <name>` commands; bare `coop profiles` defaults to `list`
- Consolidate builtin profiles into a single `const BUILTIN_PROFILES: &[BuiltinProfile]` array — all profile data (name, apt packages, scripts, plugins) is compile-time static in one place
- Remove the `full` meta-profile — users can pass `--profile python,node,c,fuzz,rust,go` explicitly
- `profiles list` derives summaries from `BuiltinProfile` fields directly, no hand-written descriptions
- Integration test covers list output, show output, default behavior, and unknown-profile rejection

## Test plan

- [x] `cargo test` — 181 passed
- [x] `cargo clippy` — clean
- [x] `./tests/run-integration.sh` — 104 passed (17 new from `test_profiles_cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)