### PR TITLE
Fix codex install skipped when claude binary already present

### DIFF
--- a/scripts/guest/claude-code.sh
+++ b/scripts/guest/claude-code.sh
@@ -2,43 +2,45 @@ set -euo pipefail
 
 # Skip if a profile already provided a claude binary (e.g. stub-claude
 # for testing). Profile post_install scripts run before this script.
+# Using if/else (not early `exit 0`) because this file is concatenated
+# with codex.sh into a single shell invocation; an unconditional exit
+# would skip the codex installer too.
 if [ -x /home/ubuntu/.local/bin/claude ]; then
     echo '  [guest] Claude Code CLI already installed, skipping.'
-    return 0 2>/dev/null || exit 0
+else
+    echo '  [guest] Installing Claude Code CLI...'
+
+    # Download the installer to a file first. The `curl | bash` pattern causes
+    # the installer's `install` subcommand to inherit curl's pipe as stdin,
+    # hanging on interactive prompts in non-interactive contexts (cloud-init,
+    # chroot). Running from a file with stdin from /dev/null avoids this.
+    INSTALLER=$(mktemp)
+    chmod 644 "$INSTALLER"
+    trap 'rm -f "$INSTALLER"' EXIT
+
+    # Retry with exponential backoff — transient network errors are common
+    # during cloud-init (DNS not ready, CDN hiccups, etc.).
+    # Uses `if` to suppress set -e for the curl command.
+    MAX_RETRIES=4
+    RETRY_DELAY=5
+    for attempt in $(seq 1 "$MAX_RETRIES"); do
+        if curl -fsSL -o "$INSTALLER" https://claude.ai/install.sh 2>/tmp/claude-curl-err; then
+            break
+        fi
+        CURL_EXIT=$?
+        CURL_ERR=$(cat /tmp/claude-curl-err 2>/dev/null || true)
+        if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+            echo "  [guest] ERROR: Failed to download Claude Code installer" \
+                 "after $MAX_RETRIES attempts." >&2
+            echo "  [guest] curl exit code: $CURL_EXIT" >&2
+            echo "  [guest] curl error: ${CURL_ERR:-none}" >&2
+            exit 1
+        fi
+        echo "  [guest] Download failed (attempt $attempt/$MAX_RETRIES," \
+             "curl exit $CURL_EXIT), retrying in ${RETRY_DELAY}s..."
+        sleep "$RETRY_DELAY"
+        RETRY_DELAY=$((RETRY_DELAY * 2))
+    done
+
+    su - ubuntu -c "bash '$INSTALLER'" </dev/null
 fi
-
-echo '  [guest] Installing Claude Code CLI...'
-
-# Download the installer to a file first. The `curl | bash` pattern causes
-# the installer's `install` subcommand to inherit curl's pipe as stdin,
-# hanging on interactive prompts in non-interactive contexts (cloud-init,
-# chroot). Running from a file with stdin from /dev/null avoids this.
-INSTALLER=$(mktemp)
-chmod 644 "$INSTALLER"
-trap 'rm -f "$INSTALLER"' EXIT
-
-# Retry with exponential backoff — transient network errors are common
-# during cloud-init (DNS not ready, CDN hiccups, etc.).
-# Uses `if` to suppress set -e for the curl command.
-MAX_RETRIES=4
-RETRY_DELAY=5
-for attempt in $(seq 1 "$MAX_RETRIES"); do
-    if curl -fsSL -o "$INSTALLER" https://claude.ai/install.sh 2>/tmp/claude-curl-err; then
-        break
-    fi
-    CURL_EXIT=$?
-    CURL_ERR=$(cat /tmp/claude-curl-err 2>/dev/null || true)
-    if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-        echo "  [guest] ERROR: Failed to download Claude Code installer" \
-             "after $MAX_RETRIES attempts." >&2
-        echo "  [guest] curl exit code: $CURL_EXIT" >&2
-        echo "  [guest] curl error: ${CURL_ERR:-none}" >&2
-        exit 1
-    fi
-    echo "  [guest] Download failed (attempt $attempt/$MAX_RETRIES," \
-         "curl exit $CURL_EXIT), retrying in ${RETRY_DELAY}s..."
-    sleep "$RETRY_DELAY"
-    RETRY_DELAY=$((RETRY_DELAY * 2))
-done
-
-su - ubuntu -c "bash '$INSTALLER'" </dev/null

--- a/scripts/guest/codex.sh
+++ b/scripts/guest/codex.sh
@@ -1,54 +1,56 @@
 set -euo pipefail
 
+# Using if/else (not early `exit 0`) because this file is concatenated
+# with claude-code.sh into a single shell invocation; an unconditional
+# exit would short-circuit anything appended after it.
 if [ -x /usr/local/bin/codex ]; then
     echo '  [guest] Codex CLI already installed, skipping.'
-    return 0 2>/dev/null || exit 0
-fi
+else
+    echo '  [guest] Installing Codex CLI...'
 
-echo '  [guest] Installing Codex CLI...'
+    case "$(uname -m)" in
+        x86_64)
+            ASSET="codex-x86_64-unknown-linux-musl.tar.gz"
+            ;;
+        aarch64|arm64)
+            ASSET="codex-aarch64-unknown-linux-musl.tar.gz"
+            ;;
+        *)
+            echo "  [guest] ERROR: Unsupported architecture for Codex CLI: $(uname -m)" >&2
+            exit 1
+            ;;
+    esac
 
