### PR TITLE
Add `coop uninstall` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Integration test — coop update
         run: ./tests/integration-update.sh
 
+      - name: Integration test — coop uninstall
+        run: ./tests/integration-uninstall.sh
+
   deny:
     runs-on: ubuntu-latest
     steps:

--- a/plans/issue-93-uninstall.md
+++ b/plans/issue-93-uninstall.md
@@ -1,0 +1,126 @@
+# Issue #93 — `coop uninstall`
+
+Add a `coop uninstall` subcommand. There is already a `coop update` (and a `coop destroy --all`), but no command that fully reverses an install: removing the binary, the data directory, and the XDG state file. Issue #93 asks for that, with a confirmation prompt before removing data directories.
+
+## Current state (2026-05-17)
+
+- `coop update` (`src/update.rs`) replaces the running binary with the latest release; it owns the `confirm()` helper at `src/update.rs:463`.
+- `coop destroy --all` (`src/main.rs:1010-1043`) tears down every instance, removes images / kernel / firecracker binary / jailer / SSH key / instances dir, and strips all coop blocks from `~/.ssh/config`. It does **not** remove `~/.coop` itself, the `config.toml`, the XDG update-check state, or the binary.
+- The data directory is `cfg.data_dir` (default `~/.coop`, see `default_data_dir` in `src/config.rs:1217`). The XDG state file lives at `${state_dir or data_local_dir}/coop/update-check.json` (see `state_path` in `src/update.rs:602`).
+- `CoopConfig::load` tolerates a missing config file and returns defaults, so uninstall can run cleanly even on a half-installed system.
+
+## CLI surface
+
+```rust
+/// Remove the coop binary and (optionally) its data directories
+Uninstall {
+    /// Skip interactive confirmation prompts
+    #[arg(short = 'y', long)]
+    yes: bool,
+    /// Remove only the binary, keep ~/.coop and update-check state
+    #[arg(long, conflicts_with = "purge")]
+    keep_data: bool,
+    /// Also remove data without prompting (pairs with --yes for CI)
+    #[arg(long, conflicts_with = "keep_data")]
+    purge: bool,
+}
+```
+
+Behaviour matrix:
+
+| invocation | binary | data dir | prompts |
+|---|---|---|---|
+| `coop uninstall` | yes (after confirm) | asked separately | 2 |
+| `coop uninstall --yes` | yes | yes | 0 |
+| `coop uninstall --yes --keep-data` | yes | no | 0 |
+| `coop uninstall --purge` | yes (after confirm) | yes | 1 (binary only) |
+| `coop uninstall --yes --purge` | yes | yes | 0 |
+
+`--keep-data` is the safety lever; `--purge` is the "yes to everything" shortcut for scripts. Without `--yes`, the command is fully interactive — two y/N prompts (binary, then data).
+
+## Implementation
+
+### 1. Dispatch (`src/main.rs`)
+
+Handle `Uninstall` *before* `load_and_validate_config` so it works even when no config exists. Load best-effort with `CoopConfig::load(&cli.config).unwrap_or_default()` — `load` already returns defaults for a missing file, and a parse error shouldn't block uninstall.
+
+```rust
+if let Commands::Uninstall { yes, keep_data, purge } = cli.command {
+    let cfg = config::CoopConfig::load(&cli.config).unwrap_or_default();
+    let be = backend::PlatformBackend::new();
+    return cmd_uninstall(&be, &cfg, UninstallOpts { yes, keep_data, purge });
+}
+```
+
+### 2. Refactor: extract `purge_all_data` from `cmd_destroy`
+
+The body of `destroy --all` in `src/main.rs:1010-1043` becomes:
+
+```rust
+fn purge_all_data(be: &backend::PlatformBackend, cfg: &config::CoopConfig) -> Result<()> { ... }
+```
+
+`cmd_destroy(.., all=true)` and `cmd_uninstall` both call it. No behaviour change for `destroy --all`.
+
+### 3. `cmd_uninstall` flow
+
+1. **Survey** — count instances (`cfg.list_instances()?`), images (`cfg.list_images()?`), and whether `cfg.data_dir` exists. Print a one-shot summary so the user sees what's at stake before either prompt.
+2. **Confirm binary removal** unless `--yes`. Print the full path from `env::current_exe()?`.
+3. **Decide data removal**:
+   - `--keep-data` → `false`
+   - `--yes` (with or without `--purge`) → `true`
+   - `--purge` (without `--yes`) → still ask once for the binary, then proceed with data
+   - otherwise → `confirm("Also remove data directory {data_dir} (N instances, M images)?")`
+4. **If removing data**: call `purge_all_data(be, cfg)`, then:
+   - `fs::remove_dir_all(&cfg.data_dir)` with a `sudo rm -rf` fallback (mirrors the existing instances-dir cleanup at `src/main.rs:1031`).
+   - Remove the XDG update-check state: `${state_dir}/coop/update-check.json` and its parent if empty. Add a small `pub fn remove_state()` to `src/update.rs` so the path computation stays in one place.
+5. **Always** call `workspace::remove_all_ssh_config()` — even with `--keep-data`, the blocks reference IPs that won't exist.
+6. **Remove the binary**: `fs::remove_file(env::current_exe()?)`. Unix keeps the open inode alive for the rest of the process. Special cases:
+   - **Dev-build guard**: if the resolved path contains `/target/debug/` or `/target/release/`, *do not* remove. Warn instead — `cargo run -- uninstall` shouldn't nuke build artifacts.
+   - **EPERM** (root-owned install dir): surface as `Cannot remove {path}: {err}. Try \`sudo coop uninstall\`.` No auto-sudo for the binary itself — different blast radius from the data-dir cleanup which already uses sudo for root-owned instance dirs.
+7. Final `tracing::info!("coop uninstalled.")` with a one-line install.sh hint.
+
+### 4. Share `confirm()`
+
+Move `confirm()` out of `src/update.rs:463` into a small `src/prompt.rs` module (or fold into `src/cmd.rs`). Same signature, no behaviour change. `update.rs` and `main.rs::cmd_uninstall` both `use crate::prompt::confirm;`.
+
+### 5. Edge cases
+
+- **Dev build**: do *not* refuse like `coop update` does. The `target/` guard above is the only protection.
+- **Custom `--config` path outside `data_dir`**: don't touch it. Print a note: "Config at {path} is outside the data directory and was not removed."
+- **No instances exist / data dir already absent**: silent no-ops, not errors.
+- **Lima backend**: `destroy_shared` only removes the images dir; the rest of `~/.coop` cleanup is platform-agnostic. Already correct.
+
+## Tests
+
+### Unit (`src/main.rs::tests`)
+
+CLI parsing only — filesystem cleanup is integration territory:
+
+- `uninstall_subcommand_parses`
+- `uninstall_yes_flag_parses`
+- `uninstall_short_y_flag_parses`
+- `uninstall_keep_data_flag_parses`
+- `uninstall_purge_flag_parses`
+- `uninstall_keep_data_and_purge_conflict`
+
+### Integration (`tests/integration.sh`)
+
+Optional, off-by-default phase guarded by `--uninstall` (this nukes everything in `~/.coop` and the staged binary):
+
+1. After the normal lifecycle, run `coop uninstall --yes --purge`.
+2. Assert the binary path no longer exists.
+3. Assert `~/.coop` no longer exists.
+4. Assert `~/.ssh/config` no longer contains coop markers.
+
+Document the flag's destructive nature in `CLAUDE.md` (the "## Testing" section) alongside the existing `--full` flag.
+
+## Files touched
+
+- `src/main.rs` — new `Commands::Uninstall` variant, `cmd_uninstall`, `purge_all_data` (extracted), `UninstallOpts` struct, parsing tests.
+- `src/update.rs` — export `confirm()` via a shared module; add `remove_state()` helper.
+- `src/prompt.rs` *(new)* — shared `confirm()`.
+- `tests/integration.sh` — optional `--uninstall` phase.
+- `CLAUDE.md` — note the new test phase.
+
+No new dependencies.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod guest;
 mod lima;
 #[cfg_attr(target_os = "macos", expect(dead_code, reason = "Firecracker-only"))]
 mod network;
