### PR TITLE
Support Lima v2.1.0 disk layout (disk instead of diffdisk)

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -26,14 +26,14 @@ Setup verifies that `limactl --version` is reachable. If it is not, setup fails 
 2. Creates a temporary builder VM from an Ubuntu 24.04 cloud image. The Lima YAML template includes a cloud-init provision script.
 3. The provision script installs all packages (Docker, GitHub CLI, Claude Code, and any profile packages), creates the `ubuntu` user with SSH access, and enables services.
 4. After provisioning completes, cleans cloud-init state so it re-runs on cloned instances.
-5. Stops the builder VM and extracts its diffdisk as the golden image.
+5. Stops the builder VM and extracts its disk as the golden image.
 6. Generates a fast-start Lima template that references the golden image directly. No cloud-init provisioning runs on instance start.
 
 The builder VM is deleted after extraction, whether the build succeeds or fails.
 
 ### How instances work
 
-Each instance is a Lima VM created with `limactl start` using the fast-start template. Lima names are prefixed with `coop-` (e.g., `coop-my-instance`). The instance gets its own diffdisk, a copy-on-write layer over the golden image. Lima handles SSH port allocation automatically; coop reads the assigned port from `limactl list --json`.
+Each instance is a Lima VM created with `limactl start` using the fast-start template. Lima names are prefixed with `coop-` (e.g., `coop-my-instance`). The instance gets its own disk, a copy-on-write layer over the golden image. Lima handles SSH port allocation automatically; coop reads the assigned port from `limactl list --json`.
 
 The Lima template configures:
 - `vmType: "vz"` (Virtualization.framework, not QEMU)
@@ -43,7 +43,7 @@ The Lima template configures:
 
 ### Disk resize
 
-Resizing a stopped instance truncates the Lima diffdisk to the new size. Cloud-init's `growpart` module expands the partition and filesystem on next boot. Shrinking is not supported.
+Resizing a stopped instance truncates the Lima disk to the new size. Cloud-init's `growpart` module expands the partition and filesystem on next boot. Shrinking is not supported.
 
 ### Resource ownership
 
@@ -147,7 +147,7 @@ Both backends support the same CLI commands and guest capabilities:
 | `coop status` | Queries `limactl list --json` | Reads PID file, queries guest via SSH |
 | `coop logs` | Reads Lima's `serial.log` | Reads Firecracker log file |
 | `coop shell` | SSH to localhost on Lima-assigned port | SSH to guest IP on configured port |
