### PR TITLE
Add `coop update` self-update command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Unit tests
         run: cargo test
 
+      - name: Integration test — coop update
+        run: ./tests/integration-update.sh
+
   deny:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- **`coop update`** (#34) — Self-update the coop binary from GitHub Releases.
+  Downloads the tarball matching the host triple, verifies SHA-256 via the
+  release's `SHA256SUMS`, and optionally checks provenance with `gh
+  attestation verify` before atomically replacing the running binary. Flags:
+  `--check` (probe only), `--force` (reinstall same version), `--version
+  <tag>` (pin), and `-y`/`--yes` (skip confirmation). Dev builds refuse to
+  self-update — re-run `install.sh` to replace them.
+
+- **Background update-check notifications** — On every command, coop checks
+  the persisted state in `$XDG_STATE_HOME/coop/update-check.json`; if a newer
+  release is known, a one-line notice is printed on stderr. The refresh runs
+  in a detached thread and never blocks the command. Disable globally with
+  `updates.mode = "off"` in `config.toml`, or per-invocation with
+  `COOP_NO_UPDATE_CHECK=1`. The check is also silent when `CI=true` or when
+  stdin is not a TTY.
+
+- **`coop --version` includes git metadata** — Release builds display the
+  short commit sha (e.g. `coop 0.3.1 (a1b2c3d)`); dev builds add `-dev` and a
+  `+dirty` suffix when the working tree has uncommitted changes.
+
+### Dependencies
+
+- New: `semver` 1
+
 ## v0.3.1
 
 Re-release of v0.3.0. The v0.3.0 release artifacts failed to publish because

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "hex",
  "indexmap",
  "libc",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1.2"
 tracing = "0.1"
+semver = "1"
 sha2 = "0.11"
 tempfile = "3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,36 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 | `images` | List or delete template images |
 | `resize` | Grow a stopped instance's disk |
 | `validate` | Check config and prerequisites |
+| `update` | Self-update coop to the latest GitHub release |
+
+## Updating
+
+`coop update` replaces the running binary with the latest release from
+`github.com/trailofbits/coop`. It downloads the tarball matching the current
+host triple, verifies the SHA-256 against the release's `SHA256SUMS`, and
+(when `gh` is installed) verifies the GitHub build-provenance attestation
+before swapping the binary atomically.
+
+```sh
+coop update --check             # report whether a newer release exists
+coop update                     # prompt, then install the latest release
+coop update --yes               # skip confirmation
+coop update --version v0.3.2    # pin to a specific release
+coop update --force             # reinstall the current version
+```
+
+If coop is installed in a protected directory (e.g. `/usr/local/bin`), run
+with `sudo`. Dev builds (built from an untagged or dirty tree) refuse to
+self-update — use `install.sh` to replace them.
+
+By default, coop checks for a newer release in the background at most once
+per day and prints a one-line notice on stderr when an update is available.
+Opt out with either:
+
+- `updates.mode = "off"` in `~/.coop/config.toml`, or
+- `COOP_NO_UPDATE_CHECK=1` in the environment.
+
+The check is also silent when `CI=true` or when stdin is not a TTY.
 
 ## Requirements
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,114 @@
+//! Build script: embed git metadata for version reporting and dev-build detection.
+//!
+//! Emits four compile-time env vars consumed via `env!()` in the crate:
+//! - `COOP_GIT_SHA` — short commit sha, or "unknown" if no git tree.
+//! - `COOP_GIT_DIRTY` — "true" if `git status --porcelain` is non-empty, else "false".
+//! - `COOP_BUILD_KIND` — "release" iff HEAD is tagged with `v{CARGO_PKG_VERSION}` and the
+//!   tree is clean, otherwise "dev".
+//! - `COOP_VERSION_STR` — pre-formatted version string for clap's `--version` output.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    // Invalidate the build script (and thus the embedded version) whenever any of git's
+    // state-tracking files change. We resolve the real gitdir first so this also works
+    // inside worktrees, where `.git` is a file pointing at `<maindir>/.git/worktrees/<n>`.
+    for path in git_rerun_paths() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+    // Build-time test hook: allows the integration test to produce a "release" binary from
+    // an untagged branch. Runtime behaviour is unaffected — the override only influences
+    // what build.rs bakes into `COOP_BUILD_KIND`.
+    println!("cargo:rerun-if-env-changed=COOP_FORCE_BUILD_KIND");
+
+    let sha = git_short_sha().unwrap_or_else(|| "unknown".to_string());
+    let dirty = git_is_dirty();
+    let pkg_version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
+    let computed = build_kind(&sha, dirty, &pkg_version);
+    let kind = match env::var("COOP_FORCE_BUILD_KIND").as_deref() {
+        Ok("release") => "release",
+        Ok("dev") => "dev",
+        Ok(_) | Err(_) => computed,
+    };
+    let version_str = format_version(&pkg_version, &sha, dirty, kind);
+
+    println!("cargo:rustc-env=COOP_GIT_SHA={sha}");
+    println!(
+        "cargo:rustc-env=COOP_GIT_DIRTY={}",
+        if dirty { "true" } else { "false" }
+    );
+    println!("cargo:rustc-env=COOP_BUILD_KIND={kind}");
+    println!("cargo:rustc-env=COOP_VERSION_STR={version_str}");
+}
+
+/// Files whose mtimes should invalidate the build script. Resolves `.git` to the real
+/// gitdir when the repo is a worktree (`.git` is a `gitdir: <path>` file, not a directory).
+fn git_rerun_paths() -> Vec<PathBuf> {
+    let gitdir = resolve_gitdir().unwrap_or_else(|| PathBuf::from(".git"));
+    vec![gitdir.join("HEAD"), gitdir.join("index")]
+}
+
+fn resolve_gitdir() -> Option<PathBuf> {
+    let dot_git = PathBuf::from(".git");
+    let meta = fs::metadata(&dot_git).ok()?;
+    if meta.is_dir() {
+        return Some(dot_git);
+    }
+    // Worktree: `.git` is a file containing `gitdir: <path>`.
+    let text = fs::read_to_string(&dot_git).ok()?;
+    let target = text.lines().find_map(|l| l.strip_prefix("gitdir: "))?;
+    Some(PathBuf::from(target.trim()))
+}
+
+fn git_short_sha() -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn git_is_dirty() -> bool {
+    let Ok(out) = Command::new("git").args(["status", "--porcelain"]).output() else {
+        return false;
+    };
+    out.status.success() && !out.stdout.is_empty()
+}
+
+fn build_kind(sha: &str, dirty: bool, pkg_version: &str) -> &'static str {
+    if sha == "unknown" || dirty {
+        return "dev";
+    }
+    let expected_tag = format!("v{pkg_version}");
+    let Ok(out) = Command::new("git")
+        .args(["describe", "--exact-match", "--tags", "HEAD"])
+        .output()
+    else {
+        return "dev";
+    };
+    if !out.status.success() {
+        return "dev";
+    }
+    match String::from_utf8(out.stdout) {
+        Ok(tag) if tag.trim() == expected_tag => "release",
+        Ok(_) | Err(_) => "dev",
+    }
+}
+
+fn format_version(pkg_version: &str, sha: &str, dirty: bool, kind: &str) -> String {
+    let dev_suffix = if kind == "dev" { "-dev" } else { "" };
+    let dirty_suffix = if dirty { "+dirty" } else { "" };
+    format!("{pkg_version}{dev_suffix} ({sha}{dirty_suffix})")
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -58,3 +58,7 @@
 # apt_packages = ["ripgrep", "fd-find", "jq"]
 # pre_install = "curl -fsSL https://example.com/setup.sh | bash"
 # post_install = "echo 'done'"
+
+# [updates]
+# mode = "notify"                # off | notify (default: notify)
+# check_interval_hours = 24      # minimum age before background re-check

--- a/src/config.rs
+++ b/src/config.rs
@@ -292,6 +292,10 @@ pub struct CoopConfig {
     /// User-defined profiles (name -> definition)
     #[serde(default)]
     pub profiles: HashMap<String, CustomProfile>,
+
+    /// Self-update behaviour
+    #[serde(default)]
+    pub updates: crate::update::UpdateConfig,
 }
 
 /// User-defined profile in `config.toml`.
@@ -985,6 +989,7 @@ impl Default for CoopConfig {
             claude: ClaudeConfig::default(),
             codex: CodexConfig::default(),
             profiles: HashMap::new(),
+            updates: crate::update::UpdateConfig::default(),
         }
     }
 }

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,8 +1,25 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
+
+/// Build a writer-unique sibling temp path. Including pid + a nanosecond
+/// counter keeps concurrent writers (across threads or processes) from
+/// clobbering each other's tmp files before the final rename.
+fn unique_tmp_path(target: &Path) -> PathBuf {
+    let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    let stem = target.file_name().map_or_else(
+        || "coop-atomic".to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    );
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or_default();
+    parent.join(format!(".{stem}.{}.{nanos}.tmp", std::process::id()))
+}
 
 /// Write JSON content to a file atomically via temp file + rename.
 ///
@@ -24,7 +41,7 @@ pub fn atomic_write_json(path: &Path, json: &str) -> Result<()> {
         fs::Permissions::from_mode(0o644)
     };
 
-    let tmp_path = path.with_extension("tmp");
+    let tmp_path = unique_tmp_path(path);
     fs::write(&tmp_path, json)
         .with_context(|| format!("Failed to write temp file {}", tmp_path.display()))?;
     fs::set_permissions(&tmp_path, perms)
@@ -43,10 +60,6 @@ pub fn atomic_write_json(path: &Path, json: &str) -> Result<()> {
 /// Write content to a file atomically, preserving SSH-appropriate
 /// permissions (0o600 default).
 pub fn atomic_write_ssh(path: &Path, content: &str) -> Result<()> {
-    let parent = path
-        .parent()
-        .context("Cannot determine parent directory for atomic write")?;
-
     let perms = if path.exists() {
         fs::metadata(path)
             .context("Failed to read file metadata")?
@@ -55,7 +68,7 @@ pub fn atomic_write_ssh(path: &Path, content: &str) -> Result<()> {
         fs::Permissions::from_mode(0o600)
     };
 
-    let tmp_path = parent.join(".coop-ssh-config.tmp");
+    let tmp_path = unique_tmp_path(path);
     fs::write(&tmp_path, content)
         .with_context(|| format!("Failed to write temp file {}", tmp_path.display()))?;
     fs::set_permissions(&tmp_path, perms)
@@ -82,8 +95,25 @@ mod tests {
         let path = dir.path().join("test.json");
         atomic_write_json(&path, r#"{"key": "value"}"#).unwrap();
         assert_eq!(fs::read_to_string(&path).unwrap(), r#"{"key": "value"}"#);
-        // No temp file left behind
-        assert!(!path.with_extension("tmp").exists());
+        // No sibling .tmp files left behind
+        let siblings: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(siblings.is_empty(), "stray tmp file remains");
+    }
+
+    #[test]
+    fn unique_tmp_path_differs_per_call() {
+        let target = Path::new("/tmp/coop/test.json");
+        let a = unique_tmp_path(target);
+        std::thread::sleep(std::time::Duration::from_nanos(1));
+        let b = unique_tmp_path(target);
+        // Same pid but different nanosecond stamps.
+        assert_ne!(a, b);
+        assert!(a.to_string_lossy().ends_with(".tmp"));
+        assert_eq!(a.parent(), target.parent());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod signal;
 mod setup;
 mod shell;
 mod ssh;
+mod update;
 #[cfg_attr(target_os = "macos", expect(dead_code, reason = "Firecracker-only"))]
 mod vm;
 mod workspace;
@@ -40,7 +41,7 @@ use backend::VmBackend as _;
 use cmd::Cmd;
 
 #[derive(Parser)]
-#[command(name = "coop", version)]
+#[command(name = "coop", version = env!("COOP_VERSION_STR"))]
 #[command(about = "Isolated VM environment for running Claude Code and Codex")]
 struct Cli {
     /// Path to coop config file
@@ -261,6 +262,21 @@ enum Commands {
     Validate,
     /// Generate a starter config file at ~/.coop/config.toml
     Init,
+    /// Replace the running coop binary with the latest GitHub release
+    Update {
+        /// Only check for an available update — do not download or install
+        #[arg(long)]
+        check: bool,
+        /// Reinstall even if the current binary is already up to date
+        #[arg(long)]
+        force: bool,
+        /// Install a specific version (e.g. `v0.3.2` or `0.3.2`)
+        #[arg(long = "version", value_name = "VERSION")]
+        target_version: Option<String>,
+        /// Skip the interactive confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -317,8 +333,24 @@ fn main() -> Result<()> {
     if matches!(cli.command, Commands::Init) {
         return cmd_init(&cli.config);
     }
+    if let Commands::Update {
+        check,
+        force,
+        target_version,
+        yes,
+    } = cli.command
+    {
+        return update::run(&update::UpdateOpts {
+            check_only: check,
+            force,
+            pinned_version: target_version,
+            skip_confirm: yes,
+        });
+    }
 
     let mut cfg = load_and_validate_config(&cli.config)?;
+    update::maybe_print_notify(&cfg.updates);
+    update::maybe_run_background_check(&cfg.updates);
     let be: backend::PlatformBackend = backend::PlatformBackend::new();
     tracing::debug!("Using backend: {be}");
 
@@ -465,7 +497,9 @@ fn main() -> Result<()> {
             cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
         }
         Commands::Validate => cmd_validate(&cfg, &be),
-        Commands::Init => unreachable!("handled before config loading"),
+        Commands::Init | Commands::Update { .. } => {
+            unreachable!("handled before config loading")
+        }
     }
 }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,809 @@
+//! Self-update for the coop binary.
+//!
+//! Fetches the latest release metadata from GitHub, downloads the matching
+//! tarball and `SHA256SUMS`, verifies the checksum (and optionally the
+//! attestation via `gh`), then atomically replaces the running binary.
+//!
+//! Also provides a background update-check path used by every invocation
+//! to nudge users when a newer release is available.
+
+use std::env;
+use std::fs;
+use std::io::{IsTerminal as _, Write as _};
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail, ensure};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::cmd::Cmd;
+use crate::fs_util::atomic_write_json;
+
+const REPO: &str = "trailofbits/coop";
+const DEFAULT_API_BASE: &str = "https://api.github.com";
+const DEFAULT_CHECK_INTERVAL_HOURS: u64 = 24;
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateMode {
+    /// Do not check for updates or display notifications.
+    Off,
+    /// Check in the background and print a banner when a newer release is known.
+    #[default]
+    Notify,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateConfig {
+    #[serde(default)]
+    pub mode: UpdateMode,
+    #[serde(default = "default_check_interval_hours")]
+    pub check_interval_hours: u64,
+}
+
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self {
+            mode: UpdateMode::default(),
+            check_interval_hours: DEFAULT_CHECK_INTERVAL_HOURS,
+        }
+    }
+}
+
+fn default_check_interval_hours() -> u64 {
+    DEFAULT_CHECK_INTERVAL_HOURS
+}
+
+// ── Command-line options ─────────────────────────────────────────────────────
+
+/// Options for the `coop update` subcommand.
+#[derive(Debug, Default)]
+pub struct UpdateOpts {
+    /// Probe latest release but do not download or install.
+    pub check_only: bool,
+    /// Reinstall even if the target version is not newer.
+    pub force: bool,
+    /// Pin to a specific version (with or without leading `v`).
+    pub pinned_version: Option<String>,
+    /// Skip the interactive confirmation prompt.
+    pub skip_confirm: bool,
+}
+
+// ── Build metadata (from build.rs) ───────────────────────────────────────────
+
+fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[must_use]
+pub fn is_dev_build() -> bool {
+    env!("COOP_BUILD_KIND") == "dev"
+}
+
+// ── Platform + URL helpers ───────────────────────────────────────────────────
+
+pub fn target_triple() -> Result<&'static str> {
+    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        Ok("aarch64-apple-darwin")
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        Ok("x86_64-unknown-linux-musl")
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        Ok("aarch64-unknown-linux-musl")
+    } else {
+        bail!(
+            "No prebuilt coop binary for {}-{}; build from source.",
+            env::consts::OS,
+            env::consts::ARCH
+        )
+    }
+}
+
+#[must_use]
+pub fn asset_name(tag: &str, triple: &str) -> String {
+    format!("coop-{tag}-{triple}.tar.gz")
+}
+
+fn api_base() -> String {
+    env::var("COOP_UPDATE_API_BASE_URL").unwrap_or_else(|_| DEFAULT_API_BASE.to_string())
+}
+
+fn api_base_overridden() -> bool {
+    env::var("COOP_UPDATE_API_BASE_URL").is_ok()
+}
+
+fn warn_if_api_base_overridden() {
+    if api_base_overridden() {
+        tracing::warn!(
+            "COOP_UPDATE_API_BASE_URL is set — attestation verification is DISABLED. \
+             This is a test-only mode; do not use with untrusted URLs."
+        );
+    }
+}
+
+/// Normalize a user-supplied version to a `v`-prefixed semver tag.
+///
+/// Rejects any input that does not parse as semver once the optional `v`
+/// prefix is stripped. This is the security boundary for `coop update
+/// --version <tag>`: the tag string is interpolated into the GitHub API
+/// URL path, so admitting only semver-like values prevents path traversal
+/// (e.g. `../other-user/repo/releases/latest`).
+fn normalize_tag(input: &str) -> Result<String> {
+    let trimmed = input.trim();
+    let body = trimmed.strip_prefix('v').unwrap_or(trimmed);
+    Version::parse(body)
+        .with_context(|| format!("--version {trimmed:?} is not a valid semver tag"))?;
+    Ok(format!("v{body}"))
+}
+
+fn strip_v(tag: &str) -> &str {
+    tag.strip_prefix('v').unwrap_or(tag)
+}
+
+// ── GitHub release metadata ──────────────────────────────────────────────────
+
+/// Minimal subset of the GitHub release JSON schema.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Release {
+    #[serde(rename = "tag_name")]
+    pub tag: String,
+    #[serde(default)]
+    pub assets: Vec<Asset>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Asset {
+    pub name: String,
+    #[serde(rename = "browser_download_url")]
+    pub url: String,
+}
+
+impl Release {
+    fn find_asset(&self, name: &str) -> Option<&Asset> {
+        self.assets.iter().find(|a| a.name == name)
+    }
+}
+
+pub fn fetch_latest() -> Result<Release> {
+    let url = format!("{}/repos/{REPO}/releases/latest", api_base());
+    fetch_release(&url).context("Failed to fetch latest release metadata")
+}
+
+pub fn fetch_by_tag(tag: &str) -> Result<Release> {
+    let url = format!("{}/repos/{REPO}/releases/tags/{tag}", api_base());
+    fetch_release(&url).with_context(|| format!("Failed to fetch release metadata for {tag}"))
+}
+
+fn fetch_release(url: &str) -> Result<Release> {
+    let body = curl_capture(url)?;
+    serde_json::from_str(&body).context("Failed to parse GitHub release JSON")
+}
+
+// ── Network I/O (shell-out to curl) ──────────────────────────────────────────
+
+fn curl_capture(url: &str) -> Result<String> {
+    Cmd::new("curl")
+        .arg("-fsSL")
+        .arg("-H")
+        .arg("Accept: application/vnd.github+json")
+        .arg(url)
+        .capture()
+        .with_context(|| format!("curl GET {url} failed"))
+}
+
+fn download_to(url: &str, dest: &Path) -> Result<()> {
+    Cmd::new("curl")
+        .arg("-fsSL")
+        .arg(url)
+        .arg("-o")
+        .arg(dest)
+        .run()
+        .with_context(|| format!("curl download from {url} failed"))
+}
+
+// ── Checksum verification ────────────────────────────────────────────────────
+
+/// Parse a `sha256sum`-style `SHA256SUMS` file and return the hex digest for
+/// `target_filename`. Handles both `<hash>  <file>` (binary mode) and
+/// `<hash> *<file>` variants; tolerates blank lines and `#` comments.
+#[must_use]
+pub fn parse_sha256sums(content: &str, target_filename: &str) -> Option<String> {
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (hash, rest) = line.split_once(|c: char| c.is_ascii_whitespace())?;
+        let file = rest.trim_start().trim_start_matches('*');
+        if file == target_filename
+            && hash.len() == 64
+            && hash.bytes().all(|b| b.is_ascii_hexdigit())
+        {
+            return Some(hash.to_ascii_lowercase());
+        }
+    }
+    None
+}
+
+fn verify_sha256(file: &Path, expected_hex: &str) -> Result<()> {
+    let bytes = fs::read(file)
+        .with_context(|| format!("Failed to read {} for checksum", file.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let digest = hasher.finalize();
+    let actual = hex::encode(digest);
+    ensure!(
+        actual.eq_ignore_ascii_case(expected_hex),
+        "SHA-256 mismatch for {}: expected {expected_hex}, got {actual}",
+        file.display()
+    );
+    Ok(())
+}
+
+// ── Attestation verification (best-effort) ───────────────────────────────────
+
+fn has_command(prog: &str) -> bool {
+    Cmd::new("sh")
+        .arg("-c")
+        .arg(format!("command -v {prog} >/dev/null 2>&1"))
+        .status_ok()
+}
+
+fn verify_attestation(tarball: &Path) -> Result<()> {
+    // Skip when the API base is overridden — the local test fixture serves
+    // synthetic artifacts that have no provenance in GitHub's attestation
+    // API. `warn_if_api_base_overridden` has already surfaced this to the
+    // user as a visible stderr warning.
+    if api_base_overridden() {
+        return Ok(());
+    }
+    if !has_command("gh") {
+        tracing::warn!(
+            "`gh` CLI not found — skipping attestation verification. \
+             Install it for cryptographic verification of release artifacts."
+        );
+        return Ok(());
+    }
+    Cmd::new("gh")
+        .arg("attestation")
+        .arg("verify")
+        .arg(tarball)
+        .arg("--repo")
+        .arg(REPO)
+        .run()
+        .with_context(|| {
+            format!(
+                "Attestation verification failed for {} — refusing to install",
+                tarball.display()
+            )
+        })
+}
+
+// ── Atomic self-replace ──────────────────────────────────────────────────────
+
+fn check_parent_writable(dir: &Path) -> Result<()> {
+    let probe = dir.join(format!(".coop-update-probe-{}", std::process::id()));
+    match fs::File::create(&probe) {
+        Ok(_) => {
+            if let Err(e) = fs::remove_file(&probe) {
+                tracing::debug!("Failed to remove probe file {}: {e}", probe.display());
+            }
+            Ok(())
+        }
+        Err(e) => bail!(
+            "Cannot write to {}: {e}.\n\
+             Try `sudo coop update` if coop is installed in a protected directory.",
+            dir.display()
+        ),
+    }
+}
+
+fn atomic_replace_self(new_binary: &Path) -> Result<()> {
+    let current = env::current_exe().context("Failed to resolve current executable path")?;
+    let dir = current
+        .parent()
+        .context("Current executable has no parent directory")?;
+    check_parent_writable(dir)?;
+
+    let tmp = dir.join(format!(".coop-update-{}", std::process::id()));
+    fs::copy(new_binary, &tmp)
+        .with_context(|| format!("Failed to stage update at {}", tmp.display()))?;
+    fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755))
+        .with_context(|| format!("Failed to chmod staged binary {}", tmp.display()))?;
+
+    fs::File::open(&tmp)
+        .with_context(|| format!("Failed to reopen staged binary {}", tmp.display()))?
+        .sync_all()
+        .with_context(|| format!("Failed to fsync staged binary {}", tmp.display()))?;
+
+    fs::rename(&tmp, &current).with_context(|| {
+        format!(
+            "Failed to swap {} over {}",
+            tmp.display(),
+            current.display()
+        )
+    })?;
+    Ok(())
+}
+
+// ── Interactive confirmation ─────────────────────────────────────────────────
+
+fn confirm(prompt: &str) -> Result<bool> {
+    if !std::io::stdin().is_terminal() {
+        // Non-interactive: caller must pass --yes explicitly.
+        return Ok(false);
+    }
+    let mut stderr = std::io::stderr();
+    write!(stderr, "{prompt} [y/N] ").context("Failed to write confirmation prompt")?;
+    stderr.flush().context("Failed to flush stderr")?;
+    let mut response = String::new();
+    std::io::stdin()
+        .read_line(&mut response)
+        .context("Failed to read confirmation")?;
+    Ok(matches!(
+        response.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+// ── Main update flow ─────────────────────────────────────────────────────────
+
+pub fn run(opts: &UpdateOpts) -> Result<()> {
+    if is_dev_build() {
+        bail!(
+            "This is a dev build ({}); `coop update` only replaces release binaries.\n\
+             Re-run install.sh (or build from source) to replace a dev build.",
+            env!("COOP_VERSION_STR")
+        );
+    }
+
+    warn_if_api_base_overridden();
+
+    let triple = target_triple()?;
+    let current = Version::parse(current_version())
+        .with_context(|| format!("Current version {} is not valid semver", current_version()))?;
+
+    let release = match &opts.pinned_version {
+        Some(v) => fetch_by_tag(&normalize_tag(v)?)?,
+        None => fetch_latest()?,
+    };
+    let target = Version::parse(strip_v(&release.tag))
+        .with_context(|| format!("Release tag {} is not valid semver", release.tag))?;
+
+    let newer = target > current;
+    if opts.check_only {
+        if newer {
+            tracing::info!("Update available: {current} -> {target}");
+        } else {
+            tracing::info!("Up to date: coop {current}");
+        }
+        return Ok(());
+    }
+
+    if !newer && !opts.force && opts.pinned_version.is_none() {
+        tracing::info!("Already on latest: coop {current}");
+        return Ok(());
+    }
+
+    if !opts.skip_confirm && !confirm(&format!("Update coop from {current} to {target}?"))? {
+        tracing::info!("Update cancelled");
+        return Ok(());
+    }
+
+    perform_update(&release, triple)?;
+    tracing::info!("coop updated to {target}");
+    persist_state(Some(&release.tag));
+    Ok(())
+}
+
+fn perform_update(release: &Release, triple: &str) -> Result<()> {
+    let tmp = tempfile::tempdir().context("Failed to create temporary working directory")?;
+    let tarball_name = asset_name(&release.tag, triple);
+
+    let tarball_asset = release.find_asset(&tarball_name).with_context(|| {
+        format!(
+            "Release {} has no asset {tarball_name}; \
+             this platform may not be supported by that release.",
+            release.tag
+        )
+    })?;
+    let sums_asset = release
+        .find_asset("SHA256SUMS")
+        .context("Release has no SHA256SUMS asset; refusing to install unverified binary")?;
+
+    let tarball_path = tmp.path().join(&tarball_name);
+    let sums_path = tmp.path().join("SHA256SUMS");
+
+    tracing::info!("Downloading {tarball_name}");
+    download_to(&tarball_asset.url, &tarball_path)?;
+    download_to(&sums_asset.url, &sums_path)?;
+
+    let sums_content = fs::read_to_string(&sums_path)
+        .with_context(|| format!("Failed to read {}", sums_path.display()))?;
+    let expected = parse_sha256sums(&sums_content, &tarball_name)
+        .with_context(|| format!("{tarball_name} not listed in SHA256SUMS"))?;
+    verify_sha256(&tarball_path, &expected)?;
+
+    verify_attestation(&tarball_path)?;
+
+    // `--no-same-owner --no-same-permissions` ignore embedded uid/mode metadata.
+    // `-C <tempdir>` plus modern tar's default refusal of `..`-segmented and absolute
+    // paths keep extraction inside the tempdir even if the archive is malicious.
+    Cmd::new("tar")
+        .arg("-xzf")
+        .arg(&tarball_path)
+        .arg("--no-same-owner")
+        .arg("--no-same-permissions")
+        .arg("-C")
+        .arg(tmp.path())
+        .run()
+        .context("Failed to extract release tarball")?;
+
+    let extracted = tmp
+        .path()
+        .join(format!("coop-{}-{triple}", release.tag))
+        .join("coop");
+    ensure!(
+        extracted.exists(),
+        "Extracted binary not found at {}",
+        extracted.display()
+    );
+
+    atomic_replace_self(&extracted)
+}
+
+// ── Background update-check state ────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct UpdateState {
+    #[serde(default)]
+    last_checked_at: u64,
+    #[serde(default)]
+    latest_known_version: Option<String>,
+}
+
+fn state_path() -> Option<PathBuf> {
+    let base = dirs::state_dir().or_else(dirs::data_local_dir)?;
+    Some(base.join("coop").join("update-check.json"))
+}
+
+fn read_state() -> Option<UpdateState> {
+    let path = state_path()?;
+    let content = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn write_state(state: &UpdateState) -> Result<()> {
+    let path = state_path().context("Cannot determine state directory")?;
+    let json = serde_json::to_string_pretty(state).context("Failed to serialize update state")?;
+    atomic_write_json(&path, &json)
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default()
+}
+
+/// Persist the update-check state, swallowing I/O failures.
+///
+/// State writes are best-effort — if XDG dirs are unavailable or the filesystem
+/// is read-only we silently skip, letting the background check retry next run.
+fn persist_state(tag: Option<&str>) {
+    let state = UpdateState {
+        last_checked_at: now_unix(),
+        latest_known_version: tag.map(str::to_string),
+    };
+    if let Err(e) = write_state(&state) {
+        tracing::debug!("Failed to persist update-check state: {e}");
+    }
+}
+
+// ── Disable sources (env + TTY + dev) ────────────────────────────────────────
+
+fn background_check_disabled() -> bool {
+    if is_dev_build() {
+        return true;
+    }
+    if env::var("COOP_NO_UPDATE_CHECK")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    if env::var("CI").map(|v| v == "true").unwrap_or(false) {
+        return true;
+    }
+    if !std::io::stdin().is_terminal() {
+        return true;
+    }
+    false
+}
+
+// ── Public notify + check entrypoints ────────────────────────────────────────
+
+/// Print a one-line notice on stderr if a newer release is known from the
+/// last successful background check. Silent otherwise.
+pub fn maybe_print_notify(cfg: &UpdateConfig) {
+    if cfg.mode == UpdateMode::Off || background_check_disabled() {
+        return;
+    }
+    let Ok(current) = Version::parse(current_version()) else {
+        return;
+    };
+    let Some(latest) = read_state()
+        .as_ref()
+        .and_then(|s| s.latest_known_version.as_deref())
+        .and_then(|t| Version::parse(strip_v(t)).ok())
+    else {
+        return;
+    };
+    if notify_is_due(&current, &latest) {
+        tracing::warn!("A newer coop ({latest}) is available. Run `coop update` to install it.");
+    }
+}
+
+/// Pure comparison used by [`maybe_print_notify`]. Extracted for testability —
+/// the state-I/O seam in `maybe_print_notify` is not easily mocked without
+/// dependency injection.
+fn notify_is_due(current: &Version, latest: &Version) -> bool {
+    latest > current
+}
+
+/// Kick off a non-blocking background refresh of release metadata if the
+/// persisted state is older than `check_interval_hours`. Safe to call on
+/// every command: honours all disable sources and never blocks the caller.
+///
+/// The `last_checked_at` stamp is written synchronously **before** the thread
+/// is spawned — short-lived commands (`coop status`, `coop stop`) often exit
+/// before the HTTPS round-trip completes, so without the pre-spawn stamp the
+/// interval gate would retrigger on every invocation.
+pub fn maybe_run_background_check(cfg: &UpdateConfig) {
+    if cfg.mode == UpdateMode::Off || background_check_disabled() {
+        return;
+    }
+    let state = read_state().unwrap_or_default();
+    if !interval_elapsed(now_unix(), state.last_checked_at, cfg.check_interval_hours) {
+        return;
+    }
+    persist_state(state.latest_known_version.as_deref());
+    std::thread::spawn(|| match fetch_latest() {
+        Ok(release) => persist_state(Some(&release.tag)),
+        Err(e) => tracing::debug!("background update-check failed: {e}"),
+    });
+}
+
+/// Pure interval check used by [`maybe_run_background_check`]. Returns `true`
+/// when `now - last_checked_at >= interval_hours * 3600`.
+fn interval_elapsed(now: u64, last_checked_at: u64, interval_hours: u64) -> bool {
+    let interval_secs = interval_hours.saturating_mul(3600);
+    now.saturating_sub(last_checked_at) >= interval_secs
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code — panics are assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_v_removes_leading_v() {
+        assert_eq!(strip_v("v0.3.1"), "0.3.1");
+        assert_eq!(strip_v("0.3.1"), "0.3.1");
+        assert_eq!(strip_v("v"), "");
+    }
+
+    #[test]
+    fn normalize_tag_adds_v_when_missing() {
+        assert_eq!(normalize_tag("0.3.1").unwrap(), "v0.3.1");
+        assert_eq!(normalize_tag("v0.3.1").unwrap(), "v0.3.1");
+        assert_eq!(normalize_tag(" 0.3.1 ").unwrap(), "v0.3.1");
+        assert_eq!(normalize_tag("0.3.1-rc.1").unwrap(), "v0.3.1-rc.1");
+    }
+
+    #[test]
+    fn normalize_tag_rejects_non_semver_inputs() {
+        // Prevents path traversal via the tag segment of the GitHub API URL.
+        for bad in [
+            "../attacker/evil/releases/latest",
+            "latest",
+            "0.3.1/../evil",
+            "",
+            "v",
+            "not-a-version",
+        ] {
+            assert!(
+                normalize_tag(bad).is_err(),
+                "normalize_tag should reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn asset_name_matches_release_workflow_naming() {
+        assert_eq!(
+            asset_name("v0.3.1", "x86_64-unknown-linux-musl"),
+            "coop-v0.3.1-x86_64-unknown-linux-musl.tar.gz"
+        );
+    }
+
+    #[test]
+    fn parse_sha256sums_finds_matching_entry() {
+        let content = concat!(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  other.tar.gz\n",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  coop-v1.tar.gz\n",
+        );
+        let got = parse_sha256sums(content, "coop-v1.tar.gz").unwrap();
+        assert_eq!(
+            got,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+    }
+
+    #[test]
+    fn parse_sha256sums_handles_binary_asterisk_form() {
+        let content =
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc *coop.tar.gz\n";
+        assert_eq!(
+            parse_sha256sums(content, "coop.tar.gz"),
+            Some("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_sha256sums_skips_blank_and_comment_lines() {
+        let content = concat!(
+            "\n",
+            "# generated by release.yml\n",
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  x.tar.gz\n",
+        );
+        assert_eq!(
+            parse_sha256sums(content, "x.tar.gz"),
+            Some("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_sha256sums_returns_none_for_missing_entry() {
+        let content =
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee  other.tar.gz\n";
+        assert!(parse_sha256sums(content, "coop.tar.gz").is_none());
+    }
+
+    #[test]
+    fn parse_sha256sums_rejects_malformed_hash() {
+        let short = "abcd  x.tar.gz\n";
+        assert!(parse_sha256sums(short, "x.tar.gz").is_none());
+        let nonhex = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz  x.tar.gz\n";
+        assert!(parse_sha256sums(nonhex, "x.tar.gz").is_none());
+    }
+
+    #[test]
+    fn semver_ordering_tracks_expectations() {
+        let a = Version::parse("0.3.1").unwrap();
+        let b = Version::parse("0.3.2").unwrap();
+        let pre = Version::parse("0.4.0-rc.1").unwrap();
+        let rel = Version::parse("0.4.0").unwrap();
+        assert!(b > a);
+        assert!(rel > pre, "pre-release must sort below its release");
+        assert!(pre > b);
+    }
+
+    #[test]
+    fn target_triple_resolves_on_this_host() {
+        // Should succeed on every host CI runs on; the function only bails
+        // on truly unsupported targets (e.g. x86_64-apple-darwin).
+        let triple = target_triple();
+        if cfg!(any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "linux", target_arch = "aarch64"),
+        )) {
+            assert!(triple.is_ok());
+        }
+    }
+
+    #[test]
+    fn update_mode_default_is_notify() {
+        assert_eq!(UpdateMode::default(), UpdateMode::Notify);
+    }
+
+    #[test]
+    fn update_config_default_interval_is_24_hours() {
+        let cfg = UpdateConfig::default();
+        assert_eq!(cfg.check_interval_hours, 24);
+        assert_eq!(cfg.mode, UpdateMode::Notify);
+    }
+
+    #[test]
+    fn update_config_deserializes_snake_case_modes() {
+        let cfg: UpdateConfig = toml::from_str(r#"mode = "off""#).unwrap();
+        assert_eq!(cfg.mode, UpdateMode::Off);
+        let cfg: UpdateConfig = toml::from_str(r#"mode = "notify""#).unwrap();
+        assert_eq!(cfg.mode, UpdateMode::Notify);
+    }
+
+    #[test]
+    fn verify_sha256_accepts_correct_hash_and_rejects_wrong() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("payload");
+        fs::write(&path, b"hello world").unwrap();
+
+        // sha256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+        let correct = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        verify_sha256(&path, correct).unwrap();
+        verify_sha256(&path, &"0".repeat(64)).unwrap_err();
+    }
+
+    #[test]
+    fn parse_sha256sums_returns_first_of_duplicates() {
+        let content = concat!(
+            "1111111111111111111111111111111111111111111111111111111111111111  x.tar.gz\n",
+            "2222222222222222222222222222222222222222222222222222222222222222  x.tar.gz\n",
+        );
+        assert_eq!(
+            parse_sha256sums(content, "x.tar.gz"),
+            Some("1111111111111111111111111111111111111111111111111111111111111111".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_sha256sums_tolerates_crlf_line_endings() {
+        let content =
+            "3333333333333333333333333333333333333333333333333333333333333333  x.tar.gz\r\n";
+        assert_eq!(
+            parse_sha256sums(content, "x.tar.gz"),
+            Some("3333333333333333333333333333333333333333333333333333333333333333".to_string())
+        );
+    }
+
+    #[test]
+    fn notify_is_due_tracks_strict_newer() {
+        let current = Version::parse("0.3.1").unwrap();
+        assert!(notify_is_due(&current, &Version::parse("0.3.2").unwrap()));
+        assert!(notify_is_due(&current, &Version::parse("1.0.0").unwrap()));
+        assert!(!notify_is_due(&current, &current));
+        assert!(!notify_is_due(&current, &Version::parse("0.3.0").unwrap()));
+        // Pre-release of a future minor still sorts below the release but above current.
+        assert!(notify_is_due(
+            &current,
+            &Version::parse("0.4.0-rc.1").unwrap()
+        ));
+    }
+
+    #[test]
+    fn interval_elapsed_behaviour() {
+        let one_hour = 3600;
+        // Zero last_checked_at means "never" — always elapsed.
+        assert!(interval_elapsed(100_000, 0, 24));
+        // Freshly checked — not elapsed.
+        assert!(!interval_elapsed(100_000, 99_999, 1));
+        // Exactly at the boundary counts as elapsed.
+        assert!(interval_elapsed(100_000 + one_hour, 100_000, 1));
+        // One second before the boundary does not.
+        assert!(!interval_elapsed(100_000 + one_hour - 1, 100_000, 1));
+        // Saturating arithmetic: now earlier than last_checked_at must not panic.
+        assert!(!interval_elapsed(0, 100_000, 24));
+    }
+
+    #[test]
+    fn serde_deserializes_release_from_github_shape() {
+        let json = r#"{
+            "tag_name": "v9.9.9",
+            "assets": [
+                {"name": "x.tar.gz", "browser_download_url": "https://example.com/x.tar.gz"}
+            ]
+        }"#;
+        let release: Release = serde_json::from_str(json).unwrap();
+        assert_eq!(release.tag, "v9.9.9");
+        assert_eq!(release.assets.len(), 1);
+        assert_eq!(release.assets[0].name, "x.tar.gz");
+        assert_eq!(release.assets[0].url, "https://example.com/x.tar.gz");
+    }
+}

--- a/tests/integration-update.sh
+++ b/tests/integration-update.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end test for `coop update`.
+#
+# Serves a synthetic GitHub-shaped fixture from a local HTTP server and
+# verifies that the update flow downloads, checksums, and atomically
+# replaces the running binary. Also verifies checksum rollback,
+# `--check` behaviour, and dev-build refusal.
+#
+# Run manually:   ./tests/integration-update.sh
+# Run in CI:      same (fast — no VM, no external network)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Platform detection (matches install.sh / update::target_triple) ──────────
+
+detect_triple() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "${os}-${arch}" in
+        Linux-x86_64)   echo "x86_64-unknown-linux-musl" ;;
+        Linux-aarch64)  echo "aarch64-unknown-linux-musl" ;;
+        Darwin-arm64)   echo "aarch64-apple-darwin" ;;
+        Darwin-aarch64) echo "aarch64-apple-darwin" ;;
+        *)
+            echo "Unsupported platform: ${os}-${arch}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+TARGET_TRIPLE="$(detect_triple)"
+FAKE_TAG="v9.9.9"
+FAKE_DIR="coop-${FAKE_TAG}-${TARGET_TRIPLE}"
+FAKE_TARBALL="${FAKE_DIR}.tar.gz"
+
+# ── Temp workspace + server lifecycle ────────────────────────────────────────
+
+TMPDIR="$(mktemp -d)"
+SERVER_PID=""
+
+cleanup() {
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2> /dev/null; then
+        kill "$SERVER_PID" 2> /dev/null || true
+        wait "$SERVER_PID" 2> /dev/null || true
+    fi
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+FIXTURE="$TMPDIR/fixture"
+mkdir -p "$FIXTURE/repos/trailofbits/coop/releases/tags"
+mkdir -p "$TMPDIR/bin" "$TMPDIR/build/${FAKE_DIR}"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+pass_count=0
+fail_count=0
+
+pass() {
+    pass_count=$((pass_count + 1))
+    echo "  PASS  $1"
+}
+
+fail() {
+    fail_count=$((fail_count + 1))
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+if command -v sha256sum > /dev/null 2>&1; then
+    SHA256_CMD=(sha256sum)
+elif command -v shasum > /dev/null 2>&1; then
+    SHA256_CMD=(shasum -a 256)
+else
+    echo "Neither sha256sum nor shasum is available" >&2
+    exit 1
+fi
+
+sha_of() {
+    "${SHA256_CMD[@]}" "$1" | cut -d' ' -f1
+}
+
+sha256sums_line() {
+    "${SHA256_CMD[@]}" "$1"
+}
+
+write_release_json() {
+    local path="$1" tag="$2" assets_block="$3"
+    cat > "$path" << JSON
+{
+  "tag_name": "${tag}",
+  "assets": ${assets_block}
+}
+JSON
+}
+
+full_assets_block() {
+    cat << JSON
+[
+  {"name": "${FAKE_TARBALL}", "browser_download_url": "${BASE_URL}/${FAKE_TARBALL}"},
+  {"name": "SHA256SUMS", "browser_download_url": "${BASE_URL}/SHA256SUMS"}
+]
+JSON
+}
+
+# ── Build the real coop binary (release kind, for success tests) ─────────────
+
+echo "==> Building release binary..."
+(
+    cd "$PROJECT_DIR"
+    COOP_FORCE_BUILD_KIND=release cargo build --release --quiet
+)
+RELEASE_BIN="$PROJECT_DIR/target/release/coop"
+cp "$RELEASE_BIN" "$TMPDIR/bin/coop"
+export COOP_BIN="$TMPDIR/bin/coop"
+
+# ── Fabricate a "newer" release tarball ──────────────────────────────────────
+
+cat > "$TMPDIR/build/${FAKE_DIR}/coop" << 'EOF'
+#!/bin/sh
+echo "MARKER: fake-replacement-binary"
+EOF
+chmod +x "$TMPDIR/build/${FAKE_DIR}/coop"
+(cd "$TMPDIR/build" && tar -czf "$FIXTURE/${FAKE_TARBALL}" "$FAKE_DIR")
+(cd "$FIXTURE" && sha256sums_line "${FAKE_TARBALL}" > SHA256SUMS)
+
+# ── Start local HTTP server ──────────────────────────────────────────────────
+
+PICK_PORT='import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()'
+PORT="$(python3 -c "$PICK_PORT")"
+(cd "$FIXTURE" && python3 -m http.server "$PORT" > /dev/null 2>&1) &
+SERVER_PID=$!
+BASE_URL="http://127.0.0.1:${PORT}"
+
+# Wait for server readiness
+for _ in $(seq 1 30); do
+    if curl -fsS "${BASE_URL}/SHA256SUMS" > /dev/null 2>&1; then
+        break
+    fi
+    sleep 0.1
+done
+if ! curl -fsS "${BASE_URL}/SHA256SUMS" > /dev/null 2>&1; then
+    echo "FATAL: local HTTP server did not come up on ${BASE_URL}" >&2
+    exit 1
+fi
+
+export COOP_UPDATE_API_BASE_URL="$BASE_URL"
+
+# ── Test 1: success flow ─────────────────────────────────────────────────────
+
+write_release_json \
+    "$FIXTURE/repos/trailofbits/coop/releases/latest" \
+    "$FAKE_TAG" \
+    "$(full_assets_block)"
+
+echo "==> Test 1: successful update replaces binary"
+if "$COOP_BIN" update --yes > "$TMPDIR/t1.log" 2>&1; then
+    out="$("$COOP_BIN" 2>&1 || true)"
+    if echo "$out" | grep -q "MARKER: fake-replacement-binary"; then
+        pass "update --yes replaces binary with release contents"
+    else
+        fail "update --yes left binary unchanged" "got: ${out}"
+    fi
+else
+    fail "update --yes returned non-zero" "$(tail -5 "$TMPDIR/t1.log")"
+fi
+
+# ── Test 2: --check when already up to date ──────────────────────────────────
+
+# Restore the real binary; point "latest" at its version.
+cp "$RELEASE_BIN" "$COOP_BIN"
+CURRENT_VERSION="$("$COOP_BIN" --version | awk '{print $2}')"
+write_release_json \
+    "$FIXTURE/repos/trailofbits/coop/releases/latest" \
+    "v${CURRENT_VERSION}" \
+    "[]"
+
+echo "==> Test 2: --check reports up-to-date"
+if out="$("$COOP_BIN" update --check 2>&1)"; then
+    if echo "$out" | grep -qi "up to date"; then
+        pass "--check emits up-to-date message"
+    else
+        fail "--check did not mention up-to-date" "got: ${out}"
+    fi
+else
+    fail "--check exited non-zero" "$out"
+fi
+
+# ── Test 3: checksum mismatch leaves binary unchanged ────────────────────────
+
+cp "$RELEASE_BIN" "$COOP_BIN"
+ORIG_SHA="$(sha_of "$COOP_BIN")"
+
+# Restore the newer-release fixture but corrupt SHA256SUMS.
+write_release_json \
+    "$FIXTURE/repos/trailofbits/coop/releases/latest" \
+    "$FAKE_TAG" \
+    "$(full_assets_block)"
+echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  ${FAKE_TARBALL}" \
+    > "$FIXTURE/SHA256SUMS"
+
+echo "==> Test 3: checksum mismatch aborts"
+if "$COOP_BIN" update --yes > "$TMPDIR/t3.log" 2>&1; then
+    fail "update --yes should have failed on checksum mismatch"
+else
+    new_sha="$(sha_of "$COOP_BIN")"
+    if [[ "$new_sha" == "$ORIG_SHA" ]]; then
+        pass "checksum mismatch leaves binary unchanged"
+    else
+        fail "binary replaced despite checksum mismatch"
+    fi
+fi
+
+# Restore valid SHA256SUMS for subsequent tests (not needed here — test 4 rebuilds).
+(cd "$FIXTURE" && sha256sums_line "${FAKE_TARBALL}" > SHA256SUMS)
+
+# ── Test 4: dev build refuses to self-update ─────────────────────────────────
+
+echo "==> Building dev binary..."
+(
+    cd "$PROJECT_DIR"
+    unset COOP_FORCE_BUILD_KIND
+    cargo build --release --quiet
+)
+cp "$PROJECT_DIR/target/release/coop" "$TMPDIR/bin/coop-dev"
+
+echo "==> Test 4: dev build refusal"
+if "$TMPDIR/bin/coop-dev" update --yes > "$TMPDIR/t4.log" 2>&1; then
+    fail "dev build should have refused"
+else
+    if grep -qi "dev build" "$TMPDIR/t4.log"; then
+        pass "dev build refuses update"
+    else
+        fail "dev-build refusal message missing" "$(cat "$TMPDIR/t4.log")"
+    fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo
+echo "  $pass_count passed, $fail_count failed"
+[[ $fail_count -eq 0 ]]


### PR DESCRIPTION
## Summary

- New `coop update` subcommand downloads the latest release from GitHub, verifies SHA-256 against `SHA256SUMS`, optionally verifies the build-provenance attestation via `gh`, and atomically replaces the running binary.
- Flags: `--check`, `--force`, `--version <tag>`, `-y/--yes`. Dev builds refuse to self-update.
- Background update check runs on every command (detached thread, timestamp persisted before spawn so short commands don't retrigger on every invocation). Notify banner on stderr when a newer release is known. Opt out with `updates.mode = "off"`, `COOP_NO_UPDATE_CHECK=1`, `CI=true`, or non-TTY stdin.
- `build.rs` bakes git sha, dirty flag, and release/dev kind into compile-time env vars. `coop --version` now reports provenance (e.g. `coop 0.3.1-dev (ef835aa+dirty)`).

Closes #34.

## Test plan

- [x] `cargo test` — 249 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `tests/integration-update.sh` (4 cases: success, `--check` up-to-date, checksum rollback, dev refusal) — all pass locally and wired into `.github/workflows/ci.yml`
- [x] Full VM integration suite (`tests/run-integration.sh`) — 105 passed / 1 skipped on this Linux/Firecracker host
- [x] CI green on Ubuntu
- [ ] Post-merge: tag a test release, verify `coop update` end-to-end against the real GitHub API

🤖 Generated with [Claude Code](https://claude.com/claude-code)