### PR TITLE
Add `coop list` / `coop ls` to enumerate instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 | `exec` | Run a command in the VM non-interactively |
 | `push` | Sync local directory into the VM |
 | `pull` | Sync VM workspace back to the host |
+| `list` (`ls`) | List instances by name and state |
 | `status` | Show instance status and resource usage |
 | `logs` | Stream VM serial console output |
 | `vscode` | Open VS Code connected to the guest |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -223,6 +223,17 @@ coop destroy my-project
 coop destroy --all
 ```
 
+### `list`
+
+Print every instance with its state (`running` or `stopped`). Reads from local on-disk state only — no SSH probing, so it returns instantly even when VMs are unreachable. Use `status` instead when you need resource usage or per-instance detail.
+
+```
+coop list
+coop ls
+```
+
+Alias: `ls`.
+
 ### `status`
 
 Print instance status. Without a name, lists every instance with its state, image, backend, and resource usage (for running instances). With a name, prints detailed status for that instance.

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -14,7 +14,7 @@ coop start my-project
 coop start
 ```
 
-Named instances pay off when you have several running at once. The name appears in `coop status` output and targets commands at a specific instance.
+Named instances pay off when you have several running at once. The name appears in `coop list` / `coop status` output and targets commands at a specific instance.
 
 ### Name validation rules
 
@@ -47,9 +47,20 @@ This applies to `shell`, `stop`, `destroy`, `status <name>`, `logs`, `push`, `pu
 
 ## Checking status
 
+### Just the names
+
+`coop list` (alias `ls`) prints a minimal name/state table. It reads from local on-disk state only, so it's fast and works even when VMs are unreachable. Use it when you just need to remember what's available:
+
+```
+$ coop list
+NAME             STATE
+another-project  stopped
+my-project       running
+```
+
 ### All instances
 
-`coop status` with no arguments lists every instance in a table:
+`coop status` with no arguments lists every instance in a richer table, including image, backend, and resource usage for running instances:
 
 ```
 $ coop status

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,9 @@ enum Commands {
         #[arg(long)]
         all: bool,
     },
