### PR TITLE
Include `.git/` in workspace transfers by default

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,6 +84,7 @@ coop start [NAME] [FLAGS]
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
 | `--image <name>` | Named image to use (default: `default`) |
 | `--mount <spec>` | Mount host directory into guest (`HOST_PATH[:GUEST_PATH]`, repeatable). Conflicts with `--workspace` and `--git-repo`. |
+| `--exclude-git` | Skip the `.git/` directory when syncing the workspace (conflicts with `--git-repo`). |
 
 `--workspace` and `--git-repo` are mutually exclusive. Use `--workspace` to tar-pipe a local directory into the guest. Use `--git-repo` to clone a repository inside the VM at boot.
 
@@ -282,6 +283,7 @@ coop push [--name NAME] [DIR] [FLAGS]
 | `--name <name>` | Instance name (required if multiple instances exist) |
 | `DIR` | Local directory to push (defaults to the workspace host path) |
 | `--force` | Overwrite guest changes without confirmation |
+| `--exclude-git` | Skip the `.git/` directory in this transfer |
 
 ```
 coop push
@@ -301,6 +303,7 @@ coop pull [--name NAME] [DIR] [FLAGS]
 | `--name <name>` | Instance name (required if multiple instances exist) |
 | `DIR` | Local directory to pull into (defaults to the workspace host path) |
 | `--force` | Overwrite local changes without confirmation |
+| `--exclude-git` | Skip the `.git/` directory in this transfer |
 
 ```
 coop pull

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -90,22 +90,29 @@ The destination directory is created if absent. Transport selection follows the 
 
 ## Default exclusions
 
-All transfers (rsync and tar-pipe) unconditionally exclude:
+All transfers (rsync and tar-pipe) exclude these reproducible build and cache directories:
 
-- `.git/`
 - `node_modules/`
 - `target/`
 - `__pycache__/`
 - `.venv/`
 - `.coop/`
 
-These are not configurable.
+`.git/` is **included** by default so agents in the guest get full history, branches, and the ability to make commits that survive a `coop pull`. Pass `--exclude-git` to `coop start`, `coop push`, or `coop pull` to skip it on a per-transfer basis (useful for very large repos where transfer time dominates).
 
 ## .gitignore integration
 
 When rsync is available, transfers pass `--filter=':- .gitignore'`. Rsync reads `.gitignore` files at each directory level and skips matching paths.
 
 The tar-pipe fallback on Linux uses GNU tar's `--exclude-vcs-ignores` for the same effect. On macOS, BSD tar lacks this flag, so only the default exclusions above apply.
+
+### `.git/` and .gitignore
+
+A repo whose `.gitignore` lists `.git/` (rare, but legal — sometimes seen in dotfile repos or repos vendoring other repos) gets special handling so the new include-by-default behaviour is not silently undone:
+
+- **rsync**: a protective `--filter=+ /.git/***` is prepended before the per-directory `.gitignore` merge, so `.git/` and its contents are always transferred unless `--exclude-git` is passed.
+- **GNU tar (Linux)**: `--exclude-vcs-ignores` is all-or-nothing. If your `.gitignore` lists `.git/`, the tar-pipe transport will skip it. Pass `--exclude-git` explicitly if that is what you want, or remove the entry from `.gitignore`.
+- **BSD tar (macOS)**: not affected — it doesn't read `.gitignore` at all.
 
 ## Checksum verification
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,9 @@ enum Commands {
         /// Named image to use (default: "default")
         #[arg(long, default_value = config::DEFAULT_IMAGE)]
         image: String,
+        /// Skip the `.git` directory when syncing the workspace
+        #[arg(long, conflicts_with = "git_repo")]
+        exclude_git: bool,
     },
     /// Open an interactive shell in the VM (or run a command non-interactively)
     #[command(alias = "ssh")]
