### PR TITLE
Add Rust authoring and review guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,69 @@ SSH commands (`exec`) are unaffected — the remote shell expands `~` normally. 
 ## Tracing output goes to stderr
 
 The coop binary's tracing output (INFO/DEBUG/WARN logs) goes to **stderr**.
+
+## Authoring and reviewing Rust code
+
+These notes complement the global Rust guidance (clippy lints, `thiserror`/`anyhow`, `tracing`, newtypes, enums over bools). The focus here is on **using the type system to eliminate error states** — not on style. Apply these patterns when they pay for themselves; skip them when a primitive is genuinely fine. A type system that fights the reader is worse than one that lets a bug through.
+
+### Lean on the type system before lean on validation
+
+The default move when you see a bug is to add a runtime check. The better move is usually to change a type so the bug cannot be expressed. Before writing a check or returning an error, ask: *can the function signature make this case unreachable?*
+
+- **Parse, don't validate.** A function that takes a `&str` and returns `Result<Url, _>` is better than one that takes a validated `&str` by convention. Downstream code should not have to re-check what an earlier layer already proved. Convert untrusted inputs to strong types at the boundary; pass the strong type inward.
+- **Smart constructors.** When an invariant cannot be expressed structurally, wrap the type in a module-private struct and expose a `fn new(...) -> Result<Self, Error>`. The invariant then holds by construction everywhere the type appears.
+- **Make illegal states unrepresentable.** Two `Option<T>` fields that are always both-`Some` or both-`None` should be one `Option<(T, T)>`. A `bool` plus a payload that's only meaningful when the bool is true should be an `Option`. A `String` that holds one of three values should be an enum.
+
+### Type-state for lifecycles
+
+This crate orchestrates VMs through a sequence — `setup → start → shell → stop → destroy`. Operations are only legal on certain states (you can't `shell` into a stopped VM). When you find yourself writing `if self.state == State::Running { ... } else { return Err(...) }`, consider whether the state belongs in the type rather than in a field.
+
+Two flavors, pick the lightest that works:
+
+- **State enum with method gating.** Cheap and clear: an enum representing the state, and methods that pattern-match the variant and return an error for illegal transitions. Use this when the call sites are few and an explicit error is reasonable.
+- **Type-state with phantom markers.** `Vm<Stopped>`, `Vm<Running>`, where `start(self) -> Vm<Running>` consumes the stopped value. Illegal transitions become compile errors. Use this when the lifecycle is the *primary* abstraction a type exposes and call sites would benefit from compile-time enforcement. Don't reach for it on a type that mostly does something else.
+
+### Newtypes that earn their keep
+
+The global guidance says "newtypes over primitives." In practice the win comes when:
+
+- Two primitives of the same underlying type are easy to swap at a call site (`fn copy(src: PathBuf, dst: PathBuf)` — newtype the destination, or use a struct).
+- A primitive carries an invariant (non-empty, valid UTF-8, an absolute path, a hostname). The newtype's constructor is the one place that invariant is checked.
+- A primitive is a domain concept that shows up in many signatures (a VM name, a guest path, an SSH user). The newtype reads as documentation and resists drift.
+
+If a primitive appears in one place and crosses no boundary, leave it alone. Wrapping `u8` because "newtypes are good" is noise.
+
+### Error design
+
+- Distinct failure modes → distinct enum variants. A function that can fail because the VM is missing *or* because SSH timed out should return an error type whose variants reflect that. Callers can then handle them differently without string-matching.
+- Attach context at boundaries, not at every `?`. Use `anyhow::Context` at the layer where an error becomes user-facing; let library code propagate clean variants. Re-wrapping at every level produces verbose, low-signal errors.
+- `unwrap`/`expect` are forbidden by the global lints in production paths. If you genuinely need one, the comment should explain *why the invariant holds*, not just *what is being unwrapped*. "Safe because `parse` was called above" is a smell — restructure to carry the parsed value through.
+
+### Other small idioms worth checking
+
+- `&str` over `&String`, `&[T]` over `&Vec<T>` in parameters — accepts more callers, costs nothing.
+- `Cow<'_, str>` when a function sometimes returns a borrowed slice and sometimes an owned modification.
+- `NonZeroU32` / `NonZeroUsize` when zero is a real invariant (capacities, indices into a known-nonempty structure).
+- `#[non_exhaustive]` on public enums and structs that may grow variants/fields; saves a breaking change later.
+- `From`/`Into` for infallible conversions, `TryFrom`/`TryInto` for fallible. Don't write `fn from_x(...) -> Result<Self, _>` — that's `TryFrom`.
+- Sealed traits when you publish a trait but want to control implementations.
+
+### Review checklist (in priority order)
+
+1. **Correctness against the spec.** Does the change do what was asked, including edge cases the author may not have surfaced? Run the relevant tests and re-read the diff against the request.
+2. **Invariants in types vs. checks.** Scan for `bool` parameters, primitive types representing domain concepts, sentinel values (`-1`, `""`, `0` meaning "missing"), and `Option<Option<T>>`. Each is a candidate for a stronger type. Flag the ones with real payoff; don't demand a refactor for every primitive.
+3. **Error paths.** Every `?` produces an error that bubbles somewhere. Is the eventual user-facing message specific enough to act on? Are distinct failures distinguishable by the caller without string matching?
+4. **`unwrap`/`expect`/`panic`.** Forbidden by global lints, but easy to slip in. If one exists, the justification must be in a comment and must be load-bearing.
+5. **API surface.** New public items: do they need to be public? Public types: are they `#[non_exhaustive]` where appropriate? Public functions: do they accept the most general parameter types (`&str`, `&[T]`, `impl AsRef<Path>`) without overreaching?
+6. **Tests cover behavior, not shape.** Refactoring the implementation shouldn't break tests if the behavior is the same. Edge cases — empty inputs, boundaries, the error variants the code actually returns — should each have a test.
+7. **Tracing.** New operations that can take time, fail, or alter state should log at an appropriate level. INFO for user-visible lifecycle, DEBUG for internals, WARN/ERROR for actual problems. No `println!`/`eprintln!` outside the CLI's intentional output.
+8. **Cross-platform.** Touching anything backend-shared? Confirm the abstraction still holds for both Firecracker and Lima paths. Integration tests must run on both platforms per the "Before committing" section.
+
+### Authoring checklist
+
+1. **Sketch the types first.** Before writing the body, write the signatures. If the signatures don't make the legal call sequences obvious, the types are wrong — fix them before the implementation locks them in.
+2. **Take the smallest input you need.** `&str` not `String`, `&Path` not `PathBuf`, `&[T]` not `Vec<T>`. Owning is the caller's choice.
+3. **Return owned values; let callers borrow.** The reverse forces lifetimes through the call graph.
+4. **One `?` per error category.** If a function has five `?`s that all produce different user-meaningful errors, the function probably wants an error enum with five variants, not one `anyhow::Error` with five contexts.
+5. **Resist the "configuration knob" reflex.** A new flag, env var, or option is a long-lived commitment. Add it only when a real caller needs it. (See global "no speculative features.")
+6. **Re-read your diff.** Before pushing for review, read your own change as if you were the reviewer. Most cleanup happens here, not in review.


### PR DESCRIPTION
## Summary
- Adds an "Authoring and reviewing Rust code" section to `CLAUDE.md` that complements the global Rust guidance with project-specific patterns
- Focus is on using the type system to eliminate error states: parse-don't-validate, smart constructors, type-state for the VM lifecycle, newtypes that earn their keep, error design
- Includes prioritized review and authoring checklists referencing the Firecracker/Lima split and the cross-platform integration test requirement

## Test plan
- [ ] Read the new section end-to-end and confirm the guidance matches how reviews are conducted in this repo
- [ ] Confirm no duplication of rules already present in the global `~/.claude/CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)