### PR TITLE
Make Codex auth.json copy visible in logs and docs

### DIFF
--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -79,6 +79,25 @@ config_dir = "~/.codex"
 
 The default is `~/.codex`. Set to `false` to disable config file copying entirely.
 
+### Auth handling
+
+If you have run `codex login` on the host, `~/.codex/auth.json` contains an OAuth access token and a long-lived refresh token. By default, coop copies this file into every guest at `~/.codex/auth.json` so that `codex` inside the VM starts already signed in.
+
+This is a posture difference from the Claude integration, whose allowlist (`CLAUDE.md`, `rules/`, `commands/`) intentionally contains no auth material.
+
+Each bootstrap emits a visible log line when `auth.json` is copied:
+
+```
+INFO Copied Codex auth.json (OAuth tokens from `codex login`) to guest ~/.codex/auth.json. Set `codex.config_dir = false` to opt out.
+```
+
+Trade-offs:
+
+- **Default (copy `auth.json`)**: Seamless `codex` usage inside the guest, at the cost of OAuth tokens living on the guest disk. The guest is the isolation boundary, not the tokens.
+- **Opt out (`codex.config_dir = false`)**: No Codex config or tokens are copied. You will need to run `codex login` inside each new guest, or forward `OPENAI_API_KEY` via `codex.api_key` / the host env var and skip OAuth entirely.
+
+You can also point `config_dir` at a directory that does not contain `auth.json` to keep the rest of the Codex config copy while excluding tokens.
+
 ### Environment variable forwarding
 
 `env_forward` lists additional environment variable names to forward from the host to the guest via SSH `SendEnv`. These are forwarded on every SSH session, not just during bootstrap.
@@ -110,7 +129,7 @@ If `config_dir` also provides a `config.toml`, coop preserves its other settings
 When `coop start` runs (without `--no-agents`), it executes the following steps after the VM boots and SSH becomes available:
 
 1. **GitHub auth**: If a `GITHUB_TOKEN` is available, run `gh auth setup-git` in the guest.
-2. **User content**: Copy the allowlisted Codex entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from `config_dir` to `~/.codex/` in the guest.
+2. **User content**: Copy the allowlisted Codex entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from `config_dir` to `~/.codex/` in the guest. If `auth.json` is present, a visible log line calls out that OAuth tokens were copied (see [Auth handling](#auth-handling)).
 3. **MCP servers**: Merge configured MCP server definitions into `~/.codex/config.toml`.
 
 On restart (`coop start` of a stopped instance), the same Codex config files are refreshed so host-side updates are reflected in the guest.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,8 @@ GitHub auth is off by default. Set `github = "auto"` explicitly to enable it.
 
 coop picks up `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from your environment automatically. Setting them explicitly under `claude.api_key` or `codex.api_key` also works, but environment variables are preferred.
 
+**Codex auth note**: if `~/.codex/auth.json` exists on the host (i.e., you have run `codex login`), coop copies it into every new guest at `~/.codex/auth.json` so Codex starts already signed in. This copies an OAuth access token and a long-lived refresh token onto the guest disk. See [Codex integration: Auth handling](codex-integration.md#auth-handling) for how to opt out.
+
 ## First run
 
 ### 1. Setup

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1176,6 +1176,12 @@ fn copy_codex_config(
     }
 
     tracing::info!("Copied Codex config into guest");
+    if staging_path.join("auth.json").is_file() {
+        tracing::info!(
+            "Copied Codex auth.json (OAuth tokens from `codex login`) to guest ~/.codex/auth.json. \
+             Set `codex.config_dir = false` to opt out."
+        );
+    }
     Ok(())
 }
 
@@ -1692,6 +1698,20 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             std::fs::read_to_string(staging.path().join("auth.json")).unwrap(),
             "{\"access_token\":\"test\"}"
         );
+    }
+
+    #[test]
+    fn stage_codex_files_omits_auth_json_when_source_has_none() {
+        // `copy_codex_config` gates its "OAuth tokens copied" log on the
+        // presence of `auth.json` in the staging dir. This test pins the
+        // invariant that staging only contains `auth.json` when the source
+        // directory does — otherwise the log would fire spuriously.
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(src.path().join("AGENTS.md"), "# agents").unwrap();
+
+        let staging =
+            stage_codex_files(Some(src.path()), &std::collections::HashMap::new()).unwrap();
+        assert!(!staging.path().join("auth.json").is_file());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stacked on #49. Closes #46.

- `copy_codex_config` emits a second `tracing::info!` when `auth.json` was staged, naming the OAuth-token source and the `codex.config_dir = false` opt-out.
- `docs/codex-integration.md` gains an **Auth handling** subsection explaining what is copied, the posture difference from the Claude integration, the visible log line, and two opt-out paths.
- `docs/getting-started.md` cross-references the new subsection from the Codex integration setup.
- Adds `stage_codex_files_omits_auth_json_when_source_has_none` to pin the invariant the log gate relies on (staging only contains `auth.json` when the source directory does).

Issue #46 lists three options; this PR takes **document prominently + log visibly** and skips the `codex.copy_auth` opt-in flag. The opt-in flag can be added separately if the visibility changes alone are judged insufficient.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (229 passed)
- [ ] `./tests/run-integration.sh` on Linux/Firecracker
- [ ] `./tests/run-integration.sh` on macOS/Lima

🤖 Generated with [Claude Code](https://claude.com/claude-code)