### PR TITLE
Release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.4.3
+
+### Fixes
+
+- **`coop update` works on the private/internal `trailofbits/coop` repo**
+  (#70, #71) — Previously the in-binary update shelled out to bare
+  `curl`, which the GitHub API answers with 404 for unauthenticated
+  requests against private repos, surfacing as `curl exited with exit
+  status: 22`. The update path now authenticates the same way
+  `install.sh` already did: prefer `gh` (when installed and authenticated
+  against `github.com`), fall back to `GITHUB_TOKEN`, then bare curl
+  (which works once the repo is public).
+
+- **GitHub token no longer appears on argv** (#71) — Both `src/update.rs`
+  and `install.sh` now feed the `Authorization` header to curl on stdin
+  (`curl -H @-`) instead of as a command-line argument, so
+  `$GITHUB_TOKEN` is no longer visible in `/proc/<pid>/cmdline` or in
+  `coop -v update`'s tracing debug log.
+
+### Documentation
+
+- README and `docs/commands.md` note that `coop update` requires `gh` or
+  `GITHUB_TOKEN` while the repository is private (#71).
+
 ## v0.4.2
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coop"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coop"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
 


### PR DESCRIPTION
## Summary

Patch release. One user-visible fix since v0.4.2:

- **`coop update` works on the private repo** (#70, #71) — Authenticates against the GitHub API and asset downloads via `gh` (preferred) or `GITHUB_TOKEN`, mirroring `install.sh`. Previously surfaced as `curl exited with exit status: 22`.

The fix also moves the `Authorization` header off curl's argv (passed via `-H @-` on stdin) so `$GITHUB_TOKEN` is no longer visible in `/proc/<pid>/cmdline` or in `coop -v update`'s tracing debug log. Same hardening applied in `install.sh`.

README and `docs/commands.md` updated to note the auth requirement while the repo is private.

Full notes: [CHANGELOG.md](https://github.com/trailofbits/coop/blob/release/v0.4.3/CHANGELOG.md#v043).

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (267 passed)
- [x] `tests/integration-update.sh` — 5/5 pass (CurlBare path via local fixture)
- [x] Manual: `coop update --check` against the private repo via gh, via `GITHUB_TOKEN`, and bare (verified the bare path still fails with the original error, which is the correct fail-mode while the repo is private)
- [x] CI green on #71 (`check`, `deny`, `zizmor`)
