### PR TITLE
Set `IdentitiesOnly` for SSH

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -144,6 +144,8 @@ impl SshTarget {
             "-o".into(),
             "UserKnownHostsFile=/dev/null".into(),
             "-o".into(),
+            "IdentitiesOnly=yes".into(),
+            "-o".into(),
             "LogLevel=ERROR".into(),
             "-i".into(),
             self.key_path.display().to_string(),
@@ -179,6 +181,8 @@ impl SshTarget {
             "StrictHostKeyChecking=no".into(),
             "-o".into(),
             "UserKnownHostsFile=/dev/null".into(),
+            "-o".into(),
+            "IdentitiesOnly=yes".into(),
             "-o".into(),
             "LogLevel=ERROR".into(),
             "-i".into(),
@@ -309,7 +313,7 @@ impl SshTarget {
     pub fn rsync_ssh_cmd(&self) -> String {
         format!(
             "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-             -o LogLevel=ERROR -i {} -p {}",
+             -o IdentitiesOnly=yes -o LogLevel=ERROR -i {} -p {}",
             self.key_path.display(),
             self.port,
         )

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -706,6 +706,7 @@ fn ssh_config_block(target: &SshTarget, inst: &Instance) -> String {
          \x20   Port {}\n\
          \x20   User {}\n\
          \x20   IdentityFile {}\n\
+         \x20   IdentitiesOnly yes\n\
          \x20   StrictHostKeyChecking no\n\
          \x20   UserKnownHostsFile /dev/null\n\
          \x20   LogLevel ERROR\n\


### PR DESCRIPTION
Set `IdentitiesOnly` for SSH so that only the VM SSH key is tried. This fixes an error where if a user has >= 6 keys in their ssh-agent, the user gets "Too many authentication failures" when trying to connect to the VM.