-| `coop resize` | Truncates Lima diffdisk | Truncates + resize2fs on rootfs |
+| `coop resize` | Truncates Lima disk | Truncates + resize2fs on rootfs |
 | Resource monitoring | SSH query to guest | SSH query to guest |
 | Docker in guest | Works (full kernel) | Works (with iptables-legacy workaround) |
 | `--mount` host mounts | Live virtiofs (changes visible immediately) | One-time rsync sync (use `push`/`pull` to re-sync) |

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -826,7 +826,7 @@ impl VmBackend for LimaBackend {
     }
 
     fn disk_path(&self, inst: &Instance) -> Result<PathBuf> {
-        crate::lima::diffdisk_path(inst)
+        crate::lima::disk_path(inst)
     }
 
     fn mounts_are_live(&self) -> bool {

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -239,22 +239,22 @@ pub fn destroy(inst: &Instance) -> Result<()> {
 
 /// Resize the disk of a stopped Lima instance.
 ///
-/// Truncates the diffdisk to the new size. Cloud-init's `growpart`
+/// Truncates the disk to the new size. Cloud-init's `growpart`
 /// will expand the partition and filesystem on next boot.
 pub fn resize_disk(_cfg: &CoopConfig, inst: &Instance, new_size: crate::config::GiB) -> Result<()> {
-    let diffdisk = diffdisk_path(inst)?;
+    let disk = disk_path(inst)?;
 
-    if !diffdisk.exists() {
+    if !disk.exists() {
         bail!(
             "Lima disk not found at {}.\n\
              Is instance '{}' created?",
-            diffdisk.display(),
+            disk.display(),
             inst.name,
         );
     }
 
-    let current_bytes = std::fs::metadata(&diffdisk)
-        .with_context(|| format!("Failed to stat {}", diffdisk.display()))?
+    let current_bytes = std::fs::metadata(&disk)
+        .with_context(|| format!("Failed to stat {}", disk.display()))?
         .len();
     let current_gib = current_bytes / (1024 * 1024 * 1024);
     let new_gib = u64::from(new_size.as_u32());
@@ -277,12 +277,12 @@ pub fn resize_disk(_cfg: &CoopConfig, inst: &Instance, new_size: crate::config::
     let status = Command::new("truncate")
         .arg("-s")
         .arg(format!("{new_size}G"))
-        .arg(&diffdisk)
+        .arg(&disk)
         .status()
         .context("Failed to run truncate")?;
 
     if !status.success() {
-        bail!("truncate failed for {}", diffdisk.display());
+        bail!("truncate failed for {}", disk.display());
     }
 
     tracing::info!(
@@ -292,10 +292,18 @@ pub fn resize_disk(_cfg: &CoopConfig, inst: &Instance, new_size: crate::config::
     Ok(())
 }
 
-/// Path to the diffdisk for a Lima instance.
-pub fn diffdisk_path(inst: &Instance) -> Result<PathBuf> {
+/// Path to the VM disk for a Lima instance.
+///
+/// Lima v2.1.0 renamed `diffdisk` to `disk`. We try `disk` first
+/// (new layout) and fall back to `diffdisk` (pre-v2.1.0).
+pub fn disk_path(inst: &Instance) -> Result<PathBuf> {
     let name = lima_name(inst);
-    Ok(lima_home()?.join(name).join("diffdisk"))
+    let dir = lima_home()?.join(name);
+    let new_path = dir.join("disk");
+    if new_path.exists() {
+        return Ok(new_path);
+    }
+    Ok(dir.join("diffdisk"))
 }
 
 /// Check if a Lima instance is running.
@@ -317,7 +325,7 @@ pub fn status(cfg: &CoopConfig, inst: &Instance) -> Result<String> {
     let cpus = info["cpus"].as_u64().unwrap_or(0);
     let memory_bytes = info["memory"].as_u64().unwrap_or(0);
     let memory_mib = memory_bytes / (1024 * 1024);
-    let disk_gib = diffdisk_path(inst)
+    let disk_gib = disk_path(inst)
         .and_then(|p| {
             std::fs::metadata(&p).with_context(|| format!("Failed to stat {}", p.display()))
         })
@@ -658,17 +666,25 @@ fn run_builder_vm(
         bail!("Failed to stop builder VM");
     }
 
-    // Extract the disk image
+    // Extract the disk image.
+    // Lima v2.1.0 renamed "diffdisk" to "disk"; try new name first.
     eprintln!("  Extracting disk image...");
     let lima_dir = lima_home()?.join(BUILDER_NAME);
-    let src_disk = lima_dir.join("diffdisk");
-    if !src_disk.exists() {
-        bail!(
-            "Builder disk not found at {}.\n\
-             Lima may use a different disk layout.",
-            src_disk.display()
-        );
-    }
+    let src_disk = lima_dir.join("disk");
+    let src_disk = if src_disk.exists() {
+        src_disk
+    } else {
+        let legacy = lima_dir.join("diffdisk");
+        if !legacy.exists() {
+            bail!(
+                "Builder disk not found at {} or {}.\n\
+                 Lima may use a different disk layout.",
+                lima_dir.join("disk").display(),
+                legacy.display(),
+            );
+        }
+        legacy
+    };
 
     if let Some(parent) = output_path.parent() {
         fs::create_dir_all(parent)


### PR DESCRIPTION
## Summary

- Lima v2.1.0 ([lima-vm/lima#4587](https://github.com/lima-vm/lima/pull/4587)) renamed `diffdisk` to `disk` in instance directories. `coop setup` fails on Lima v2.1.0+ when extracting the builder disk.
- `disk_path()` now tries `disk` first and falls back to `diffdisk`, supporting both old and new Lima versions.
- Updated docs to use current Lima terminology.

Closes #37

## Test plan

- [ ] `coop setup` succeeds on Lima v2.1.0+
- [ ] `coop setup` still works on pre-v2.1.0 Lima
- [ ] `coop resize` works with both disk layouts
- [ ] `coop status` reports disk size correctly with both layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)