### PR TITLE
Release v0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,22 @@ jobs:
         with:
           subject-path: "coop-*.tar.gz"
 
+      - name: Extract release notes from CHANGELOG
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          awk -v tag="## $TAG" '
+            $0 == tag { found=1; next }
+            found && /^## / { exit }
+            found
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "No CHANGELOG entry found for $TAG" >&2
+            exit 1
+          fi
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
-        run: gh release create "$TAG" --generate-notes coop-*.tar.gz SHA256SUMS
+        run: gh release create "$TAG" --notes-file RELEASE_NOTES.md coop-*.tar.gz SHA256SUMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.3.1
+
+Re-release of v0.3.0. The v0.3.0 release artifacts failed to publish because
+the release workflow conflicted with a pre-created GitHub release. Release
+notes are now sourced from `CHANGELOG.md` so the workflow owns the full
+release end-to-end.
+
+No functional changes since v0.3.0.
+
 ## v0.3.0
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coop"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
 


### PR DESCRIPTION
## Summary

Re-release of v0.3.0 with working binary artifacts.

- Bump version to 0.3.1
- Fix release workflow: extract notes from `CHANGELOG.md` instead of using `--generate-notes`, so the workflow owns the full release creation (no manual `gh release create` needed)
- Add v0.3.1 entry to CHANGELOG

## Background

v0.3.0 binaries failed to attach because I pre-created the GitHub release with curated CHANGELOG notes, which conflicted with the workflow's `gh release create` step. Org-wide immutable releases prevent re-using the v0.3.0 tag, so we bump to v0.3.1.

No functional changes to `coop` itself since v0.3.0.

## Test plan

- [x] `cargo check` passes
- [x] Changelog extraction verified locally (`awk` produces correct v0.3.1 section)
- [ ] Workflow runs end-to-end on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)