+mod prompt;
 mod rootfs;
 mod signal;
 // Setup is an interactive CLI workflow — stderr output is intentional user communication.
@@ -312,6 +313,18 @@ enum Commands {
         #[arg(short = 'y', long)]
         yes: bool,
     },
+    /// Remove the coop binary and (optionally) its data directories
+    Uninstall {
+        /// Skip interactive confirmation prompts (removes data unless --keep-data)
+        #[arg(short = 'y', long)]
+        yes: bool,
+        /// Remove only the binary, keep ~/.coop and update-check state
+        #[arg(long, conflicts_with = "purge")]
+        keep_data: bool,
+        /// Also remove data without prompting (pairs with --yes for CI)
+        #[arg(long, conflicts_with = "keep_data")]
+        purge: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -381,6 +394,41 @@ fn main() -> Result<()> {
             pinned_version: target_version,
             skip_confirm: yes,
         });
+    }
+    if let Commands::Uninstall {
+        yes,
+        keep_data,
+        purge,
+    } = cli.command
+    {
+        // Best-effort config load — uninstall must work even on a half-installed
+        // or partially-corrupted system. `load` already tolerates a missing file;
+        // a parse failure means we fall back to defaults, which can mask a
+        // custom `data_dir` — warn so the user can re-run with --keep-data.
+        let cfg = match config::CoopConfig::load(&cli.config) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to parse {} ({e}); using defaults. \
+                     A custom data_dir may not be honoured — re-run with \
+                     --keep-data if your data lives outside {}.",
+                    cli.config.display(),
+                    config::CoopConfig::default().data_dir.display(),
+                );
+                config::CoopConfig::default()
+            }
+        };
+        let be: backend::PlatformBackend = backend::PlatformBackend::new();
+        return cmd_uninstall(
+            &be,
+            &cfg,
+            &cli.config,
+            &UninstallOpts {
+                yes,
+                keep_data,
+                purge,
+            },
+        );
     }
 
     let mut cfg = load_and_validate_config(&cli.config)?;
@@ -553,7 +601,7 @@ fn main() -> Result<()> {
             cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
         }
         Commands::Validate => cmd_validate(&cfg, &be),
-        Commands::Init | Commands::Update { .. } => {
+        Commands::Init | Commands::Update { .. } | Commands::Uninstall { .. } => {
             unreachable!("handled before config loading")
         }
     }
