### PR TITLE
Switch chroot apt sources from HTTP to HTTPS

### DIFF
--- a/scripts/guest/preamble.sh
+++ b/scripts/guest/preamble.sh
@@ -14,5 +14,13 @@ chmod +x /usr/sbin/policy-rc.d
 dpkg-divert --local --rename --add /sbin/initctl 2>/dev/null || true
 ln -sf /bin/true /sbin/initctl 2>/dev/null || true
 
+# Switch apt sources from HTTP to HTTPS. Some networks block outbound port 80
+# to Canonical's archive servers while port 443 works fine. HTTPS is also
+# better practice (integrity + privacy of package metadata). The squashfs
+# ships with http:// URIs; rewrite them before the first apt-get update.
+echo '  [guest] Switching apt sources to HTTPS...'
+sed -i 's|http://|https://|g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true
+
 echo '  [guest] Updating package lists...'
 apt-get update -qq


### PR DESCRIPTION
## Summary
- Rewrites apt source URIs from `http://` to `https://` in the chroot preamble before the first `apt-get update`
- Fixes setup failures on networks that block outbound port 80 to Canonical's archive servers (`91.189.x.x`, `185.125.x.x`) while port 443 works fine
- Covers both deb822 format (`ubuntu.sources`) and legacy format (`sources.list`)

## Test plan
- [x] macOS/Lima integration tests pass (104/104)
- [x] Linux/Firecracker integration tests pass on the previously-failing host (101/101, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)