-case "$(uname -m)" in
-    x86_64)
-        ASSET="codex-x86_64-unknown-linux-musl.tar.gz"
-        ;;
-    aarch64|arm64)
-        ASSET="codex-aarch64-unknown-linux-musl.tar.gz"
-        ;;
-    *)
-        echo "  [guest] ERROR: Unsupported architecture for Codex CLI: $(uname -m)" >&2
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+    ARCHIVE="$TMPDIR/$ASSET"
+    BIN="$TMPDIR/${ASSET%.tar.gz}"
+
+    MAX_RETRIES=4
+    RETRY_DELAY=5
+    URL="https://github.com/openai/codex/releases/latest/download/$ASSET"
+    for attempt in $(seq 1 "$MAX_RETRIES"); do
+        if curl -fsSL -o "$ARCHIVE" "$URL" 2>/tmp/codex-curl-err; then
+            break
+        fi
+        CURL_EXIT=$?
+        CURL_ERR=$(cat /tmp/codex-curl-err 2>/dev/null || true)
+        if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+            echo "  [guest] ERROR: Failed to download Codex CLI archive after $MAX_RETRIES attempts." >&2
+            echo "  [guest] curl exit code: $CURL_EXIT" >&2
+            echo "  [guest] curl error: ${CURL_ERR:-none}" >&2
+            exit 1
+        fi
+        echo "  [guest] Download failed (attempt $attempt/$MAX_RETRIES, curl exit $CURL_EXIT), retrying in ${RETRY_DELAY}s..."
+        sleep "$RETRY_DELAY"
+        RETRY_DELAY=$((RETRY_DELAY * 2))
+    done
+
+    tar -xzf "$ARCHIVE" -C "$TMPDIR"
+    if [ ! -x "$BIN" ]; then
+        echo '  [guest] ERROR: Codex archive did not contain the expected binary.' >&2
         exit 1
-        ;;
-esac
-
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
-ARCHIVE="$TMPDIR/$ASSET"
-BIN="$TMPDIR/${ASSET%.tar.gz}"
-
-MAX_RETRIES=4
-RETRY_DELAY=5
-URL="https://github.com/openai/codex/releases/latest/download/$ASSET"
-for attempt in $(seq 1 "$MAX_RETRIES"); do
-    if curl -fsSL -o "$ARCHIVE" "$URL" 2>/tmp/codex-curl-err; then
-        break
     fi
-    CURL_EXIT=$?
-    CURL_ERR=$(cat /tmp/codex-curl-err 2>/dev/null || true)
-    if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-        echo "  [guest] ERROR: Failed to download Codex CLI archive after $MAX_RETRIES attempts." >&2
-        echo "  [guest] curl exit code: $CURL_EXIT" >&2
-        echo "  [guest] curl error: ${CURL_ERR:-none}" >&2
-        exit 1
-    fi
-    echo "  [guest] Download failed (attempt $attempt/$MAX_RETRIES, curl exit $CURL_EXIT), retrying in ${RETRY_DELAY}s..."
-    sleep "$RETRY_DELAY"
-    RETRY_DELAY=$((RETRY_DELAY * 2))
-done
 
-tar -xzf "$ARCHIVE" -C "$TMPDIR"
-if [ ! -x "$BIN" ]; then
-    echo '  [guest] ERROR: Codex archive did not contain the expected binary.' >&2
-    exit 1
+    install -m 755 "$BIN" /usr/local/bin/codex
 fi
-
-install -m 755 "$BIN" /usr/local/bin/codex


### PR DESCRIPTION
## Summary

`scripts/guest/claude-code.sh` and `scripts/guest/codex.sh` are concatenated into a single shell invocation by `src/setup.rs:614-616`. Both started with `set -euo pipefail` and used `return 0 2>/dev/null || exit 0` as an "already installed, skip" short-circuit. Since the script is run as `bash script.sh` (not sourced), `return` fails and `exit 0` runs — terminating the **entire** concatenated script and skipping anything appended after.

The `stub-claude` integration profile triggers this: the profile pre-installs a stub `claude` binary, claude-code.sh sees it, exits 0, and codex.sh never runs. The post-install verifier then fails with `Golden image is missing required binaries: /usr/local/bin/codex`.

This regression was introduced in v0.4.0 (PR #44, codex install) and caught by the `setup with stub claude image exits 0` integration test after merging the v0.4.0 release prep (#58). It would also affect any future profile that stubs codex symmetrically.

## Fix

Restructure both scripts to use `if [ -x ... ]; then ... else ... fi` so the skip path falls through to whatever follows. No call-site changes needed.

## Test plan

- [x] `cargo build --release` and `cargo test --release` pass.
- [x] `./tests/run-integration.sh --full` on Linux/Firecracker — 173 passed, 0 failed (previously 166 passed, 1 failed at "setup with stub claude image exits 0").
- [ ] `./tests/run-integration.sh --remote <macos-host>` on macOS/Lima.

This should land **before** v0.4.0 is tagged so the release artifact doesn't ship the regression.