### PR TITLE
Refresh docs ahead of next release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # coop
 
-Isolated VM environment for running Claude Code — Firecracker on Linux, Lima on macOS.
+Isolated VM environment for running Claude Code and Codex — Firecracker on Linux, Lima on macOS.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ coop update --force             # reinstall the current version
 
 If coop is installed in a protected directory (e.g. `/usr/local/bin`), run
 with `sudo`. Dev builds (built from an untagged or dirty tree) refuse to
-self-update — use `install.sh` to replace them.
+self-update; use `install.sh` to replace them.
 
 By default, coop checks for a newer release in the background at most once
 per day and prints a one-line notice on stderr when an update is available.

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -2,7 +2,7 @@
 
 coop selects its VM backend at compile time. macOS builds use Lima. Linux builds use Firecracker. The binary determines the backend; there is no runtime override.
 
-Both backends expose the same CLI commands and produce the same guest environment: Ubuntu with Docker, GitHub CLI, and Claude Code pre-installed. The backends differ in how they create and manage the VM underneath.
+Both backends expose the same CLI commands and produce the same guest environment: Ubuntu with Docker, GitHub CLI, Claude Code, and Codex pre-installed. The backends differ in how they create and manage the VM underneath.
 
 ## macOS / Lima
 
@@ -24,7 +24,7 @@ Setup verifies that `limactl --version` is reachable. If it is not, setup fails 
 
 1. Generates an ed25519 SSH key pair, stored in the coop data directory.
 2. Creates a temporary builder VM from an Ubuntu 24.04 cloud image. The Lima YAML template includes a cloud-init provision script.
-3. The provision script installs all packages (Docker, GitHub CLI, Claude Code, and any profile packages), creates the `ubuntu` user with SSH access, and enables services.
+3. The provision script installs all packages (Docker, GitHub CLI, Claude Code, Codex, and any profile packages), creates the `ubuntu` user with SSH access, and enables services.
 4. After provisioning completes, cleans cloud-init state so it re-runs on cloned instances.
 5. Stops the builder VM and extracts its disk as the golden image.
 6. Generates a fast-start Lima template that references the golden image directly. No cloud-init provisioning runs on instance start.
