### PR TITLE
Authenticate self-update against private GitHub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ host triple, verifies the SHA-256 against the release's `SHA256SUMS`, and
 (when `gh` is installed) verifies the GitHub build-provenance attestation
 before swapping the binary atomically.
 
+While `trailofbits/coop` is private, `coop update` requires either
+[`gh`](https://cli.github.com/) authenticated against `github.com` or
+`GITHUB_TOKEN` in the environment to reach the API and download release
+assets. Once the repository is public, no auth is needed.
+
 ```sh
 coop update --check             # report whether a newer release exists
 coop update                     # prompt, then install the latest release

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -378,6 +378,8 @@ coop profiles show rust
 
 Replace the running coop binary with a release from `github.com/trailofbits/coop`. Downloads the tarball matching the current host triple, verifies its SHA-256 against the release's `SHA256SUMS`, and (when `gh` is installed) verifies the GitHub build-provenance attestation before swapping the binary atomically.
 
+While `trailofbits/coop` is private, `coop update` requires either [`gh`](https://cli.github.com/) authenticated against `github.com` or `GITHUB_TOKEN` in the environment to reach the API and download release assets. Once the repository is public, no auth is needed.
+
 ```
 coop update [FLAGS]
 ```

--- a/install.sh
+++ b/install.sh
@@ -58,11 +58,15 @@ latest_version() {
         gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null && return
     fi
     local url="https://api.github.com/repos/${REPO}/releases/latest"
-    local auth_args=()
+    # Pass the auth header on stdin (`-H @-`) so $GITHUB_TOKEN never appears
+    # on argv where it would be visible in /proc/<pid>/cmdline or `set -x`.
     if [ -n "${GITHUB_TOKEN:-}" ]; then
-        auth_args=(-H "Authorization: token ${GITHUB_TOKEN}")
+        printf 'Authorization: token %s\n' "${GITHUB_TOKEN}" \
+            | curl -fsSL -H @- "$url" \
+            | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+    else
+        curl -fsSL "$url" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
     fi
-    curl -fsSL "${auth_args[@]}" "$url" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
 }
 
 # Download a release asset. Tries gh first, then curl with token, then plain curl.
@@ -77,13 +81,16 @@ download_asset() {
     fi
 
     local url="https://github.com/${REPO}/releases/download/${VERSION}/${filename}"
-    local auth_args=()
-    if [ -n "${GITHUB_TOKEN:-}" ]; then
-        auth_args=(-H "Authorization: token ${GITHUB_TOKEN}")
-    fi
 
     info "Downloading ${filename}..."
-    curl -fsSL "${auth_args[@]}" -o "$dest" "$url"
+    # Pass the auth header on stdin (`-H @-`) so $GITHUB_TOKEN never appears
+    # on argv where it would be visible in /proc/<pid>/cmdline or `set -x`.
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        printf 'Authorization: token %s\n' "${GITHUB_TOKEN}" \
+            | curl -fsSL -H @- -o "$dest" "$url"
+    else
+        curl -fsSL -o "$dest" "$url"
+    fi
 }
 
 verify_checksum() {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,4 +1,5 @@
 use std::ffi::{OsStr, OsString};
+use std::io::Write as _;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
@@ -12,6 +13,7 @@ pub struct Cmd {
     program: OsString,
     args: Vec<OsString>,
     sudo: bool,
+    stdin: Option<Vec<u8>>,
 }
 
 impl Cmd {
@@ -20,6 +22,7 @@ impl Cmd {
             program: program.as_ref().to_owned(),
             args: Vec::new(),
             sudo: false,
+            stdin: None,
         }
     }
 
@@ -41,6 +44,19 @@ impl Cmd {
     /// Run the command under `sudo`.
     pub fn sudo(mut self) -> Self {
         self.sudo = true;
+        self
+    }
+
+    /// Pipe `bytes` to the child's stdin instead of inheriting the parent's.
+    ///
+    /// Use this for any data that must NOT appear on argv — secrets, tokens,
+    /// or large payloads. The bytes are written and stdin is closed before
+    /// the child exits, so the child sees EOF without further input.
+    ///
+    /// Compatible with [`Cmd::run`] and [`Cmd::capture`]; the existing
+    /// [`Cmd::stdin_write`] takes its data per-call instead.
+    pub fn stdin_input(mut self, bytes: impl Into<Vec<u8>>) -> Self {
+        self.stdin = Some(bytes.into());
         self
     }
 
@@ -74,10 +90,23 @@ impl Cmd {
     pub fn run(&self) -> Result<()> {
         let desc = self.describe();
         tracing::debug!("Running: {desc}");
-        let status = self
-            .build()
-            .status()
-            .with_context(|| format!("Failed to execute {desc}"))?;
+        let status = match self.stdin.as_deref() {
+            None => self
+                .build()
+                .status()
+                .with_context(|| format!("Failed to execute {desc}"))?,
+            Some(bytes) => {
+                let mut child = self
+                    .build()
+                    .stdin(Stdio::piped())
+                    .spawn()
+                    .with_context(|| format!("Failed to start {desc}"))?;
+                write_stdin_and_close(&mut child, bytes, &desc)?;
+                child
+                    .wait()
+                    .with_context(|| format!("Failed to wait for {desc}"))?
+            }
+        };
         if !status.success() {
             bail!("{desc} exited with {status}");
         }
@@ -86,8 +115,6 @@ impl Cmd {
 
     /// Pipe `data` into stdin, suppress stdout, and check exit status.
     pub fn stdin_write(&self, data: &[u8]) -> Result<()> {
-        use std::io::Write as _;
-
         let desc = self.describe();
         tracing::debug!("Running (stdin pipe): {desc}");
         let mut child = self
@@ -96,12 +123,7 @@ impl Cmd {
             .stdout(Stdio::null())
             .spawn()
             .with_context(|| format!("Failed to start {desc}"))?;
-
-        if let Some(ref mut stdin) = child.stdin {
-            stdin
-                .write_all(data)
-                .with_context(|| format!("Failed to write stdin for {desc}"))?;
-        }
+        write_stdin_and_close(&mut child, data, &desc)?;
         let status = child
             .wait()
             .with_context(|| format!("Failed to wait for {desc}"))?;
@@ -127,11 +149,26 @@ impl Cmd {
     pub fn capture(&self) -> Result<String> {
         let desc = self.describe();
         tracing::debug!("Running (capture): {desc}");
-        let output = self
-            .build()
-            .stderr(Stdio::null())
-            .output()
-            .with_context(|| format!("Failed to execute {desc}"))?;
+        let output = match self.stdin.as_deref() {
+            None => self
+                .build()
+                .stderr(Stdio::null())
+                .output()
+                .with_context(|| format!("Failed to execute {desc}"))?,
+            Some(bytes) => {
+                let mut child = self
+                    .build()
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .with_context(|| format!("Failed to start {desc}"))?;
+                write_stdin_and_close(&mut child, bytes, &desc)?;
+                child
+                    .wait_with_output()
+                    .with_context(|| format!("Failed to wait for {desc}"))?
+            }
+        };
         if !output.status.success() {
             bail!("{desc} exited with {}", output.status);
         }
@@ -141,6 +178,9 @@ impl Cmd {
 
     /// Run the command with stdout and stderr suppressed.
     /// Returns `true` if the exit status is success.
+    ///
+    /// `stdin_input` is ignored here — `status_ok` is used for probes
+    /// (`command -v gh`, `gh auth status`) that take no input.
     pub fn status_ok(&self) -> bool {
         let desc = self.describe();
         tracing::debug!("Running (status_ok): {desc}");
@@ -150,6 +190,24 @@ impl Cmd {
             .status()
             .is_ok_and(|s| s.success())
     }
+}
+
+/// Write `bytes` to the child's stdin, then close it so the child sees EOF.
+///
+/// Used by [`Cmd::run`] and [`Cmd::capture`] when [`Cmd::stdin_input`] was
+/// configured. Closing the handle is what curl `-H @-` and similar idioms
+/// rely on to know the input is complete.
+fn write_stdin_and_close(child: &mut std::process::Child, bytes: &[u8], desc: &str) -> Result<()> {
+    let mut stdin = child
+        .stdin
+        .take()
+        .with_context(|| format!("stdin pipe missing for {desc}"))?;
+    stdin
+        .write_all(bytes)
+        .with_context(|| format!("Failed to write stdin for {desc}"))?;
+    // Dropping `stdin` closes the pipe so the child sees EOF.
+    drop(stdin);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -229,6 +287,23 @@ mod tests {
     fn cmd_describe_no_args() {
         let cmd = Cmd::new("ls");
         assert_eq!(cmd.describe(), "ls");
+    }
+
+    #[test]
+    fn stdin_input_round_trips_through_capture() {
+        // `cat` echoes stdin to stdout — verifies the pipe is wired and closed.
+        let out = Cmd::new("cat").stdin_input(b"hello".to_vec()).capture();
+        assert_eq!(out.expect("cat capture"), "hello");
+    }
+
+    #[test]
+    fn stdin_input_run_succeeds_for_consumer_command() {
+        // `cat` exits 0 after consuming stdin; closing the pipe must signal EOF
+        // so it does not hang.
+        Cmd::new("cat")
+            .stdin_input(b"data".to_vec())
+            .run()
+            .expect("cat run");
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -169,40 +169,164 @@ impl Release {
 }
 
 pub fn fetch_latest() -> Result<Release> {
-    let url = format!("{}/repos/{REPO}/releases/latest", api_base());
-    fetch_release(&url).context("Failed to fetch latest release metadata")
+    fetch_release_metadata("latest").context("Failed to fetch latest release metadata")
 }
 
 pub fn fetch_by_tag(tag: &str) -> Result<Release> {
-    let url = format!("{}/repos/{REPO}/releases/tags/{tag}", api_base());
-    fetch_release(&url).with_context(|| format!("Failed to fetch release metadata for {tag}"))
+    fetch_release_metadata(&format!("tags/{tag}"))
+        .with_context(|| format!("Failed to fetch release metadata for {tag}"))
 }
 
-fn fetch_release(url: &str) -> Result<Release> {
-    let body = curl_capture(url)?;
+/// Fetch release JSON for the given API path suffix (`latest` or `tags/<tag>`).
+///
+/// Selects an auth strategy at call time so changes to `GITHUB_TOKEN` /
+/// `gh auth` between invocations take effect.
+fn fetch_release_metadata(path_suffix: &str) -> Result<Release> {
+    let body = match select_auth_strategy_from_env() {
+        AuthStrategy::Gh => gh_api_capture(&format!("repos/{REPO}/releases/{path_suffix}"))?,
+        AuthStrategy::CurlBearer(token) => {
+            let url = format!("{}/repos/{REPO}/releases/{path_suffix}", api_base());
+            curl_capture(&url, Some(&token))?
+        }
+        AuthStrategy::CurlBare => {
+            let url = format!("{}/repos/{REPO}/releases/{path_suffix}", api_base());
+            curl_capture(&url, None)?
+        }
+    };
     serde_json::from_str(&body).context("Failed to parse GitHub release JSON")
 }
 
-// ── Network I/O (shell-out to curl) ──────────────────────────────────────────
+// ── Auth strategy selection ──────────────────────────────────────────────────
 
-fn curl_capture(url: &str) -> Result<String> {
-    Cmd::new("curl")
+/// How to authenticate against GitHub for release metadata and asset downloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AuthStrategy {
+    /// Use the `gh` CLI (already authenticated to github.com).
+    Gh,
+    /// Use curl with a bearer token from `GITHUB_TOKEN`.
+    CurlBearer(String),
+    /// Use curl without authentication (public repo or test fixture).
+    CurlBare,
+}
+
+/// Pure strategy picker. Extracted from I/O so it is unit-testable.
+///
+/// When `api_base_overridden` is true, the integration test fixture is in use
+/// and we must not consult `gh` or `GITHUB_TOKEN` — the local server speaks
+/// neither.
+fn select_auth_strategy(
+    api_base_overridden: bool,
+    has_gh: bool,
+    gh_authed: bool,
+    github_token: Option<&str>,
+) -> AuthStrategy {
+    if api_base_overridden {
+        return AuthStrategy::CurlBare;
+    }
+    if has_gh && gh_authed {
+        return AuthStrategy::Gh;
+    }
+    match github_token.filter(|t| !t.is_empty()) {
+        Some(token) => AuthStrategy::CurlBearer(token.to_string()),
+        None => AuthStrategy::CurlBare,
+    }
+}
+
+fn select_auth_strategy_from_env() -> AuthStrategy {
+    let overridden = api_base_overridden();
+    let has_gh = !overridden && has_command("gh");
+    let gh_authed = has_gh && gh_authenticated();
+    let token = env::var("GITHUB_TOKEN").ok();
+    select_auth_strategy(overridden, has_gh, gh_authed, token.as_deref())
+}
+
+fn gh_authenticated() -> bool {
+    Cmd::new("gh")
+        .arg("auth")
+        .arg("status")
+        .arg("--hostname")
+        .arg("github.com")
+        .status_ok()
+}
+
+// ── Network I/O (shell-out to curl / gh) ─────────────────────────────────────
+
+fn curl_capture(url: &str, bearer_token: Option<&str>) -> Result<String> {
+    let mut cmd = Cmd::new("curl")
         .arg("-fsSL")
         .arg("-H")
-        .arg("Accept: application/vnd.github+json")
-        .arg(url)
+        .arg("Accept: application/vnd.github+json");
+    if let Some(token) = bearer_token {
+        // Pass the auth header on stdin via curl's `-H @-` so the secret
+        // never touches argv (visible in /proc and `Cmd::describe` logs).
+        cmd = cmd
+            .arg("-H")
+            .arg("@-")
+            .stdin_input(format!("Authorization: token {token}\n"));
+    }
+    cmd.arg(url)
         .capture()
         .with_context(|| format!("curl GET {url} failed"))
 }
 
-fn download_to(url: &str, dest: &Path) -> Result<()> {
-    Cmd::new("curl")
-        .arg("-fsSL")
-        .arg(url)
+fn gh_api_capture(path: &str) -> Result<String> {
+    Cmd::new("gh")
+        .arg("api")
+        .arg(path)
+        .arg("-H")
+        .arg("Accept: application/vnd.github+json")
+        .capture()
+        .with_context(|| format!("gh api {path} failed"))
+}
+
+/// Download a release asset, choosing auth strategy at call time.
+///
+/// `tag` and `asset_name` are required for the `gh release download` path;
+/// `url` is the `browser_download_url` used by the curl fallbacks.
+fn download_asset(tag: &str, asset_name: &str, url: &str, dest: &Path) -> Result<()> {
+    match select_auth_strategy_from_env() {
+        AuthStrategy::Gh => gh_release_download(tag, asset_name, dest),
+        AuthStrategy::CurlBearer(token) => curl_download(url, dest, Some(&token)),
+        AuthStrategy::CurlBare => curl_download(url, dest, None),
+    }
+}
+
+fn curl_download(url: &str, dest: &Path, bearer_token: Option<&str>) -> Result<()> {
+    let mut cmd = Cmd::new("curl").arg("-fsSL");
+    if let Some(token) = bearer_token {
+        // Pass the auth header on stdin via curl's `-H @-` so the secret
+        // never touches argv (visible in /proc and `Cmd::describe` logs).
+        cmd = cmd
+            .arg("-H")
+            .arg("@-")
+            .stdin_input(format!("Authorization: token {token}\n"));
+    }
+    cmd.arg(url)
         .arg("-o")
         .arg(dest)
         .run()
         .with_context(|| format!("curl download from {url} failed"))
+}
+
+fn gh_release_download(tag: &str, asset_name: &str, dest: &Path) -> Result<()> {
+    Cmd::new("gh")
+        .arg("release")
+        .arg("download")
+        .arg(tag)
+        .arg("--repo")
+        .arg(REPO)
+        .arg("--pattern")
+        .arg(asset_name)
+        .arg("--output")
+        .arg(dest)
+        .arg("--clobber")
+        .run()
+        .with_context(|| {
+            format!(
+                "gh release download {tag} --pattern {asset_name} -> {} failed",
+                dest.display()
+            )
+        })
 }
 
 // ── Checksum verification ────────────────────────────────────────────────────
@@ -423,8 +547,13 @@ fn perform_update(release: &Release, triple: &str) -> Result<()> {
     let sums_path = tmp.path().join("SHA256SUMS");
 
     tracing::info!("Downloading {tarball_name}");
-    download_to(&tarball_asset.url, &tarball_path)?;
-    download_to(&sums_asset.url, &sums_path)?;
+    download_asset(
+        &release.tag,
+        &tarball_name,
+        &tarball_asset.url,
+        &tarball_path,
+    )?;
+    download_asset(&release.tag, "SHA256SUMS", &sums_asset.url, &sums_path)?;
 
     let sums_content = fs::read_to_string(&sums_path)
         .with_context(|| format!("Failed to read {}", sums_path.display()))?;
@@ -794,6 +923,52 @@ mod tests {
         assert!(!interval_elapsed(100_000 + one_hour - 1, 100_000, 1));
         // Saturating arithmetic: now earlier than last_checked_at must not panic.
         assert!(!interval_elapsed(0, 100_000, 24));
+    }
+
+    #[test]
+    fn select_auth_strategy_prefers_bare_when_api_base_overridden() {
+        // Even with gh authed and a token present, the local fixture forces bare curl.
+        let strat = select_auth_strategy(true, true, true, Some("ghp_xyz"));
+        assert_eq!(strat, AuthStrategy::CurlBare);
+    }
+
+    #[test]
+    fn select_auth_strategy_prefers_gh_when_authed() {
+        let strat = select_auth_strategy(false, true, true, Some("ghp_xyz"));
+        assert_eq!(strat, AuthStrategy::Gh);
+    }
+
+    #[test]
+    fn select_auth_strategy_falls_back_to_token_when_gh_unauthed() {
+        // gh installed but not authed -> use token if available.
+        let strat = select_auth_strategy(false, true, false, Some("ghp_abc"));
+        assert_eq!(strat, AuthStrategy::CurlBearer("ghp_abc".to_string()));
+    }
+
+    #[test]
+    fn select_auth_strategy_falls_back_to_token_when_gh_missing() {
+        let strat = select_auth_strategy(false, false, false, Some("ghp_abc"));
+        assert_eq!(strat, AuthStrategy::CurlBearer("ghp_abc".to_string()));
+    }
+
+    #[test]
+    fn select_auth_strategy_uses_bare_when_no_auth_available() {
+        let strat = select_auth_strategy(false, false, false, None);
+        assert_eq!(strat, AuthStrategy::CurlBare);
+    }
+
+    #[test]
+    fn select_auth_strategy_treats_empty_token_as_absent() {
+        // GITHUB_TOKEN="" should not produce a bogus Authorization header.
+        let strat = select_auth_strategy(false, false, false, Some(""));
+        assert_eq!(strat, AuthStrategy::CurlBare);
+    }
+
+    #[test]
+    fn select_auth_strategy_ignores_token_when_gh_authed() {
+        // gh wins over token when both are available — no need to leak the token.
+        let strat = select_auth_strategy(false, true, true, Some("ghp_xyz"));
+        assert_eq!(strat, AuthStrategy::Gh);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `coop update` now authenticates against `api.github.com` and asset downloads, mirroring `install.sh`'s strategy: prefer `gh` (when installed and authenticated), fall back to `GITHUB_TOKEN`, then bare curl. Fixes the `curl exit 22 / 404` failure on the private `trailofbits/coop` repo.
- Bearer tokens are passed via curl `-H @-` (header read from stdin), so `$GITHUB_TOKEN` never appears on argv where it would be visible in `/proc/<pid>/cmdline` or in `coop -v update`'s tracing debug log. Same hygiene applied to `install.sh`.

Fixes #70.

## Changes
- `src/update.rs`: pure `select_auth_strategy(api_base_overridden, has_gh, gh_authed, github_token)` returning `Gh | CurlBearer(token) | CurlBare`. New `gh_api_capture` and `gh_release_download` paths. The `COOP_UPDATE_API_BASE_URL` test seam still forces `CurlBare`, keeping the integration fixture unchanged. Strategy is selected per call so a mid-session `gh auth login` takes effect immediately.
- `src/cmd.rs`: new `Cmd::stdin_input(bytes)` builder honored by `run()` and `capture()`. Shared `write_stdin_and_close` helper; existing `stdin_write` refactored onto it.
- `install.sh`: `latest_version` and `download_asset` pipe `Authorization: token …` from `printf` into `curl -fsSL -H @-`. No other changes.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 267 passed (includes 7 new strategy-picker tests and 2 new `Cmd::stdin_input` round-trip tests)
- [x] `shellcheck install.sh`
- [ ] `coop update --check` against the private repo with `gh` authenticated
- [ ] `coop update --check` with `GITHUB_TOKEN` set and `gh` absent
- [ ] `tests/integration-update.sh` (synthetic v9.9.9 fixture, exercises the `CurlBare` path)
- [ ] Verify token absent from `ps auxf` / `/proc/<pid>/cmdline` while `coop update` runs

## Notes
- `gh release download --pattern` treats `*?[` as glob metacharacters. Today's asset names are literal so this is fine; flagging in case asset naming ever changes.
- `gh auth status` runs once per `select_auth_strategy_from_env()` call (three times per `coop update` run). Kept per-call so re-authing mid-session works.
