### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.4.1
+
+Re-release of v0.4.0. The v0.4.0 tag did not produce release artifacts
+because `tests/integration-update.sh` Test 4 ("dev build refusal") fails
+whenever CI runs on a commit tagged `v{cargo_version}` — `build.rs`
+correctly bakes `COOP_BUILD_KIND=release` for that commit, so the test's
+unset-override path produced a release binary instead of a dev one. Test 4
+now sets `COOP_FORCE_BUILD_KIND=dev` explicitly, mirroring Test 1's
+`=release` override. No functional changes to `coop` itself since v0.4.0.
+
 ## v0.4.0
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coop"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coop"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
 

--- a/build.rs
+++ b/build.rs
@@ -19,8 +19,9 @@ fn main() {
     for path in git_rerun_paths() {
         println!("cargo:rerun-if-changed={}", path.display());
     }
-    // Build-time test hook: allows the integration test to produce a "release" binary from
-    // an untagged branch. Runtime behaviour is unaffected — the override only influences
+    // Build-time test hook: lets the integration test pin `COOP_BUILD_KIND` to either
+    // "release" (from an untagged branch) or "dev" (from a tagged commit), independent
+    // of git state. Runtime behaviour is unaffected — the override only influences
     // what build.rs bakes into `COOP_BUILD_KIND`.
     println!("cargo:rerun-if-env-changed=COOP_FORCE_BUILD_KIND");
 

--- a/tests/integration-update.sh
+++ b/tests/integration-update.sh
@@ -221,10 +221,12 @@ fi
 # ── Test 4: dev build refuses to self-update ─────────────────────────────────
 
 echo "==> Building dev binary..."
+# Force kind=dev rather than relying on git state. When CI runs on a tag
+# matching the Cargo version (the release workflow's normal trigger),
+# build.rs correctly bakes kind=release, which would defeat this test.
 (
     cd "$PROJECT_DIR"
-    unset COOP_FORCE_BUILD_KIND
-    cargo build --release --quiet
+    COOP_FORCE_BUILD_KIND=dev cargo build --release --quiet
 )
 cp "$PROJECT_DIR/target/release/coop" "$TMPDIR/bin/coop-dev"
 


### PR DESCRIPTION
## Summary

- Bumps version `0.4.0` → `0.4.1` in `Cargo.toml` / `Cargo.lock` and adds a `v0.4.1` section to `CHANGELOG.md`.
- Fixes `tests/integration-update.sh` Test 4 ("dev build refusal") to set `COOP_FORCE_BUILD_KIND=dev` explicitly, mirroring Test 1's `=release` override. Without this, the test fails whenever CI runs on a commit tagged `v{cargo_version}` — `build.rs` (correctly) bakes `COOP_BUILD_KIND=release` for that commit, defeating the test's reliance on git state.
- Updates the `build.rs` doc comment for `COOP_FORCE_BUILD_KIND` to acknowledge bidirectional use (both `=release` from untagged and `=dev` from tagged trees).

## Why a fresh version

The `v0.4.0` tag was pushed but the release workflow's CI re-run hit Test 4's failure, so artifacts never published. Re-using the `v0.4.0` tag isn't an option (immutable releases policy), so this ships as v0.4.1. No functional changes to `coop` itself since v0.4.0 — see the v0.4.0 changelog section for the actual feature/fix list.

## Test plan

- [x] `cargo build --release` succeeds and `coop --version` reports `0.4.1`.
- [x] `./tests/integration-update.sh` passes locally (4/4).
- [x] Simulated tag-context build (HEAD tagged with `v{cargo_version}`) — Test 4 still passes via the `=dev` override.
- [x] CI on this PR is green.
- [ ] After merge, tag `v0.4.1` and confirm release workflow publishes artifacts.