@@ -227,6 +230,9 @@ enum Commands {
         /// Overwrite guest changes without confirmation
         #[arg(long)]
         force: bool,
+        /// Skip the `.git` directory in this transfer
+        #[arg(long)]
+        exclude_git: bool,
     },
     /// Pull guest workspace to local directory
     Pull {
@@ -238,6 +244,9 @@ enum Commands {
         /// Overwrite local changes without confirmation
         #[arg(long)]
         force: bool,
+        /// Skip the `.git` directory in this transfer
+        #[arg(long)]
+        exclude_git: bool,
     },
     /// Run a command in the VM and return its output (non-interactive)
     Exec {
@@ -414,6 +423,7 @@ fn main() -> Result<()> {
             no_agents,
             mount,
             image,
+            exclude_git,
         } => {
             if raw_args_use_deprecated_no_claude(std::env::args()) {
                 tracing::warn!(
@@ -438,6 +448,7 @@ fn main() -> Result<()> {
                         .map(|d| config::GiB::new(d).context("--disk must be > 0"))
                         .transpose()?,
                     mounts,
+                    exclude_git,
                 },
             )
         }
@@ -482,13 +493,35 @@ fn main() -> Result<()> {
             let running = resolve_running(&be, &cfg, name.as_deref())?;
             be.stream_logs(&cfg, &running.inst, follow)
         }
-        Commands::Push { name, dir, force } => {
+        Commands::Push {
+            name,
+            dir,
+            force,
+            exclude_git,
+        } => {
             let running = resolve_running(&be, &cfg, name.as_deref())?;
-            workspace::push(&running.target, &running.inst, dir.as_deref(), force)
+            workspace::push(
+                &running.target,
+                &running.inst,
+                dir.as_deref(),
+                force,
+                exclude_git,
+            )
         }
-        Commands::Pull { name, dir, force } => {
+        Commands::Pull {
+            name,
+            dir,
+            force,
+            exclude_git,
+        } => {
             let running = resolve_running(&be, &cfg, name.as_deref())?;
-            workspace::pull(&running.target, &running.inst, dir.as_deref(), force)
+            workspace::pull(
+                &running.target,
+                &running.inst,
+                dir.as_deref(),
+                force,
+                exclude_git,
+            )
         }
         Commands::Exec { name, command } => cmd_exec(&be, &cfg, name.as_deref(), &command),
         Commands::Vscode {
@@ -592,6 +625,7 @@ struct StartOpts<'a> {
     no_agents: bool,
     disk: Option<config::GiB>,
     mounts: Vec<config::Mount>,
+    exclude_git: bool,
 }
 
 fn cmd_start(
@@ -604,14 +638,15 @@ fn cmd_start(
         let has_ignored_flags = !opts.mounts.is_empty()
             || opts.workspace_dir.is_some()
             || opts.git_repo.is_some()
-            || opts.disk.is_some();
+            || opts.disk.is_some()
+            || opts.exclude_git;
 
         if has_ignored_flags {
             bail!(
                 "Instance '{}' already exists (stopped). The flags \
-                 --mount, --workspace, --git-repo, and --disk are only \
-                 applied at creation time and would be silently ignored \
-                 on restart.\n\
+                 --mount, --workspace, --git-repo, --disk, and --exclude-git \
+                 are only applied at creation time and would be silently \
+                 ignored on restart.\n\
                  To apply new options, destroy the instance first:\n  \
                  coop destroy {0}\n  coop start {0} [options]",
                 inst.name,
@@ -829,7 +864,7 @@ fn start_instance(
             .canonicalize()
             .with_context(|| format!("Failed to resolve {ws_dir}"))?;
 
-        workspace::tar_pipe_transfer(&target, &abs_path)?;
+        workspace::tar_pipe_transfer(&target, &abs_path, opts.exclude_git)?;
 
         let state = workspace::WorkspaceState {
             host_path: Some(abs_path),
@@ -847,7 +882,7 @@ fn start_instance(
         };
         state.save(inst)?;
     } else if !opts.mounts.is_empty() && !be.mounts_are_live() {
-        workspace::sync_mounts(&target, inst, &opts.mounts)?;
+        workspace::sync_mounts(&target, inst, &opts.mounts, opts.exclude_git)?;
         tracing::warn!(
             "Firecracker mounts use one-time sync, not live filesystem sharing. \
              Use `coop push` / `coop pull` to sync changes."

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -11,15 +11,19 @@ use crate::config::Instance;
 
 const GUEST_WORKSPACE: &str = "/workspace";
 
-/// Default exclusions for transfers.
+/// Default exclusions for transfers — reproducible build/cache directories
+/// only. `.git/` is intentionally absent: agents inside the guest need
+/// history, branches, and the ability to make commits that survive a
+/// `coop pull`. Opt out per-transfer with `exclude_git: true`.
 const DEFAULT_EXCLUDES: &[&str] = &[
-    ".git/",
     "node_modules/",
     "target/",
     "__pycache__/",
     ".venv/",
     ".coop/",
 ];
+
+const GIT_EXCLUDE: &str = ".git/";
 
 /// Persisted workspace metadata written during `start`.
 #[derive(Debug, Serialize, Deserialize)]
@@ -71,7 +75,7 @@ impl WorkspaceState {
 /// No staging file on either side, so peak disk usage on the guest is
 /// just the extracted tree. Integrity relies on SSH's MAC over the
 /// localhost transport plus tar's per-header checksums.
-pub fn tar_pipe_transfer(target: &SshTarget, source_dir: &Path) -> Result<()> {
+pub fn tar_pipe_transfer(target: &SshTarget, source_dir: &Path, exclude_git: bool) -> Result<()> {
     tracing::info!(
         "Transferring {} to guest:{GUEST_WORKSPACE} via tar-pipe",
         source_dir.display()
@@ -81,6 +85,9 @@ pub fn tar_pipe_transfer(target: &SshTarget, source_dir: &Path) -> Result<()> {
     tar_cmd.args(["cf", "-"]);
     for exc in DEFAULT_EXCLUDES {
         tar_cmd.arg(format!("--exclude={exc}"));
+    }
+    if exclude_git {
+        tar_cmd.arg(format!("--exclude={GIT_EXCLUDE}"));
     }
     // --exclude-vcs-ignores is GNU tar only (not available on macOS BSD tar)
     if !cfg!(target_os = "macos") {
@@ -290,7 +297,13 @@ fn load_or_default(inst: &Instance, dir: Option<&str>, cmd: &str) -> Result<Work
 }
 
 /// Push local directory to guest. Uses rsync if available, falls back to tar-pipe.
-pub fn push(target: &SshTarget, inst: &Instance, dir: Option<&str>, force: bool) -> Result<()> {
+pub fn push(
+    target: &SshTarget,
+    inst: &Instance,
+    dir: Option<&str>,
+    force: bool,
+    exclude_git: bool,
+) -> Result<()> {
     let state = load_or_default(inst, dir, "push")?;
     let source_dir = resolve_host_dir(dir, &state)?;
 
@@ -309,10 +322,10 @@ pub fn push(target: &SshTarget, inst: &Instance, dir: Option<&str>, force: bool)
     );
 
     if target.exec_ok("which rsync") {
-        rsync_push(target, &source_dir, &state.guest_path)?;
+        rsync_push(target, &source_dir, &state.guest_path, exclude_git)?;
     } else {
         tracing::info!("rsync not available on guest, using tar-pipe");
-        tar_pipe_transfer(target, &source_dir)?;
+        tar_pipe_transfer(target, &source_dir, exclude_git)?;
     }
 
     tracing::info!("Push complete");
@@ -320,7 +333,13 @@ pub fn push(target: &SshTarget, inst: &Instance, dir: Option<&str>, force: bool)
 }
 
 /// Pull guest workspace to local directory. Uses rsync if available, falls back to tar-pipe.
-pub fn pull(target: &SshTarget, inst: &Instance, dir: Option<&str>, force: bool) -> Result<()> {
+pub fn pull(
+    target: &SshTarget,
+    inst: &Instance,
+    dir: Option<&str>,
+    force: bool,
+    exclude_git: bool,
+) -> Result<()> {
     let state = load_or_default(inst, dir, "pull")?;
     let dest_dir = resolve_host_dir_for_pull(dir, &state)?;
 
@@ -338,10 +357,10 @@ pub fn pull(target: &SshTarget, inst: &Instance, dir: Option<&str>, force: bool)
     );
 
     if target.exec_ok("which rsync") {
-        rsync_pull(target, &state.guest_path, &dest_dir)?;
+        rsync_pull(target, &state.guest_path, &dest_dir, exclude_git)?;
     } else {
         tracing::info!("rsync not available on guest, using tar-pipe");
-        tar_pipe_pull(target, &state.guest_path, &dest_dir)?;
+        tar_pipe_pull(target, &state.guest_path, &dest_dir, exclude_git)?;
     }
 
     tracing::info!("Pull complete");
@@ -356,6 +375,7 @@ pub fn sync_mounts(
     target: &SshTarget,
     inst: &Instance,
     mounts: &[crate::config::Mount],
+    exclude_git: bool,
 ) -> Result<()> {
     for m in mounts {
         let guest = &m.guest_path;
@@ -366,10 +386,10 @@ pub fn sync_mounts(
         tracing::info!("Syncing {} -> guest:{guest}", m.host_path.display(),);
 
         if target.exec_ok("which rsync") {
-            rsync_push(target, &m.host_path, guest)?;
+            rsync_push(target, &m.host_path, guest, exclude_git)?;
         } else {
             tracing::info!("rsync not available on guest, using tar-pipe");
-            tar_pipe_transfer(target, &m.host_path)?;
+            tar_pipe_transfer(target, &m.host_path, exclude_git)?;
         }
     }
 
@@ -447,21 +467,32 @@ pub fn remove_ssh_config(inst: &Instance) -> Result<()> {
 
 // ── Transport: rsync ──────────────────────────────────────────
 
-fn rsync_base_args(target: &SshTarget) -> Vec<String> {
-    let mut args = vec![
-        "-az".to_string(),
-        "-e".to_string(),
-        target.rsync_ssh_cmd(),
-        "--filter=:- .gitignore".to_string(),
-    ];
+fn rsync_base_args(target: &SshTarget, exclude_git: bool) -> Vec<String> {
+    let mut args = vec!["-az".to_string(), "-e".to_string(), target.rsync_ssh_cmd()];
+    // `.git/` rule must precede the per-directory `.gitignore` merge: rsync
+    // uses first-match-wins, so without this a repo whose `.gitignore`
+    // happens to list `.git/` would silently strip git state from the
+    // transfer regardless of `--exclude-git`.
+    if exclude_git {
+        args.push(format!("--exclude={GIT_EXCLUDE}"));
+    } else {
+        // `/.git/***` matches the directory itself and everything inside.
+        args.push("--filter=+ /.git/***".to_string());
+    }
+    args.push("--filter=:- .gitignore".to_string());
     for exc in DEFAULT_EXCLUDES {
         args.push(format!("--exclude={exc}"));
     }
     args
 }
 
-pub fn rsync_push(target: &SshTarget, source: &Path, guest_path: &str) -> Result<()> {
-    let mut args = rsync_base_args(target);
+pub fn rsync_push(
+    target: &SshTarget,
+    source: &Path,
+    guest_path: &str,
+    exclude_git: bool,
+) -> Result<()> {
+    let mut args = rsync_base_args(target, exclude_git);
     args.push("--delete".to_string());
     args.push(format!("{}/", source.display()));
     args.push(format!("{}:{guest_path}/", target.addr()));
@@ -477,8 +508,8 @@ pub fn rsync_push(target: &SshTarget, source: &Path, guest_path: &str) -> Result
     Ok(())
 }
 
-fn rsync_pull(target: &SshTarget, guest_path: &str, dest: &Path) -> Result<()> {
-    let mut args = rsync_base_args(target);
+fn rsync_pull(target: &SshTarget, guest_path: &str, dest: &Path, exclude_git: bool) -> Result<()> {
+    let mut args = rsync_base_args(target, exclude_git);
     args.push(format!("{}:{guest_path}/", target.addr()));
     args.push(format!("{}/", dest.display()));
 
@@ -495,11 +526,19 @@ fn rsync_pull(target: &SshTarget, guest_path: &str, dest: &Path) -> Result<()> {
 
 // ── Transport: tar-pipe ───────────────────────────────────────
 
-fn tar_pipe_pull(target: &SshTarget, guest_path: &str, dest: &Path) -> Result<()> {
-    let excludes: Vec<String> = DEFAULT_EXCLUDES
+fn tar_pipe_pull(
+    target: &SshTarget,
+    guest_path: &str,
+    dest: &Path,
+    exclude_git: bool,
+) -> Result<()> {
+    let mut excludes: Vec<String> = DEFAULT_EXCLUDES
         .iter()
         .map(|exc| format!("--exclude={exc}"))
         .collect();
+    if exclude_git {
+        excludes.push(format!("--exclude={GIT_EXCLUDE}"));
+    }
     let exclude_str = excludes.join(" ");
 
     let remote_cmd = format!("tar cf - -C {guest_path} {exclude_str} .");
@@ -625,9 +664,21 @@ fn resolve_host_dir_for_pull(explicit: Option<&str>, state: &WorkspaceState) -> 
 }
 
 fn check_guest_dirty(target: &SshTarget, guest_path: &str) -> Result<()> {
+    // Untracked files are excluded — they're almost always host-side noise
+    // (build artifacts, editor state) that was copied in at start time, not
+    // edits made inside the guest. Modified tracked files and unpushed
+    // commits are the real signal that an agent has done work the host
+    // doesn't yet know about.
     let check_cmd = format!(
         "if [ -d {guest_path}/.git ]; then \
-            cd {guest_path} && git status --porcelain; \
+            cd {guest_path} && \
+            git status --porcelain --untracked-files=no && \
+            if git rev-parse --abbrev-ref '@{{u}}' >/dev/null 2>&1; then \
+                ahead=$(git rev-list --count '@{{u}}..HEAD' 2>/dev/null); \
+                if [ \"${{ahead:-0}}\" -gt 0 ]; then \
+                    echo \"AHEAD $ahead\"; \
+                fi; \
+            fi; \
          fi"
     );
 
@@ -643,8 +694,8 @@ fn check_guest_dirty(target: &SshTarget, guest_path: &str) -> Result<()> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     if !stdout.trim().is_empty() {
         bail!(
-            "Guest workspace has uncommitted changes:\n{stdout}\n\
-             Use --force to overwrite"
+            "Guest workspace has changes the host does not know about:\n{stdout}\n\
+             Pull them with `coop pull`, or overwrite with `coop push --force`."
         );
     }
 
@@ -1100,5 +1151,75 @@ Host coop-0\n\
 
         let result = remove_marker_blocks(input);
         assert!(result.is_empty());
+    }
+
+    // ── exclude_git policy ────────────────────────────────────
+
+    fn fake_ssh_target() -> SshTarget {
+        SshTarget {
+            host: "127.0.0.1".to_string(),
+            port: std::num::NonZeroU16::new(2222).unwrap(),
+            user: "ubuntu".to_string(),
+            key_path: PathBuf::from("/tmp/key"),
+        }
+    }
+
+    #[test]
+    fn default_excludes_omit_git() {
+        // Issue #91: `.git/` was previously hardcoded into DEFAULT_EXCLUDES,
+        // which silently stripped git history from agents in the guest. The
+        // policy is now opt-out via --exclude-git; lock it in here so a
+        // future tidy-up doesn't accidentally re-add `.git/`.
+        assert!(
+            !DEFAULT_EXCLUDES.iter().any(|e| e.contains(".git")),
+            "DEFAULT_EXCLUDES must not contain a .git pattern; got {DEFAULT_EXCLUDES:?}"
+        );
+        assert_eq!(GIT_EXCLUDE, ".git/");
+    }
+
+    #[test]
+    fn rsync_args_include_git_by_default() {
+        let args = rsync_base_args(&fake_ssh_target(), false);
+        // The protective filter must precede the .gitignore merge so
+        // first-match-wins doesn't let a user's .gitignore strip .git/.
+        let protect_idx = args
+            .iter()
+            .position(|a| a == "--filter=+ /.git/***")
+            .expect("expected protective .git/ include filter");
+        let gitignore_idx = args
+            .iter()
+            .position(|a| a == "--filter=:- .gitignore")
+            .expect("expected .gitignore merge filter");
+        assert!(
+            protect_idx < gitignore_idx,
+            "protective filter must come before .gitignore merge: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--exclude=.git/"),
+            "default rsync must not exclude .git/: {args:?}"
+        );
+    }
+
+    #[test]
+    fn rsync_args_exclude_git_when_requested() {
+        let args = rsync_base_args(&fake_ssh_target(), true);
+        // Opt-out path: no protective filter, explicit exclude before the
+        // .gitignore merge so the exclude wins.
+        let exclude_idx = args
+            .iter()
+            .position(|a| a == "--exclude=.git/")
+            .expect("expected --exclude=.git/");
+        let gitignore_idx = args
+            .iter()
+            .position(|a| a == "--filter=:- .gitignore")
+            .expect("expected .gitignore merge filter");
+        assert!(
+            exclude_idx < gitignore_idx,
+            "explicit --exclude=.git/ must precede .gitignore merge: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--filter=+ /.git/***"),
+            "exclude_git=true must drop the protective filter: {args:?}"
+        );
     }
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1297,6 +1297,13 @@ test_restart_rejects_ignored_flags() {
         coop stop "$INSTANCE" 2>/dev/null || true
     fi
 
+    if moat_fails start "$INSTANCE" --no-agents --exclude-git; then
+        pass "restart with --exclude-git rejected"
+    else
+        fail "restart with --exclude-git rejected" "should have failed"
+        coop stop "$INSTANCE" 2>/dev/null || true
+    fi
+
     # Plain restart (no conflicting flags) should still work
     if coop start "$INSTANCE" --no-agents; then
         pass "restart without flags still works"
@@ -1430,6 +1437,14 @@ test_workspace_sync() {
     mkdir -p "$ws_tmpdir/subdir"
     echo "nested" > "$ws_tmpdir/subdir/nested.txt"
 
+    # Initialise a git repo so the .git/ inclusion path (issue #91) is
+    # exercised end-to-end. Use a local-only commit; no remote is set up.
+    (
+        cd "$ws_tmpdir" && \
+        git init --quiet --initial-branch=main && \
+        git -c user.email=ci@test -c user.name=CI commit --allow-empty --quiet -m "init"
+    ) || fail "set up git repo in workspace tmpdir" "git init/commit failed"
+
     # Start instance with --workspace
     local args=(start "$ws_instance" --no-agents --workspace "$ws_tmpdir")
     if coop "${args[@]}"; then
@@ -1464,6 +1479,21 @@ test_workspace_sync() {
         fi
     else
         fail "nested workspace files synced" "nested file not found"
+    fi
+
+    # Issue #91: `.git/` is now included by default. Verify the guest has
+    # a usable git workspace, not just the HEAD file.
+    if guest_exec test -f /workspace/.git/HEAD; then
+        pass ".git/ directory transferred to guest"
+    else
+        fail ".git/ directory transferred to guest" "/workspace/.git/HEAD missing"
+    fi
+
+    if guest_exec git -C /workspace rev-parse HEAD >/dev/null; then
+        pass "guest git repo is functional after sync"
+    else
+        fail "guest git repo is functional after sync" \
+            "git rev-parse HEAD failed: $(guest_stderr)"
     fi
 
     # Modify file in guest, then pull


### PR DESCRIPTION
## Summary

- `coop start --workspace`, `coop push`, and `coop pull` no longer strip `.git/` from transfers — agents in the guest get history, branches, and round-trip commits.
- New `--exclude-git` opt-out on `start`/`push`/`pull` for repos where transfer cost dominates. Rejected at parse time when combined with `--git-repo` (which clones in-guest anyway) and gated on restart like other create-time flags.
- `check_guest_dirty` now actually fires (it was a silent no-op when `.git/` was excluded). Adjusted to ignore untracked files — host-side noise transferred at `start` time would otherwise block the first `coop push` — and to detect unpushed commits (`@{u}..HEAD`) so in-guest commits aren't silently destroyed by a `coop push`.
- rsync `--filter=+ /.git/***` ordered before the `.gitignore` merge so a `.gitignore` listing `.git/` can't silently re-exclude it. The equivalent gotcha for GNU tar's `--exclude-vcs-ignores` (all-or-nothing) is documented in `docs/workspaces.md`.

Fixes #91.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (289 passed; 3 new unit tests locking the policy)
- [x] Pre-VM integration phases (validate, invalid_names, profiles_cli): 24/24 passed
- [x] Manual: `coop start --exclude-git --git-repo …` rejected at parse time with a clear error
- [x] Manual: rsync filter verified against a synthetic repo whose `.gitignore` lists `.git/` — protective filter preserves `.git/`, opt-out path drops it
- [ ] **VM-dependent integration phases need to run on a real host** — `test_workspace_sync` (now asserts `.git/` arrives in the guest) and `test_restart_rejects_ignored_flags` (now covers `--exclude-git`). Background CI lacks `/dev/kvm`/Lima; run `./tests/run-integration.sh` (macOS/Lima) and `./tests/run-integration.sh --remote …` (Linux/Firecracker) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)