### PR TITLE
Extract open_ssh_session helper from claude/codex/agents dispatch

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -101,11 +101,12 @@ pub struct SshTarget {
 // ── SSH session ───────────────────────────────────────────────
 
 /// SSH operations that combine connection details with environment
-/// forwarding. Borrows both to avoid duplication at call sites
-/// where target and env are always passed together.
-pub struct SshSession<'a> {
-    pub target: &'a SshTarget,
-    pub env: &'a EnvForward,
+/// forwarding. Owns both so call sites can construct a session once
+/// and pass it around without juggling lifetimes; `SshTarget` and
+/// `EnvForward` are cheap to clone (small string buffers).
+pub struct SshSession {
+    pub target: SshTarget,
+    pub env: EnvForward,
 }
 
 impl SshTarget {
@@ -382,7 +383,7 @@ impl SshTarget {
     }
 }
 
-impl SshSession<'_> {
+impl SshSession {
     /// SSH options with environment variable forwarding.
     pub fn ssh_opts(&self) -> Vec<String> {
         let mut opts = self.target.ssh_opts();
@@ -921,7 +922,7 @@ pub fn prepare_env_forwarding(cfg: &CoopConfig) -> Result<EnvForward> {
 
 /// Bootstrap configured guest agents in the guest declaratively.
 pub fn bootstrap_agents(
-    session: &SshSession<'_>,
+    session: &SshSession,
     cfg: &CoopConfig,
     inst: &crate::config::Instance,
     restart: bool,
@@ -953,7 +954,7 @@ pub fn bootstrap_agents(
 /// `ANTHROPIC_API_KEY` (if set) is forwarded via `SendEnv`
 /// on every SSH session automatically.
 fn bootstrap_claude(
-    session: &SshSession<'_>,
+    session: &SshSession,
     cfg: &CoopConfig,
     inst: &crate::config::Instance,
     restart: bool,
@@ -980,7 +981,7 @@ fn bootstrap_claude(
     }
 
     // User config (CLAUDE.md, rules/, commands/) — host files may have changed
-    copy_claude_config(session.target, &claude.config_dir)?;
+    copy_claude_config(&session.target, &claude.config_dir)?;
 
     // Marketplaces, plugins, MCP servers — persisted on guest disk,
     // only install on first boot
@@ -1011,7 +1012,7 @@ fn bootstrap_claude(
 /// Codex uses `~/.codex/config.toml` for MCP registration and related
 /// settings, so bootstrap writes allowlisted user config files and a
 /// managed MCP section there when configured.
-fn bootstrap_codex(session: &SshSession<'_>, cfg: &CoopConfig, restart: bool) -> Result<()> {
+fn bootstrap_codex(session: &SshSession, cfg: &CoopConfig, restart: bool) -> Result<()> {
     let codex = &cfg.codex;
     let source_dir = resolve_config_source_dir(&codex.config_dir, ".codex", "codex.config_dir");
     let needs_codex = codex_bootstrap_needed(source_dir.as_deref(), &codex.mcp_servers);
@@ -1027,7 +1028,7 @@ fn bootstrap_codex(session: &SshSession<'_>, cfg: &CoopConfig, restart: bool) ->
         bail!("{}", codex_missing_guest_cli_message());
     }
 
-    copy_codex_config(session.target, source_dir.as_deref(), codex)?;
+    copy_codex_config(&session.target, source_dir.as_deref(), codex)?;
 
     if restart {
         tracing::info!("Codex bootstrap refreshed");
@@ -1096,7 +1097,7 @@ fn resolve_github_token(strategy: Option<&GitHubAuth>) -> Option<String> {
     }
 }
 
-fn setup_github_auth(session: &SshSession<'_>) -> Result<()> {
+fn setup_github_auth(session: &SshSession) -> Result<()> {
     session
         .exec("gh auth setup-git")
         .context("Failed to configure git credential helper in guest")
@@ -1396,10 +1397,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 
 const GUEST_MARKETPLACE_DIR: &str = "~/.coop/marketplaces";
 
-pub(crate) fn install_marketplaces(
-    session: &SshSession<'_>,
-    marketplaces: &[String],
-) -> Result<()> {
+pub(crate) fn install_marketplaces(session: &SshSession, marketplaces: &[String]) -> Result<()> {
     let mut has_local = false;
 
     for source in marketplaces {
@@ -1447,7 +1445,7 @@ pub(crate) fn install_marketplaces(
     Ok(())
 }
 
-pub(crate) fn install_plugins(session: &SshSession<'_>, plugins: &[String]) -> Result<()> {
+pub(crate) fn install_plugins(session: &SshSession, plugins: &[String]) -> Result<()> {
     for plugin in plugins {
         tracing::info!("Installing plugin: {plugin}");
         let cmd = format!(
@@ -1463,7 +1461,7 @@ pub(crate) fn install_plugins(session: &SshSession<'_>, plugins: &[String]) -> R
 }
 
 fn register_mcp_servers(
-    session: &SshSession<'_>,
+    session: &SshSession,
     servers: &std::collections::HashMap<String, McpServerDef>,
 ) -> Result<()> {
     for (name, def) in servers {

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -739,10 +739,7 @@ fn install_builder_plugins(
         env.set("GITHUB_TOKEN", token);
     }
 
-    let session = crate::backend::SshSession {
-        target: &target,
-        env: &env,
-    };
+    let session = crate::backend::SshSession { target, env };
 
     if !marketplaces.is_empty() {
         crate::backend::install_marketplaces(&session, &marketplaces)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -447,12 +447,7 @@ fn main() -> Result<()> {
             ask,
             mut args,
         } => {
-            let running = resolve_running(&be, &cfg, session.name.as_deref())?;
-            let env_vars = backend::prepare_env_forwarding(&cfg)?;
-            let sess = backend::SshSession {
-                target: &running.target,
-                env: &env_vars,
-            };
+            let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
             if !ask {
                 args.insert(0, "--dangerously-skip-permissions".to_string());
             }
@@ -460,23 +455,13 @@ fn main() -> Result<()> {
             ssh::run_interactive(&sess, crate::guest::CLAUDE_BIN, &args, tmux)
         }
         Commands::ClaudeAgents { session, mut args } => {
-            let running = resolve_running(&be, &cfg, session.name.as_deref())?;
-            let env_vars = backend::prepare_env_forwarding(&cfg)?;
-            let sess = backend::SshSession {
-                target: &running.target,
-                env: &env_vars,
-            };
+            let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
             args.insert(0, "agents".to_string());
             let tmux = session.tmux_session_opt_in();
             ssh::run_interactive(&sess, crate::guest::CLAUDE_BIN, &args, tmux)
         }
         Commands::Codex { session, args } => {
-            let running = resolve_running(&be, &cfg, session.name.as_deref())?;
-            let env_vars = backend::prepare_env_forwarding(&cfg)?;
-            let sess = backend::SshSession {
-                target: &running.target,
-                env: &env_vars,
-            };
+            let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
             let tmux = session.tmux_session("codex");
             ssh::run_interactive(&sess, crate::guest::CODEX_BIN, &args, tmux)
         }
@@ -780,10 +765,10 @@ fn restart_instance(
     if no_agents {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
-        let env_vars = backend::prepare_env_forwarding(cfg)?;
+        let env = backend::prepare_env_forwarding(cfg)?;
         let session = backend::SshSession {
-            target: &target,
-            env: &env_vars,
+            target: target.clone(),
+            env,
         };
         backend::bootstrap_agents(&session, cfg, inst, true)?;
     }
@@ -814,14 +799,13 @@ fn start_instance(
 
     signal::check_shutdown()?;
 
-    let env_vars = backend::prepare_env_forwarding(cfg)?;
-
     if opts.no_agents {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
+        let env = backend::prepare_env_forwarding(cfg)?;
         let session = backend::SshSession {
-            target: &target,
-            env: &env_vars,
+            target: target.clone(),
+            env,
         };
         backend::bootstrap_agents(&session, cfg, inst, false)?;
     }
@@ -959,12 +943,7 @@ fn cmd_shell(
     command: &[String],
     tmux_session: Option<&str>,
 ) -> Result<()> {
-    let running = resolve_running(be, cfg, name)?;
-    let env_vars = backend::prepare_env_forwarding(cfg)?;
-    let session = backend::SshSession {
-        target: &running.target,
-        env: &env_vars,
-    };
+    let session = open_ssh_session(be, cfg, name)?;
     if command.is_empty() {
         ssh::connect(&session, tmux_session)
     } else {
@@ -978,13 +957,26 @@ fn cmd_exec(
     name: Option<&str>,
     command: &[String],
 ) -> Result<()> {
-    let running = resolve_running(be, cfg, name)?;
-    let env_vars = backend::prepare_env_forwarding(cfg)?;
-    let session = backend::SshSession {
-        target: &running.target,
-        env: &env_vars,
-    };
+    let session = open_ssh_session(be, cfg, name)?;
     ssh::exec_command(&session, command)
+}
+
+/// Resolve a running instance and prepare an SSH session with env
+/// forwarding in one step. Returns an owned session ready to pass to
+/// `ssh::*` and `backend::*` helpers. Callers that also need the
+/// `Instance` (e.g. for workspace push/pull) should call
+/// `resolve_running` directly.
+fn open_ssh_session(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    name: Option<&str>,
+) -> Result<backend::SshSession> {
+    let running = resolve_running(be, cfg, name)?;
+    let env = backend::prepare_env_forwarding(cfg)?;
+    Ok(backend::SshSession {
+        target: running.target,
+        env,
+    })
 }
 
 fn cmd_stop(

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -28,7 +28,7 @@ fn guest_term() -> String {
 /// When `tmux_session` is `Some`, the session runs inside a named
 /// tmux session that survives SSH disconnects. Reconnecting
 /// reattaches to the existing session.
-pub fn connect(session: &SshSession<'_>, tmux_session: Option<&str>) -> Result<()> {
+pub fn connect(session: &SshSession, tmux_session: Option<&str>) -> Result<()> {
     tracing::info!(
         "Connecting via SSH to {}:{}",
         session.target.host,
@@ -64,7 +64,7 @@ pub fn connect(session: &SshSession<'_>, tmux_session: Option<&str>) -> Result<(
 /// Run a command non-interactively over SSH (no PTY).
 ///
 /// Propagates the remote command's exit code via the process exit code.
-pub fn run_command(session: &SshSession<'_>, command: &[String]) -> Result<()> {
+pub fn run_command(session: &SshSession, command: &[String]) -> Result<()> {
     let remote_cmd = command
         .iter()
         .map(|a| shell_escape(a))
@@ -96,7 +96,7 @@ pub fn run_command(session: &SshSession<'_>, command: &[String]) -> Result<()> {
 /// tmux session. If the session already exists, it reattaches
 /// (the command argument is ignored by tmux on reattach).
 pub fn run_interactive(
-    session: &SshSession<'_>,
+    session: &SshSession,
     cmd: &str,
     extra_args: &[String],
     tmux_session: Option<&str>,
@@ -143,7 +143,7 @@ pub fn run_interactive(
 /// Stdout and stderr from the remote command are written to the local
 /// stdout/stderr respectively. The process exits with the remote
 /// command's exit code, making this suitable for scripting and CI.
-pub fn exec_command(session: &SshSession<'_>, command: &[String]) -> Result<()> {
+pub fn exec_command(session: &SshSession, command: &[String]) -> Result<()> {
     let remote_cmd = command
         .iter()
         .map(|a| shell_escape(a))


### PR DESCRIPTION
Closes #81.

## Summary
- Adds `open_ssh_session(be, cfg, name) -> Result<SshSession>` in `src/main.rs` that combines `resolve_running` and `prepare_env_forwarding` and returns an owned `SshSession`.
- Collapses the 5-line construction boilerplate in `Commands::Claude`, `Commands::ClaudeAgents`, `Commands::Codex`, `cmd_shell`, and `cmd_exec`. (The issue listed shell/exec as "out of scope unless the helper fits cleanly" — it fit.)
- Drops the lifetime parameter from `SshSession`: `SshTarget` and `EnvForward` are now owned by the session. This removes `SshSession<'_>` from nine downstream signatures and lets the helper return a self-contained value. Both fields are cheap to clone (small strings, an `IndexMap`).
- Migrates the remaining direct constructors (`start_instance`, `restart_instance`, `lima::install_builder_plugins`) to the owned form. The first two clone `target` because it's reused for logging after the session is built; the lima one moves both since neither is reused.

## Incidental behavior change
In `start_instance`/`restart_instance`, `prepare_env_forwarding` previously ran unconditionally before the `--no-agents` check. It now runs only inside the bootstrap branch. With `--no-agents`, a misconfigured `cmd:`-prefixed secret source no longer fails the boot path. Worth noting for bisect.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (286 passed)
- [ ] Integration test on Lima (macOS) — needs maintainer run
- [ ] Integration test on Firecracker (Linux) — needs maintainer run

🤖 Generated with [Claude Code](https://claude.com/claude-code)