### PR TITLE
Add `coop github setup-pat` wizard for scoped GitHub PAT auth (#85)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -6,10 +6,15 @@
 # data_dir = "~/.coop"          # VM artifacts: images, instances, keys
 # ssh_port = 22                 # Guest SSH port
 # firecracker_bin = "~/.coop/firecracker"  # Linux only
+# GitHub auth strategy. Pick ONE of the two forms below — `github` cannot
+# be both a string and a table at the same time.
+#
+# Form A — simple string:
 # github = "auto"               # "auto", "env", "off", or "pat"
 #
-# Per-repo fine-grained PAT (server-enforced scope to one repo):
-# Run `coop github setup-pat --repo owner/name` to add entries via wizard.
+# Form B — table, required when you want per-repo PAT entries.
+# Run `coop github setup-pat --repo owner/name` to populate it via wizard.
+# Form B `mode = "pat"` is equivalent to form A `github = "pat"`.
 #
 # [github]
 # mode = "pat"

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,7 +6,20 @@
 # data_dir = "~/.coop"          # VM artifacts: images, instances, keys
 # ssh_port = 22                 # Guest SSH port
 # firecracker_bin = "~/.coop/firecracker"  # Linux only
-# github = "auto"               # "auto", "env", or "off"
+# github = "auto"               # "auto", "env", "off", or "pat"
+#
+# Per-repo fine-grained PAT (server-enforced scope to one repo):
+# Run `coop github setup-pat --repo owner/name` to add entries via wizard.
+#
+# [github]
+# mode = "pat"
+# skip = ["owner/big-repo"]       # repos to skip the auto-prompt for
+#
+# [github.pat."trailofbits/coop"]
+# token = "cmd:security find-generic-password -s coop-github-pat -a trailofbits-coop -w"
+
+# [setup]
+# prompt_for_pat = true           # auto-prompt to set up a PAT at `coop start`
 
 # [vm]
 # vcpu_count = 2                # vCPUs per VM (override: --vcpus)

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -98,6 +98,7 @@ The `github` field controls how coop obtains a `GITHUB_TOKEN` for the guest. Thi
 | `"auto"` | Check the `GITHUB_TOKEN` env var first. If unset, run `gh auth token` on the host to extract a token from the GitHub CLI. |
 | `"env"`  | Require `GITHUB_TOKEN` in the host environment. Warns if missing. |
 | `"off"`  | Skip GitHub token forwarding entirely. This is the default when `github` is unset. |
+| `"pat"`  | Use a per-repo fine-grained PAT from `[github.pat]`. Scope is server-enforced to one repo. Run `coop github setup-pat --repo owner/name` to add an entry; see [configuration.md](configuration.md#fine-grained-pat-github--pat) for the full reference. |
 
 When a token is available, coop runs `gh auth setup-git` in the guest during bootstrap. This configures the git credential helper so `git clone` works against private repositories without further setup.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -85,6 +85,7 @@ coop start [NAME] [FLAGS]
 | `--image <name>` | Named image to use (default: `default`) |
 | `--mount <spec>` | Mount host directory into guest (`HOST_PATH[:GUEST_PATH]`, repeatable). Conflicts with `--workspace` and `--git-repo`. |
 | `--exclude-git` | Skip the `.git/` directory when syncing the workspace (conflicts with `--git-repo`). |
+| `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 
 `--workspace` and `--git-repo` are mutually exclusive. Use `--workspace` to tar-pipe a local directory into the guest. Use `--git-repo` to clone a repository inside the VM at boot.
 
@@ -421,12 +422,38 @@ coop update --force
 
 See also the [`updates` section](configuration.md#updates-section) of the configuration reference for the background-notification settings.
 
+### `github`
+
+Manage GitHub authentication. Specifically, the scoped fine-grained PAT (FGPAT) workflow that pairs `github = "pat"` mode with per-repo `[github.pat."owner/repo"]` entries in `config.toml`. See the [GitHub auth section](configuration.md#github-auth) of the configuration reference for the full data model.
+
+```
+coop github <subcommand>
+```
+
+| Subcommand | Effect |
+|------------|--------|
+| `setup-pat [--repo owner/name]` | Run the wizard end-to-end: open the GitHub PAT-creation form, validate the pasted token against `api.github.com`, store it in a chosen secret manager (Keychain / Secret Service / 1Password / file), and write a `[github.pat."owner/repo"]` entry. The repo is auto-detected from `git remote get-url origin` when `--repo` is omitted. |
+| `rotate-pat --repo owner/name` | Re-run the wizard for an existing entry (FGPATs expire — max 1 year). |
+| `status [--probe]` | List configured entries and their storage backend. By default the cmd-invocation is *not* resolved (so Keychain / 1Password prompts don't fire). Pass `--probe` to also resolve each entry and report whether the secret store still serves it. |
+| `forget-pat --repo owner/name` | Delete the stored secret from its backend and drop the `[github.pat."owner/repo"]` entry. Does **not** add a skip marker — use the auto-prompt's `never` answer if you want coop to stop asking about this repo. Does **not** revoke the PAT on GitHub. |
+
+```
+coop github setup-pat --repo trailofbits/coop
+coop github status
+coop github status --probe
+coop github rotate-pat --repo trailofbits/coop
+coop github forget-pat --repo trailofbits/coop
+```
+
 ### `validate`
 
-Check the configuration file and prerequisites. Prints warnings and confirms the config loads correctly.
+Check the configuration file and prerequisites. Prints warnings and confirms the config loads correctly. With `--probe`, also exercises each `[github.pat]` entry against `api.github.com` to confirm the token is still live.
 
 ```
 coop validate
+coop validate --probe
 ```
 
-No additional flags.
+| Flag | Description |
+|------|-------------|
+| `--probe` | For each `[github.pat]` entry, resolve the token and call `GET /user` on `api.github.com` to confirm it authenticates. Network-dependent; may trigger Keychain / 1Password prompts on macOS. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ Other subcommands:
 | `coop github status` | List configured entries, storage backend, and whether each token still resolves. Never prints token material. |
 | `coop github rotate-pat --repo X/Y` | Re-run the wizard against an existing entry (PATs expire — max 1 year). |
 | `coop github forget-pat --repo X/Y` | Remove the stored secret and the `[github.pat."X/Y"]` entry. Does **not** add a skip marker; the token may still be live on GitHub. |
-| `coop validate --probe` | Resolves each entry and probes `GET /user` against api.github.com. |
+| `coop validate --probe` | Resolves each entry and probes `GET /user` against api.github.com. May trigger Keychain authorization or a 1Password Touch-ID prompt the first time per session. |
 
 #### Auto-prompt at `coop start`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ Run `coop validate` to surface errors and warnings before anything touches a VM.
 | `data_dir` | string (path) | `~/.coop` | Directory for VM artifacts: images, instances, keys, kernel, Firecracker binary. |
 | `ssh_port` | integer | `22` | SSH port on the guest VM. Must be > 0. |
 | `firecracker_bin` | string (path) | `~/.coop/firecracker` | Path to the Firecracker binary. Linux only; ignored on macOS (Lima backend). |
-| `github` | string | unset (treated as `"off"`) | GitHub authentication strategy. See [GitHub auth](#github-auth). |
+| `github` | string or table | unset (treated as `"off"`) | GitHub authentication strategy. See [GitHub auth](#github-auth). |
 
 ## GitHub auth
 
@@ -24,8 +24,78 @@ The `github` field determines how coop obtains a `GITHUB_TOKEN` for the guest:
 | `"auto"` | Checks `$GITHUB_TOKEN` first. Falls back to `gh auth token` if unset. |
 | `"env"` | Reads `$GITHUB_TOKEN` from the environment only. Warns if unset. |
 | `"off"` | No GitHub token forwarding. |
+| `"pat"` | Uses a per-repo fine-grained PAT recorded under `[github.pat]`. Scope is **server-enforced** to one repository. |
 
 When a token is present, coop runs `gh auth setup-git` inside the guest to wire up git credential helpers.
+
+### Fine-grained PAT (`github = "pat"`)
+
+In pat mode coop forwards a *per-repo* fine-grained personal access token: the resolved `owner/repo` at `coop start` time selects the matching entry in `[github.pat]`. Compared with `"auto"` / `"env"`, the effective reach of a leaked token is bounded by the repos and permissions GitHub recorded when it was created — GitHub rejects out-of-scope operations (REST and GraphQL) server-side, not in coop.
+
+Configure via the wizard:
+
+```sh
+coop github setup-pat --repo trailofbits/coop
+```
+
+The wizard opens the PAT-creation form in your browser, validates the token via `/user` and `/repos/<repo>`, stores the token in a secret manager you choose (macOS Keychain, Linux Secret Service, 1Password, or a `0600` file under `~/.coop/state/github-pat/`), and writes a `[github.pat."owner/repo"]` entry. The token itself is stored only in the chosen secret manager — the config file holds a `cmd:` invocation that retrieves it.
+
+Multi-repo example:
+
+```toml
+[github]
+mode = "pat"
+
+[github.pat."trailofbits/coop"]
+token = "cmd:security find-generic-password -s coop-github-pat -a trailofbits-coop -w"
+
+[github.pat."trailofbits/coop-plugins"]
+token = "cmd:security find-generic-password -s coop-github-pat -a trailofbits-coop-plugins -w"
+```
+
+Bring-your-own-token (no wizard, useful for CI/Terraform). Any `cmd:` invocation that prints the token on stdout works. Examples:
+
+```toml
+[github]
+mode = "pat"
+
+# Vault
+[github.pat."trailofbits/coop"]
+token = "cmd:vault read -field=token secret/coop/github/trailofbits-coop"
+
+# 1Password (matches what the wizard emits)
+[github.pat."trailofbits/coop-plugins"]
+token = "cmd:op item get 'coop-github-pat (trailofbits-coop-plugins)' --fields password --reveal"
+```
+
+Other subcommands:
+
+| Command | Effect |
+|---------|--------|
+| `coop github status` | List configured entries, storage backend, and whether each token still resolves. Never prints token material. |
+| `coop github rotate-pat --repo X/Y` | Re-run the wizard against an existing entry (PATs expire — max 1 year). |
+| `coop github forget-pat --repo X/Y` | Remove the stored secret and the `[github.pat."X/Y"]` entry. Does **not** add a skip marker; the token may still be live on GitHub. |
+| `coop validate --probe` | Resolves each entry and probes `GET /user` against api.github.com. |
+
+#### Auto-prompt at `coop start`
+
+When `coop start` runs with a resolvable repo (from `--git-repo` or the synced workspace's `origin`) and `github` is `"off"` (or `"pat"` with no matching entry), coop offers to run the wizard inline: `[y/N/never]`. Three answers:
+
+- `y` — run the wizard, then continue the start.
+- `N` (default) — start unauthenticated, ask again next time.
+- `never` — record a skip marker under `[github.skip]` so coop won't ask again for this repo.
+
+Non-interactive contexts (`CI` is set, stdin is not a TTY) skip the prompt and log a one-line tip pointing at `coop github setup-pat`. The `--no-prompt` flag skips the prompt silently. Set `[setup] prompt_for_pat = false` in `config.toml` to disable the prompt globally.
+
+#### Skip markers
+
+```toml
+[github]
+mode = "pat"
+skip = ["trailofbits/big-repo"]
+```
+
+`coop github setup-pat --repo X/Y` removes any skip marker for `X/Y` when it adds a new entry.
 
 ## `vm` section
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,8 +70,9 @@ The `github` field controls how coop resolves a GitHub token for the guest:
 - `"off"` (default): disables GitHub auth forwarding
 - `"auto"`: checks `$GITHUB_TOKEN` env var first, falls back to `gh auth token` if unset
 - `"env"`: requires `GITHUB_TOKEN` in your environment
+- `"pat"`: forwards a per-repo fine-grained PAT recorded under `[github.pat."owner/repo"]`. GitHub enforces the token's scope server-side — see [GitHub auth](configuration.md#fine-grained-pat-github--pat) for the full reference.
 
-GitHub auth is off by default. Set `github = "auto"` explicitly to enable it.
+GitHub auth is off by default. Set `github = "auto"` (or run `coop github setup-pat --repo owner/name` for a scoped PAT) to enable it. `coop start` itself offers to run the PAT wizard inline the first time you start an instance against a GitHub repo without auth configured.
 
 coop picks up `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from your environment automatically. Setting them explicitly under `claude.api_key` or `codex.api_key` also works, but environment variables are preferred.
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -865,6 +865,30 @@ pub type PlatformBackend = FirecrackerBackend;
 
 // ── Shared guest operations ───────────────────────────────────
 
+/// Detect the GitHub `owner/repo` slug for an existing instance, if any.
+///
+/// Looks at the saved workspace state in priority order: a `git-repo`
+/// clone records the original URL (parsed for a slug); a `workspace` /
+/// `mount` source has a host path we can scan for a `.git/config`
+/// `origin`. Returns `None` when no slug can be derived — pat-mode
+/// then falls back to a clear error.
+pub fn detect_instance_repo(inst: &crate::config::Instance) -> Option<String> {
+    let state = crate::workspace::WorkspaceState::try_load(inst)
+        .ok()
+        .flatten()?;
+    if let Some(url) = state.git_repo_url.as_deref()
+        && let Some(slug) = crate::github_repo::parse_repo_slug_from_url(url)
+    {
+        return Some(slug);
+    }
+    if let Some(host) = state.host_path.as_deref()
+        && let Ok(Some(slug)) = crate::github_repo::detect_workspace_repo(host)
+    {
+        return Some(slug);
+    }
+    None
+}
+
 /// Resolve tokens and build env vars to forward via SSH `SendEnv`.
 ///
 /// Collects values from config and the process environment into an
@@ -873,7 +897,13 @@ pub type PlatformBackend = FirecrackerBackend;
 /// `claude.api_key` values that use the `cmd:` prefix are resolved
 /// here (at VM start time, not config parse time) so that secret
 /// manager calls only happen when actually needed.
-pub fn prepare_env_forwarding(cfg: &CoopConfig) -> Result<EnvForward> {
+///
+/// When `github = "pat"`, `repo` selects the matching entry under
+/// `[github.pat]`. Pass the slug resolved from `--git-repo` or
+/// `git remote get-url origin` of the workspace. Pass `None` when no
+/// repo context is available; pat-mode then yields no token (the start
+/// flow surfaces a clearer error elsewhere).
+pub fn prepare_env_forwarding(cfg: &CoopConfig, repo: Option<&str>) -> Result<EnvForward> {
     let claude = &cfg.claude;
     let codex = &cfg.codex;
     let mut env = EnvForward::default();
@@ -897,8 +927,10 @@ pub fn prepare_env_forwarding(cfg: &CoopConfig) -> Result<EnvForward> {
     }
 
     // GITHUB_TOKEN: resolve via configured strategy
-    if let Some(token) = resolve_github_token(cfg.github.as_ref()) {
+    if let Some(token) = resolve_github_token(cfg.github.as_ref(), repo)? {
         env.set("GITHUB_TOKEN", token);
+    } else {
+        tracing::debug!("no GITHUB_TOKEN forwarded to guest");
     }
 
     // User-specified env_forward vars from process environment
@@ -1078,15 +1110,24 @@ fn compute_plugin_delta(cfg: &CoopConfig, image: &str) -> (Vec<String>, Vec<Stri
     }
 }
 
-fn resolve_github_token(strategy: Option<&GitHubAuth>) -> Option<String> {
+/// Resolve a GitHub token for the guest given the configured auth strategy
+/// and the resolved target repo (when known).
+///
+/// Returns `Ok(None)` when no token should be forwarded; errors when a
+/// strategy was selected but the lookup is unrecoverable (e.g. pat-mode
+/// with an entry that fails to resolve).
+fn resolve_github_token(
+    strategy: Option<&GitHubAuth>,
+    repo: Option<&str>,
+) -> Result<Option<String>> {
     // Default to Off — never forward tokens without explicit opt-in.
-    // Users must set `github = "auto"` or `github = "env"` in
+    // Users must set `github = "auto"` / `"env"` / `"pat"` in
     // config.toml to enable GitHub auth in the guest.
     match strategy.unwrap_or(&GitHubAuth::Off) {
-        GitHubAuth::Auto => std::env::var("GITHUB_TOKEN")
+        GitHubAuth::Auto => Ok(std::env::var("GITHUB_TOKEN")
             .ok()
             .filter(|t| !t.is_empty())
-            .or_else(gh_auth_token),
+            .or_else(gh_auth_token)),
         GitHubAuth::Env => {
             let token = std::env::var("GITHUB_TOKEN").ok().filter(|t| !t.is_empty());
             if token.is_none() {
@@ -1095,10 +1136,39 @@ fn resolve_github_token(strategy: Option<&GitHubAuth>) -> Option<String> {
                      Private repo access will fail."
                 );
             }
-            token
+            Ok(token)
         }
-        GitHubAuth::Off => None,
+        GitHubAuth::Off => Ok(None),
+        GitHubAuth::Pat(_) => {
+            if let Some(slug) = repo {
+                resolve_pat_token(strategy, slug).map(Some)
+            } else {
+                tracing::warn!(
+                    "github: \"pat\" requires a resolvable repo (via --git-repo or \
+                     workspace origin). No token will be forwarded."
+                );
+                Ok(None)
+            }
+        }
     }
+}
+
+/// Look up a `[github.pat."repo"]` entry and resolve its `token` via
+/// the `cmd:` indirection.
+fn resolve_pat_token(strategy: Option<&GitHubAuth>, repo: &str) -> Result<String> {
+    let entry = strategy
+        .and_then(|s| s.pat_entry(repo))
+        .with_context(|| crate::github_pat::missing_entry_error(repo))?;
+    let token = crate::config::resolve_cmd_value(&entry.token)
+        .with_context(|| format!("Failed to resolve token for [github.pat.\"{repo}\"]"))?;
+    if !token.starts_with(crate::github_pat::TOKEN_PREFIX) {
+        tracing::warn!(
+            "github.pat.\"{repo}\".token did not start with '{prefix}' — proceeding, \
+             but the FGPAT server-side scope guarantees do not apply.",
+            prefix = crate::github_pat::TOKEN_PREFIX,
+        );
+    }
+    Ok(token)
 }
 
 fn setup_github_auth(session: &SshSession) -> Result<()> {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1140,15 +1140,26 @@ fn resolve_github_token(
         }
         GitHubAuth::Off => Ok(None),
         GitHubAuth::Pat(_) => {
-            if let Some(slug) = repo {
-                resolve_pat_token(strategy, slug).map(Some)
-            } else {
+            let Some(slug) = repo else {
                 tracing::warn!(
                     "github: \"pat\" requires a resolvable repo (via --git-repo or \
                      workspace origin). No token will be forwarded."
                 );
-                Ok(None)
+                return Ok(None);
+            };
+            // Missing entry is not fatal: follow-up commands (shell / exec /
+            // claude / codex / restart) must still work without a token,
+            // matching the "off" mode shape. The wizard's pre-flight prompt
+            // is the discovery path for missing entries.
+            if strategy.and_then(|s| s.pat_entry(slug)).is_none() {
+                tracing::warn!(
+                    "github: \"pat\" mode has no [github.pat.\"{slug}\"] entry. \
+                     No token forwarded. Run `coop github setup-pat --repo {slug}` \
+                     to add one."
+                );
+                return Ok(None);
             }
+            resolve_pat_token(strategy, slug).map(Some)
         }
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -14,6 +14,9 @@ pub struct Cmd {
     args: Vec<OsString>,
     sudo: bool,
     stdin: Option<Vec<u8>>,
+    /// Indices into `args` whose values should be redacted in [`Cmd::describe`].
+    /// Use [`Cmd::redact_next`] when staging an arg that carries a secret.
+    redacted_args: Vec<usize>,
 }
 
 impl Cmd {
@@ -23,11 +26,24 @@ impl Cmd {
             args: Vec::new(),
             sudo: false,
             stdin: None,
+            redacted_args: Vec::new(),
         }
     }
 
     pub fn arg(mut self, arg: impl AsRef<OsStr>) -> Self {
         self.args.push(arg.as_ref().to_owned());
+        self
+    }
+
+    /// Add an argument that holds a secret, redacted in [`Cmd::describe`]
+    /// (and therefore in debug logs). The bytes still appear on argv —
+    /// callers should prefer [`Cmd::stdin_input`] when the tool supports
+    /// reading from stdin. Use this only for tools that have no
+    /// stdin-friendly path (e.g. macOS `security add-generic-password -w`).
+    pub fn redacted_arg(mut self, arg: impl AsRef<OsStr>) -> Self {
+        let idx = self.args.len();
+        self.args.push(arg.as_ref().to_owned());
+        self.redacted_args.push(idx);
         self
     }
 
@@ -81,7 +97,18 @@ impl Cmd {
         if self.args.is_empty() {
             format!("{prefix}{prog}")
         } else {
-            let args: Vec<_> = self.args.iter().map(|a| a.to_string_lossy()).collect();
+            let args: Vec<String> = self
+                .args
+                .iter()
+                .enumerate()
+                .map(|(i, a)| {
+                    if self.redacted_args.contains(&i) {
+                        "<redacted>".to_string()
+                    } else {
+                        a.to_string_lossy().into_owned()
+                    }
+                })
+                .collect();
             format!("{prefix}{prog} {}", args.join(" "))
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -945,6 +945,23 @@ impl CoopConfig {
             }
         }
 
+        if let Some(GitHubAuth::Pat(pat)) = self.github.as_ref() {
+            for key in pat.entries.keys() {
+                if let Err(e) = crate::github_repo::validate_repo_slug(key) {
+                    errors.push(format!(
+                        "github.pat.\"{key}\" key is not a valid 'owner/repo' slug: {e}"
+                    ));
+                }
+            }
+            for slug in &pat.skip {
+                if let Err(e) = crate::github_repo::validate_repo_slug(slug) {
+                    errors.push(format!(
+                        "github.skip entry '{slug}' is not a valid 'owner/repo' slug: {e}"
+                    ));
+                }
+            }
+        }
+
         if errors.is_empty() {
             Ok(warnings)
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,6 +281,10 @@ pub struct CoopConfig {
     #[serde(default)]
     pub github: Option<GitHubAuth>,
 
+    /// Setup-time UX behaviour
+    #[serde(default)]
+    pub setup: SetupConfig,
+
     /// Claude Code config forwarding settings
     #[serde(default)]
     pub claude: ClaudeConfig,
@@ -354,12 +358,179 @@ pub struct NetworkConfig {
     pub host_iface: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+/// GitHub authentication mode for the guest VM.
+///
+/// Accepts either a plain string (`"auto"`, `"env"`, `"off"`, `"pat"`)
+/// or a table form. The table form is required to attach per-repo PAT
+/// entries (see [`PatConfig`]):
+///
+/// ```toml
+/// [github]
+/// mode = "pat"
+/// skip = ["owner/big-repo"]
+///
+/// [github.pat."owner/repo"]
+/// token = "cmd:security find-generic-password -s coop-github-pat -a owner-repo -w"
+/// ```
+///
+/// The plain string `"pat"` form is equivalent to a table with `mode = "pat"`
+/// and no `pat` entries — lookup will fail at start-time until an entry is added.
+#[derive(Debug, Clone)]
 pub enum GitHubAuth {
     Auto,
     Env,
     Off,
+    Pat(PatConfig),
+}
+
+impl GitHubAuth {
+    /// Short, human-readable name for the configured mode.
+    pub fn mode_name(&self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Env => "env",
+            Self::Off => "off",
+            Self::Pat(_) => "pat",
+        }
+    }
+
+    /// Look up a `[github.pat."owner/repo"]` entry by repo slug.
+    ///
+    /// Returns `None` for non-pat modes or when no entry exists.
+    pub fn pat_entry(&self, repo: &str) -> Option<&PatEntry> {
+        match self {
+            Self::Pat(cfg) => cfg.entries.get(repo),
+            _ => None,
+        }
+    }
+}
+
+/// Top-level `[github]` table with PAT entries and skip markers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PatConfig {
+    /// Per-repo PAT entries, keyed by `owner/repo`.
+    ///
+    /// Uses `BTreeMap` so TOML serialization is stable across runs.
+    #[serde(default, rename = "pat")]
+    pub entries: std::collections::BTreeMap<String, PatEntry>,
+    /// Repos for which the auto-prompt at `coop start` is suppressed.
+    #[serde(default)]
+    pub skip: Vec<String>,
+}
+
+/// One per-repo PAT entry under `[github.pat."owner/repo"]`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatEntry {
+    /// Token value. Accepts a literal token or a `cmd:`-prefixed shell
+    /// command. Resolved via [`resolve_cmd_value`].
+    pub token: String,
+}
+
+/// Custom deserializer accepts either a string (legacy/simple) or a table.
+impl<'de> Deserialize<'de> for GitHubAuth {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::{Error, MapAccess, Visitor};
+
+        struct AuthVisitor;
+
+        impl<'de> Visitor<'de> for AuthVisitor {
+            type Value = GitHubAuth;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a string (\"auto\" / \"env\" / \"off\" / \"pat\") or a table")
+            }
+
+            fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "auto" => Ok(GitHubAuth::Auto),
+                    "env" => Ok(GitHubAuth::Env),
+                    "off" => Ok(GitHubAuth::Off),
+                    "pat" => Ok(GitHubAuth::Pat(PatConfig::default())),
+                    other => Err(E::custom(format!(
+                        "unknown github mode '{other}' (expected auto, env, off, or pat)"
+                    ))),
+                }
+            }
+
+            fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
+                self.visit_str(&v)
+            }
+
+            fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+                #[derive(Deserialize)]
+                #[serde(field_identifier, rename_all = "snake_case")]
+                enum Field {
+                    Mode,
+                    Pat,
+                    Skip,
+                    #[serde(other)]
+                    Unknown,
+                }
+
+                let mut mode: Option<String> = None;
+                let mut entries: Option<std::collections::BTreeMap<String, PatEntry>> = None;
+                let mut skip: Option<Vec<String>> = None;
+                while let Some(field) = map.next_key::<Field>()? {
+                    match field {
+                        Field::Mode => mode = Some(map.next_value()?),
+                        Field::Pat => entries = Some(map.next_value()?),
+                        Field::Skip => skip = Some(map.next_value()?),
+                        Field::Unknown => {
+                            let _: serde::de::IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+
+                // When the table form omits `mode`, the implied mode is
+                // "pat" if any pat/skip entries are present (the user is
+                // recording per-repo intent without explicitly stating
+                // the mode); otherwise "off".
+                let has_pat_data =
+                    entries.as_ref().is_some_and(|m| !m.is_empty()) || skip.is_some();
+                let mode = mode
+                    .or_else(|| has_pat_data.then(|| "pat".to_string()))
+                    .unwrap_or_else(|| "off".to_string());
+                match mode.as_str() {
+                    "auto" => Ok(GitHubAuth::Auto),
+                    "env" => Ok(GitHubAuth::Env),
+                    "off" => Ok(GitHubAuth::Off),
+                    "pat" => Ok(GitHubAuth::Pat(PatConfig {
+                        entries: entries.unwrap_or_default(),
+                        skip: skip.unwrap_or_default(),
+                    })),
+                    other => Err(M::Error::custom(format!(
+                        "unknown github mode '{other}' (expected auto, env, off, or pat)"
+                    ))),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(AuthVisitor)
+    }
+}
+
+/// Serialize as a string for `auto`/`env`/`off` modes, and as a table
+/// for `pat` mode (so per-repo entries round-trip).
+impl Serialize for GitHubAuth {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Auto => serializer.serialize_str("auto"),
+            Self::Env => serializer.serialize_str("env"),
+            Self::Off => serializer.serialize_str("off"),
+            Self::Pat(cfg) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(3))?;
+                map.serialize_entry("mode", "pat")?;
+                if !cfg.entries.is_empty() {
+                    map.serialize_entry("pat", &cfg.entries)?;
+                }
+                if !cfg.skip.is_empty() {
+                    map.serialize_entry("skip", &cfg.skip)?;
+                }
+                map.end()
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -468,6 +639,29 @@ pub struct ClaudeConfig {
     /// Source directory for Claude config files (CLAUDE.md, rules/, commands/)
     #[serde(default)]
     pub config_dir: ConfigDir,
+}
+
+/// `[setup]` section: controls one-time UX behaviour at `coop start`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetupConfig {
+    /// Whether `coop start` prompts the user to set up a fine-grained PAT
+    /// when the resolved repo has no entry. Set to `false` to suppress
+    /// globally. The per-repo `skip` list under `[github]` suppresses
+    /// individual repos.
+    #[serde(default = "default_prompt_for_pat")]
+    pub prompt_for_pat: bool,
+}
+
+impl Default for SetupConfig {
+    fn default() -> Self {
+        Self {
+            prompt_for_pat: default_prompt_for_pat(),
+        }
+    }
+}
+
+fn default_prompt_for_pat() -> bool {
+    true
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -986,6 +1180,7 @@ impl Default for CoopConfig {
             ssh_port: default_ssh_port(),
             firecracker_bin: default_firecracker_bin(),
             github: None,
+            setup: SetupConfig::default(),
             claude: ClaudeConfig::default(),
             codex: CodexConfig::default(),
             profiles: HashMap::new(),
@@ -1266,6 +1461,7 @@ fn default_firecracker_bin() -> PathBuf {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::panic, reason = "tests use panic! for unreachable arms")]
 mod tests {
     use super::*;
     use tempfile::TempDir;
@@ -1690,6 +1886,124 @@ mod tests {
             serde_json::from_str::<GitHubAuth>(r#""off""#).unwrap(),
             GitHubAuth::Off
         ));
+        assert!(matches!(
+            serde_json::from_str::<GitHubAuth>(r#""pat""#).unwrap(),
+            GitHubAuth::Pat(_)
+        ));
+    }
+
+    #[test]
+    fn github_auth_rejects_unknown_mode() {
+        let err = serde_json::from_str::<GitHubAuth>(r#""bogus""#).unwrap_err();
+        assert!(err.to_string().contains("bogus"));
+    }
+
+    #[test]
+    fn github_auth_table_form_with_entries() {
+        let toml_str = r#"
+mode = "pat"
+
+[pat."trailofbits/coop"]
+token = "cmd:echo x"
+
+[pat."trailofbits/coop-plugins"]
+token = "cmd:echo y"
+"#;
+        let auth: GitHubAuth = toml::from_str(toml_str).unwrap();
+        let pat = match auth {
+            GitHubAuth::Pat(p) => p,
+            other => panic!("expected Pat variant, got {other:?}"),
+        };
+        assert_eq!(pat.entries.len(), 2);
+        assert_eq!(
+            pat.entries
+                .get("trailofbits/coop")
+                .map(|e| e.token.as_str()),
+            Some("cmd:echo x")
+        );
+        assert!(pat.skip.is_empty());
+    }
+
+    #[test]
+    fn github_auth_table_form_with_skip_only() {
+        // No explicit `mode`, no entries, only a skip array. Should
+        // parse as pat-mode with empty entries and the recorded skip list.
+        let toml_str = r#"
+skip = ["a/b"]
+"#;
+        let auth: GitHubAuth = toml::from_str(toml_str).unwrap();
+        let pat = match auth {
+            GitHubAuth::Pat(p) => p,
+            other => panic!("expected Pat variant, got {other:?}"),
+        };
+        assert_eq!(pat.skip, vec!["a/b".to_string()]);
+        assert!(pat.entries.is_empty());
+    }
+
+    #[test]
+    fn github_auth_lookup_returns_entry() {
+        let toml_str = r#"
+mode = "pat"
+
+[pat."a/b"]
+token = "cmd:echo x"
+"#;
+        let auth: GitHubAuth = toml::from_str(toml_str).unwrap();
+        let entry = auth.pat_entry("a/b").unwrap();
+        assert_eq!(entry.token, "cmd:echo x");
+        assert!(auth.pat_entry("c/d").is_none());
+    }
+
+    #[test]
+    fn github_auth_lookup_returns_none_for_non_pat_modes() {
+        let auth = GitHubAuth::Auto;
+        assert!(auth.pat_entry("a/b").is_none());
+        let auth = GitHubAuth::Env;
+        assert!(auth.pat_entry("a/b").is_none());
+        let auth = GitHubAuth::Off;
+        assert!(auth.pat_entry("a/b").is_none());
+    }
+
+    #[test]
+    fn github_auth_serializes_round_trip_for_pat() {
+        // pat-mode → table form; deserialize the serialized output and
+        // confirm the entries survived.
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            "a/b".to_string(),
+            PatEntry {
+                token: "cmd:echo x".to_string(),
+            },
+        );
+        let auth = GitHubAuth::Pat(PatConfig {
+            entries,
+            skip: vec!["c/d".to_string()],
+        });
+        let serialized = toml::to_string(&auth).unwrap();
+        let parsed: GitHubAuth = toml::from_str(&serialized).unwrap();
+        let pat = match parsed {
+            GitHubAuth::Pat(p) => p,
+            other => panic!("expected Pat variant after round-trip, got {other:?}"),
+        };
+        assert_eq!(pat.skip, vec!["c/d".to_string()]);
+        assert_eq!(
+            pat.entries.get("a/b").map(|e| e.token.as_str()),
+            Some("cmd:echo x")
+        );
+    }
+
+    #[test]
+    fn github_auth_serializes_string_form_for_simple_modes() {
+        for (auth, want) in [
+            (GitHubAuth::Auto, "\"auto\""),
+            (GitHubAuth::Env, "\"env\""),
+            (GitHubAuth::Off, "\"off\""),
+        ] {
+            // serde_json gives a JSON-style scalar; sufficient to confirm
+            // the serializer chose a string, not an object.
+            let json = serde_json::to_string(&auth).unwrap();
+            assert_eq!(json, want);
+        }
     }
 
     #[test]

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,9 +1,10 @@
-use std::fs;
+use std::fs::{self, File};
 use std::os::unix::fs::PermissionsExt as _;
+use std::os::unix::io::AsRawFd as _;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 /// Build a writer-unique sibling temp path. Including pid + a nanosecond
 /// counter keeps concurrent writers (across threads or processes) from
@@ -54,6 +55,85 @@ pub fn atomic_write_json(path: &Path, json: &str) -> Result<()> {
         )
     })?;
 
+    Ok(())
+}
+
+/// RAII file lock acquired via `flock(LOCK_EX)`. Blocks until the lock
+/// is available; releases on drop.
+///
+/// Use [`lock_sibling`] to obtain a lock keyed off a target path.
+pub struct FileLock {
+    _file: File,
+}
+
+/// Acquire an exclusive flock on a sibling `.lock` file next to `target`.
+///
+/// The lock file is created if necessary and lives across calls — its
+/// purpose is purely to serialize access to `target`. Releases on drop.
+/// Returns an error if the parent directory cannot be created or the
+/// lock cannot be acquired.
+pub fn lock_sibling(target: &Path) -> Result<FileLock> {
+    let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    if !parent.as_os_str().is_empty() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+    let stem = target
+        .file_name()
+        .map_or_else(|| "coop".to_string(), |n| n.to_string_lossy().into_owned());
+    let lock_path = parent.join(format!(".{stem}.lock"));
+    let file = File::create(&lock_path)
+        .with_context(|| format!("Failed to create lock file {}", lock_path.display()))?;
+    // SAFETY: flock is safe on a valid fd. The File owns the fd and
+    // outlives this call.
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if ret != 0 {
+        bail!(
+            "Failed to acquire lock on {}: {}",
+            lock_path.display(),
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(FileLock { _file: file })
+}
+
+/// Write `content` to `path` atomically with permissions `mode`.
+///
+/// If the target file already exists with stricter permissions (any
+/// bit in `mode` not also set on the existing file), the existing
+/// permissions are preserved — we never relax a file's mode.
+pub fn atomic_write_with_mode(path: &Path, content: &str, mode: u32) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("Cannot determine parent directory for atomic write")?;
+    if !parent.as_os_str().is_empty() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+    let perms = if path.exists() {
+        let existing = fs::metadata(path)
+            .with_context(|| format!("Failed to read metadata for {}", path.display()))?
+            .permissions()
+            .mode()
+            & 0o777;
+        // Pick the more restrictive of (existing, requested).
+        let combined = existing & mode;
+        fs::Permissions::from_mode(combined)
+    } else {
+        fs::Permissions::from_mode(mode)
+    };
+    let tmp_path = unique_tmp_path(path);
+    fs::write(&tmp_path, content)
+        .with_context(|| format!("Failed to write temp file {}", tmp_path.display()))?;
+    fs::set_permissions(&tmp_path, perms)
+        .with_context(|| format!("Failed to set permissions on {}", tmp_path.display()))?;
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "Failed to rename {} -> {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })?;
     Ok(())
 }
 

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -255,6 +255,12 @@ fn read_token_no_echo() -> Result<String> {
 /// it on drop. Disabling fails silently if no controlling TTY exists or
 /// `stty` is unavailable (`is_active` then returns false, so the caller
 /// can skip the trailing newline).
+///
+/// `Drop` runs on normal scope exit but **not** when the process is killed
+/// by an uncaught signal (Ctrl-C / SIGTERM). Users who interrupt the
+/// wizard mid-paste can restore echo with `stty echo`. A `tcsetattr`-based
+/// implementation would let the kernel handle restoration via terminal
+/// reset, but the shell-out keeps the dependency footprint minimal.
 struct EchoGuard {
     active: bool,
 }

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -399,7 +399,8 @@ fn pick_backend() -> Result<crate::secret_store::Backend> {
 /// writes.
 fn upsert_pat_entry(path: &Path, repo: &str, token_cmd: &str) -> Result<()> {
     let _lock = crate::fs_util::lock_sibling(path)?;
-    let mut doc = read_or_init_doc(path)?;
+    let original = read_or_init_doc(path)?;
+    let mut doc = original.clone();
 
     // Ensure the `github` table exists.
     let github = doc
@@ -442,6 +443,17 @@ fn upsert_pat_entry(path: &Path, repo: &str, token_cmd: &str) -> Result<()> {
         arr.retain(|v| v.as_str() != Some(repo));
     }
 
+    // Skip the rewrite when the parsed result equals what's already on disk.
+    // `rotate-pat` routinely hits this: the `cmd:` invocation produced by
+    // `store_secret` is deterministic in `(service, account)` for every
+    // backend we support, so re-storing the same repo's token through the
+    // same backend yields an entry value identical to the existing one.
+    // Without this guard each rotation would rewrite the file (bumping mtime
+    // and stripping any user-added comments via the `toml::Value` round-trip)
+    // for no observable change in coop's behaviour.
+    if doc == original {
+        return Ok(());
+    }
     write_doc(path, &doc)
 }
 
@@ -604,6 +616,24 @@ mod tests {
         upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
         let cfg = CoopConfig::load(&path).unwrap();
         assert!(matches!(cfg.github, Some(GitHubAuth::Pat(_))));
+    }
+
+    #[test]
+    fn upsert_is_noop_when_entry_unchanged() {
+        // Re-upserting the same (repo, cmd) into an already-pat config must
+        // not rewrite the file. Verified by leaving a comment in the input
+        // — `toml::Value` strips comments on round-trip, so a rewrite would
+        // be visible as comment loss.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        let original = "# user comment\n[github]\nmode = \"pat\"\n\n[github.pat.\"a/b\"]\ntoken = \"cmd:echo x\"\n";
+        std::fs::write(&path, original).unwrap();
+        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            after, original,
+            "no-op upsert must not rewrite the file (lost comments / formatting)"
+        );
     }
 
     #[test]

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -1,0 +1,683 @@
+//! `coop github` subcommand implementations: the fine-grained PAT wizard
+//! and helpers for `rotate-pat`, `status`, `forget-pat`.
+//!
+//! The wizard is intentionally a thin orchestration layer over the secret
+//! store and the validation helpers. Anything that talks to GitHub goes
+//! through `curl` so we don't pick up a new HTTP-client dependency.
+
+#![expect(
+    clippy::print_stderr,
+    reason = "wizard is interactive CLI — stderr is user communication"
+)]
+#![expect(
+    clippy::print_stdout,
+    reason = "wizard is interactive CLI — stdout is user communication"
+)]
+
+use std::fs;
+use std::io::{BufRead as _, Write as _};
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+use crate::cmd::Cmd;
+use crate::config::{CoopConfig, GitHubAuth, resolve_cmd_value};
+use crate::github_repo::{detect_workspace_repo, parse_repo_slug_from_url, validate_repo_slug};
+use crate::secret_store::{
+    SERVICE, account_for_repo, available_backends, delete_secret, infer_backend, store_secret,
+};
+
+/// Prefix every fine-grained PAT starts with. Surfaced as `pub const` so
+/// `backend.rs` and `main.rs` can share the same literal for validation.
+pub const TOKEN_PREFIX: &str = "github_pat_";
+
+const PAT_NEW_URL: &str = "https://github.com/settings/personal-access-tokens/new";
+
+/// Options resolved by clap for `coop github setup-pat`.
+pub struct SetupOpts<'a> {
+    pub repo: Option<&'a str>,
+    pub config_path: &'a Path,
+}
+
+/// Entry point: run the wizard end-to-end.
+///
+/// On success, the on-disk config has a fresh `[github.pat."owner/repo"]`
+/// entry and any matching skip-marker is removed.
+pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
+    let repo = resolve_target_repo(opts.repo, None)?;
+    validate_repo_slug(&repo)?;
+
+    print_form_instructions(&repo);
+    open_browser_best_effort(PAT_NEW_URL);
+
+    let token = read_token_no_echo()?;
+    warn_token_format(&token);
+    eprintln!("\nValidating token against api.github.com…");
+    probe_user(&token)?;
+    probe_repo(&token, &repo)?;
+
+    let backend = pick_backend()?;
+    let account = account_for_repo(&repo);
+    let state_dir = cfg.data_dir.join("state");
+    fs::create_dir_all(&state_dir)
+        .with_context(|| format!("Failed to create {}", state_dir.display()))?;
+
+    let cmd_str = store_secret(backend, SERVICE, &account, &token, &state_dir)
+        .context("Failed to store secret in chosen backend")?;
+
+    upsert_pat_entry(opts.config_path, &repo, &cmd_str)?;
+
+    eprintln!(
+        "\nWrote {}:\n  github.mode = \"pat\"\n  [github.pat.\"{repo}\"]\n  token = \"{}\"",
+        opts.config_path.display(),
+        cmd_str,
+    );
+    eprintln!("\nDone. `coop start --git-repo https://github.com/{repo}` will use this token.");
+    Ok(())
+}
+
+/// `coop github rotate-pat` — same wizard, but messaging hints that
+/// we're replacing an existing entry.
+pub fn run_rotate_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
+    let repo = resolve_target_repo(opts.repo, None)?;
+    if cfg
+        .github
+        .as_ref()
+        .and_then(|g| g.pat_entry(&repo))
+        .is_none()
+    {
+        eprintln!(
+            "note: no existing PAT entry for '{repo}' — proceeding as if this were a fresh setup."
+        );
+    }
+    run_setup_pat(cfg, opts)
+}
+
+/// `coop github status` — print one line per pat entry.
+///
+/// Output is plain text, sorted by repo name. The token value is never
+/// printed. When `probe` is true, each `cmd:` invocation is resolved to
+/// confirm the secret store still serves it — this may trigger a
+/// Keychain dialog / `op` Touch-ID prompt per entry, so it is opt-in.
+pub fn run_status(cfg: &CoopConfig, probe: bool) {
+    let pat = match cfg.github.as_ref() {
+        Some(GitHubAuth::Pat(c)) => c,
+        Some(other) => {
+            println!("github mode: {} (no PAT entries)", other.mode_name());
+            return;
+        }
+        None => {
+            println!("github mode: off (no PAT entries)");
+            return;
+        }
+    };
+
+    if pat.entries.is_empty() && pat.skip.is_empty() {
+        println!("github mode: pat (no entries)");
+        return;
+    }
+
+    println!("github mode: pat");
+    println!("entries ({}):", pat.entries.len());
+    for (repo, entry) in &pat.entries {
+        let backend_label = infer_backend(&entry.token)
+            .map_or_else(|| "unknown".to_string(), |b| b.label().to_string());
+        println!("  {repo}");
+        println!("    storage: {backend_label}");
+        if probe {
+            let validity = match resolve_cmd_value(&entry.token) {
+                Ok(token) if token.starts_with(TOKEN_PREFIX) => "resolves, format ok",
+                Ok(_) => "resolves but unexpected format",
+                Err(_) => "FAILED to resolve",
+            };
+            println!("    status:  {validity}");
+        }
+    }
+    if !pat.skip.is_empty() {
+        println!("skip ({}):", pat.skip.len());
+        for repo in &pat.skip {
+            println!("  {repo}");
+        }
+    }
+}
+
+/// `coop github forget-pat --repo owner/name` — remove the secret and
+/// the config entry. Does **not** add a skip marker.
+pub fn run_forget_pat(cfg: &CoopConfig, repo: &str, config_path: &Path) -> Result<()> {
+    validate_repo_slug(repo)?;
+    let entry = cfg
+        .github
+        .as_ref()
+        .and_then(|g| g.pat_entry(repo))
+        .with_context(|| {
+            format!("No PAT entry for '{repo}' — nothing to forget. Run `coop github status`.")
+        })?;
+    let backend = infer_backend(&entry.token);
+    let account = account_for_repo(repo);
+    let state_dir = cfg.data_dir.join("state");
+    if let Some(b) = backend {
+        if let Err(e) = delete_secret(b, SERVICE, &account, &state_dir) {
+            tracing::warn!("Failed to remove secret from backend (continuing): {e}");
+        }
+    } else {
+        tracing::info!(
+            "Storage backend not recognised from cmd: invocation — config entry removed; \
+             clean up the underlying secret manually if needed."
+        );
+    }
+    remove_pat_entry(config_path, repo)?;
+    eprintln!("Removed PAT entry for {repo}.");
+    eprintln!(
+        "note: the token itself may still be live on GitHub — \
+         revoke it under https://github.com/settings/personal-access-tokens \
+         if you want to fully invalidate it."
+    );
+    Ok(())
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+/// Resolve the target repo from explicit `--repo`, fall back to a
+/// best-effort scan of the current working directory.
+fn resolve_target_repo(repo_arg: Option<&str>, git_repo_url: Option<&str>) -> Result<String> {
+    if let Some(repo) = repo_arg {
+        return Ok(repo.trim().to_string());
+    }
+    if let Some(url) = git_repo_url
+        && let Some(slug) = parse_repo_slug_from_url(url)
+    {
+        return Ok(slug);
+    }
+    if let Ok(cwd) = std::env::current_dir()
+        && let Some(slug) = detect_workspace_repo(&cwd)?
+    {
+        return Ok(slug);
+    }
+    bail!(
+        "Could not detect a target repo. Pass --repo owner/name, or run from a \
+         git working tree whose origin points at github.com."
+    )
+}
+
+fn print_form_instructions(repo: &str) {
+    // Validation has already ensured repo is "owner/name".
+    let owner = repo.split('/').next().unwrap_or(repo);
+
+    eprintln!("\nConfigure the form at {PAT_NEW_URL}:");
+    eprintln!("  Token name:        coop-{}", repo.replace('/', "-"));
+    eprintln!("  Expiration:        (your choice — 90 days is a reasonable default)");
+    eprintln!("  Resource owner:    {owner}");
+    eprintln!("  Repository access: Only select repositories → {repo}");
+    eprintln!("  Repository permissions:");
+    eprintln!("    Contents:        Read and write");
+    eprintln!("    Pull requests:   Read and write");
+    eprintln!("    Issues:          Read and write");
+    eprintln!("    Checks:          Read-only");
+    eprintln!("    Commit statuses: Read-only");
+    eprintln!("    Metadata:        Read-only (auto-included)\n");
+    eprintln!("Click \"Generate token\", then paste it below.");
+}
+
+fn open_browser_best_effort(url: &str) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        // xdg-open on Linux; Windows uses `start` but coop is unix-only.
+        "xdg-open"
+    };
+    let _ = Command::new(opener).arg(url).spawn();
+}
+
+fn read_token_no_echo() -> Result<String> {
+    eprint!("Paste token: ");
+    std::io::stderr().flush().ok();
+    let guard = EchoGuard::off();
+    let stdin = std::io::stdin();
+    let mut buf = String::new();
+    stdin
+        .lock()
+        .read_line(&mut buf)
+        .context("Failed to read token from stdin")?;
+    // Print a newline because the user's RET wasn't echoed.
+    if guard.is_active() {
+        eprintln!();
+    }
+    drop(guard);
+    let trimmed = buf.trim().to_string();
+    if trimmed.is_empty() {
+        bail!("No token entered");
+    }
+    Ok(trimmed)
+}
+
+/// RAII guard that turns terminal echo off via `stty -echo` and restores
+/// it on drop. Disabling fails silently if no controlling TTY exists or
+/// `stty` is unavailable (`is_active` then returns false, so the caller
+/// can skip the trailing newline).
+struct EchoGuard {
+    active: bool,
+}
+
+impl EchoGuard {
+    fn off() -> Self {
+        let active = Command::new("stty")
+            .arg("-echo")
+            .status()
+            .is_ok_and(|s| s.success());
+        Self { active }
+    }
+
+    fn is_active(&self) -> bool {
+        self.active
+    }
+}
+
+impl Drop for EchoGuard {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = Command::new("stty").arg("echo").status();
+        }
+    }
+}
+
+fn warn_token_format(token: &str) {
+    if !token.starts_with(TOKEN_PREFIX) {
+        // Don't fail — bring-your-own tokens (e.g. classic PATs starting
+        // with `ghp_`) are legitimate but won't get the FGPAT guarantees.
+        eprintln!(
+            "warning: token does not start with '{TOKEN_PREFIX}' — \
+             not a fine-grained PAT. Proceeding anyway."
+        );
+    }
+}
+
+fn probe_user(token: &str) -> Result<()> {
+    let (status, body) = curl_with_token(token, "https://api.github.com/user")?;
+    if status != 200 {
+        bail!("GET /user returned HTTP {status} (token may be invalid or revoked)");
+    }
+    if !body.contains("\"login\"") {
+        bail!("Token authentication failed: /user returned unexpected response");
+    }
+    eprintln!("  ✓ /user");
+    Ok(())
+}
+
+fn probe_repo(token: &str, repo: &str) -> Result<()> {
+    let url = format!("https://api.github.com/repos/{repo}");
+    let (status, _body) = curl_with_token(token, &url)?;
+    match status {
+        200 => {
+            eprintln!("  ✓ /repos/{repo}");
+            Ok(())
+        }
+        403 => bail!(
+            "GET /repos/{repo} returned 403. This is often the org's \
+             fine-grained PAT policy: ask an org admin to approve \
+             fine-grained PATs, or to approve your specific token."
+        ),
+        404 => bail!(
+            "GET /repos/{repo} returned 404. Check the repo slug and \
+             that the PAT was generated with the right resource owner."
+        ),
+        other => bail!("GET /repos/{repo} returned HTTP {other}"),
+    }
+}
+
+/// Issue a GET with the supplied token via curl, returning `(http_status, body)`.
+///
+/// Uses `-w "\n%{http_code}"` to coax the status code into stdout so we
+/// can map it without parsing curl's stderr. `-f` is **not** set: we want
+/// to see the response body even on 4xx for diagnostics, and the status
+/// alone is enough to drive the wizard branches.
+fn curl_with_token(token: &str, url: &str) -> Result<(u16, String)> {
+    let out = Cmd::new("curl")
+        .arg("-sSL")
+        .arg("-H")
+        .arg("Accept: application/vnd.github+json")
+        .arg("-H")
+        .arg("@-")
+        .stdin_input(format!("Authorization: token {token}\n"))
+        .arg("-w")
+        .arg("\n%{http_code}")
+        .arg(url)
+        .capture()
+        .with_context(|| format!("curl GET {url} failed"))?;
+    let (body, status_str) = out.rsplit_once('\n').unwrap_or(("", out.trim()));
+    let status: u16 = status_str
+        .trim()
+        .parse()
+        .with_context(|| format!("Failed to parse HTTP status from curl output: '{status_str}'"))?;
+    Ok((status, body.to_string()))
+}
+
+fn pick_backend() -> Result<crate::secret_store::Backend> {
+    let backends = available_backends();
+    eprintln!("\nWhere should I store this token?");
+    for (i, b) in backends.iter().enumerate() {
+        eprintln!("  {}) {}", i + 1, b.label());
+    }
+    eprint!("> ");
+    std::io::stderr().flush().ok();
+    let mut buf = String::new();
+    std::io::stdin()
+        .lock()
+        .read_line(&mut buf)
+        .context("Failed to read backend choice")?;
+    let n: usize = buf
+        .trim()
+        .parse()
+        .context("Backend choice must be a number")?;
+    if n == 0 || n > backends.len() {
+        bail!(
+            "Backend choice out of range (got {n}, expected 1..={})",
+            backends.len()
+        );
+    }
+    Ok(backends[n - 1])
+}
+
+// ── Config-file mutation ───────────────────────────────────────
+
+/// Read the config TOML at `path`, add/replace the entry for `repo`, and
+/// write it back. Creates a fresh file if it doesn't exist.
+///
+/// Uses `toml::Value` for round-trip-safe edits: comments are lost, but
+/// every other key/value is preserved. The wizard is the only place we
+/// rewrite config, so the trade-off is acceptable.
+///
+/// Holds an exclusive `flock` on a sibling `.lock` file across the
+/// read-modify-write window so concurrent wizard invocations (e.g. two
+/// `coop start` auto-prompts firing at once) don't lose each other's
+/// writes.
+fn upsert_pat_entry(path: &Path, repo: &str, token_cmd: &str) -> Result<()> {
+    let _lock = crate::fs_util::lock_sibling(path)?;
+    let mut doc = read_or_init_doc(path)?;
+
+    // Ensure the `github` table exists.
+    let github = doc
+        .as_table_mut()
+        .context("Config root is not a table")?
+        .entry("github".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+
+    // If `github` was previously a string (`github = "off"` etc.), upgrade
+    // to a table form.
+    if !github.is_table() {
+        *github = toml::Value::Table(toml::Table::new());
+    }
+    let github_tbl = github
+        .as_table_mut()
+        .context("github value is not a table")?;
+    github_tbl.insert("mode".to_string(), toml::Value::String("pat".to_string()));
+
+    // Ensure `[github.pat]` is a table.
+    let pat = github_tbl
+        .entry("pat".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+    if !pat.is_table() {
+        *pat = toml::Value::Table(toml::Table::new());
+    }
+    let pat_tbl = pat.as_table_mut().context("github.pat is not a table")?;
+
+    // Replace the entry for `repo`.
+    let mut entry = toml::Table::new();
+    entry.insert(
+        "token".to_string(),
+        toml::Value::String(token_cmd.to_string()),
+    );
+    pat_tbl.insert(repo.to_string(), toml::Value::Table(entry));
+
+    // Drop the repo from the skip list, if present.
+    if let Some(skip) = github_tbl.get_mut("skip")
+        && let Some(arr) = skip.as_array_mut()
+    {
+        arr.retain(|v| v.as_str() != Some(repo));
+    }
+
+    write_doc(path, &doc)
+}
+
+fn remove_pat_entry(path: &Path, repo: &str) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let _lock = crate::fs_util::lock_sibling(path)?;
+    let mut doc = read_or_init_doc(path)?;
+    if let Some(github_tbl) = doc.get_mut("github").and_then(toml::Value::as_table_mut)
+        && let Some(pat_tbl) = github_tbl
+            .get_mut("pat")
+            .and_then(toml::Value::as_table_mut)
+    {
+        pat_tbl.remove(repo);
+    }
+    write_doc(path, &doc)
+}
+
+/// Mark `repo` in `[github] skip`. Used by the auto-prompt's `never` answer.
+///
+/// Always forces `mode = "pat"`. Without this, a skip marker recorded
+/// against `github = "off"` (or unset) would be silently dropped on the
+/// next config load: the deserializer only reads the `skip` field for
+/// pat-mode. The prompt itself is gated to only fire when the mode is
+/// already "off" / unset / "pat" with no entry, so promoting to "pat"
+/// (with no entries) here is a no-op for token forwarding — pat-mode
+/// with no entries forwards no token, same as "off" — while making
+/// per-repo skip state survive a config reload.
+pub fn add_skip_marker(path: &Path, repo: &str) -> Result<()> {
+    validate_repo_slug(repo)?;
+    let _lock = crate::fs_util::lock_sibling(path)?;
+    let mut doc = read_or_init_doc(path)?;
+    let github = doc
+        .as_table_mut()
+        .context("Config root is not a table")?
+        .entry("github".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+    if !github.is_table() {
+        *github = toml::Value::Table(toml::Table::new());
+    }
+    let github_tbl = github
+        .as_table_mut()
+        .context("github value is not a table")?;
+    github_tbl.insert("mode".to_string(), toml::Value::String("pat".to_string()));
+    let skip = github_tbl
+        .entry("skip".to_string())
+        .or_insert_with(|| toml::Value::Array(Vec::new()));
+    if !skip.is_array() {
+        *skip = toml::Value::Array(Vec::new());
+    }
+    let arr = skip.as_array_mut().context("github.skip is not an array")?;
+    if !arr.iter().any(|v| v.as_str() == Some(repo)) {
+        arr.push(toml::Value::String(repo.to_string()));
+    }
+    write_doc(path, &doc)
+}
+
+fn read_or_init_doc(path: &Path) -> Result<toml::Value> {
+    if path.exists() {
+        let s = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        toml::from_str::<toml::Value>(&s)
+            .with_context(|| format!("Failed to parse {}", path.display()))
+    } else {
+        Ok(toml::Value::Table(toml::Table::new()))
+    }
+}
+
+fn write_doc(path: &Path, doc: &toml::Value) -> Result<()> {
+    let serialized = toml::to_string_pretty(doc)
+        .with_context(|| format!("Failed to serialize {}", path.display()))?;
+    // Pick mode 0600 if any pat token is stored as a literal (no `cmd:`
+    // prefix). When a token is behind `cmd:`, only the invocation is on
+    // disk and 0644 matches the existing convention. Literal tokens are
+    // a foot-gun coop accepts for BYO setups — 0600 is the minimum.
+    let mode = if doc_contains_literal_token(doc) {
+        0o600
+    } else {
+        0o644
+    };
+    crate::fs_util::atomic_write_with_mode(path, &serialized, mode)
+}
+
+fn doc_contains_literal_token(doc: &toml::Value) -> bool {
+    let Some(github_tbl) = doc.get("github").and_then(toml::Value::as_table) else {
+        return false;
+    };
+    let Some(pat_tbl) = github_tbl.get("pat").and_then(toml::Value::as_table) else {
+        return false;
+    };
+    pat_tbl.values().any(|entry| {
+        entry
+            .as_table()
+            .and_then(|t| t.get("token"))
+            .and_then(toml::Value::as_str)
+            .is_some_and(|t| !t.starts_with("cmd:"))
+    })
+}
+
+/// Hint helper used by `coop start` and other code paths to format the
+/// "no entry for this repo" error consistently.
+pub fn missing_entry_error(repo: &str) -> String {
+    format!(
+        "No GitHub PAT configured for '{repo}'. \
+         Run `coop github setup-pat --repo {repo}` to add one, \
+         or set `github = \"off\"` to disable token forwarding."
+    )
+}
+
+/// Test helper: read a pat config out of a file path.
+#[cfg(test)]
+pub(crate) fn pat_config_at(path: &Path) -> Result<Option<crate::config::PatConfig>> {
+    let cfg = CoopConfig::load(path)?;
+    Ok(cfg.github.and_then(|g| match g {
+        GitHubAuth::Pat(c) => Some(c),
+        _ => None,
+    }))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_creates_new_file_with_entry() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        upsert_pat_entry(&path, "trailofbits/coop", "cmd:cat ./t.txt").unwrap();
+        let cfg = pat_config_at(&path).unwrap().unwrap();
+        assert_eq!(cfg.entries.len(), 1);
+        let entry = cfg.entries.get("trailofbits/coop").unwrap();
+        assert_eq!(entry.token, "cmd:cat ./t.txt");
+    }
+
+    #[test]
+    fn upsert_preserves_other_keys() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "ssh_port = 2222\n\
+             [vm]\n\
+             vcpu_count = 4\n",
+        )
+        .unwrap();
+        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        let s = std::fs::read_to_string(&path).unwrap();
+        assert!(s.contains("ssh_port = 2222"));
+        assert!(s.contains("vcpu_count = 4"));
+        assert!(s.contains("[github.pat"));
+    }
+
+    #[test]
+    fn upsert_upgrades_string_github_to_table() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "github = \"off\"\n").unwrap();
+        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        let cfg = CoopConfig::load(&path).unwrap();
+        assert!(matches!(cfg.github, Some(GitHubAuth::Pat(_))));
+    }
+
+    #[test]
+    fn upsert_removes_repo_from_skip_list() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[github]\nmode = \"pat\"\nskip = [\"a/b\", \"c/d\"]\n",
+        )
+        .unwrap();
+        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        let cfg = pat_config_at(&path).unwrap().unwrap();
+        assert_eq!(cfg.skip, vec!["c/d".to_string()]);
+    }
+
+    #[test]
+    fn remove_pat_entry_is_idempotent_on_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        remove_pat_entry(&path, "x/y").unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_pat_entry_drops_only_named_entry() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[github]\nmode = \"pat\"\n\n[github.pat.\"a/b\"]\ntoken = \"cmd:echo x\"\n\n[github.pat.\"c/d\"]\ntoken = \"cmd:echo y\"\n",
+        )
+        .unwrap();
+        remove_pat_entry(&path, "a/b").unwrap();
+        let cfg = pat_config_at(&path).unwrap().unwrap();
+        assert!(!cfg.entries.contains_key("a/b"));
+        assert!(cfg.entries.contains_key("c/d"));
+    }
+
+    #[test]
+    fn skip_marker_added_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        add_skip_marker(&path, "a/b").unwrap();
+        add_skip_marker(&path, "a/b").unwrap();
+        let cfg = pat_config_at(&path).unwrap().unwrap();
+        assert_eq!(cfg.skip, vec!["a/b".to_string()]);
+    }
+
+    #[test]
+    fn skip_marker_survives_when_starting_mode_is_off() {
+        // Regression: previously the marker was written under
+        // `[github] mode = "off"`, and the deserializer dropped it.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "github = \"off\"\n").unwrap();
+        add_skip_marker(&path, "a/b").unwrap();
+        let cfg = pat_config_at(&path).unwrap().unwrap();
+        assert_eq!(cfg.skip, vec!["a/b".to_string()]);
+    }
+
+    #[test]
+    fn upsert_removes_skip_marker_after_starting_from_off() {
+        // Regression: full sequence — start at "off", record skip, then
+        // run setup-pat. The skip marker must be cleared, and the new
+        // entry must be present.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "github = \"off\"\n").unwrap();
+        add_skip_marker(&path, "a/b").unwrap();
+        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        let cfg = pat_config_at(&path).unwrap().unwrap();
+        assert!(!cfg.skip.contains(&"a/b".to_string()));
+        assert!(cfg.entries.contains_key("a/b"));
+    }
+
+    #[test]
+    fn missing_entry_error_mentions_repo_and_command() {
+        let msg = missing_entry_error("trailofbits/coop");
+        assert!(msg.contains("trailofbits/coop"));
+        assert!(msg.contains("setup-pat"));
+    }
+}

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -213,7 +213,6 @@ fn print_form_instructions(repo: &str) {
     eprintln!("    Contents:        Read and write");
     eprintln!("    Pull requests:   Read and write");
     eprintln!("    Issues:          Read and write");
-    eprintln!("    Checks:          Read-only");
     eprintln!("    Commit statuses: Read-only");
     eprintln!("    Metadata:        Read-only (auto-included)\n");
     eprintln!("Click \"Generate token\", then paste it below.");

--- a/src/github_repo.rs
+++ b/src/github_repo.rs
@@ -1,0 +1,207 @@
+//! Helpers for parsing and validating GitHub repository identifiers.
+//!
+//! A *repo slug* is the canonical `owner/repo` form (e.g. `trailofbits/coop`).
+//! Used as the key for `[github.pat."owner/repo"]` entries.
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+/// Validate that `slug` matches `owner/repo` with GitHub-allowed characters.
+///
+/// GitHub usernames and repo names allow ASCII letters, digits, `-`, `_`, `.`.
+/// Leading/trailing `.` or `-` is unusual but accepted by the API; we don't
+/// gate that here.
+pub fn validate_repo_slug(slug: &str) -> Result<()> {
+    let (owner, repo) = slug
+        .split_once('/')
+        .with_context(|| format!("Repo slug must be 'owner/repo', got '{slug}'"))?;
+    if owner.is_empty() || repo.is_empty() {
+        bail!("Repo slug 'owner/repo' must have non-empty owner and repo: '{slug}'");
+    }
+    if repo.contains('/') {
+        bail!("Repo slug must contain exactly one '/' separator: '{slug}'");
+    }
+    let valid = |s: &str| {
+        s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    };
+    if !valid(owner) || !valid(repo) {
+        bail!(
+            "Repo slug '{slug}' contains invalid characters \
+             (allowed: a-z, A-Z, 0-9, '-', '_', '.')"
+        );
+    }
+    Ok(())
+}
+
+/// Schemes recognised by [`parse_repo_slug_from_url`].
+const GITHUB_URL_PREFIXES: &[&str] = &[
+    "https://github.com/",
+    "http://github.com/",
+    "ssh://git@github.com/",
+    "git@github.com:",
+];
+
+/// Parse a GitHub URL into an `owner/repo` slug.
+///
+/// Accepts:
+/// - `https://github.com/owner/repo` (with or without `.git` suffix or trailing slash)
+/// - `http://github.com/owner/repo`
+/// - `git@github.com:owner/repo`
+/// - `ssh://git@github.com/owner/repo`
+///
+/// Returns `None` for non-GitHub URLs or malformed input.
+pub fn parse_repo_slug_from_url(url: &str) -> Option<String> {
+    let trimmed = url.trim();
+    for prefix in GITHUB_URL_PREFIXES {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            return canonicalize(rest);
+        }
+    }
+    None
+}
+
+fn canonicalize(path: &str) -> Option<String> {
+    let path = path.trim_end_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let (owner, repo) = path.split_once('/')?;
+    // Reject anything past `owner/repo` (e.g. `owner/repo/pulls`).
+    if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+/// Detect the `owner/repo` slug for the GitHub remote of `git_dir`.
+///
+/// Runs `git -C <git_dir> remote get-url origin` and parses the output.
+/// Returns `Ok(None)` if `git_dir` is not a git repo, has no origin, or
+/// origin is not a GitHub URL.
+pub fn detect_workspace_repo(git_dir: &Path) -> Result<Option<String>> {
+    if !git_dir.exists() {
+        return Ok(None);
+    }
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(git_dir)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .with_context(|| format!("Failed to invoke git in {}", git_dir.display()))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(parse_repo_slug_from_url(&url))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_https_url() {
+        assert_eq!(
+            parse_repo_slug_from_url("https://github.com/trailofbits/coop"),
+            Some("trailofbits/coop".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_url_with_git_suffix() {
+        assert_eq!(
+            parse_repo_slug_from_url("https://github.com/trailofbits/coop.git"),
+            Some("trailofbits/coop".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_url_with_trailing_slash() {
+        assert_eq!(
+            parse_repo_slug_from_url("https://github.com/trailofbits/coop/"),
+            Some("trailofbits/coop".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_url() {
+        assert_eq!(
+            parse_repo_slug_from_url("git@github.com:trailofbits/coop"),
+            Some("trailofbits/coop".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_url_with_git_suffix() {
+        assert_eq!(
+            parse_repo_slug_from_url("git@github.com:trailofbits/coop.git"),
+            Some("trailofbits/coop".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_url_with_scheme() {
+        assert_eq!(
+            parse_repo_slug_from_url("ssh://git@github.com/trailofbits/coop.git"),
+            Some("trailofbits/coop".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_http_url() {
+        assert_eq!(
+            parse_repo_slug_from_url("http://github.com/trailofbits/coop"),
+            Some("trailofbits/coop".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_non_github_url() {
+        assert_eq!(
+            parse_repo_slug_from_url("https://gitlab.com/owner/repo"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_deep_path() {
+        assert_eq!(
+            parse_repo_slug_from_url("https://github.com/owner/repo/pulls/1"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_only_owner() {
+        assert_eq!(parse_repo_slug_from_url("https://github.com/owner"), None);
+    }
+
+    #[test]
+    fn validates_canonical_slug() {
+        assert!(validate_repo_slug("trailofbits/coop").is_ok());
+        assert!(validate_repo_slug("user-name/repo.name_v2").is_ok());
+    }
+
+    #[test]
+    fn rejects_missing_slash() {
+        assert!(validate_repo_slug("trailofbits").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_segment() {
+        assert!(validate_repo_slug("/coop").is_err());
+        assert!(validate_repo_slug("trailofbits/").is_err());
+    }
+
+    #[test]
+    fn rejects_extra_slash() {
+        assert!(validate_repo_slug("a/b/c").is_err());
+    }
+
+    #[test]
+    fn rejects_bad_chars() {
+        assert!(validate_repo_slug("owner!/repo").is_err());
+        assert!(validate_repo_slug("owner repo/x").is_err());
+    }
+}

--- a/src/github_repo.rs
+++ b/src/github_repo.rs
@@ -79,6 +79,10 @@ fn canonicalize(path: &str) -> Option<String> {
 /// Runs `git -C <git_dir> remote get-url origin` and parses the output.
 /// Returns `Ok(None)` if `git_dir` is not a git repo, has no origin, or
 /// origin is not a GitHub URL.
+///
+/// `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` are stripped before
+/// invoking git so a parent hook context (e.g. a pre-commit running
+/// coop) can't redirect lookups to the wrong repository.
 pub fn detect_workspace_repo(git_dir: &Path) -> Result<Option<String>> {
     if !git_dir.exists() {
         return Ok(None);
@@ -87,6 +91,10 @@ pub fn detect_workspace_repo(git_dir: &Path) -> Result<Option<String>> {
         .arg("-C")
         .arg(git_dir)
         .args(["remote", "get-url", "origin"])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
         .output()
         .with_context(|| format!("Failed to invoke git in {}", git_dir.display()))?;
     if !output.status.success() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1094,7 +1094,13 @@ fn restart_instance(
 
 /// Best-effort GitHub repo resolution for `coop start`.
 ///
-/// Order: `--git-repo` URL → workspace `.git/config` origin → `None`.
+/// Order: `--git-repo` URL → `--workspace` `.git/config` origin → first
+/// `--mount` host path's `.git/config` origin → `None`.
+///
+/// The mount fallback matches the "first mount is the workspace"
+/// convention used by `push`/`pull`, so the slug a user sees here is the
+/// same one `detect_instance_repo` will recover on `coop shell` / `exec`
+/// / `restart`.
 fn resolve_start_repo(opts: &StartOpts<'_>) -> Result<Option<String>> {
     if let Some(url) = opts.git_repo
         && let Some(slug) = github_repo::parse_repo_slug_from_url(url)
@@ -1108,6 +1114,11 @@ fn resolve_start_repo(opts: &StartOpts<'_>) -> Result<Option<String>> {
         {
             return Ok(Some(slug));
         }
+    }
+    if let Some(m) = opts.mounts.first()
+        && let Some(slug) = github_repo::detect_workspace_repo(&m.host_path)?
+    {
+        return Ok(Some(slug));
     }
     Ok(None)
 }
@@ -1180,12 +1191,19 @@ fn start_instance(
             git_repo_url: Some(repo_url.to_string()),
         };
         state.save(inst)?;
-    } else if !opts.mounts.is_empty() && !be.mounts_are_live() {
-        workspace::sync_mounts(&target, inst, &opts.mounts, opts.exclude_git)?;
-        tracing::warn!(
-            "Firecracker mounts use one-time sync, not live filesystem sharing. \
-             Use `coop push` / `coop pull` to sync changes."
-        );
+    } else if !opts.mounts.is_empty() {
+        if be.mounts_are_live() {
+            // Lima: virtiofs already serves the host directory live. No
+            // sync step, but we still record state so `push`/`pull` and
+            // PAT slug detection work for follow-up commands.
+            workspace::record_mount_state(inst, &opts.mounts)?;
+        } else {
+            workspace::sync_mounts(&target, inst, &opts.mounts, opts.exclude_git)?;
+            tracing::warn!(
+                "Firecracker mounts use one-time sync, not live filesystem sharing. \
+                 Use `coop push` / `coop pull` to sync changes."
+            );
+        }
     }
 
     tracing::info!(
@@ -1873,6 +1891,7 @@ fn dir_size_display(dir: &std::path::Path) -> String {
 #[cfg(test)]
 #[expect(clippy::panic, reason = "tests use panic for unreachable branches")]
 #[expect(clippy::unwrap_used, reason = "test code — panics are assertions")]
+#[expect(clippy::expect_used, reason = "test code — panics are assertions")]
 mod tests {
     use clap::Parser;
 
@@ -2406,6 +2425,95 @@ mod tests {
     fn completions_subcommand_requires_shell() {
         let err = parse_err(&["completions"]);
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    fn run_git(repo: &std::path::Path, args: &[&str]) {
+        // Clear inherited env and restore only what `git` needs. This
+        // protects against parent contexts that export GIT_DIR /
+        // GIT_WORK_TREE / GIT_INDEX_FILE (e.g. a pre-commit hook
+        // running `cargo test`), which would otherwise hijack the
+        // tempdir-scoped operations below.
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .env_clear()
+            .env("PATH", path)
+            .env("HOME", repo)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .status()
+            .expect("git command runs");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    fn start_opts(
+        mounts: Vec<super::config::Mount>,
+        config_path: &std::path::Path,
+    ) -> super::StartOpts<'_> {
+        super::StartOpts {
+            name: None,
+            image: super::config::DEFAULT_IMAGE,
+            workspace_dir: None,
+            git_repo: None,
+            no_agents: false,
+            no_prompt: true,
+            disk: None,
+            mounts,
+            exclude_git: false,
+            config_path,
+        }
+    }
+
+    #[test]
+    fn resolve_start_repo_uses_first_mount_origin() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        run_git(tmp.path(), &["init", "-q"]);
+        run_git(
+            tmp.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/trailofbits/coop.git",
+            ],
+        );
+        let mount = super::config::Mount {
+            host_path: tmp.path().to_path_buf(),
+            guest_path: "/workspace".to_string(),
+        };
+        let cfg_path = tmp.path().join("config.toml");
+        let opts = start_opts(vec![mount], &cfg_path);
+        let slug = super::resolve_start_repo(&opts).expect("ok");
+        assert_eq!(slug.as_deref(), Some("trailofbits/coop"));
+    }
+
+    #[test]
+    fn resolve_start_repo_returns_none_for_non_github_mount() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        run_git(tmp.path(), &["init", "-q"]);
+        run_git(
+            tmp.path(),
+            &["remote", "add", "origin", "https://gitlab.com/x/y.git"],
+        );
+        let mount = super::config::Mount {
+            host_path: tmp.path().to_path_buf(),
+            guest_path: "/workspace".to_string(),
+        };
+        let cfg_path = tmp.path().join("config.toml");
+        let opts = start_opts(vec![mount], &cfg_path);
+        let slug = super::resolve_start_repo(&opts).expect("ok");
+        assert!(slug.is_none(), "got {slug:?}");
+    }
+
+    #[test]
+    fn resolve_start_repo_returns_none_for_no_mounts() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("config.toml");
+        let opts = start_opts(Vec::new(), &cfg_path);
+        let slug = super::resolve_start_repo(&opts).expect("ok");
+        assert!(slug.is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,11 @@ mod cmd;
 mod completions;
 mod config;
 mod fs_util;
+mod github_pat;
+mod github_repo;
 mod guest;
+mod pat_prompt;
+mod secret_store;
 // Lima is an interactive CLI workflow — stderr output is intentional user communication.
 #[cfg_attr(not(target_os = "macos"), expect(dead_code, reason = "Lima-only"))]
 #[expect(
@@ -169,6 +173,10 @@ enum Commands {
         /// Skip the `.git` directory when syncing the workspace
         #[arg(long, conflicts_with = "git_repo")]
         exclude_git: bool,
+        /// Suppress the interactive prompt to set up a scoped GitHub PAT
+        /// when one is missing for the resolved repo.
+        #[arg(long)]
+        no_prompt: bool,
     },
     /// Open an interactive shell in the VM (or run a command non-interactively)
     #[command(alias = "ssh")]
@@ -318,8 +326,17 @@ enum Commands {
         #[command(subcommand)]
         action: Option<ProfilesAction>,
     },
+    /// Manage GitHub authentication (fine-grained PAT wizard, status, rotate, forget)
+    Github {
+        #[command(subcommand)]
+        action: GithubAction,
+    },
     /// Validate configuration and check prerequisites
-    Validate,
+    Validate {
+        /// Probe live state for each `[github.pat]` entry (talks to api.github.com)
+        #[arg(long)]
+        probe: bool,
+    },
     /// Generate a starter config file at ~/.coop/config.toml
     Init,
     /// Replace the running coop binary with the latest GitHub release
@@ -388,6 +405,35 @@ enum ProfilesAction {
         /// Profile name to inspect
         #[arg(add = ArgValueCandidates::new(completions::profile_candidates))]
         name: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum GithubAction {
+    /// Run the fine-grained PAT wizard for a repo
+    SetupPat {
+        /// Repo slug to scope to (auto-detected if omitted)
+        #[arg(long)]
+        repo: Option<String>,
+    },
+    /// Re-run the wizard against an existing entry
+    RotatePat {
+        /// Repo slug to rotate
+        #[arg(long, required = true)]
+        repo: String,
+    },
+    /// Print configured PAT entries and their validation state
+    Status {
+        /// Resolve each entry's `cmd:` invocation (may trigger Keychain /
+        /// 1Password prompts) to confirm the secret store still serves it.
+        #[arg(long)]
+        probe: bool,
+    },
+    /// Remove a configured PAT entry and its stored secret
+    ForgetPat {
+        /// Repo slug whose entry should be removed
+        #[arg(long, required = true)]
+        repo: String,
     },
 }
 
@@ -537,6 +583,7 @@ fn main() -> Result<()> {
             mount,
             image,
             exclude_git,
+            no_prompt,
         } => {
             if raw_args_use_deprecated_no_claude(std::env::args()) {
                 tracing::warn!(
@@ -550,18 +597,20 @@ fn main() -> Result<()> {
                 .collect::<Result<Vec<_>>>()?;
             cmd_start(
                 &be,
-                &cfg,
+                &mut cfg,
                 &StartOpts {
                     name: name.as_deref(),
                     image: &image,
                     workspace_dir: workspace.as_deref(),
                     git_repo: git_repo.as_deref(),
                     no_agents,
+                    no_prompt,
                     disk: disk
                         .map(|d| config::GiB::new(d).context("--disk must be > 0"))
                         .transpose()?,
                     mounts,
                     exclude_git,
+                    config_path: &cli.config,
                 },
             )
         }
@@ -665,13 +714,38 @@ fn main() -> Result<()> {
         Commands::Profiles { action } => {
             cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
         }
-        Commands::Validate => cmd_validate(&cfg, &be),
+        Commands::Github { action } => cmd_github(&cfg, &cli.config, &action),
+        Commands::Validate { probe } => cmd_validate(&cfg, &be, probe),
         Commands::Init
         | Commands::Update { .. }
         | Commands::Uninstall { .. }
         | Commands::Completions { .. } => {
             unreachable!("handled before config loading")
         }
+    }
+}
+
+fn cmd_github(cfg: &config::CoopConfig, config_path: &Path, action: &GithubAction) -> Result<()> {
+    match action {
+        GithubAction::SetupPat { repo } => {
+            let opts = github_pat::SetupOpts {
+                repo: repo.as_deref(),
+                config_path,
+            };
+            github_pat::run_setup_pat(cfg, &opts)
+        }
+        GithubAction::RotatePat { repo } => {
+            let opts = github_pat::SetupOpts {
+                repo: Some(repo),
+                config_path,
+            };
+            github_pat::run_rotate_pat(cfg, &opts)
+        }
+        GithubAction::Status { probe } => {
+            github_pat::run_status(cfg, *probe);
+            Ok(())
+        }
+        GithubAction::ForgetPat { repo } => github_pat::run_forget_pat(cfg, repo, config_path),
     }
 }
 
@@ -698,7 +772,11 @@ fn cmd_init(config_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn cmd_validate(cfg: &config::CoopConfig, be: &backend::PlatformBackend) -> Result<()> {
+fn cmd_validate(
+    cfg: &config::CoopConfig,
+    be: &backend::PlatformBackend,
+    probe: bool,
+) -> Result<()> {
     writeln!(std::io::stdout(), "Validating config (backend: {be})...",).ok();
 
     let warnings = cfg.validate()?;
@@ -707,8 +785,72 @@ fn cmd_validate(cfg: &config::CoopConfig, be: &backend::PlatformBackend) -> Resu
         writeln!(std::io::stdout(), "  warning: {w}").ok();
     }
 
+    // Per-repo PAT validation
+    if let Some(config::GitHubAuth::Pat(pat)) = cfg.github.as_ref() {
+        for (repo, entry) in &pat.entries {
+            match config::resolve_cmd_value(&entry.token) {
+                Ok(token) => {
+                    if token.starts_with(github_pat::TOKEN_PREFIX) {
+                        writeln!(
+                            std::io::stdout(),
+                            "  github.pat.\"{repo}\": ok (resolves, fine-grained PAT format)"
+                        )
+                        .ok();
+                    } else {
+                        writeln!(
+                            std::io::stdout(),
+                            "  github.pat.\"{repo}\": warning — token resolves but is not \
+                             a fine-grained PAT (no '{prefix}' prefix)",
+                            prefix = github_pat::TOKEN_PREFIX,
+                        )
+                        .ok();
+                    }
+                    if probe {
+                        match probe_pat_token(&token) {
+                            Ok(login) => {
+                                writeln!(std::io::stdout(), "    probe: /user as '{login}'").ok();
+                            }
+                            Err(e) => {
+                                writeln!(std::io::stdout(), "    probe: FAILED ({e})").ok();
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    writeln!(
+                        std::io::stdout(),
+                        "  github.pat.\"{repo}\": FAILED to resolve token ({e})"
+                    )
+                    .ok();
+                }
+            }
+        }
+    }
+
     writeln!(std::io::stdout(), "Config OK").ok();
     Ok(())
+}
+
+/// Issue `GET https://api.github.com/user` with `token`. Returns the
+/// authenticated user's login on success.
+fn probe_pat_token(token: &str) -> Result<String> {
+    let body = cmd::Cmd::new("curl")
+        .arg("-fsSL")
+        .arg("-H")
+        .arg("Accept: application/vnd.github+json")
+        .arg("-H")
+        .arg("@-")
+        .stdin_input(format!("Authorization: token {token}\n"))
+        .arg("https://api.github.com/user")
+        .capture()
+        .context("curl /user failed")?;
+    // Naive extraction: grab the first `"login": "..."`. Avoids a JSON dep.
+    let login = body
+        .split("\"login\"")
+        .nth(1)
+        .and_then(|s| s.split('"').nth(1))
+        .unwrap_or("?");
+    Ok(login.to_string())
 }
 
 fn apply_vm_overrides(
@@ -742,14 +884,19 @@ struct StartOpts<'a> {
     workspace_dir: Option<&'a str>,
     git_repo: Option<&'a str>,
     no_agents: bool,
+    /// Skip the interactive PAT auto-prompt unconditionally.
+    no_prompt: bool,
     disk: Option<config::GiB>,
     mounts: Vec<config::Mount>,
     exclude_git: bool,
+    /// Path to the on-disk config file. Re-read after the auto-prompt
+    /// in case the wizard added a new `[github.pat."..."]` entry.
+    config_path: &'a Path,
 }
 
 fn cmd_start(
     be: &backend::PlatformBackend,
-    cfg: &config::CoopConfig,
+    cfg: &mut config::CoopConfig,
     opts: &StartOpts<'_>,
 ) -> Result<()> {
     let ws_path = opts.workspace_dir.map(Path::new);
@@ -779,7 +926,7 @@ fn cmd_start(
     tracing::info!("Starting instance '{}' (index {})", inst.name, inst.index);
 
     let _guard = signal::install_handlers();
-    let result = start_instance(be, cfg, &inst, opts);
+    let result = start_instance(be, &mut *cfg, &inst, opts);
 
     if let Err(e) = &result {
         tracing::error!("Failed to start instance '{}': {e}", inst.name);
@@ -923,7 +1070,8 @@ fn restart_instance(
     if no_agents {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
-        let env = backend::prepare_env_forwarding(cfg)?;
+        let repo = backend::detect_instance_repo(inst);
+        let env = backend::prepare_env_forwarding(cfg, repo.as_deref())?;
         let session = backend::SshSession {
             target: target.clone(),
             env,
@@ -940,12 +1088,38 @@ fn restart_instance(
     Ok(())
 }
 
+/// Best-effort GitHub repo resolution for `coop start`.
+///
+/// Order: `--git-repo` URL → workspace `.git/config` origin → `None`.
+fn resolve_start_repo(opts: &StartOpts<'_>) -> Result<Option<String>> {
+    if let Some(url) = opts.git_repo
+        && let Some(slug) = github_repo::parse_repo_slug_from_url(url)
+    {
+        return Ok(Some(slug));
+    }
+    if let Some(ws_dir) = opts.workspace_dir {
+        let path = Path::new(ws_dir);
+        if path.is_dir()
+            && let Some(slug) = github_repo::detect_workspace_repo(path)?
+        {
+            return Ok(Some(slug));
+        }
+    }
+    Ok(None)
+}
+
 fn start_instance(
     be: &backend::PlatformBackend,
-    cfg: &config::CoopConfig,
+    cfg: &mut config::CoopConfig,
     inst: &config::Instance,
     opts: &StartOpts<'_>,
 ) -> Result<()> {
+    // Derive the GitHub repo slug as early as possible so the auto-prompt
+    // can fire before any VM cost is incurred, and so pat-mode token
+    // forwarding works at bootstrap time.
+    let repo = resolve_start_repo(opts)?;
+    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_deref(), opts.no_prompt)?;
+
     be.create_and_start(cfg, inst, opts.disk, &opts.mounts)?;
 
     signal::check_shutdown()?;
@@ -960,7 +1134,7 @@ fn start_instance(
     if opts.no_agents {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
-        let env = backend::prepare_env_forwarding(cfg)?;
+        let env = backend::prepare_env_forwarding(cfg, repo.as_deref())?;
         let session = backend::SshSession {
             target: target.clone(),
             env,
@@ -989,6 +1163,7 @@ fn start_instance(
             host_path: Some(abs_path),
             guest_path: "/workspace".to_string(),
             source: workspace::WorkspaceSource::Workspace,
+            git_repo_url: None,
         };
         state.save(inst)?;
     } else if let Some(repo_url) = opts.git_repo {
@@ -998,6 +1173,7 @@ fn start_instance(
             host_path: None,
             guest_path: "/workspace".to_string(),
             source: workspace::WorkspaceSource::GitRepo,
+            git_repo_url: Some(repo_url.to_string()),
         };
         state.save(inst)?;
     } else if !opts.mounts.is_empty() && !be.mounts_are_live() {
@@ -1130,7 +1306,8 @@ fn open_ssh_session(
     name: Option<&str>,
 ) -> Result<backend::SshSession> {
     let running = resolve_running(be, cfg, name)?;
-    let env = backend::prepare_env_forwarding(cfg)?;
+    let repo = backend::detect_instance_repo(&running.inst);
+    let env = backend::prepare_env_forwarding(cfg, repo.as_deref())?;
     Ok(backend::SshSession {
         target: running.target,
         env,

--- a/src/main.rs
+++ b/src/main.rs
@@ -919,7 +919,7 @@ fn cmd_start(
             );
         }
 
-        return restart_instance(be, cfg, &inst, opts.no_agents);
+        return restart_instance(be, cfg, &inst, opts);
     }
 
     let inst = cfg.allocate_instance(opts.name, opts.image, ws_path)?;
@@ -1048,13 +1048,18 @@ fn find_stopped_instance(
 /// Restart a stopped instance: boot VM, wait for SSH, re-bootstrap guest tools.
 fn restart_instance(
     be: &backend::PlatformBackend,
-    cfg: &config::CoopConfig,
+    cfg: &mut config::CoopConfig,
     inst: &config::Instance,
-    no_agents: bool,
+    opts: &StartOpts<'_>,
 ) -> Result<()> {
     tracing::info!("Restarting stopped instance '{}'", inst.name);
 
     let _guard = signal::install_handlers();
+
+    // Pre-flight: same auto-prompt as a fresh start. Uses the instance's
+    // recorded workspace-state to recover the repo slug.
+    let repo = backend::detect_instance_repo(inst);
+    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_deref(), opts.no_prompt)?;
 
     be.start_existing(cfg, inst)?;
 
@@ -1067,10 +1072,9 @@ fn restart_instance(
 
     signal::check_shutdown()?;
 
-    if no_agents {
+    if opts.no_agents {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
-        let repo = backend::detect_instance_repo(inst);
         let env = backend::prepare_env_forwarding(cfg, repo.as_deref())?;
         let session = backend::SshSession {
             target: target.clone(),

--- a/src/pat_prompt.rs
+++ b/src/pat_prompt.rs
@@ -1,0 +1,291 @@
+//! `coop start` pre-flight hook: offer to scope GitHub auth to the resolved
+//! repo before the VM boots.
+//!
+//! Decision logic lives in [`Decision::resolve`]; the side-effecting wrapper
+//! [`maybe_prompt`] is what `start_instance` calls.
+
+#![expect(
+    clippy::print_stderr,
+    reason = "auto-prompt is interactive CLI — stderr is user communication"
+)]
+
+use std::io::{BufRead as _, IsTerminal as _, Write as _};
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::config::{CoopConfig, GitHubAuth};
+use crate::github_pat::{self, SetupOpts};
+
+/// Effective answer to "should we offer the user a PAT wizard right now?"
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Nothing to do — proceed with the start as-is.
+    Skip,
+    /// Show the prompt; the user decides.
+    Prompt,
+}
+
+impl Decision {
+    /// Pure decision step — no I/O. Easy to unit-test.
+    ///
+    /// `repo` is the resolved `owner/repo` slug, if any.
+    /// `tty` reflects whether stdin is interactive.
+    /// `ci` reflects whether the `CI` env var is set.
+    /// `no_prompt_flag` reflects whether `--no-prompt` was passed.
+    pub fn resolve(
+        cfg: &CoopConfig,
+        repo: Option<&str>,
+        tty: bool,
+        ci: bool,
+        no_prompt_flag: bool,
+    ) -> Self {
+        // No repo → nothing to scope to.
+        let Some(repo) = repo else {
+            return Self::Skip;
+        };
+        // Hard suppressors first.
+        if no_prompt_flag || ci || !tty || !cfg.setup.prompt_for_pat {
+            return Self::Skip;
+        }
+        match cfg.github.as_ref() {
+            // No mode set → defaults to "off" — eligible.
+            None | Some(GitHubAuth::Off) => Self::Prompt,
+            Some(GitHubAuth::Pat(pc)) => {
+                // Already opted in but missing entry for this repo → prompt.
+                if pc.skip.iter().any(|s| s == repo) {
+                    return Self::Skip;
+                }
+                if pc.entries.contains_key(repo) {
+                    Self::Skip
+                } else {
+                    Self::Prompt
+                }
+            }
+            // User explicitly chose Auto / Env — respect that choice.
+            Some(GitHubAuth::Auto | GitHubAuth::Env) => Self::Skip,
+        }
+    }
+}
+
+/// Wire-up: consult [`Decision::resolve`], interact with the user, run the
+/// wizard if asked. Failures inside the wizard fall back to "continue
+/// without GitHub auth?" — they never abort the start unilaterally.
+///
+/// On success this may mutate `cfg.github` in place to reflect whatever
+/// the wizard / skip-marker step wrote to disk, so the caller can use
+/// the same in-memory `cfg` for downstream token resolution without
+/// reloading the whole file (which would erase CLI overrides).
+pub fn maybe_prompt(
+    cfg: &mut CoopConfig,
+    config_path: &Path,
+    repo: Option<&str>,
+    no_prompt_flag: bool,
+) -> Result<()> {
+    let tty = std::io::stdin().is_terminal();
+    let ci = std::env::var("CI").is_ok();
+    let decision = Decision::resolve(cfg, repo, tty, ci, no_prompt_flag);
+    match decision {
+        Decision::Skip => {
+            // Even when we skip the prompt, surface a hint to non-interactive
+            // contexts so users discover the wizard exists.
+            if let Some(slug) = repo
+                && (!tty || ci)
+                && matches!(cfg.github.as_ref(), None | Some(GitHubAuth::Off))
+            {
+                tracing::info!(
+                    "tip: run 'coop github setup-pat --repo {slug}' to scope GitHub auth to this repo"
+                );
+            }
+            return Ok(());
+        }
+        Decision::Prompt => {}
+    }
+
+    // Safe because Decision::Prompt is only returned when repo is Some.
+    let Some(slug) = repo else {
+        return Ok(());
+    };
+
+    eprintln!();
+    eprintln!(
+        "No GitHub credential is configured for {slug} (github = {:?}).",
+        cfg.github.as_ref().map_or("off", GitHubAuth::mode_name),
+    );
+    eprintln!("Pushes and private-repo operations from the guest will fail.");
+    eprintln!();
+    eprint!("Set up a scoped fine-grained PAT now? [y/N/never] ");
+    std::io::stderr().flush().ok();
+
+    let mut buf = String::new();
+    std::io::stdin().lock().read_line(&mut buf)?;
+    match buf.trim().to_ascii_lowercase().as_str() {
+        "y" | "yes" => {
+            run_wizard_or_recover(cfg, config_path, slug)?;
+            refresh_github_from_disk(cfg, config_path)?;
+            Ok(())
+        }
+        "never" => {
+            github_pat::add_skip_marker(config_path, slug)?;
+            refresh_github_from_disk(cfg, config_path)?;
+            tracing::info!("recorded skip marker for {slug}; continuing without GitHub auth");
+            Ok(())
+        }
+        _ => {
+            tracing::info!("continuing without GitHub auth for {slug}");
+            Ok(())
+        }
+    }
+}
+
+/// Re-read only the `github` field from disk into `cfg`. CLI overrides
+/// on other fields stay intact.
+fn refresh_github_from_disk(cfg: &mut CoopConfig, config_path: &Path) -> Result<()> {
+    let fresh = CoopConfig::load(config_path)?;
+    cfg.github = fresh.github;
+    Ok(())
+}
+
+fn run_wizard_or_recover(cfg: &CoopConfig, config_path: &Path, repo: &str) -> Result<()> {
+    let opts = SetupOpts {
+        repo: Some(repo),
+        config_path,
+    };
+    match github_pat::run_setup_pat(cfg, &opts) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            tracing::warn!("PAT setup failed ({e}); falling back to unauthenticated start");
+            eprint!("continue without GitHub auth? [y/N] ");
+            std::io::stderr().flush().ok();
+            let mut buf = String::new();
+            std::io::stdin().lock().read_line(&mut buf)?;
+            if matches!(buf.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{PatConfig, PatEntry};
+
+    fn cfg_with(github: Option<GitHubAuth>) -> CoopConfig {
+        CoopConfig {
+            github,
+            ..CoopConfig::default()
+        }
+    }
+
+    #[test]
+    fn skips_when_no_repo() {
+        let cfg = cfg_with(None);
+        assert_eq!(
+            Decision::resolve(&cfg, None, true, false, false),
+            Decision::Skip
+        );
+    }
+
+    #[test]
+    fn skips_when_no_tty() {
+        let cfg = cfg_with(None);
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), false, false, false),
+            Decision::Skip
+        );
+    }
+
+    #[test]
+    fn skips_when_ci() {
+        let cfg = cfg_with(None);
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, true, false),
+            Decision::Skip
+        );
+    }
+
+    #[test]
+    fn skips_when_no_prompt_flag() {
+        let cfg = cfg_with(None);
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, false, true),
+            Decision::Skip
+        );
+    }
+
+    #[test]
+    fn prompts_when_mode_off_and_interactive() {
+        let cfg = cfg_with(Some(GitHubAuth::Off));
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::Prompt
+        );
+    }
+
+    #[test]
+    fn prompts_when_pat_mode_but_no_entry() {
+        let cfg = cfg_with(Some(GitHubAuth::Pat(PatConfig::default())));
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::Prompt
+        );
+    }
+
+    #[test]
+    fn skips_when_pat_mode_has_entry() {
+        let mut pc = PatConfig::default();
+        pc.entries.insert(
+            "a/b".to_string(),
+            PatEntry {
+                token: "cmd:echo x".to_string(),
+            },
+        );
+        let cfg = cfg_with(Some(GitHubAuth::Pat(pc)));
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::Skip
+        );
+    }
+
+    #[test]
+    fn skips_when_repo_marked_skip() {
+        let mut pc = PatConfig::default();
+        pc.skip.push("a/b".to_string());
+        let cfg = cfg_with(Some(GitHubAuth::Pat(pc)));
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::Skip
+        );
+    }
+
+    #[test]
+    fn skips_when_mode_auto() {
+        let cfg = cfg_with(Some(GitHubAuth::Auto));
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::Skip
+        );
+    }
+
+    #[test]
+    fn skips_when_mode_env() {
+        let cfg = cfg_with(Some(GitHubAuth::Env));
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::Skip
+        );
+    }
+
+    #[test]
+    fn skips_when_prompt_for_pat_false() {
+        let mut cfg = cfg_with(Some(GitHubAuth::Off));
+        cfg.setup.prompt_for_pat = false;
+        assert_eq!(
+            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::Skip
+        );
+    }
+}

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -21,11 +21,22 @@ use anyhow::{Context, Result};
 use crate::cmd::Cmd;
 
 /// All secret-store backends recognised by the wizard.
+///
+/// Platform-specific system keychains (`MacosKeychain`, `LinuxSecretService`)
+/// are `cfg`-gated: the variants only exist on the targets where they can be
+/// read. A binary built for Linux therefore cannot represent — let alone
+/// attempt to use — the macOS Keychain backend, and vice versa. The secret
+/// itself is always host-local, so a config entry produced by one platform's
+/// system keychain is meaningless on the other.
+///
+/// `OnePassword` and `File` are cross-platform and always present.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Backend {
     /// macOS Keychain via `/usr/bin/security`.
+    #[cfg(target_os = "macos")]
     MacosKeychain,
     /// Linux Secret Service (GNOME Keyring / `KWallet`) via `secret-tool`.
+    #[cfg(target_os = "linux")]
     LinuxSecretService,
     /// 1Password CLI (`op`) — used when explicitly chosen by the user.
     OnePassword,
@@ -36,7 +47,9 @@ pub enum Backend {
 impl Backend {
     pub fn label(self) -> &'static str {
         match self {
+            #[cfg(target_os = "macos")]
             Self::MacosKeychain => "macOS Keychain",
+            #[cfg(target_os = "linux")]
             Self::LinuxSecretService => "Linux Secret Service (GNOME Keyring / KWallet)",
             Self::OnePassword => "1Password CLI",
             Self::File => "Plain file (~/.coop/state/github-pat/<slug>.txt, mode 0600)",
@@ -44,12 +57,15 @@ impl Backend {
     }
 
     /// Probe whether this backend is usable on the current host.
+    ///
+    /// The variant's existence already proves target-OS compatibility; this
+    /// only checks the *runtime* prerequisites (binary on PATH, etc.).
     pub fn is_available(self) -> bool {
         match self {
-            Self::MacosKeychain => {
-                cfg!(target_os = "macos") && Path::new("/usr/bin/security").exists()
-            }
-            Self::LinuxSecretService => cfg!(target_os = "linux") && tool_on_path("secret-tool"),
+            #[cfg(target_os = "macos")]
+            Self::MacosKeychain => Path::new("/usr/bin/security").exists(),
+            #[cfg(target_os = "linux")]
+            Self::LinuxSecretService => tool_on_path("secret-tool"),
             Self::OnePassword => tool_on_path("op"),
             Self::File => true,
         }
@@ -77,14 +93,16 @@ fn is_safe_tool_name_char(c: char) -> bool {
 /// natural-default order. The file fallback always appears last.
 pub fn available_backends() -> Vec<Backend> {
     let mut out = Vec::new();
-    for b in [
-        Backend::MacosKeychain,
-        Backend::LinuxSecretService,
-        Backend::OnePassword,
-    ] {
-        if b.is_available() {
-            out.push(b);
-        }
+    #[cfg(target_os = "macos")]
+    if Backend::MacosKeychain.is_available() {
+        out.push(Backend::MacosKeychain);
+    }
+    #[cfg(target_os = "linux")]
+    if Backend::LinuxSecretService.is_available() {
+        out.push(Backend::LinuxSecretService);
+    }
+    if Backend::OnePassword.is_available() {
+        out.push(Backend::OnePassword);
     }
     out.push(Backend::File);
     out
@@ -103,7 +121,9 @@ pub fn store_secret(
     state_dir: &Path,
 ) -> Result<String> {
     match backend {
+        #[cfg(target_os = "macos")]
         Backend::MacosKeychain => store_keychain(service, account, token),
+        #[cfg(target_os = "linux")]
         Backend::LinuxSecretService => store_secret_service(service, account, token),
         Backend::OnePassword => store_onepassword(service, account, token),
         Backend::File => store_file(service, account, token, state_dir),
@@ -120,6 +140,7 @@ pub fn delete_secret(
     state_dir: &Path,
 ) -> Result<()> {
     match backend {
+        #[cfg(target_os = "macos")]
         Backend::MacosKeychain => {
             let _ = Cmd::new("security")
                 .arg("delete-generic-password")
@@ -130,6 +151,7 @@ pub fn delete_secret(
                 .output();
             Ok(())
         }
+        #[cfg(target_os = "linux")]
         Backend::LinuxSecretService => {
             let _ = Cmd::new("secret-tool")
                 .arg("clear")
@@ -167,18 +189,26 @@ pub fn delete_secret(
 /// Recognise a `cmd:` invocation as the backend that wrote it.
 ///
 /// Used by `coop github status` to display the storage location without
-/// reading the secret. Returns `None` for opaque commands.
+/// reading the secret. Returns `None` for opaque commands *and* for entries
+/// produced by a system keychain that the current build cannot represent
+/// (e.g. a `security find-generic-password …` entry seen by a Linux binary
+/// — the secret itself is unreachable from this host anyway, so we treat
+/// it as unknown rather than describing a variant that doesn't exist here).
 ///
 /// The File-backend match requires the path to end in `/github-pat/<name>.txt`
 /// (the canonical layout coop writes) so user-supplied `cmd:cat …` paths
 /// that don't follow that shape correctly fall through to `unknown`.
 pub fn infer_backend(cmd: &str) -> Option<Backend> {
     let cmd_str = cmd.strip_prefix("cmd:").map_or(cmd, str::trim_start);
+    #[cfg(target_os = "macos")]
     if cmd_str.starts_with("security find-generic-password") {
-        Some(Backend::MacosKeychain)
-    } else if cmd_str.starts_with("secret-tool lookup") {
-        Some(Backend::LinuxSecretService)
-    } else if cmd_str.starts_with("op read") || cmd_str.starts_with("op item get") {
+        return Some(Backend::MacosKeychain);
+    }
+    #[cfg(target_os = "linux")]
+    if cmd_str.starts_with("secret-tool lookup") {
+        return Some(Backend::LinuxSecretService);
+    }
+    if cmd_str.starts_with("op read") || cmd_str.starts_with("op item get") {
         Some(Backend::OnePassword)
     } else if cmd_str.starts_with("cat ")
         && cmd_str.contains("github-pat/")
@@ -192,6 +222,7 @@ pub fn infer_backend(cmd: &str) -> Option<Backend> {
 
 // ── Backend impls ──────────────────────────────────────────────
 
+#[cfg(target_os = "macos")]
 fn store_keychain(service: &str, account: &str, token: &str) -> Result<String> {
     // macOS `security` lacks a stdin-driven write for generic passwords:
     // `-w <password>` reads the secret from argv. The bytes are briefly
@@ -217,6 +248,7 @@ fn store_keychain(service: &str, account: &str, token: &str) -> Result<String> {
     ))
 }
 
+#[cfg(target_os = "linux")]
 fn store_secret_service(service: &str, account: &str, token: &str) -> Result<String> {
     // `secret-tool store` reads the password from stdin.
     Cmd::new("secret-tool")
@@ -397,16 +429,36 @@ mod tests {
         assert!(!path.exists());
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
-    fn infer_backend_recognises_known_invocations() {
+    fn infer_backend_recognises_macos_keychain() {
         assert_eq!(
             infer_backend("cmd:security find-generic-password -s coop-github-pat -a x -w"),
             Some(Backend::MacosKeychain)
         );
+        // Non-target keychain invocations are opaque to this build.
+        assert_eq!(
+            infer_backend("cmd:secret-tool lookup service coop-github-pat account x"),
+            None
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn infer_backend_recognises_linux_secret_service() {
         assert_eq!(
             infer_backend("cmd:secret-tool lookup service coop-github-pat account x"),
             Some(Backend::LinuxSecretService)
         );
+        // Non-target keychain invocations are opaque to this build.
+        assert_eq!(
+            infer_backend("cmd:security find-generic-password -s coop-github-pat -a x -w"),
+            None
+        );
+    }
+
+    #[test]
+    fn infer_backend_recognises_cross_platform_backends() {
         assert_eq!(
             infer_backend("cmd:op read op://Private/coop/token"),
             Some(Backend::OnePassword)

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -141,13 +141,14 @@ pub fn delete_secret(
             Ok(())
         }
         Backend::OnePassword => {
-            // 1Password CLI doesn't have a direct delete by tag — users
-            // who chose 1Password should manage entries themselves. Best
-            // effort: try `op item delete` with the canonical title.
+            // Best-effort soft-delete: `--archive` keeps the item
+            // recoverable from the 1Password trash. Manual cleanup is
+            // always available via the 1Password UI.
             let title = format!("{service} ({account})");
             let _ = Cmd::new("op")
                 .arg("item")
                 .arg("delete")
+                .arg("--archive")
                 .arg(&title)
                 .output();
             Ok(())
@@ -167,6 +168,10 @@ pub fn delete_secret(
 ///
 /// Used by `coop github status` to display the storage location without
 /// reading the secret. Returns `None` for opaque commands.
+///
+/// The File-backend match requires the path to end in `/github-pat/<name>.txt`
+/// (the canonical layout coop writes) so user-supplied `cmd:cat …` paths
+/// that don't follow that shape correctly fall through to `unknown`.
 pub fn infer_backend(cmd: &str) -> Option<Backend> {
     let cmd_str = cmd.strip_prefix("cmd:").map_or(cmd, str::trim_start);
     if cmd_str.starts_with("security find-generic-password") {
@@ -175,7 +180,10 @@ pub fn infer_backend(cmd: &str) -> Option<Backend> {
         Some(Backend::LinuxSecretService)
     } else if cmd_str.starts_with("op read") || cmd_str.starts_with("op item get") {
         Some(Backend::OnePassword)
-    } else if cmd_str.starts_with("cat ") && cmd_str.contains("github-pat") {
+    } else if cmd_str.starts_with("cat ")
+        && cmd_str.contains("github-pat/")
+        && cmd_str.contains(".txt")
+    {
         Some(Backend::File)
     } else {
         None
@@ -232,8 +240,16 @@ fn store_secret_service(service: &str, account: &str, token: &str) -> Result<Str
 fn store_onepassword(service: &str, account: &str, token: &str) -> Result<String> {
     // `op item create` reads field values from argv. The token is briefly
     // visible to local observers via /proc; redacted from coop's own
-    // debug log via `redacted_arg`.
+    // debug log via `redacted_arg`. 1Password rejects duplicate titles, so
+    // soft-delete any existing item with the same title first (rotate-pat
+    // calls store_onepassword on an existing entry).
     let title = format!("{service} ({account})");
+    let _ = Cmd::new("op")
+        .arg("item")
+        .arg("delete")
+        .arg("--archive")
+        .arg(&title)
+        .output();
     let password_field = format!("password={token}");
     Cmd::new("op")
         .arg("item")
@@ -396,9 +412,30 @@ mod tests {
             Some(Backend::OnePassword)
         );
         assert_eq!(
+            infer_backend("cmd:op item get 'foo' --fields password --reveal"),
+            Some(Backend::OnePassword)
+        );
+        assert_eq!(
             infer_backend("cmd:cat ~/.coop/state/github-pat/x.txt"),
             Some(Backend::File)
         );
         assert_eq!(infer_backend("cmd:echo opaque"), None);
+    }
+
+    #[test]
+    fn infer_backend_rejects_cat_without_canonical_layout() {
+        // A `cat` invocation that doesn't follow the `…/github-pat/<x>.txt`
+        // layout should not be reported as the File backend — otherwise
+        // `forget-pat` would happily try to delete a file coop never wrote.
+        assert_eq!(
+            infer_backend("cmd:cat ~/some/path/secret.txt"),
+            None,
+            "cat invocation without github-pat in the path must not match File"
+        );
+        assert_eq!(
+            infer_backend("cmd:cat ~/.coop/state/github-pat/x.bin"),
+            None,
+            "non-.txt suffix must not match File"
+        );
     }
 }

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -1,0 +1,404 @@
+//! Pluggable secret-storage backends used by the `coop github setup-pat` wizard.
+//!
+//! Each backend stores a secret keyed by `(service, account)` and returns a
+//! `cmd:`-prefixed string that coop's config layer (`resolve_cmd_value`) can
+//! invoke at runtime to read the secret back. coop itself never reads the
+//! stored secret directly — the indirection keeps long-lived plaintext off
+//! disk and out of the config file.
+//!
+//! Backend detection is fail-soft: anything unavailable on the current host
+//! is omitted from [`available_backends`]. The file fallback is always
+//! available so the wizard always has at least one storage choice.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+use crate::cmd::Cmd;
+
+/// All secret-store backends recognised by the wizard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    /// macOS Keychain via `/usr/bin/security`.
+    MacosKeychain,
+    /// Linux Secret Service (GNOME Keyring / `KWallet`) via `secret-tool`.
+    LinuxSecretService,
+    /// 1Password CLI (`op`) — used when explicitly chosen by the user.
+    OnePassword,
+    /// Plain file under `~/.coop/state/github-pat/<slug>.txt`, mode 0600.
+    File,
+}
+
+impl Backend {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::MacosKeychain => "macOS Keychain",
+            Self::LinuxSecretService => "Linux Secret Service (GNOME Keyring / KWallet)",
+            Self::OnePassword => "1Password CLI",
+            Self::File => "Plain file (~/.coop/state/github-pat/<slug>.txt, mode 0600)",
+        }
+    }
+
+    /// Probe whether this backend is usable on the current host.
+    pub fn is_available(self) -> bool {
+        match self {
+            Self::MacosKeychain => {
+                cfg!(target_os = "macos") && Path::new("/usr/bin/security").exists()
+            }
+            Self::LinuxSecretService => cfg!(target_os = "linux") && tool_on_path("secret-tool"),
+            Self::OnePassword => tool_on_path("op"),
+            Self::File => true,
+        }
+    }
+}
+
+fn tool_on_path(name: &str) -> bool {
+    // `command -v` is a shell builtin — execute it via `sh -c`. Reject
+    // names with whitespace defensively so we don't shell-inject.
+    if name.is_empty() || name.chars().any(|c| !is_safe_tool_name_char(c)) {
+        return false;
+    }
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!("command -v {name}"))
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+fn is_safe_tool_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')
+}
+
+/// Return the list of usable backends on the current host, in the
+/// natural-default order. The file fallback always appears last.
+pub fn available_backends() -> Vec<Backend> {
+    let mut out = Vec::new();
+    for b in [
+        Backend::MacosKeychain,
+        Backend::LinuxSecretService,
+        Backend::OnePassword,
+    ] {
+        if b.is_available() {
+            out.push(b);
+        }
+    }
+    out.push(Backend::File);
+    out
+}
+
+/// Store `token` in `backend` keyed by `(service, account)`.
+///
+/// Returns a `cmd:`-prefixed string suitable for the `token = ...` field
+/// in `[github.pat."owner/repo"]`. The returned command, when evaluated by
+/// `resolve_cmd_value`, must print the token on stdout.
+pub fn store_secret(
+    backend: Backend,
+    service: &str,
+    account: &str,
+    token: &str,
+    state_dir: &Path,
+) -> Result<String> {
+    match backend {
+        Backend::MacosKeychain => store_keychain(service, account, token),
+        Backend::LinuxSecretService => store_secret_service(service, account, token),
+        Backend::OnePassword => store_onepassword(service, account, token),
+        Backend::File => store_file(service, account, token, state_dir),
+    }
+}
+
+/// Remove the secret stored under `(service, account)` from `backend`.
+///
+/// Best-effort: missing entries are not an error.
+pub fn delete_secret(
+    backend: Backend,
+    service: &str,
+    account: &str,
+    state_dir: &Path,
+) -> Result<()> {
+    match backend {
+        Backend::MacosKeychain => {
+            let _ = Cmd::new("security")
+                .arg("delete-generic-password")
+                .arg("-s")
+                .arg(service)
+                .arg("-a")
+                .arg(account)
+                .output();
+            Ok(())
+        }
+        Backend::LinuxSecretService => {
+            let _ = Cmd::new("secret-tool")
+                .arg("clear")
+                .arg("service")
+                .arg(service)
+                .arg("account")
+                .arg(account)
+                .output();
+            Ok(())
+        }
+        Backend::OnePassword => {
+            // 1Password CLI doesn't have a direct delete by tag — users
+            // who chose 1Password should manage entries themselves. Best
+            // effort: try `op item delete` with the canonical title.
+            let title = format!("{service} ({account})");
+            let _ = Cmd::new("op")
+                .arg("item")
+                .arg("delete")
+                .arg(&title)
+                .output();
+            Ok(())
+        }
+        Backend::File => {
+            let path = file_backend_path(state_dir, account);
+            if path.exists() {
+                fs::remove_file(&path)
+                    .with_context(|| format!("Failed to remove {}", path.display()))?;
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Recognise a `cmd:` invocation as the backend that wrote it.
+///
+/// Used by `coop github status` to display the storage location without
+/// reading the secret. Returns `None` for opaque commands.
+pub fn infer_backend(cmd: &str) -> Option<Backend> {
+    let cmd_str = cmd.strip_prefix("cmd:").map_or(cmd, str::trim_start);
+    if cmd_str.starts_with("security find-generic-password") {
+        Some(Backend::MacosKeychain)
+    } else if cmd_str.starts_with("secret-tool lookup") {
+        Some(Backend::LinuxSecretService)
+    } else if cmd_str.starts_with("op read") || cmd_str.starts_with("op item get") {
+        Some(Backend::OnePassword)
+    } else if cmd_str.starts_with("cat ") && cmd_str.contains("github-pat") {
+        Some(Backend::File)
+    } else {
+        None
+    }
+}
+
+// ── Backend impls ──────────────────────────────────────────────
+
+fn store_keychain(service: &str, account: &str, token: &str) -> Result<String> {
+    // macOS `security` lacks a stdin-driven write for generic passwords:
+    // `-w <password>` reads the secret from argv. The bytes are briefly
+    // visible to local `ps`-equivalent observers — an unavoidable cost
+    // for the duration of the call. `redacted_arg` keeps the token out
+    // of coop's own debug log, but `ps` is out of our reach. Users with
+    // stronger threat models can use the file or Secret Service backends.
+    Cmd::new("security")
+        .arg("add-generic-password")
+        .arg("-U")
+        .arg("-s")
+        .arg(service)
+        .arg("-a")
+        .arg(account)
+        .arg("-w")
+        .redacted_arg(token)
+        .run()
+        .context("Failed to write secret to macOS Keychain")?;
+    Ok(format!(
+        "cmd:security find-generic-password -s {} -a {} -w",
+        shell_quote(service),
+        shell_quote(account),
+    ))
+}
+
+fn store_secret_service(service: &str, account: &str, token: &str) -> Result<String> {
+    // `secret-tool store` reads the password from stdin.
+    Cmd::new("secret-tool")
+        .arg("store")
+        .arg("--label")
+        .arg(format!("coop github PAT for {account}"))
+        .arg("service")
+        .arg(service)
+        .arg("account")
+        .arg(account)
+        .stdin_input(token.as_bytes().to_vec())
+        .run()
+        .context("Failed to write secret to Linux Secret Service")?;
+    Ok(format!(
+        "cmd:secret-tool lookup service {} account {}",
+        shell_quote(service),
+        shell_quote(account),
+    ))
+}
+
+fn store_onepassword(service: &str, account: &str, token: &str) -> Result<String> {
+    // `op item create` reads field values from argv. The token is briefly
+    // visible to local observers via /proc; redacted from coop's own
+    // debug log via `redacted_arg`.
+    let title = format!("{service} ({account})");
+    let password_field = format!("password={token}");
+    Cmd::new("op")
+        .arg("item")
+        .arg("create")
+        .arg("--category=login")
+        .arg(format!("--title={title}"))
+        .redacted_arg(password_field)
+        .run()
+        .context("Failed to create 1Password item")?;
+    let title_quoted = shell_quote(&title);
+    Ok(format!(
+        "cmd:op item get {title_quoted} --fields password --reveal"
+    ))
+}
+
+fn store_file(service: &str, account: &str, token: &str, state_dir: &Path) -> Result<String> {
+    let dir = state_dir.join("github-pat");
+    fs::create_dir_all(&dir).with_context(|| format!("Failed to create {}", dir.display()))?;
+    set_dir_mode(&dir, 0o700)?;
+    let path = file_backend_path(state_dir, account);
+    let mut f = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&path)
+        .with_context(|| format!("Failed to create {}", path.display()))?;
+    f.write_all(token.as_bytes())
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    // Newline-terminate so `cat` output is friendly.
+    if !token.ends_with('\n') {
+        f.write_all(b"\n")
+            .with_context(|| format!("Failed to write {}", path.display()))?;
+    }
+    // Suppress unused-warning for `service` when the file backend ignores it.
+    let _ = service;
+    Ok(format!("cmd:cat {}", shell_quote(&path.to_string_lossy())))
+}
+
+fn file_backend_path(state_dir: &Path, account: &str) -> PathBuf {
+    state_dir
+        .join("github-pat")
+        .join(format!("{}.txt", sanitize(account)))
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn set_dir_mode(path: &Path, mode: u32) -> Result<()> {
+    let perms = std::fs::Permissions::from_mode(mode);
+    fs::set_permissions(path, perms)
+        .with_context(|| format!("Failed to chmod {} to {mode:#o}", path.display()))
+}
+
+/// POSIX shell-quote `s` for safe embedding in a `cmd:` invocation.
+fn shell_quote(s: &str) -> String {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return s.to_string();
+    }
+    let escaped = s.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}
+
+/// Build the conventional account name for a repo's PAT entry.
+pub fn account_for_repo(repo: &str) -> String {
+    repo.replace('/', "-")
+}
+
+/// Conventional service name used across all backends.
+pub const SERVICE: &str = "coop-github-pat";
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_backend_always_available() {
+        assert!(Backend::File.is_available());
+    }
+
+    #[test]
+    fn available_backends_includes_file_last() {
+        let backends = available_backends();
+        assert!(!backends.is_empty());
+        assert_eq!(*backends.last().unwrap(), Backend::File);
+    }
+
+    #[test]
+    fn account_replaces_slash() {
+        assert_eq!(
+            account_for_repo("trailofbits/coop"),
+            "trailofbits-coop".to_string()
+        );
+    }
+
+    #[test]
+    fn shell_quote_passes_simple_strings() {
+        assert_eq!(shell_quote("trailofbits-coop"), "trailofbits-coop");
+        assert_eq!(shell_quote("/tmp/foo.txt"), "/tmp/foo.txt");
+    }
+
+    #[test]
+    fn shell_quote_wraps_unsafe_strings() {
+        assert_eq!(shell_quote("a b"), "'a b'");
+        assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+    }
+
+    #[test]
+    fn sanitize_replaces_unsafe_chars() {
+        assert_eq!(sanitize("owner/repo"), "owner-repo");
+        assert_eq!(sanitize("safe-name_v2"), "safe-name_v2");
+    }
+
+    #[test]
+    fn file_backend_round_trip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cmd = store_file(SERVICE, "trailofbits-coop", "github_pat_xyz", tmp.path()).unwrap();
+        assert!(cmd.starts_with("cmd:cat "));
+        // Verify the file exists with the right contents and mode.
+        let path = file_backend_path(tmp.path(), "trailofbits-coop");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content.trim(), "github_pat_xyz");
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn file_backend_delete_removes_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _ = store_file(SERVICE, "x-y", "token", tmp.path()).unwrap();
+        delete_secret(Backend::File, SERVICE, "x-y", tmp.path()).unwrap();
+        let path = file_backend_path(tmp.path(), "x-y");
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn infer_backend_recognises_known_invocations() {
+        assert_eq!(
+            infer_backend("cmd:security find-generic-password -s coop-github-pat -a x -w"),
+            Some(Backend::MacosKeychain)
+        );
+        assert_eq!(
+            infer_backend("cmd:secret-tool lookup service coop-github-pat account x"),
+            Some(Backend::LinuxSecretService)
+        );
+        assert_eq!(
+            infer_backend("cmd:op read op://Private/coop/token"),
+            Some(Backend::OnePassword)
+        );
+        assert_eq!(
+            infer_backend("cmd:cat ~/.coop/state/github-pat/x.txt"),
+            Some(Backend::File)
+        );
+        assert_eq!(infer_backend("cmd:echo opaque"), None);
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -34,6 +34,14 @@ pub struct WorkspaceState {
     pub guest_path: String,
     /// How the workspace was created
     pub source: WorkspaceSource,
+    /// Original repo URL when source is [`WorkspaceSource::GitRepo`].
+    ///
+    /// Recorded so that follow-up commands (`coop shell`, `claude`, etc.)
+    /// can re-derive the `owner/repo` slug without re-asking — pat-mode
+    /// otherwise has no way to look up the entry for a git-repo instance
+    /// where `host_path` is `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_repo_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -287,6 +295,7 @@ fn load_or_default(inst: &Instance, dir: Option<&str>, cmd: &str) -> Result<Work
             host_path: None,
             guest_path: GUEST_WORKSPACE.to_string(),
             source: WorkspaceSource::Workspace,
+            git_repo_url: None,
         });
     }
     bail!(
@@ -399,6 +408,7 @@ pub fn sync_mounts(
             host_path: Some(m.host_path.clone()),
             guest_path: m.guest_path.clone(),
             source: WorkspaceSource::Mount,
+            git_repo_url: None,
         };
         state.save(inst)?;
     }
@@ -1040,6 +1050,7 @@ mod tests {
             host_path: Some(PathBuf::from("/tmp/project")),
             guest_path: "/workspace".to_string(),
             source: WorkspaceSource::Workspace,
+            git_repo_url: None,
         };
         state.save(&inst).expect("save");
         let loaded = WorkspaceState::try_load(&inst)
@@ -1066,6 +1077,7 @@ mod tests {
             host_path: Some(PathBuf::from("/host/dir")),
             guest_path: "/custom".to_string(),
             source: WorkspaceSource::GitRepo,
+            git_repo_url: None,
         };
         state.save(&inst).expect("save");
         let loaded = load_or_default(&inst, None, "push").expect("load");

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -402,7 +402,16 @@ pub fn sync_mounts(
         }
     }
 
-    // Save state for the first mount so push/pull work
+    record_mount_state(inst, mounts)
+}
+
+/// Persist mount metadata to `workspace.json`.
+///
+/// Records the first mount's host path as the canonical workspace so
+/// that `push`/`pull` and PAT slug detection (`detect_instance_repo`)
+/// work on follow-up commands. Used by `sync_mounts` after a Firecracker
+/// rsync, and directly on Lima where mounts are live (no sync step).
+pub fn record_mount_state(inst: &Instance, mounts: &[crate::config::Mount]) -> Result<()> {
     if let Some(m) = mounts.first() {
         let state = WorkspaceState {
             host_path: Some(m.host_path.clone()),
@@ -412,7 +421,6 @@ pub fn sync_mounts(
         };
         state.save(inst)?;
     }
-
     Ok(())
 }
 
@@ -1092,6 +1100,45 @@ mod tests {
         let loaded = load_or_default(&inst, Some("./project"), "push").expect("load");
         assert_eq!(loaded.guest_path, GUEST_WORKSPACE);
         assert!(loaded.host_path.is_none());
+    }
+
+    #[test]
+    fn record_mount_state_persists_first_mount() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inst = temp_instance(dir.path());
+        let primary = tempfile::tempdir().expect("primary");
+        let secondary = tempfile::tempdir().expect("secondary");
+        let mounts = vec![
+            crate::config::Mount {
+                host_path: primary.path().to_path_buf(),
+                guest_path: "/workspace".to_string(),
+            },
+            crate::config::Mount {
+                host_path: secondary.path().to_path_buf(),
+                guest_path: "/data".to_string(),
+            },
+        ];
+        record_mount_state(&inst, &mounts).expect("save");
+        let loaded = WorkspaceState::try_load(&inst)
+            .expect("no IO error")
+            .expect("state should exist");
+        assert!(matches!(loaded.source, WorkspaceSource::Mount));
+        assert_eq!(loaded.host_path.as_deref(), Some(primary.path()));
+        assert_eq!(loaded.guest_path, "/workspace");
+        assert!(loaded.git_repo_url.is_none());
+    }
+
+    #[test]
+    fn record_mount_state_noop_on_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inst = temp_instance(dir.path());
+        record_mount_state(&inst, &[]).expect("ok");
+        assert!(
+            WorkspaceState::try_load(&inst)
+                .expect("no IO error")
+                .is_none(),
+            "empty mounts should not write state"
+        );
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -703,6 +703,8 @@ test_github_token_forwarding() {
     echo "=== Phase: github token forwarding ==="
 
     # Check the config's github auth strategy to determine expected behavior.
+    # `github` may be a plain string ("auto" / "env" / "off" / "pat") or a
+    # table — collapse the table form to its `mode` field.
     local github_setting
     local cfg_path="${HOME}/.coop/config.toml"
     github_setting=$(python3 -c "
@@ -714,7 +716,10 @@ except ImportError:
 try:
     with open('$cfg_path', 'rb') as f:
         cfg = tomllib.load(f)
-    print(cfg.get('github', 'off'))
+    raw = cfg.get('github', 'off')
+    if isinstance(raw, dict):
+        raw = raw.get('mode', 'off')
+    print(raw)
 except Exception:
     print('off')
 " 2>/dev/null || echo "off")
@@ -731,13 +736,106 @@ except Exception:
             fail "GITHUB_TOKEN forwarded to guest (github: $github_setting)" "got: ${token_out:-empty}"
         fi
     else
-        # Token should NOT be forwarded
+        # Token should NOT be forwarded (off / pat / unset)
         if [[ -z "$token_out" || "$token_out" != *"test-leak-token"* ]]; then
             pass "GITHUB_TOKEN not forwarded to guest (github: $github_setting)"
         else
             fail "GITHUB_TOKEN not forwarded to guest (github: $github_setting)" "got: $token_out"
         fi
     fi
+}
+
+# Verify that github = "pat" + a matching [github.pat] entry forwards the
+# configured token (a server-side dummy literal, never a real PAT) for an
+# instance whose `--git-repo` matches the entry. Runs in the --full bucket
+# because it boots a fresh VM.
+test_github_pat_forwarding() {
+    echo ""
+    echo "=== Phase: github pat-mode token forwarding ==="
+
+    local pat_instance="${INSTANCE}-pat"
+    local token_file="$tmpdir/pat-token.txt"
+    local cfg_file="$tmpdir/coop-pat.toml"
+    local repo_url="https://github.com/trailofbits/coop.git"
+    local repo_slug="trailofbits/coop"
+    local sentinel="github_pat_test_FORWARDED_OK"
+
+    # File-backend secret store: a 0600 file the wizard would have written.
+    printf '%s' "$sentinel" > "$token_file"
+    chmod 0600 "$token_file"
+
+    # Config inherits the default data_dir + golden image. github =/= pat
+    # mode is the only override.
+    cat > "$cfg_file" <<CFGEOF
+[github]
+mode = "pat"
+
+[github.pat."$repo_slug"]
+token = "cmd:cat $token_file"
+CFGEOF
+
+    # Step 1: `coop validate` must parse pat-mode and report the entry.
+    if env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" validate \
+            >"$tmpdir/pat-validate.out" 2>&1; then
+        if grep -q "github.pat.\"$repo_slug\": ok" "$tmpdir/pat-validate.out"; then
+            pass "pat: validate reports the configured entry"
+        else
+            fail "pat: validate reports the configured entry" \
+                "validate output: $(cat "$tmpdir/pat-validate.out")"
+        fi
+    else
+        fail "pat: validate succeeds with a [github.pat] entry" \
+            "$(cat "$tmpdir/pat-validate.out")"
+    fi
+
+    # Step 2: `coop github status` must list the entry without resolving it
+    # (no --probe).
+    if env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" github status \
+            >"$tmpdir/pat-status.out" 2>&1; then
+        if grep -q "$repo_slug" "$tmpdir/pat-status.out"; then
+            pass "pat: github status lists the entry"
+        else
+            fail "pat: github status lists the entry" \
+                "status output: $(cat "$tmpdir/pat-status.out")"
+        fi
+    else
+        fail "pat: github status runs cleanly" "$(cat "$tmpdir/pat-status.out")"
+    fi
+
+    # Step 3: boot a VM with --git-repo so workspace.json records the URL,
+    # then `exec` and read GITHUB_TOKEN out of the guest. Network access to
+    # github.com is required (same as `test_git_repo_private_clone`). Skip
+    # if we can't reach github.com from the host — keeps CI honest.
+    if ! curl -fsS --max-time 10 -o /dev/null https://github.com 2>/dev/null; then
+        skip "pat: token forwarding via --git-repo" "github.com unreachable from host"
+        return
+    fi
+
+    if env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" start \
+            "$pat_instance" \
+            --git-repo "$repo_url" \
+            --no-prompt \
+            >"$tmpdir/pat-start.out" 2>&1; then
+        STARTED_INSTANCES+=("$pat_instance")
+        pass "pat: start with --git-repo for the configured slug"
+    else
+        fail "pat: start with --git-repo for the configured slug" \
+            "$(cat "$tmpdir/pat-start.out")"
+        env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" destroy "$pat_instance" 2>/dev/null || true
+        return
+    fi
+
+    local pat_token_out
+    pat_token_out=$(env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY RUST_LOG=off \
+        "$BINARY" --config "$cfg_file" exec "$pat_instance" -- printenv GITHUB_TOKEN 2>/dev/null) || true
+    if [[ "$pat_token_out" == *"$sentinel"* ]]; then
+        pass "pat: configured token forwarded to guest"
+    else
+        fail "pat: configured token forwarded to guest" "got: ${pat_token_out:-empty}"
+    fi
+
+    # Cleanup.
+    env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" destroy "$pat_instance" 2>/dev/null || true
 }
 
 test_term_handling() {
@@ -2726,6 +2824,9 @@ main() {
 
         # Local marketplace directory copy
         test_local_marketplace
+
+        # github = "pat" mode + per-repo token forwarding (uses a stub image)
+        test_github_pat_forwarding
 
         # Config sources: CLAUDE.md + rules copy
         test_config_dir


### PR DESCRIPTION
## Summary

Implements issue #85: a new `github = "pat"` mode and a `coop github setup-pat` wizard that walks the user through creating a fine-grained personal access token scoped to one repo, with the minimum permissions an agent needs.

- Per-repo PAT entries keyed under `[github.pat."owner/repo"]`. At `coop start` time the resolved repo (`--git-repo` URL or workspace `origin`) selects the matching entry and the token is forwarded as `GITHUB_TOKEN`.
- Secret-store abstraction (`src/secret_store.rs`) with backends for macOS Keychain, Linux Secret Service, 1Password CLI, and a `0600` file fallback. The config holds a `cmd:` invocation that reads the token back at start time — the secret itself never lives in `config.toml` when the wizard places it.
- Subcommands: `setup-pat`, `rotate-pat`, `status` (lazy; `--probe` to also resolve), `forget-pat`.
- `coop start` pre-flight hook (`src/pat_prompt.rs`) that offers the wizard inline when the resolved repo has no entry. `[y/N/never]` answers; the `never` answer records a skip marker that survives reloads (regression test included).
- `coop validate --probe` exercises `/user` per entry.
- `WorkspaceState` now records the `--git-repo` URL so follow-up commands (`shell`, `claude`, `codex`, `exec`) re-derive the slug and find the same PAT entry.
- `Cmd::redacted_arg` keeps tokens out of debug logs when a backend has no stdin-driven write path (macOS `security`, `op item create`).
- Config file is written atomically under an `flock`, with mode `0600` when any literal token (no `cmd:` prefix) is detected.

Default permission set in the wizard form: contents/pull-requests/issues read-write, checks/commit-statuses read. See `docs/configuration.md` for the full reference and multi-repo example.

Existing `"auto"` / `"env"` / `"off"` behaviour is unchanged; default stays `"off"`.

## Test plan

- [x] `cargo test` — 338 unit tests pass, including new tests for slug parsing, PAT config (de)serialization, skip-marker survival across modes, atomic upsert, prompt-decision matrix.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.
- [x] Manual smoke: `coop github status`, `coop github status --probe`, `coop validate` against a config with a `[github.pat]` entry.
- [ ] Integration tests on Lima (`./tests/run-integration.sh`) — pending local run.
- [ ] Integration tests on Firecracker (`./tests/run-integration.sh --remote …`) — pending remote run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)