@@ -1042,38 +1090,7 @@ fn cmd_destroy(
     all: bool,
 ) -> Result<()> {
     if all {
-        let instances = cfg.list_instances()?;
-        for inst in &instances {
-            tracing::info!("Destroying instance '{}'", inst.name);
-            be.destroy_instance(cfg, inst)?;
-            workspace::remove_ssh_config(inst)?;
-        }
-
-        be.destroy_shared(cfg);
-
-        let key = cfg.ssh_key_path();
-        if let Err(e) = std::fs::remove_file(&key) {
-            tracing::debug!("Failed to remove SSH private key (non-fatal): {e}");
-        }
-        if let Err(e) = std::fs::remove_file(key.with_extension("pub")) {
-            tracing::debug!("Failed to remove SSH public key (non-fatal): {e}");
-        }
-
-        let instances_dir = cfg.instances_dir();
-        if instances_dir.exists() {
-            // Instance dirs may be root-owned (Firecracker) or user-owned (Lima)
-            if let Err(e) = std::fs::remove_dir_all(&instances_dir) {
-                tracing::debug!("User remove_dir_all failed, trying sudo: {e}");
-                if let Err(e) = Cmd::new("rm").arg("-rf").arg(&instances_dir).sudo().run() {
-                    tracing::debug!(
-                        "Failed to remove instances dir {} (non-fatal): {e}",
-                        instances_dir.display()
-                    );
-                }
-            }
-        }
-
-        workspace::remove_all_ssh_config()?;
+        purge_all_data(be, cfg)?;
         tracing::info!("All resources cleaned up");
     } else {
         let inst = cfg.resolve_instance(name)?;
@@ -1107,6 +1124,220 @@ fn cmd_list(be: &backend::PlatformBackend, cfg: &config::CoopConfig) -> Result<(
             .map_err(|e| anyhow::anyhow!("Failed to write list: {e}"))?;
     }
     Ok(())
+}
+
+/// Destroy every instance, delegate backend-specific shared-state cleanup
+/// (`destroy_shared`), wipe the SSH keypair and instances dir, and strip every
+/// coop block from `~/.ssh/config`.
+///
+/// Shared by `coop destroy --all` and `coop uninstall`. Does **not** remove
+/// the `data_dir` itself or the binary — uninstall handles those.
+fn purge_all_data(be: &backend::PlatformBackend, cfg: &config::CoopConfig) -> Result<()> {
+    let instances = cfg.list_instances()?;
+    for inst in &instances {
+        tracing::info!("Destroying instance '{}'", inst.name);
+        be.destroy_instance(cfg, inst)?;
+        workspace::remove_ssh_config(inst)?;
+    }
+
+    be.destroy_shared(cfg);
+
+    let key = cfg.ssh_key_path();
+    if let Err(e) = std::fs::remove_file(&key) {
+        tracing::debug!("Failed to remove SSH private key (non-fatal): {e}");
+    }
+    if let Err(e) = std::fs::remove_file(key.with_extension("pub")) {
+        tracing::debug!("Failed to remove SSH public key (non-fatal): {e}");
+    }
+
+    let instances_dir = cfg.instances_dir();
+    if instances_dir.exists() {
+        // Instance dirs may be root-owned (Firecracker) or user-owned (Lima)
+        if let Err(e) = std::fs::remove_dir_all(&instances_dir) {
+            tracing::debug!("User remove_dir_all failed, trying sudo: {e}");
+            if let Err(e) = Cmd::new("rm").arg("-rf").arg(&instances_dir).sudo().run() {
+                tracing::debug!(
+                    "Failed to remove instances dir {} (non-fatal): {e}",
+                    instances_dir.display()
+                );
+            }
+        }
+    }
+
+    workspace::remove_all_ssh_config()?;
+    Ok(())
+}
+
+struct UninstallOpts {
+    yes: bool,
+    keep_data: bool,
+    purge: bool,
+}
+
+fn cmd_uninstall(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    config_path: &Path,
+    opts: &UninstallOpts,
+) -> Result<()> {
+    use std::io::IsTerminal as _;
+
+    let binary_path =
+        std::env::current_exe().context("Failed to resolve current executable path for removal")?;
+
+    // `current_exe` reads /proc/self/exe on Linux, which dereferences symlinks.
+    // Removing the resolved target leaves any PATH-level symlinks dangling —
+    // surface the resolved path so the user knows what's actually about to go.
+    tracing::debug!("Resolved binary path: {}", binary_path.display());
+
+    if !opts.yes && !std::io::stdin().is_terminal() {
+        bail!(
+            "stdin is not a TTY; pass --yes (and optionally --keep-data or --purge) \
+             for non-interactive uninstall."
+        );
+    }
+
+    print_uninstall_summary(cfg, &binary_path);
+
+    if !opts.yes && !prompt::confirm(&format!("Remove coop binary at {}?", binary_path.display()))?
+    {
+        tracing::info!("Uninstall cancelled");
+        return Ok(());
+    }
+
+    let remove_data = decide_remove_data(cfg, opts)?;
+
+    if remove_data {
+        purge_all_data(be, cfg)?;
+        wipe_data_dir(&cfg.data_dir);
+        if let Err(e) = update::remove_state() {
+            tracing::debug!("Failed to remove update-check state (non-fatal): {e}");
+        }
+        if !config_path_is_under_data_dir(config_path, &cfg.data_dir) && config_path.exists() {
+            tracing::info!(
+                "Config at {} is outside the data directory and was not removed",
+                config_path.display()
+            );
+        }
+    } else {
+        if let Err(e) = workspace::remove_all_ssh_config() {
+            tracing::debug!("SSH config cleanup failed (non-fatal): {e}");
+        }
+        if cfg.data_dir.exists() {
+            tracing::info!(
+                "Keeping {}; reinstall coop to manage existing instances.",
+                cfg.data_dir.display()
+            );
+        }
+    }
+
+    remove_self_binary(&binary_path)?;
+    tracing::info!(
+        "coop uninstalled. To reinstall: curl -fsSL https://raw.githubusercontent.com/trailofbits/coop/main/install.sh | sh"
+    );
+    Ok(())
+}
+
+fn print_uninstall_summary(cfg: &config::CoopConfig, binary_path: &Path) {
+    let instance_count = cfg.list_instances().map(|v| v.len()).unwrap_or(0);
+    let image_count = cfg.list_images().map(|v| v.len()).unwrap_or(0);
+    tracing::info!("This will remove:");
+    tracing::info!("  binary:    {}", binary_path.display());
+    if cfg.data_dir.exists() {
+        tracing::info!(
+            "  data dir:  {} ({instance_count} instance(s), {image_count} image(s))",
+            cfg.data_dir.display()
+        );
+    } else {
+        tracing::info!("  data dir:  {} (already absent)", cfg.data_dir.display());
+    }
+}
+
+fn decide_remove_data(cfg: &config::CoopConfig, opts: &UninstallOpts) -> Result<bool> {
+    if opts.keep_data {
+        return Ok(false);
+    }
+    if opts.yes || opts.purge {
+        return Ok(true);
+    }
+    let instance_count = cfg.list_instances().map(|v| v.len()).unwrap_or(0);
+    let image_count = cfg.list_images().map(|v| v.len()).unwrap_or(0);
+    prompt::confirm(&format!(
+        "Also remove data directory {} ({instance_count} instance(s), {image_count} image(s))?",
+        cfg.data_dir.display()
+    ))
+}
+
+fn wipe_data_dir(data_dir: &Path) {
+    if !data_dir.exists() {
+        return;
+    }
+    if let Err(e) = std::fs::remove_dir_all(data_dir) {
+        tracing::debug!("User remove_dir_all failed, trying sudo: {e}");
+        if let Err(e) = Cmd::new("rm").arg("-rf").arg(data_dir).sudo().run() {
+            tracing::warn!(
+                "Failed to remove data dir {} (non-fatal): {e}",
+                data_dir.display()
+            );
+        }
+    }
+}
+
+/// True when `config_path` lives inside `data_dir`.
+///
+/// Canonicalises both sides so `./`, symlinks, and macOS `/private/var` aliases
+/// don't produce false negatives. Falls back to a lexical comparison only when
+/// *both* sides fail to canonicalise — mixing canonical with lexical produced
+/// platform-dependent wrong answers (e.g. `/private/var/.coop` vs `/var/.coop`).
+fn config_path_is_under_data_dir(config_path: &Path, data_dir: &Path) -> bool {
+    match (config_path.canonicalize(), data_dir.canonicalize()) {
+        (Ok(c), Ok(d)) => c.starts_with(&d),
+        (Err(_), Err(_)) => config_path.starts_with(data_dir),
+        // Exactly one side resolved — canonicalisation diverged from lexical
+        // form, so the comparison would be apples-to-oranges. Treat as
+        // "we can't tell" and skip the informational notice rather than print
+        // a misleading one.
+        _ => true,
+    }
+}
+
+/// Resolved path is under `cargo` build output — almost certainly a dev build
+/// being run via `cargo run -- uninstall`. Nuking the target artifact is
+/// rarely what the developer intended.
+///
+/// Matches consecutive components `target/<debug|release>` so unrelated
+/// directories named "target" or "release" do not trigger the guard
+/// (e.g. `/opt/release/target/bin/coop` or `~/target-foo/release/coop`).
+fn is_dev_target_path(path: &Path) -> bool {
+    let components: Vec<_> = path.components().collect();
+    components.windows(2).any(|w| {
+        w[0].as_os_str() == "target"
+            && matches!(w[1].as_os_str().to_str(), Some("debug" | "release"))
+    })
+}
+
+fn remove_self_binary(binary_path: &Path) -> Result<()> {
+    if is_dev_target_path(binary_path) {
+        tracing::warn!(
+            "Refusing to remove {} — looks like a cargo build artifact. \
+             Run `cargo clean` if you really want to delete it.",
+            binary_path.display()
+        );
+        return Ok(());
+    }
+    std::fs::remove_file(binary_path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            anyhow::anyhow!(
+                "Cannot remove {}: {e}. Try `sudo coop uninstall`.",
+                binary_path.display()
+            )
+        } else {
+            anyhow::Error::from(e).context(format!(
+                "Failed to remove binary at {}",
+                binary_path.display()
+            ))
+        }
+    })
 }
 
 fn cmd_status(
@@ -1392,6 +1623,7 @@ fn dir_size_display(dir: &std::path::Path) -> String {
 
 #[cfg(test)]
 #[expect(clippy::panic, reason = "tests use panic for unreachable branches")]
+#[expect(clippy::unwrap_used, reason = "test code — panics are assertions")]
 mod tests {
     use clap::Parser;
 
@@ -1733,5 +1965,180 @@ mod tests {
     fn profiles_show_requires_name() {
         let err = parse_err(&["profiles", "show"]);
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn uninstall_subcommand_parses() {
+        let cli = parse(&["uninstall"]);
+        let super::Commands::Uninstall {
+            yes,
+            keep_data,
+            purge,
+        } = cli.command
+        else {
+            panic!("expected Uninstall variant");
+        };
+        assert!(!yes);
+        assert!(!keep_data);
+        assert!(!purge);
+    }
+
+    #[test]
+    fn uninstall_yes_flag_parses() {
+        let cli = parse(&["uninstall", "--yes"]);
+        let super::Commands::Uninstall { yes, .. } = cli.command else {
+            panic!("expected Uninstall variant");
+        };
+        assert!(yes);
+    }
+
+    #[test]
+    fn uninstall_short_y_flag_parses() {
+        let cli = parse(&["uninstall", "-y"]);
+        let super::Commands::Uninstall { yes, .. } = cli.command else {
+            panic!("expected Uninstall variant");
+        };
+        assert!(yes);
+    }
+
+    #[test]
+    fn uninstall_keep_data_flag_parses() {
+        let cli = parse(&["uninstall", "--keep-data"]);
+        let super::Commands::Uninstall { keep_data, .. } = cli.command else {
+            panic!("expected Uninstall variant");
+        };
+        assert!(keep_data);
+    }
+
+    #[test]
+    fn uninstall_purge_flag_parses() {
+        let cli = parse(&["uninstall", "--purge"]);
+        let super::Commands::Uninstall { purge, .. } = cli.command else {
+            panic!("expected Uninstall variant");
+        };
+        assert!(purge);
+    }
+
+    #[test]
+    fn uninstall_keep_data_and_purge_conflict() {
+        let err = parse_err(&["uninstall", "--keep-data", "--purge"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn dev_target_path_requires_consecutive_components() {
+        use std::path::Path;
+        // True: target immediately followed by debug/release
+        assert!(super::is_dev_target_path(Path::new(
+            "/home/u/repo/target/debug/coop"
+        )));
+        assert!(super::is_dev_target_path(Path::new(
+            "/home/u/repo/target/release/coop"
+        )));
+        // False: real install paths
+        assert!(!super::is_dev_target_path(Path::new(
+            "/home/u/.local/bin/coop"
+        )));
+        assert!(!super::is_dev_target_path(Path::new("/usr/local/bin/coop")));
+        // False: `target` and `release`/`debug` present but not adjacent
+        assert!(!super::is_dev_target_path(Path::new(
+            "/opt/release/target/bin/coop"
+        )));
+        assert!(!super::is_dev_target_path(Path::new(
+            "/home/u/target-foo/release/coop"
+        )));
+        assert!(!super::is_dev_target_path(Path::new(
+            "/srv/debug/lib/target/coop"
+        )));
+    }
+
+    fn opts(yes: bool, keep_data: bool, purge: bool) -> super::UninstallOpts {
+        super::UninstallOpts {
+            yes,
+            keep_data,
+            purge,
+        }
+    }
+
+    fn cfg_with_data_dir(dir: std::path::PathBuf) -> super::config::CoopConfig {
+        super::config::CoopConfig {
+            data_dir: dir,
+            ..super::config::CoopConfig::default()
+        }
+    }
+
+    #[test]
+    fn decide_remove_data_keeps_data_when_keep_data_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        assert!(!super::decide_remove_data(&cfg, &opts(true, true, false)).unwrap());
+        assert!(!super::decide_remove_data(&cfg, &opts(false, true, false)).unwrap());
+    }
+
+    #[test]
+    fn decide_remove_data_removes_when_yes_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        assert!(super::decide_remove_data(&cfg, &opts(true, false, false)).unwrap());
+    }
+
+    #[test]
+    fn decide_remove_data_removes_when_purge_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        assert!(super::decide_remove_data(&cfg, &opts(false, false, true)).unwrap());
+        assert!(super::decide_remove_data(&cfg, &opts(true, false, true)).unwrap());
+    }
+
+    #[test]
+    fn decide_remove_data_interactive_returns_false_without_tty() {
+        // In `cargo test` stdin is not a TTY, so `prompt::confirm` returns
+        // `Ok(false)` — exercising the interactive branch deterministically.
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        assert!(!super::decide_remove_data(&cfg, &opts(false, false, false)).unwrap());
+    }
+
+    #[test]
+    fn config_path_under_data_dir_recognises_nested() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data = tmp.path();
+        let config = data.join("config.toml");
+        std::fs::write(&config, "").unwrap();
+        assert!(super::config_path_is_under_data_dir(&config, data));
+    }
+
+    #[test]
+    fn config_path_under_data_dir_rejects_sibling() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data = tmp.path().join("data");
+        let other = tmp.path().join("elsewhere");
+        std::fs::create_dir(&data).unwrap();
+        std::fs::create_dir(&other).unwrap();
+        let config = other.join("config.toml");
+        std::fs::write(&config, "").unwrap();
+        assert!(!super::config_path_is_under_data_dir(&config, &data));
+    }
+
+    #[test]
+    fn config_path_under_data_dir_falls_back_lexically_when_both_missing() {
+        // Neither side exists — function falls back to lexical starts_with.
+        let config = std::path::Path::new("/nonexistent/data/config.toml");
+        let data = std::path::Path::new("/nonexistent/data");
+        assert!(super::config_path_is_under_data_dir(config, data));
+
+        let other = std::path::Path::new("/nonexistent/other/config.toml");
+        assert!(!super::config_path_is_under_data_dir(other, data));
+    }
+
+    #[test]
+    fn config_path_under_data_dir_skips_notice_on_half_canonical() {
+        // Data dir exists, config doesn't — historically this returned a wrong
+        // answer by mixing canonical/lexical forms. The function now treats it
+        // as "can't tell" and returns true to suppress the (potentially wrong)
+        // informational notice.
+        let tmp = tempfile::tempdir().unwrap();
+        let config = std::path::Path::new("/nonexistent/path/config.toml");
+        assert!(super::config_path_is_under_data_dir(config, tmp.path()));
     }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,26 @@
+//! Interactive y/N prompt used by `coop update` and `coop uninstall`.
+//!
+//! Reads from stdin / writes to stderr. Returns `Ok(false)` immediately when
+//! stdin is not a TTY — non-interactive callers must opt in with their own
+//! `--yes`-style flag rather than getting silently confirmed.
+
+use std::io::{IsTerminal as _, Write as _};
+
+use anyhow::{Context, Result};
+
+pub fn confirm(prompt: &str) -> Result<bool> {
+    if !std::io::stdin().is_terminal() {
+        return Ok(false);
+    }
+    let mut stderr = std::io::stderr();
+    write!(stderr, "{prompt} [y/N] ").context("Failed to write confirmation prompt")?;
+    stderr.flush().context("Failed to flush stderr")?;
+    let mut response = String::new();
+    std::io::stdin()
+        .read_line(&mut response)
+        .context("Failed to read confirmation")?;
+    Ok(matches!(
+        response.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -9,7 +9,7 @@
 
 use std::env;
 use std::fs;
-use std::io::{IsTerminal as _, Write as _};
+use std::io::IsTerminal as _;
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -21,6 +21,7 @@ use sha2::{Digest as _, Sha256};
 
 use crate::cmd::Cmd;
 use crate::fs_util::atomic_write_json;
+use crate::prompt::confirm;
 
 const REPO: &str = "trailofbits/coop";
 const DEFAULT_API_BASE: &str = "https://api.github.com";
@@ -458,26 +459,6 @@ fn atomic_replace_self(new_binary: &Path) -> Result<()> {
     Ok(())
 }
 
-// ── Interactive confirmation ─────────────────────────────────────────────────
-
-fn confirm(prompt: &str) -> Result<bool> {
-    if !std::io::stdin().is_terminal() {
-        // Non-interactive: caller must pass --yes explicitly.
-        return Ok(false);
-    }
-    let mut stderr = std::io::stderr();
-    write!(stderr, "{prompt} [y/N] ").context("Failed to write confirmation prompt")?;
-    stderr.flush().context("Failed to flush stderr")?;
-    let mut response = String::new();
-    std::io::stdin()
-        .read_line(&mut response)
-        .context("Failed to read confirmation")?;
-    Ok(matches!(
-        response.trim().to_ascii_lowercase().as_str(),
-        "y" | "yes"
-    ))
-}
-
 // ── Main update flow ─────────────────────────────────────────────────────────
 
 pub fn run(opts: &UpdateOpts) -> Result<()> {
@@ -602,6 +583,27 @@ struct UpdateState {
 fn state_path() -> Option<PathBuf> {
     let base = dirs::state_dir().or_else(dirs::data_local_dir)?;
     Some(base.join("coop").join("update-check.json"))
+}
+
+/// Remove the background update-check state file (and its parent if empty).
+///
+/// Best-effort — used by `coop uninstall`. Returns `Ok` even if nothing exists.
+pub fn remove_state() -> Result<()> {
+    let Some(path) = state_path() else {
+        return Ok(());
+    };
+    if path.exists() {
+        fs::remove_file(&path).with_context(|| format!("Failed to remove {}", path.display()))?;
+    }
+    if let Some(parent) = path.parent()
+        && parent.exists()
+    {
+        // remove_dir only succeeds when empty — perfect for "leave alone if shared".
+        if let Err(e) = fs::remove_dir(parent) {
+            tracing::debug!("Leaving state dir {} in place ({e})", parent.display());
+        }
+    }
+    Ok(())
 }
 
 fn read_state() -> Option<UpdateState> {

--- a/tests/integration-uninstall.sh
+++ b/tests/integration-uninstall.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end test for `coop uninstall`.
+#
+# Runs the uninstall flow with HOME pointed at a throwaway tempdir, so the
+# tests never touch the developer's real ~/.coop. Verifies:
+#
+#   1. --yes --keep-data removes the binary and leaves the data dir alone.
+#   2. --yes --purge removes binary, data dir, XDG update-check state, and
+#      any coop SSH config blocks.
+#   3. Non-interactive (non-TTY) without --yes exits non-zero with a hint.
+#   4. The dev-build guard refuses to remove a binary that lives under
+#      `target/release` or `target/debug`.
+#
+# Run manually:   ./tests/integration-uninstall.sh
+# Run in CI:      same (fast — no VM, no network)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Temp workspace ───────────────────────────────────────────────────────────
+
+TMPDIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+mkdir -p "$TMPDIR/bin" "$TMPDIR/home"
+
+pass_count=0
+fail_count=0
+
+pass() {
+    pass_count=$((pass_count + 1))
+    echo "  PASS  $1"
+}
+
+fail() {
+    fail_count=$((fail_count + 1))
+    echo "  FAIL  $1"
+    # Detail line ($2) is optional. Return 0 explicitly so that calling `fail`
+    # with one argument under `set -e` doesn't abort the whole script — the
+    # short-circuit `[[ -n "" ]] && echo` would otherwise propagate rc=1 out of
+    # the function.
+    if [[ -n "${2:-}" ]]; then
+        echo "        $2"
+    fi
+    return 0
+}
+
+# ── Build a release binary outside the project's target/ tree ────────────────
+#
+# The uninstall command refuses to delete binaries whose path contains
+# `target/{debug,release}` (the dev-build guard). For the success-path tests we
+# need a binary that *isn't* under that pattern, so we stash a copy in
+# $TMPDIR/bin. Test 4 deliberately runs the in-target binary to exercise the
+# guard.
+
+echo "==> Building release binary..."
+(cd "$PROJECT_DIR" && cargo build --release --quiet)
+TARGET_BIN="$PROJECT_DIR/target/release/coop"
+STABLE_BIN="$TMPDIR/bin/coop-stable"
+cp "$TARGET_BIN" "$STABLE_BIN"
+
+# ── Isolate $HOME / XDG dirs ─────────────────────────────────────────────────
+
+export HOME="$TMPDIR/home"
+export XDG_STATE_HOME="$HOME/.local/state"
+export XDG_DATA_HOME="$HOME/.local/share"
+mkdir -p "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$HOME/.ssh"
+
+# Pre-populate an XDG state file so we can assert it's wiped by --purge.
+seed_state() {
+    local state_dir="$XDG_STATE_HOME/coop"
+    mkdir -p "$state_dir"
+    cat > "$state_dir/update-check.json" << 'JSON'
+{"last_checked_at": 0, "latest_known_version": "v9.9.9"}
+JSON
+}
+
+# Pre-populate ~/.coop with stub files so we can assert it's preserved or wiped.
+seed_data_dir() {
+    local data_dir="$HOME/.coop"
+    mkdir -p "$data_dir/images" "$data_dir/instances"
+    # Touch a config so config_path_is_under_data_dir has something to look at.
+    : > "$data_dir/config.toml"
+}
+
+# Pre-populate ~/.ssh/config with a coop marker block; uninstall should strip
+# it. Markers must match the literal MARKER_PREFIX / MARKER_END strings used by
+# src/workspace.rs (`# coop START <host>` and `# coop END`).
+SSH_MARKER_BEGIN="# coop START coop-uninstall-test"
+SSH_MARKER_END="# coop END"
+seed_ssh_config() {
+    cat > "$HOME/.ssh/config" << EOF
+$SSH_MARKER_BEGIN
+Host coop-uninstall-test
+    HostName 172.16.0.42
+$SSH_MARKER_END
+
+# unrelated user block
+Host github.com
+    User git
+EOF
+}
+
+# Fresh copy of the binary at $TMPDIR/bin/coop for each test that removes it.
+fresh_binary() {
+    cp "$STABLE_BIN" "$TMPDIR/bin/coop"
+}
+
+# ── Test 1: --yes --keep-data preserves the data directory ───────────────────
+
+echo "==> Test 1: --yes --keep-data removes binary, keeps data"
+fresh_binary
+seed_data_dir
+seed_state
+seed_ssh_config
+
+if "$TMPDIR/bin/coop" uninstall --yes --keep-data > "$TMPDIR/t1.log" 2>&1; then
+    if [[ -e "$TMPDIR/bin/coop" ]]; then
+        fail "binary still present after uninstall"
+    else
+        pass "binary removed"
+    fi
+    if [[ -d "$HOME/.coop" ]]; then
+        pass "data directory preserved"
+    else
+        fail "data directory was removed despite --keep-data"
+    fi
+    if [[ -f "$XDG_STATE_HOME/coop/update-check.json" ]]; then
+        pass "XDG update-check state preserved"
+    else
+        fail "XDG state was removed despite --keep-data"
+    fi
+    if grep -q "$SSH_MARKER_BEGIN" "$HOME/.ssh/config"; then
+        fail "SSH coop block not stripped" "blocks should be removed even with --keep-data"
+    else
+        pass "SSH coop blocks stripped"
+    fi
+    if grep -q "github.com" "$HOME/.ssh/config"; then
+        pass "unrelated SSH blocks preserved"
+    else
+        fail "unrelated SSH content was clobbered"
+    fi
+else
+    fail "uninstall --yes --keep-data exited non-zero" "$(tail -5 "$TMPDIR/t1.log")"
+fi
+
+# ── Test 2: --yes --purge wipes everything ───────────────────────────────────
+
+echo "==> Test 2: --yes --purge removes binary + data + XDG state"
+fresh_binary
+seed_data_dir
+seed_state
+seed_ssh_config
+
+if "$TMPDIR/bin/coop" uninstall --yes --purge > "$TMPDIR/t2.log" 2>&1; then
+    if [[ -e "$TMPDIR/bin/coop" ]]; then
+        fail "binary still present after --purge"
+    else
+        pass "binary removed"
+    fi
+    if [[ -d "$HOME/.coop" ]]; then
+        fail "data directory still present after --purge"
+    else
+        pass "data directory removed"
+    fi
+    if [[ -e "$XDG_STATE_HOME/coop/update-check.json" ]]; then
+        fail "XDG update-check state survived --purge"
+    else
+        pass "XDG update-check state removed"
+    fi
+    if grep -q "$SSH_MARKER_BEGIN" "$HOME/.ssh/config" 2> /dev/null; then
+        fail "SSH coop block survived --purge"
+    else
+        pass "SSH coop blocks stripped"
+    fi
+else
+    fail "uninstall --yes --purge exited non-zero" "$(tail -5 "$TMPDIR/t2.log")"
+fi
+
+# ── Test 3: non-TTY without --yes fails with a helpful message ───────────────
+
+echo "==> Test 3: non-TTY without --yes errors"
+fresh_binary
+seed_data_dir
+
+# stdin is already not a TTY when running under bash via the script harness;
+# redirect from /dev/null to be explicit.
+if "$TMPDIR/bin/coop" uninstall < /dev/null > "$TMPDIR/t3.log" 2>&1; then
+    fail "uninstall without --yes succeeded in non-interactive mode"
+elif grep -qi "not a tty" "$TMPDIR/t3.log" && grep -q -- "--yes" "$TMPDIR/t3.log"; then
+    pass "non-TTY without --yes errors with --yes hint"
+else
+    fail "exit was non-zero but message lacks the --yes hint" \
+        "$(tail -5 "$TMPDIR/t3.log")"
+fi
+
+if [[ -e "$TMPDIR/bin/coop" ]]; then
+    pass "binary preserved after refusal"
+else
+    fail "binary removed despite refusal"
+fi
+
+# ── Test 4: dev-build guard refuses to remove target/release/coop ────────────
+
+echo "==> Test 4: dev-build guard refuses target/release binary"
+seed_data_dir
+
+# Run the in-target binary directly. It's under PROJECT_DIR/target/release/,
+# which matches the consecutive `target/release` guard.
+if "$TARGET_BIN" uninstall --yes --keep-data > "$TMPDIR/t4.log" 2>&1; then
+    if [[ -e "$TARGET_BIN" ]]; then
+        if grep -qi "cargo build artifact" "$TMPDIR/t4.log"; then
+            pass "dev-build guard refused to remove $TARGET_BIN"
+        else
+            fail "binary preserved but guard message missing" \
+                "$(tail -5 "$TMPDIR/t4.log")"
+        fi
+    else
+        fail "guard failed — target/release/coop was deleted"
+    fi
+else
+    fail "uninstall returned non-zero on dev-build guard path" \
+        "$(tail -5 "$TMPDIR/t4.log")"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo
+echo "  $pass_count passed, $fail_count failed"
+[[ $fail_count -eq 0 ]]


### PR DESCRIPTION
## Summary
- Adds `coop uninstall`, mirroring `coop update`'s ergonomics, to reverse what `install.sh` does.
- Removes the running coop binary; optionally wipes the data dir (`~/.coop`) and the XDG `update-check.json` state. Default is fully interactive (two prompts). `--yes` is "yes to everything", `--keep-data` keeps `~/.coop`, `--purge` is the explicit no-prompt-for-data flag for scripts.
- Reuses the existing `destroy --all` teardown via a new `purge_all_data` helper. Refuses to delete binaries living at `target/{debug,release}/coop` (dev-build guard). Surfaces EPERM with a `sudo coop uninstall` hint. Bails with a clear error on non-TTY stdin when `--yes` is missing rather than silently exiting 0.
- Shared `confirm()` y/N prompt moves out of `update.rs` into a new `src/prompt.rs` (also used by `update`).
- Adds `tests/integration-uninstall.sh` (4 phases / 12 assertions, ~30s, no VM required) and wires it into `ci.yml` next to the existing `integration-update.sh` step.

Closes #93

## Behaviour matrix
| invocation | binary | data dir | prompts |
|---|---|---|---|
| `coop uninstall` | yes (after confirm) | asked separately | 2 |
| `coop uninstall --yes` | yes | yes | 0 |
| `coop uninstall --yes --keep-data` | yes | no | 0 |
| `coop uninstall --purge` | yes (after confirm) | yes | 1 (binary) |
| `coop uninstall --yes --purge` | yes | yes | 0 |

`--keep-data` and `--purge` are mutually exclusive.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 301 unit tests pass (15 new, covering CLI parsing for every flag combination, the dev-target-path guard, `decide_remove_data`, and `config_path_is_under_data_dir`).
- [x] `./tests/integration-uninstall.sh` — exits 0 with `12 passed, 0 failed` across the four phases:
  - `--yes --keep-data` removes the binary, preserves `~/.coop` + XDG state, strips coop SSH-config blocks, preserves unrelated SSH entries.
  - `--yes --purge` removes binary, data dir, and XDG state.
  - Non-TTY without `--yes` exits non-zero with a hint mentioning `--yes`.
  - Dev-build guard refuses to remove `target/release/coop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)