### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.4.2
+
+### Fixes
+
+- **SSH connections respect `IdentitiesOnly`** (#68) — When `ssh-agent`
+  holds many keys, ssh offered all of them before the explicit `-i` key,
+  hitting sshd's default `MaxAuthTries=6` and producing "SSH not ready"
+  on `coop start`. SSH/SCP/rsync invocations and the generated
+  `~/.ssh/config` block now set `IdentitiesOnly=yes`, matching Lima's
+  own probes.
+
+- **Workspace tar-pipe transfer** (#66, #67) — Surface SSH stderr (with
+  a `coop start --disk` hint when the message mentions "no space left
+  on device") instead of a generic "tar archive truncated" error. Peak
+  guest disk usage during transfer is now the extracted tree, not 2× —
+  the temp-file/SHA-256 dance was redundant since SSH already MACs the
+  channel. Dedicated background threads drain remote and local tar
+  stderr to prevent deadlocks when warnings fill the 64K pipe buffer
+  during extraction.
+
+- **Integration test no longer pollutes user state** (#63, #64) —
+  `tests/integration-update.sh` redirects `$HOME` and XDG vars to a
+  tempdir before invoking coop, so the synthetic `v9.9.9` release
+  served by the test fixture no longer lands in
+  `~/.local/state/coop/update-check.json` and surfaces as a bogus
+  update notification on later runs.
+
+### Dependencies
+
+- `libc` 0.2.185 → 0.2.186, `semver` 1.0.27 → 1.0.28 (#65)
+
 ## v0.4.1
 
 Re-release of v0.4.0. The v0.4.0 tag did not produce release artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coop"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coop"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
 


### PR DESCRIPTION
## Summary

Patch release. Three user-visible fixes since v0.4.1:

- **SSH `IdentitiesOnly`** (#68) — Fixes "SSH not ready" failures when `ssh-agent` holds many keys.
- **Workspace tar-pipe transfer** (#66, #67) — Surfaces SSH stderr, halves peak guest disk usage, eliminates a stderr-buffer deadlock during extraction.
- **Integration test isolation** (#63, #64) — `tests/integration-update.sh` no longer pollutes `~/.local/state/coop/update-check.json` on the developer's host.

Plus dependabot patch bumps (`libc` 0.2.185 → 0.2.186, `semver` 1.0.27 → 1.0.28, #65).

## Pre-tag validation (against locally-tagged v0.4.2)

Both prior re-releases (v0.3.1, v0.4.1) were caused by failures that only manifested on a tagged commit. Validated against that exact state before pushing:

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (258/258)
- `tests/integration-update.sh` 5/5 — including Test 4 ("dev build refusal"), the regression that broke v0.4.0
- `build.rs` reports `coop 0.4.2 (<sha>)` with no `-dev`/`+dirty` suffix on a clean tagged tree
- `release.yml` awk extractor produces a non-empty RELEASE_NOTES.md, terminating cleanly at `## v0.4.1`
- Full integration suite (`tests/run-integration.sh`) ran green on both Linux/Firecracker and macOS/Lima at origin/main (5d31d75)

`cargo deny` skipped locally (not installed) — CI will run it.

## Test plan

- [ ] CI green (cargo fmt/clippy/test, integration-update, deny, zizmor)
- [ ] After merge: tag the merge commit on main as `v0.4.2` and push the tag to trigger the release workflow
- [ ] Verify GitHub Releases shows `v0.4.2` with the three target tarballs, `SHA256SUMS`, and a build-provenance attestation

🤖 Generated with [Claude Code](https://claude.com/claude-code)