### PR TITLE
Resolve cmd: prefixed config values for secret manager integration

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -25,11 +25,21 @@
 # env_forward = ["CUSTOM_TOKEN"]  # Extra env vars to forward to guest
 # marketplaces = ["https://github.com/anthropics/claude-plugins-official"]
 # plugins = ["rust-analyzer-lsp@claude-plugins-official"]
+#
+# Secrets: any field below that holds a secret accepts a "cmd:" prefix.
+# The remainder is run via `sh -c` at VM start time and its trimmed
+# stdout is used as the value. Examples for api_key:
+#   api_key = "cmd:op read op://Private/Anthropic/credential"  # 1Password
+#   api_key = "cmd:security find-generic-password -s anthropic -w"  # macOS Keychain
+#   api_key = "cmd:pass show anthropic/api-key"  # pass
+#   api_key = "sk-ant-..."  # Plain value also works
 
 # [claude.mcp_servers.my-server]
 # command = "/usr/bin/my-mcp-server"
 # args = ["--verbose"]
 # env = { API_KEY = "MY_HOST_ENV_VAR" }
+# # Header values also accept the "cmd:" prefix:
+# # headers = { Authorization = "cmd:op read op://Private/Sentry/token" }
 
 # [profiles.my-tools]
 # apt_packages = ["ripgrep", "fd-find", "jq"]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -848,13 +848,19 @@ pub type PlatformBackend = FirecrackerBackend;
 ///
 /// Collects values from config and the process environment into an
 /// `EnvForward` struct. No process-global env mutation.
-pub fn prepare_env_forwarding(cfg: &CoopConfig) -> EnvForward {
+///
+/// `claude.api_key` values that use the `cmd:` prefix are resolved
+/// here (at VM start time, not config parse time) so that secret
+/// manager calls only happen when actually needed.
+pub fn prepare_env_forwarding(cfg: &CoopConfig) -> Result<EnvForward> {
     let claude = &cfg.claude;
     let mut env = EnvForward::default();
 
     // ANTHROPIC_API_KEY: prefer config, fall back to process env
     if let Some(key) = &claude.api_key {
-        env.set("ANTHROPIC_API_KEY", key.as_str());
+        let resolved =
+            crate::config::resolve_cmd_value(key).context("Failed to resolve claude.api_key")?;
+        env.set("ANTHROPIC_API_KEY", resolved);
     } else if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
         env.set("ANTHROPIC_API_KEY", key);
     }
@@ -873,7 +879,7 @@ pub fn prepare_env_forwarding(cfg: &CoopConfig) -> EnvForward {
         }
     }
 
-    env
+    Ok(env)
 }
 
 /// Bootstrap Claude Code in the guest declaratively.
