### PR TITLE
Fix unused variable shellcheck warning (SC2034)

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2352,8 +2352,8 @@ test_provision_failure() {
     # appends 'exit 1' to the provision script before cleanup.
     # setup --rebuild should fail with a clear error message.
     local rc=0
-    local out err
-    out=$(COOP_TEST_INJECT_PROVISION_FAILURE=1 "$BINARY" setup -y --rebuild 2>"$tmpdir/pf-stderr") || rc=$?
+    local err
+    COOP_TEST_INJECT_PROVISION_FAILURE=1 "$BINARY" setup -y --rebuild >/dev/null 2>"$tmpdir/pf-stderr" || rc=$?
     err=$(cat "$tmpdir/pf-stderr")
 
     if [[ $rc -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Redirect stdout to `/dev/null` instead of capturing into unused `out` variable in `test_provision_failure`
- Remove unused `out` from `local` declaration

Closes #30.

## Test plan
- [x] `shellcheck tests/integration.sh` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)