### PR TITLE
Clarify Codex bootstrap behavior for empty [codex] section

### DIFF
--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -43,7 +43,7 @@ command = "npx"
 args = ["-y", "@playwright/mcp@latest"]
 ```
 
-Every field is optional. An empty `[codex]` section (or omitting it entirely) skips all Codex-specific bootstrap steps.
+Every field is optional. Omitting `[codex]`, or leaving it empty, keeps `config_dir` at its default (`~/.codex`), so bootstrap still runs if that directory contains any allowlisted entry (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) or if `codex.mcp_servers` is set. To skip Codex-specific bootstrap entirely, set `codex.config_dir = false` and leave `codex.mcp_servers` empty.
 
 ### API key forwarding
 


### PR DESCRIPTION
## Summary

Stacked on #50. Closes #47.

`docs/codex-integration.md` claimed that an empty `[codex]` section (or omitting it entirely) skips all Codex-specific bootstrap. That is inaccurate: `CodexConfig::config_dir` defaults to `ConfigDir::Default`, which resolves to `~/.codex`. If that directory holds any allowlisted entry (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`), `codex_bootstrap_needed` returns true and bootstrap runs. The same applies when `codex.mcp_servers` is set.

This PR reworks the paragraph to describe what actually happens and names the two conditions needed to fully skip Codex bootstrap: `codex.config_dir = false` and empty `codex.mcp_servers`.

Issue #47 listed two fix options; this PR takes the **reword** option rather than changing the default to `ConfigDir::Disabled`. The latter would contradict #50's default-copy-`auth.json` posture, and the current default behavior is reasonable — only the docs were wrong.

## Follow-up

`docs/claude-integration.md:57` carries the same inaccuracy: "An empty `[claude]` section (or omitting it entirely) skips all bootstrap steps." `ClaudeConfig::config_dir` also defaults to `~/.claude`, so entries there trigger a config copy during bootstrap. Out of scope for this issue; worth filing separately.

## Test plan

- [x] Doc-only change, no code touched
- [x] Cross-checked against `src/config.rs` (`CodexConfig::default`, `ConfigDir` deserializer) and `src/backend.rs` (`codex_bootstrap_needed`, `CODEX_ALLOWED_FILES`, `CODEX_ALLOWED_DIRS`, `resolve_config_source_dir`)
- [x] Surrounding sections ("Config directory", "Auth handling", "Bootstrap sequence") stay internally consistent