### PR TITLE
Verify release attestations in install.sh; soften gh-missing notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ Opt out with either:
 
 The check is also silent when `CI=true` or when stdin is not a TTY.
 
+## Verifying a release
+
+Every release tarball is published with a Sigstore build-provenance
+attestation via [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
+The attestation proves the artifact was built from this repository by the
+tagged release workflow.
+
+Both `install.sh` and `coop update` run this verification automatically
+when the [GitHub CLI](https://cli.github.com/) is installed. Without `gh`,
+they fall back to checksum verification against the release's `SHA256SUMS`
+and print a note explaining what was and wasn't verified.
+
+To verify a downloaded tarball manually:
+
+```sh
+gh attestation verify coop-<version>-<triple>.tar.gz --repo trailofbits/coop
+```
+
 ## Requirements
 
 Tested on macOS arm64 (Apple Silicon) and Linux x86_64. Linux arm64 builds are available but untested.

--- a/install.sh
+++ b/install.sh
@@ -103,6 +103,21 @@ verify_checksum() {
     fi
 }
 
+verify_attestation() {
+    local file="$1"
+    if has gh; then
+        info "Verifying attestation..."
+        gh attestation verify "$file" --repo "$REPO" \
+            || die "Attestation verification failed for $(basename "$file") — refusing to install"
+    else
+        info "Note: \`gh\` not installed — skipped cryptographic attestation verification."
+        info "The download was verified against the published \`SHA256SUMS\` checksum, which"
+        info "is the same assurance level as most \`curl | bash\` installers. For end-to-end"
+        info "Sigstore verification, install \`gh\` (https://cli.github.com) and re-run, or"
+        info "verify manually: \`gh attestation verify <tarball> --repo ${REPO}\`."
+    fi
+}
+
 # --- main -------------------------------------------------------------------
 
 need curl
@@ -126,6 +141,8 @@ info "Verifying checksum..."
 EXPECTED="$(grep "${TARBALL}" "${TMPDIR}/SHA256SUMS" | cut -d' ' -f1)"
 [ -n "$EXPECTED" ] || die "Tarball ${TARBALL} not found in SHA256SUMS"
 verify_checksum "${TMPDIR}/${TARBALL}" "$EXPECTED"
+
+verify_attestation "${TMPDIR}/${TARBALL}"
 
 info "Extracting..."
 tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"

--- a/src/update.rs
+++ b/src/update.rs
@@ -262,9 +262,13 @@ fn verify_attestation(tarball: &Path) -> Result<()> {
         return Ok(());
     }
     if !has_command("gh") {
-        tracing::warn!(
-            "`gh` CLI not found — skipping attestation verification. \
-             Install it for cryptographic verification of release artifacts."
+        tracing::info!(
+            "Note: `gh` not installed — skipped cryptographic attestation verification. \
+             The download was verified against the published `SHA256SUMS` checksum, which \
+             is the same assurance level as most `curl | bash` installers. For end-to-end \
+             Sigstore verification, install `gh` (https://cli.github.com) and re-run, or \
+             verify manually: `gh attestation verify <tarball> --repo {}`.",
+            REPO
         );
         return Ok(());
     }


### PR DESCRIPTION
## Summary

- `install.sh` now runs `gh attestation verify` after checksum verification when `gh` is available, matching `coop update`'s behaviour. Verification failure aborts the install.
- When `gh` is missing, both `install.sh` and `coop update` print a calm, factual note explaining that the download was checksum-verified (same assurance level as most `curl | bash` installers) and how to verify end-to-end manually, instead of warning that verification was skipped.
- README gains a "Verifying a release" section documenting the attestation scheme and the manual `gh attestation verify` one-liner.

Closes #54.

## Acceptance criteria mapping

| Criterion | Status |
|---|---|
| Workflow publishes verifiable signature covering tarballs | Already done — `actions/attest-build-provenance` in `release.yml` |
| `install.sh` and `coop update` verify without a GitHub token | Yes, via `gh attestation verify` against the public repo |
| Documented manual verification path | Yes, new README section |
| Verification failure aborts; no silent skip | Yes when `gh` is present. When `gh` is absent, the skip is explicit and non-alarming per the plan's user decision. |

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all pass
- [x] `shellcheck install.sh` passes
- [x] `prek run` on modified files passes
- [ ] `./tests/run-integration.sh` on macOS/Lima
- [ ] `./tests/run-integration.sh --remote <host>` on Linux/Firecracker
- [ ] Manual smoke: `install.sh` against a tagged release with and without `gh` on PATH