@@ -56,7 +56,7 @@ The Firecracker backend runs [Firecracker microVMs](https://firecracker-microvm.
 ### Prerequisites
 
 - **KVM access**: `/dev/kvm` must exist and be readable/writable by the current user. Setup checks this and offers to fix permissions via `setfacl` or by adding the user to the `kvm` group.
-- **x86_64 architecture**: The Firecracker backend targets x86_64 Linux hosts.
+- **x86_64 or arm64 architecture**: The Firecracker backend supports both. x86_64 is the primary test target; arm64 builds are produced but less exercised.
 - **curl**: Required for downloading the Firecracker binary and kernel.
 - **System packages**: Setup installs `squashfs-tools` and `e2fsprogs` (for rootfs manipulation) via `apt-get` if they are missing.
 
@@ -66,7 +66,7 @@ The Firecracker backend runs [Firecracker microVMs](https://firecracker-microvm.
 
 1. **Firecracker binary**: Downloaded from the latest GitHub release and stored in the data directory. The jailer binary is extracted alongside it.
 2. **Guest kernel**: Fetched from Firecracker's CI S3 bucket. This is a minimal `vmlinux` image matching the Firecracker release version.
-3. **Template rootfs**: Built by downloading the Firecracker CI squashfs rootfs (Ubuntu-based), unpacking it, creating an ext4 image at the configured template size, and running an install script inside a chroot. The script installs Docker, GitHub CLI, Claude Code, and profile packages. It configures the `ubuntu` user with SSH keys and sets up systemd-networkd.
+3. **Template rootfs**: Built by downloading the Firecracker CI squashfs rootfs (Ubuntu-based), unpacking it, creating an ext4 image at the configured template size, and running an install script inside a chroot. The script installs Docker, GitHub CLI, Claude Code, Codex, and profile packages. It configures the `ubuntu` user with SSH keys and sets up systemd-networkd.
 
 All three steps are idempotent. If the artifact already exists and is up to date, setup skips it.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -44,7 +44,7 @@ coop setup [FLAGS]
 | `--vcpus <N>` | Number of vCPUs (overrides config) |
 | `--mem <MiB>` | Memory in MiB (overrides config) |
 | `--rebuild` | Force rebuild of template rootfs |
-| `--profile <list>` | Comma-separated install profiles: `python`, `node`, `c`, `fuzz`, `rust`, `go`, `full` |
+| `--profile <list>` | Comma-separated install profiles: `python`, `node`, `c`, `fuzz`, `rust`, `go` |
 | `--extra-packages <list>` | Comma-separated extra apt packages to install |
 | `--post-install <path>` | Path to a post-install script to run in the chroot |
 | `--template-size <GiB>` | Template rootfs size in GiB (default: 8) |
@@ -352,6 +352,54 @@ Absolute values set the disk to that exact size. A `+` prefix adds to the curren
 coop resize my-project --size 150G
 coop resize --size +20
 ```
+
+### `profiles`
+
+List or inspect available profiles. With no subcommand, lists every profile (builtin and custom).
+
+```
+coop profiles [SUBCOMMAND]
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List builtin and custom profiles with a one-line summary each (default) |
+| `show <name>` | Print the full definition of a profile: apt packages, pre/post-install scripts, marketplaces, plugins |
+
+```
+coop profiles
+coop profiles list
+coop profiles show rust
+```
+
+`list` groups builtin and custom profiles separately. `show` resolves the name against custom profiles first, then builtins, and prints `(custom)` or `(builtin)` next to the name.
+
+### `update`
+
+Replace the running coop binary with a release from `github.com/trailofbits/coop`. Downloads the tarball matching the current host triple, verifies its SHA-256 against the release's `SHA256SUMS`, and (when `gh` is installed) verifies the GitHub build-provenance attestation before swapping the binary atomically.
+
+```
+coop update [FLAGS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--check` | Report whether a newer release exists. Do not download or install. |
+| `--force` | Reinstall even if the current binary is already at the target version. |
+| `--version <VERSION>` | Install a specific release tag (e.g. `v0.3.2` or `0.3.2`). |
+| `-y`, `--yes` | Skip the interactive confirmation prompt. |
+
+If coop is installed in a protected directory (e.g. `/usr/local/bin`), run with `sudo`. Dev builds (built from an untagged or dirty tree) refuse to self-update; use `install.sh` to replace them.
+
+```
+coop update --check
+coop update
+coop update --yes
+coop update --version v0.3.2
+coop update --force
+```
+
+See also the [`updates` section](configuration.md#updates-section) of the configuration reference for the background-notification settings.
 
 ### `validate`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,23 @@ plugins = ["rust-analyzer-lsp@claude-plugins-official"]
 | `marketplaces` | array of strings | `[]` | Plugin marketplace sources for this profile. Same format as `claude.marketplaces`. |
 | `plugins` | array of strings | `[]` | Plugins to install for this profile. Same format as `claude.plugins`. |
 
-Custom profiles compose with built-in ones (`python`, `node`, `c`, `fuzz`, `rust`, `go`, `full`). Combine them with commas: `coop setup --profile python,node,my-tools`.
+Custom profiles compose with built-in ones (`python`, `node`, `c`, `fuzz`, `rust`, `go`). Combine them with commas: `coop setup --profile python,node,my-tools`.
+
+## `updates` section
+
+Background update-check behavior for `coop update`. Defaults are safe; most users do not need to set anything here.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `"notify"` or `"off"` | `"notify"` | `"notify"` runs a background check at most once per `check_interval_hours` and prints a one-line stderr notice when a newer release is known. `"off"` disables both the check and the notice. |
+| `check_interval_hours` | integer | `24` | Minimum hours between background release-metadata fetches. |
+
+The background check is also silent when `COOP_NO_UPDATE_CHECK=1`, when `CI=true`, or when stdin is not a TTY. Dev builds (untagged or dirty trees) never run the check or notice.
+
+```toml
+[updates]
+mode = "off"
+```
 
 ## CLI overrides
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ coop runs Claude Code and Codex inside isolated virtual machines. On Linux, it s
 **Linux (Firecracker backend)**
 
 - KVM access (`/dev/kvm` must exist and be writable by your user)
-- x86_64 architecture
+- x86_64 or arm64 architecture (x86_64 is the primary test target; arm64 builds are available but less exercised)
 - `sudo` privileges (Firecracker uses jailer and TAP networking)
 - `curl`, `tar`, `e2fsprogs` (for `mkfs.ext4`, `resize2fs`)
 
@@ -91,7 +91,7 @@ Install language toolchains into the template with `--profile`:
 coop setup --profile python,node
 ```
 
-Built-in profiles: `python`, `node`, `c`, `fuzz`, `rust`, `go`, `full` (all of the above).
+Built-in profiles: `python`, `node`, `c`, `fuzz`, `rust`, `go`. Combine them with commas (e.g. `--profile python,node,rust`). Use `coop profiles list` to inspect what each one installs.
 
 Skip confirmation prompts with `-y`:
 
@@ -262,7 +262,7 @@ Build multiple template images with different profiles:
 
 ```
 coop setup --image python-dev --profile python
-coop setup --image full-dev --profile full
+coop setup --image polyglot --profile python,node,rust
 ```
 
 Start an instance from a specific image:

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -45,9 +45,6 @@ coop setup --profile python,node,rust
 | `fuzz` | `clang`, `llvm`, `afl++`, `lcov` |
 | `rust` | Rust toolchain via post-install script (not apt). Installs plugin: `rust-analyzer-lsp@claude-plugins-official` |
 | `go` | `golang` |
-| `full` | All of the above, combined and deduplicated |
-
-The `full` meta-profile expands every built-in profile into a single template. Duplicate packages are removed automatically.
 
 Plugins listed above are baked into the golden image during `coop setup` and do not need to be listed separately in config.
 
@@ -107,10 +104,10 @@ By default, coop builds an image called `default`. Build multiple images with di
 
 ```bash
 coop setup --profile python --image py-dev
-coop setup --profile full --image full-dev
+coop setup --profile python,node,rust --image polyglot
 
 coop start --image py-dev
-coop start --image full-dev
+coop start --image polyglot
 ```
 
 Each named image lives in its own directory under `~/.coop/images/<name>/` with independent versioning and staleness tracking.
@@ -122,7 +119,7 @@ List all images:
 ```
 $ coop images
 default              profiles: python, node              created: 2026-03-20T14:30:00Z     size: 4.2 GiB
-full-dev             profiles: full                      created: 2026-03-22T09:15:00Z     size: 6.1 GiB
+polyglot             profiles: python, node, rust        created: 2026-03-22T09:15:00Z     size: 6.1 GiB
 ```
 
 Output includes the image name, installed profiles, creation timestamp, and disk size.
@@ -130,7 +127,7 @@ Output includes the image name, installed profiles, creation timestamp, and disk
 Delete a named image:
 
 ```bash
-coop images --delete full-dev
+coop images --delete polyglot
 ```
 
 ## Template versioning and staleness

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -43,7 +43,7 @@ coop shell my-project
 coop shell another-project
 ```
 
-This applies to `shell`, `stop`, `destroy`, `status <name>`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`, and `claude`.
+This applies to `shell`, `stop`, `destroy`, `status <name>`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`, `claude`, and `codex`.
 
 ## Checking status
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ enum Commands {
         /// Force rebuild of template rootfs
         #[arg(long)]
         rebuild: bool,
-        /// Install profiles (comma-separated: python,node,c,fuzz,rust,go,full)
+        /// Install profiles (comma-separated: python,node,c,fuzz,rust,go)
         #[arg(long, value_delimiter = ',')]
         profile: Vec<String>,
         /// Extra apt packages to install (comma-separated)


### PR DESCRIPTION
## Summary

- Documents `coop update` (#55) and `coop profiles list/show` (#31) in `docs/commands.md` — both shipped in the binary but were absent from the command reference.
- Adds an `[updates]` config section to `docs/configuration.md` covering `mode` and `check_interval_hours` for the background update notifier.
- Purges the retired `full` meta-profile from every doc that still listed it (`commands.md`, `configuration.md`, `getting-started.md`, `images-and-profiles.md`) and from the `coop setup --profile` help text in `src/main.rs`. Examples that previously used `--profile full` / `--image full-dev` now use a concrete combo (`python,node,rust` / `polyglot`).
- Mentions Codex alongside Claude Code in `CLAUDE.md` and `docs/backends.md` where the prose still described a Claude-only guest.
- Adds `codex` to the multi-instance addressing list.
- Notes Linux arm64 as supported but less exercised in `docs/getting-started.md` and `docs/backends.md`, matching the language already in `README.md`.
- Replaces the em-dash in `README.md`'s "Updating" section with a semicolon to match the ToB voice anti-pattern guidance.

CHANGELOG is intentionally left for a follow-up.

## Test plan

- [ ] `cargo run -- setup --help` shows `python,node,c,fuzz,rust,go` (no `full`)
- [ ] `cargo run -- profiles list` and `cargo run -- update --help` match the prose in `docs/commands.md`
- [ ] Markdown renders cleanly on GitHub (anchors, tables, code blocks)