@@ -1208,8 +1214,20 @@ fn register_mcp_servers(
 ) -> Result<()> {
     for (name, def) in servers {
         tracing::info!("Registering MCP server: {name}");
-        let json =
-            serde_json::to_string(def).context("Failed to serialize MCP server definition")?;
+
+        // Resolve any `cmd:` prefixed header values before sending the
+        // definition to the guest. Headers are the only secret-bearing
+        // field in McpServerDef (`env` values are host env var names,
+        // not secrets).
+        let mut resolved = def.clone();
+        for (header_key, header_value) in &mut resolved.headers {
+            *header_value = crate::config::resolve_cmd_value(header_value).with_context(|| {
+                format!("Failed to resolve header '{header_key}' for MCP server '{name}'")
+            })?;
+        }
+
+        let json = serde_json::to_string(&resolved)
+            .context("Failed to serialize MCP server definition")?;
         let cmd = format!(
             "{} mcp add-json -s user {} {}",
             crate::guest::CLAUDE_BIN,

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ use std::net::Ipv4Addr;
 use std::num::{NonZeroU8, NonZeroU16, NonZeroU32};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
@@ -13,6 +15,88 @@ use serde::{Deserialize, Serialize};
 use crate::cmd::Cmd;
 
 pub const DEFAULT_IMAGE: &str = "default";
+
+// ── Command substitution for secrets ─────────────────────────
+
+const CMD_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Resolve a config value that may use `cmd:` prefix for secret
+/// manager integration.
+///
+/// If the value starts with `cmd:`, the remainder is executed as
+/// a shell command and its trimmed stdout is returned. Plain values
+/// pass through unchanged. Commands that fail, timeout, or produce
+/// empty output return an error.
+pub(crate) fn resolve_cmd_value(value: &str) -> Result<String> {
+    let cmd_str = match value.strip_prefix("cmd:") {
+        Some(cmd) => cmd.trim(),
+        None => return Ok(value.to_string()),
+    };
+
+    if cmd_str.is_empty() {
+        bail!("Empty command after 'cmd:' prefix");
+    }
+
+    tracing::debug!("Resolving secret via command");
+
+    let mut child = Command::new("sh")
+        .args(["-c", cmd_str])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
+        .spawn()
+        .with_context(|| format!("Failed to spawn secret command: {cmd_str}"))?;
+
+    let start = Instant::now();
+
+    loop {
+        if child
+            .try_wait()
+            .context("Failed to check command status")?
+            .is_some()
+        {
+            let output = child
+                .wait_with_output()
+                .with_context(|| format!("Failed to read output: {cmd_str}"))?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let code = output
+                    .status
+                    .code()
+                    .map_or_else(|| "signal".to_string(), |c| c.to_string());
+                bail!(
+                    "Secret command failed (exit {code}): {cmd_str}\n\
+                     stderr: {stderr}"
+                );
+            }
+
+            let stdout = String::from_utf8(output.stdout)
+                .context("Secret command output is not valid UTF-8")?;
+            let resolved = stdout.trim().to_string();
+
+            if resolved.is_empty() {
+                bail!(
+                    "Secret command produced empty output: {cmd_str}\n\
+                     The command succeeded but stdout was empty after trimming."
+                );
+            }
+
+            return Ok(resolved);
+        }
+
+        if start.elapsed() >= CMD_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!(
+                "Secret command timed out after {}s: {cmd_str}\n\
+                 Ensure the command runs non-interactively.",
+                CMD_TIMEOUT.as_secs(),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
 
 // ── Newtypes ─────────────────────────────────────────────────
 
@@ -270,7 +354,7 @@ pub enum GitHubAuth {
     Off,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpServerDef {
     /// Command for stdio servers
     pub command: Option<String>,
@@ -2418,5 +2502,106 @@ mod tests {
         let cfg = test_config(&tmp);
         let inst = cfg.allocate_instance(None, DEFAULT_IMAGE, None).unwrap();
         assert_eq!(inst.name, *"0");
+    }
+
+    // ── cmd: prefix resolution ───────────────────────────────
+
+    #[test]
+    fn resolve_cmd_value_passthrough_plain() {
+        let plain = "sk-ant-plain-value";
+        assert_eq!(resolve_cmd_value(plain).unwrap(), plain);
+    }
+
+    #[test]
+    fn resolve_cmd_value_passthrough_empty_string() {
+        // Empty value (not cmd:) passes through; emptiness check
+        // only applies to resolved cmd: output.
+        assert_eq!(resolve_cmd_value("").unwrap(), "");
+    }
+
+    #[test]
+    fn resolve_cmd_value_executes_command() {
+        let resolved = resolve_cmd_value("cmd:echo hello").unwrap();
+        assert_eq!(resolved, "hello");
+    }
+
+    #[test]
+    fn resolve_cmd_value_trims_whitespace() {
+        let resolved = resolve_cmd_value("cmd:printf '  padded  \\n\\n'").unwrap();
+        assert_eq!(resolved, "padded");
+    }
+
+    #[test]
+    fn resolve_cmd_value_trims_leading_space_in_prefix() {
+        // `cmd: echo foo` (with space after colon) should still work
+        let resolved = resolve_cmd_value("cmd: echo foo").unwrap();
+        assert_eq!(resolved, "foo");
+    }
+
+    #[test]
+    fn resolve_cmd_value_preserves_internal_whitespace() {
+        let resolved = resolve_cmd_value("cmd:echo 'sk-ant token with spaces'").unwrap();
+        assert_eq!(resolved, "sk-ant token with spaces");
+    }
+
+    #[test]
+    fn resolve_cmd_value_supports_pipes() {
+        // Verifies we run via `sh -c`, not direct exec
+        let resolved = resolve_cmd_value("cmd:echo 'abc' | tr a-z A-Z").unwrap();
+        assert_eq!(resolved, "ABC");
+    }
+
+    #[test]
+    fn resolve_cmd_value_fails_on_nonzero_exit() {
+        let err = resolve_cmd_value("cmd:false").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Secret command failed"),
+            "expected failure message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_cmd_value_includes_stderr_on_failure() {
+        let err = resolve_cmd_value("cmd:echo oops 1>&2; exit 1").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("oops"), "expected stderr in error, got: {msg}");
+    }
+
+    #[test]
+    fn resolve_cmd_value_fails_on_empty_output() {
+        let err = resolve_cmd_value("cmd:true").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("empty output"),
+            "expected empty output error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_cmd_value_fails_on_empty_command() {
+        let err = resolve_cmd_value("cmd:").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Empty command"),
+            "expected empty command error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_cmd_value_fails_on_whitespace_only_command() {
+        let err = resolve_cmd_value("cmd:   ").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Empty command"),
+            "expected empty command error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_cmd_value_does_not_match_cmd_without_colon() {
+        // `cmd` (no colon) is a plain value, not a command substitution
+        assert_eq!(resolve_cmd_value("cmd").unwrap(), "cmd");
+        assert_eq!(resolve_cmd_value("cmdline").unwrap(), "cmdline");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,7 +370,7 @@ fn main() -> Result<()> {
             mut args,
         } => {
             let running = resolve_running(&be, &cfg, session.name.as_deref())?;
-            let env_vars = backend::prepare_env_forwarding(&cfg);
+            let env_vars = backend::prepare_env_forwarding(&cfg)?;
             let sess = backend::SshSession {
                 target: &running.target,
                 env: &env_vars,
@@ -679,7 +679,7 @@ fn restart_instance(
     if no_claude {
         tracing::info!("Skipping Claude Code bootstrap (--no-claude)");
     } else {
-        let env_vars = backend::prepare_env_forwarding(cfg);
+        let env_vars = backend::prepare_env_forwarding(cfg)?;
         let session = backend::SshSession {
             target: &target,
             env: &env_vars,
@@ -713,7 +713,7 @@ fn start_instance(
 
     signal::check_shutdown()?;
 
-    let env_vars = backend::prepare_env_forwarding(cfg);
+    let env_vars = backend::prepare_env_forwarding(cfg)?;
 
     if opts.no_claude {
         tracing::info!("Skipping Claude Code bootstrap (--no-claude)");
@@ -859,7 +859,7 @@ fn cmd_shell(
     tmux_session: Option<&str>,
 ) -> Result<()> {
     let running = resolve_running(be, cfg, name)?;
-    let env_vars = backend::prepare_env_forwarding(cfg);
+    let env_vars = backend::prepare_env_forwarding(cfg)?;
     let session = backend::SshSession {
         target: &running.target,
         env: &env_vars,
@@ -878,7 +878,7 @@ fn cmd_exec(
     command: &[String],
 ) -> Result<()> {
     let running = resolve_running(be, cfg, name)?;
-    let env_vars = backend::prepare_env_forwarding(cfg);
+    let env_vars = backend::prepare_env_forwarding(cfg)?;
     let session = backend::SshSession {
         target: &running.target,
         env: &env_vars,


### PR DESCRIPTION
## Summary

Closes #16.

Config values for `claude.api_key` and MCP server `headers` now accept a `cmd:` prefix. The remainder runs via `sh -c` at VM start time and its trimmed stdout becomes the value. Plain values continue to work unchanged.

```toml
[claude]
api_key = "cmd:op read op://Private/Anthropic/credential"      # 1Password
# api_key = "cmd:security find-generic-password -s anthropic -w"  # macOS Keychain
# api_key = "cmd:pass show anthropic/api-key"                     # pass
# api_key = "sk-ant-..."                                          # plain still works

[claude.mcp_servers.sentry]
type = "http"
url = "https://mcp.sentry.dev/mcp"
headers = { Authorization = "cmd:op read op://Private/Sentry/token" }
```

## Design

- Resolution happens at the consumption point (`prepare_env_forwarding` for `api_key`, `register_mcp_servers` for headers) — not at config parse time. `coop status`, `coop validate`, and `coop profiles` never shell out to secret managers.
- 10-second timeout with polling kill, so interactive auth prompts can't hang the start.
- Failures include command string, exit code, and stderr. Empty output is an error.
- `env` values on MCP servers are not resolved — they remain host env var *names* per existing design.

## Known limitation

There is no way to escape a literal value that happens to start with `cmd:`. In practice this is a non-issue (API keys start with `sk-ant-`, header tokens are never `cmd:`). If it becomes a problem we can add a tagged-enum form like `api_key = { cmd = "..." }`.

## Test plan

- [x] 13 new unit tests for `resolve_cmd_value` (passthrough, execution, pipes, trimming, exit failures, empty output, typos)
- [x] `cargo test` — 207 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `prek run --all-files` — all hooks pass
- [x] `./tests/run-integration.sh` on macOS/Lima — 104/104 pass
- [ ] `./tests/run-integration.sh --remote` on Linux/Firecracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)