### PR TITLE
Isolate integration-update.sh from user XDG state

### DIFF
--- a/tests/integration-update.sh
+++ b/tests/integration-update.sh
@@ -203,16 +203,18 @@ else
     fail "update --yes returned non-zero" "$(tail -5 "$TMPDIR/t1.log")"
 fi
 
-# Confirm the update-check state file landed inside the redirected
-# $HOME — anywhere outside means a future code change has introduced a
-# state path that bypasses HOME/XDG and would leak the synthetic v9.9.9
-# tag into the user's real home, surfacing as a bogus update warning.
-leaked_in_home="$(find "$HOME" -name update-check.json -print -quit 2> /dev/null)"
-if [[ -n "$leaked_in_home" ]]; then
-    pass "update-check state file confined to redirected HOME"
+# Confirm the update-check state file landed inside the test's tempdir,
+# not somewhere under the developer's real home. Searching $TMPDIR (not
+# $HOME) is deliberate: if a future edit accidentally drops the HOME
+# export above, $HOME would point back at the real home and a leak there
+# would still be "found" — the assertion would silently pass on the leak
+# it was meant to catch. $TMPDIR is the known-isolated boundary.
+state_under_tmpdir="$(find "$TMPDIR" -name update-check.json -print -quit 2> /dev/null)"
+if [[ -n "$state_under_tmpdir" ]]; then
+    pass "update-check state file confined to tempdir"
 else
-    fail "no update-check state file written under redirected HOME" \
-        "expected one under $HOME"
+    fail "no update-check state file written under tempdir" \
+        "either HOME redirection broke or persist_state did not run"
 fi
 
 # ── Test 2: --check when already up to date ──────────────────────────────────

--- a/tests/integration-update.sh
+++ b/tests/integration-update.sh
@@ -107,16 +107,50 @@ full_assets_block() {
 JSON
 }
 
-# ── Build the real coop binary (release kind, for success tests) ─────────────
+# ── Build both coop binaries (real HOME, before isolation) ───────────────────
+#
+# Both `cargo build` invocations must run before HOME is redirected — cargo
+# uses $HOME for its registry and toolchain caches.
 
 echo "==> Building release binary..."
 (
     cd "$PROJECT_DIR"
     COOP_FORCE_BUILD_KIND=release cargo build --release --quiet
 )
-RELEASE_BIN="$PROJECT_DIR/target/release/coop"
+# Stash the release binary at a stable path. The dev build below shares
+# `target/release/coop`, so we can't keep referring to that path after
+# `cargo build` runs again.
+RELEASE_BIN="$TMPDIR/bin/coop-release"
+cp "$PROJECT_DIR/target/release/coop" "$RELEASE_BIN"
 cp "$RELEASE_BIN" "$TMPDIR/bin/coop"
 export COOP_BIN="$TMPDIR/bin/coop"
+
+echo "==> Building dev binary..."
+# Force kind=dev rather than relying on git state. When CI runs on a tag
+# matching the Cargo version (the release workflow's normal trigger),
+# build.rs correctly bakes kind=release, which would defeat test 4.
+(
+    cd "$PROJECT_DIR"
+    COOP_FORCE_BUILD_KIND=dev cargo build --release --quiet
+)
+cp "$PROJECT_DIR/target/release/coop" "$TMPDIR/bin/coop-dev"
+
+# ── Isolate test invocations from the real user environment ──────────────────
+#
+# `coop update --yes` writes an "update-check" bookkeeping file recording the
+# latest release it learned about. Pointed at our local fixture, that file
+# would record the synthetic v9.9.9 tag — and `dirs::state_dir()` /
+# `dirs::data_local_dir()` resolve under $HOME on every supported platform
+# (`$HOME/.local/state` on Linux, `$HOME/Library/Application Support` on
+# macOS), so without redirection the file lands in the user's real home and
+# triggers a bogus "newer version available" warning on every later run.
+#
+# Redirecting $HOME (and the XDG vars, for completeness on Linux) is enough:
+# the update path doesn't read from anywhere else under the user's home.
+export HOME="$TMPDIR/home"
+export XDG_STATE_HOME="$HOME/.local/state"
+export XDG_DATA_HOME="$HOME/.local/share"
+mkdir -p "$XDG_STATE_HOME" "$XDG_DATA_HOME"
 
 # ── Fabricate a "newer" release tarball ──────────────────────────────────────
 
@@ -169,6 +203,18 @@ else
     fail "update --yes returned non-zero" "$(tail -5 "$TMPDIR/t1.log")"
 fi
 
+# Confirm the update-check state file landed inside the redirected
+# $HOME — anywhere outside means a future code change has introduced a
+# state path that bypasses HOME/XDG and would leak the synthetic v9.9.9
+# tag into the user's real home, surfacing as a bogus update warning.
+leaked_in_home="$(find "$HOME" -name update-check.json -print -quit 2> /dev/null)"
+if [[ -n "$leaked_in_home" ]]; then
+    pass "update-check state file confined to redirected HOME"
+else
+    fail "no update-check state file written under redirected HOME" \
+        "expected one under $HOME"
+fi
+
 # ── Test 2: --check when already up to date ──────────────────────────────────
 
 # Restore the real binary; point "latest" at its version.
@@ -219,16 +265,6 @@ fi
 (cd "$FIXTURE" && sha256sums_line "${FAKE_TARBALL}" > SHA256SUMS)
 
 # ── Test 4: dev build refuses to self-update ─────────────────────────────────
-
-echo "==> Building dev binary..."
-# Force kind=dev rather than relying on git state. When CI runs on a tag
-# matching the Cargo version (the release workflow's normal trigger),
-# build.rs correctly bakes kind=release, which would defeat this test.
-(
-    cd "$PROJECT_DIR"
-    COOP_FORCE_BUILD_KIND=dev cargo build --release --quiet
-)
-cp "$PROJECT_DIR/target/release/coop" "$TMPDIR/bin/coop-dev"
 
 echo "==> Test 4: dev build refusal"
 if "$TMPDIR/bin/coop-dev" update --yes > "$TMPDIR/t4.log" 2>&1; then


### PR DESCRIPTION
Fixes #63

## Summary

`tests/integration-update.sh` was writing the synthetic `v9.9.9` release tag served by its local HTTP fixture into the developer's real `~/.local/state/coop/update-check.json`, causing every subsequent normal `coop` run to print a bogus "newer version available" warning.

This change redirects `$HOME` (and Linux XDG vars under it) to a tempdir before the test invokes the binary. Both cargo builds (release and dev) now run before the override so the toolchain caches resolve normally; the release binary is stashed at a stable path so the dev rebuild doesn't clobber it.

No production code change.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 249/249 pass
- [x] `shellcheck tests/integration-update.sh` clean
- [x] `./tests/integration-update.sh` — 5/5 pass; before/after snapshot of `~/.local/state/coop/` shows no leak
- [x] Negative control: stashing this patch and re-running reproduces the leak (`v9.9.9` written to `~/.local/state/coop/update-check.json`), confirming the test infrastructure is what blocks it