+    /// List instances by name and state
+    #[command(alias = "ls")]
+    List,
     /// Show VM status
     Status {
         /// Instance name (shows all if omitted)
@@ -473,6 +476,7 @@ fn main() -> Result<()> {
             let _guard = signal::install_handlers();
             cmd_destroy(&be, &cfg, name.as_deref(), all)
         }
+        Commands::List => cmd_list(&be, &cfg),
         Commands::Status { name } => cmd_status(&be, &cfg, name.as_deref()),
         Commands::Logs { name, follow } => {
             let running = resolve_running(&be, &cfg, name.as_deref())?;
@@ -1044,6 +1048,29 @@ fn cmd_destroy(
     Ok(())
 }
 
+fn cmd_list(be: &backend::PlatformBackend, cfg: &config::CoopConfig) -> Result<()> {
+    let mut instances = cfg.list_instances()?;
+    if instances.is_empty() {
+        writeln!(std::io::stdout(), "No instances found")
+            .map_err(|e| anyhow::anyhow!("Failed to write list: {e}"))?;
+        return Ok(());
+    }
+    instances.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+
+    writeln!(std::io::stdout(), "{:<16} STATE", "NAME")
+        .map_err(|e| anyhow::anyhow!("Failed to write list: {e}"))?;
+    for inst in &instances {
+        let state = if be.is_running(inst) {
+            "running"
+        } else {
+            "stopped"
+        };
+        writeln!(std::io::stdout(), "{:<16} {state}", inst.name.as_str())
+            .map_err(|e| anyhow::anyhow!("Failed to write list: {e}"))?;
+    }
+    Ok(())
+}
+
 fn cmd_status(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
@@ -1535,6 +1562,18 @@ mod tests {
         };
         assert!(session.no_tmux);
         assert!(session.tmux_session("main").is_none());
+    }
+
+    #[test]
+    fn list_subcommand_parses() {
+        let cli = parse(&["list"]);
+        assert!(matches!(cli.command, super::Commands::List));
+    }
+
+    #[test]
+    fn ls_alias_parses_as_list() {
+        let cli = parse(&["ls"]);
+        assert!(matches!(cli.command, super::Commands::List));
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -403,6 +403,40 @@ test_status_running() {
     fi
 }
 
+test_list_running() {
+    echo ""
+    echo "=== Phase: list (running) ==="
+
+    if coop list; then
+        pass "list exits 0"
+    else
+        fail "list exits 0" "exit code: $?"
+    fi
+
+    if echo "$HARNESS_OUT" | grep -q "^NAME *STATE"; then
+        pass "list prints NAME/STATE header"
+    else
+        fail "list prints NAME/STATE header" "got: $HARNESS_OUT"
+    fi
+
+    if echo "$HARNESS_OUT" | grep -qE "^${INSTANCE} +running\$"; then
+        pass "list shows instance as running"
+    else
+        fail "list shows instance as running" "got: $HARNESS_OUT"
+    fi
+
+    # `ls` alias resolves to the same command.
+    if coop ls; then
+        if echo "$HARNESS_OUT" | grep -qE "^${INSTANCE} +running\$"; then
+            pass "ls alias prints same output"
+        else
+            fail "ls alias prints same output" "got: $HARNESS_OUT"
+        fi
+    else
+        fail "ls alias exits 0" "exit code: $?"
+    fi
+}
+
 test_auto_resolve_running() {
     echo ""
     echo "=== Phase: auto-resolve (single running) ==="
@@ -1070,6 +1104,38 @@ test_auto_resolve_stopped() {
         fi
     else
         fail "shell rejects when only stopped instances exist" "should have failed"
+    fi
+}
+
+test_list_stopped() {
+    echo ""
+    echo "=== Phase: list (stopped) ==="
+
+    if coop list; then
+        pass "list exits 0 after stop"
+    else
+        fail "list exits 0 after stop" "exit code: $?"
+    fi
+
+    if echo "$HARNESS_OUT" | grep -qE "^${INSTANCE} +stopped\$"; then
+        pass "list shows instance as stopped"
+    else
+        fail "list shows instance as stopped" "got: $HARNESS_OUT"
+    fi
+}
+
+test_list_empty() {
+    echo ""
+    echo "=== Phase: list (no instances) ==="
+
+    if coop list; then
+        if echo "$HARNESS_OUT" | grep -q "No instances found"; then
+            pass "list shows empty-state message"
+        else
+            fail "list shows empty-state message" "got: $HARNESS_OUT"
+        fi
+    else
+        fail "list exits 0 with no instances" "exit code: $?"
     fi
 }
 
@@ -2534,6 +2600,7 @@ main() {
     test_start
     test_duplicate_name
     test_status_running
+    test_list_running
     test_auto_resolve_running
     test_shell_connectivity
     test_ssh_alias
@@ -2556,11 +2623,13 @@ main() {
     test_stop
     test_auto_resolve_stopped
     test_status_stopped
+    test_list_stopped
     test_resize_status
     test_restart_stopped
     test_restart_rejects_ignored_flags
     test_destroy
     test_auto_resolve_no_instances
+    test_list_empty
 
     # Idempotency: re-run commands that should be safe to repeat
     test_idempotency


### PR DESCRIPTION
## Summary
- Adds `coop list` (alias `ls`) — a fast, local-only enumeration of instances by name and state. Reads on-disk metadata and `be.is_running` without SSH probes, so it stays usable when VMs are unreachable.
- `status` is unchanged; it remains the richer per-instance / resource-usage path.
- Closes #89.

Output:

```
NAME             STATE
another-project  stopped
my-project       running
```

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (288 tests including two new parser tests `list_subcommand_parses` and `ls_alias_parses_as_list`).
- [x] Smoke-tested the release binary against fabricated instance state: empty, single, multiple, mixed running/stopped. Surfaced and fixed an alignment bug (`InstanceName`'s `Display` impl ignores width specifiers — formatted `inst.name.as_str()` instead).
- [x] Integration suite extended with `test_list_running`, `test_list_stopped`, `test_list_empty` covering header, per-row state, the `ls` alias, and the empty-state message.
- [ ] `./tests/run-integration.sh` on macOS/Lima — needs to run on a host with the backend.
- [ ] `./tests/run-integration.sh --remote <linux-host>` on Linux/Firecracker — same.
- [x] Docs updated: README command table, `docs/commands.md` `list` section, `docs/multi-instance.md` "Just the names" subsection and header callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)