### PR TITLE
Take instance name positionally on push/pull/exec (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- **`coop push` / `coop pull` / `coop exec` take the instance name as a
+  positional argument** (#90) — these three commands previously accepted
+  `--name <name>` while the other eleven subcommands took `name`
+  positionally. The flag is removed; pass the name positionally instead.
+  Because `push` and `pull` already had `[DIR]` as a positional, the
+  directory is now a `--dir` flag. Because `exec` had `COMMAND...` as a
+  positional, the command must follow `--`. Examples:
+  `coop push my-vm --dir ./src --force`,
+  `coop pull my-vm --dir ./out --force`,
+  `coop exec my-vm -- ls -la`.
+
 ## v0.4.3
 
 ### Fixes

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -175,18 +175,20 @@ coop codex my-project -- --model gpt-5
 
 Run a command in the VM and print its output. No PTY is allocated and stdin is not forwarded; use `shell` for interactive work.
 
+The command and its arguments must follow `--` so they are not mistaken for the instance name.
+
 ```
-coop exec [--name NAME] COMMAND...
+coop exec [NAME] -- COMMAND...
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--name <name>` | Instance name (required if multiple instances exist) |
-| `COMMAND...` | Command and arguments to run (required) |
+| `NAME` | Instance name (required if multiple instances exist) |
+| `COMMAND...` | Command and arguments to run after `--` (required) |
 
 ```
-coop exec uname -a
-coop exec --name my-project docker ps
+coop exec -- uname -a
+coop exec my-project -- docker ps
 ```
 
 ### `stop`
@@ -275,19 +277,19 @@ coop logs my-project -f
 Copy a local directory into the running VM at `/workspace`. Defaults to the host path recorded when the instance was started with `--workspace`.
 
 ```
-coop push [--name NAME] [DIR] [FLAGS]
+coop push [NAME] [FLAGS]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--name <name>` | Instance name (required if multiple instances exist) |
-| `DIR` | Local directory to push (defaults to the workspace host path) |
+| `NAME` | Instance name (required if multiple instances exist) |
+| `--dir <dir>` | Local directory to push (defaults to the workspace host path) |
 | `--force` | Overwrite guest changes without confirmation |
 | `--exclude-git` | Skip the `.git/` directory in this transfer |
 
 ```
 coop push
-coop push --name my-project ./src --force
+coop push my-project --dir ./src --force
 ```
 
 ### `pull`
@@ -295,19 +297,19 @@ coop push --name my-project ./src --force
 Copy the VM's `/workspace` to a local directory. Defaults to the host path recorded when the instance was started with `--workspace`.
 
 ```
-coop pull [--name NAME] [DIR] [FLAGS]
+coop pull [NAME] [FLAGS]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--name <name>` | Instance name (required if multiple instances exist) |
-| `DIR` | Local directory to pull into (defaults to the workspace host path) |
+| `NAME` | Instance name (required if multiple instances exist) |
+| `--dir <dir>` | Local directory to pull into (defaults to the workspace host path) |
 | `--force` | Overwrite local changes without confirmation |
 | `--exclude-git` | Skip the `.git/` directory in this transfer |
 
 ```
 coop pull
-coop pull --name my-project ./local-copy --force
+coop pull my-project --dir ./local-copy --force
 ```
 
 ### `vscode`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,11 +229,11 @@ Pull guest changes back to the host:
 coop pull
 ```
 
-Both commands default to the workspace path from `coop start --workspace`. Override with a positional argument:
+Both commands default to the workspace path from `coop start --workspace`. Override with `--dir`:
 
 ```
-coop push ~/other-dir
-coop pull ~/other-dir
+coop push --dir ~/other-dir
+coop pull --dir ~/other-dir
 ```
 
 ### 6. Tear down

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -62,10 +62,11 @@ Starting a VM with `--workspace`, `--git-repo`, or `--mount` writes a `workspace
 ## Pushing: host to guest
 
 ```bash
-coop push                     # uses host_path from workspace.json
-coop push ./other-dir         # push a specific directory
-coop push --force             # skip guest dirty check
-coop push --name my-instance  # target a specific instance
+coop push                                    # uses host_path from workspace.json
+coop push --dir ./other-dir                  # push a specific directory
+coop push --force                            # skip guest dirty check
+coop push my-instance                        # target a specific instance
+coop push my-instance --dir ./src --force    # combined
 ```
 
 Before overwriting guest files, `push` runs `git status --porcelain` inside the guest workspace. If there are uncommitted changes, push prints them and exits. `--force` overrides this.
@@ -78,10 +79,11 @@ Transfer method selection is automatic:
 ## Pulling: guest to host
 
 ```bash
-coop pull                     # uses host_path from workspace.json
-coop pull ./local-copy        # pull into a specific directory
-coop pull --force             # skip local dirty check
-coop pull --name my-instance  # target a specific instance
+coop pull                                       # uses host_path from workspace.json
+coop pull --dir ./local-copy                    # pull into a specific directory
+coop pull --force                               # skip local dirty check
+coop pull my-instance                           # target a specific instance
+coop pull my-instance --dir ./local-copy        # combined
 ```
 
 Same dirty-check logic as push, applied to the local destination. If the local directory has a `.git` and uncommitted changes, pull refuses unless you pass `--force`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,9 +223,9 @@ enum Commands {
     /// Push local workspace into the running VM
     Push {
         /// Instance name (required if multiple instances exist)
-        #[arg(long)]
         name: Option<String>,
         /// Local directory to push (defaults to `workspace.json` `host_path`)
+        #[arg(long)]
         dir: Option<String>,
         /// Overwrite guest changes without confirmation
         #[arg(long)]
@@ -237,9 +237,9 @@ enum Commands {
     /// Pull guest workspace to local directory
     Pull {
         /// Instance name (required if multiple instances exist)
-        #[arg(long)]
         name: Option<String>,
         /// Local directory to pull into (defaults to `workspace.json` `host_path`)
+        #[arg(long)]
         dir: Option<String>,
         /// Overwrite local changes without confirmation
         #[arg(long)]
@@ -249,12 +249,15 @@ enum Commands {
         exclude_git: bool,
     },
     /// Run a command in the VM and return its output (non-interactive)
+    ///
+    /// The command and its arguments must follow `--` to avoid conflicting
+    /// with the optional instance name positional, e.g.
+    /// `coop exec my-vm -- ls -la` or `coop exec -- ls -la`.
     Exec {
         /// Instance name (required if multiple instances exist)
-        #[arg(long)]
         name: Option<String>,
-        /// Command and arguments to run
-        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        /// Command and arguments to run (after `--`)
+        #[arg(required = true, last = true, allow_hyphen_values = true)]
         command: Vec<String>,
     },
     /// Open VS Code connected to the guest VM
@@ -1587,6 +1590,88 @@ mod tests {
             "--name",
             "--no-claude-work"
         ]));
+    }
+
+    #[test]
+    fn push_positional_name_and_dir_flag_parse() {
+        let cli = parse(&["push", "myvm", "--dir", "./src", "--force"]);
+        let super::Commands::Push {
+            name, dir, force, ..
+        } = cli.command
+        else {
+            panic!("expected Push variant");
+        };
+        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(dir.as_deref(), Some("./src"));
+        assert!(force);
+    }
+
+    #[test]
+    fn push_single_positional_is_name_not_dir() {
+        let cli = parse(&["push", "myvm"]);
+        let super::Commands::Push {
+            name, dir, force, ..
+        } = cli.command
+        else {
+            panic!("expected Push variant");
+        };
+        assert_eq!(name.as_deref(), Some("myvm"));
+        assert!(dir.is_none());
+        assert!(!force);
+    }
+
+    #[test]
+    fn push_bare_parses() {
+        let cli = parse(&["push"]);
+        let super::Commands::Push {
+            name, dir, force, ..
+        } = cli.command
+        else {
+            panic!("expected Push variant");
+        };
+        assert!(name.is_none());
+        assert!(dir.is_none());
+        assert!(!force);
+    }
+
+    #[test]
+    fn pull_positional_name_and_dir_flag_parse() {
+        let cli = parse(&["pull", "myvm", "--dir", "./out", "--force"]);
+        let super::Commands::Pull {
+            name, dir, force, ..
+        } = cli.command
+        else {
+            panic!("expected Pull variant");
+        };
+        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(dir.as_deref(), Some("./out"));
+        assert!(force);
+    }
+
+    #[test]
+    fn exec_positional_name_and_command_parse() {
+        let cli = parse(&["exec", "myvm", "--", "ls", "-la"]);
+        let super::Commands::Exec { name, command } = cli.command else {
+            panic!("expected Exec variant");
+        };
+        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(command, vec!["ls", "-la"]);
+    }
+
+    #[test]
+    fn exec_without_name_parses() {
+        let cli = parse(&["exec", "--", "ls", "-la"]);
+        let super::Commands::Exec { name, command } = cli.command else {
+            panic!("expected Exec variant");
+        };
+        assert!(name.is_none());
+        assert_eq!(command, vec!["ls", "-la"]);
+    }
+
+    #[test]
+    fn exec_requires_command_after_separator() {
+        let err = parse_err(&["exec", "myvm"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -290,9 +290,9 @@ fn load_or_default(inst: &Instance, dir: Option<&str>, cmd: &str) -> Result<Work
         });
     }
     bail!(
-        "No workspace.json found and no directory argument given.\n\
+        "No workspace.json found and no --dir given.\n\
          Either start the VM with --workspace or provide a path: \
-         coop {cmd} ./my-project"
+         coop {cmd} --dir ./my-project"
     )
 }
 
@@ -645,8 +645,8 @@ fn resolve_host_dir(explicit: Option<&str>, state: &WorkspaceState) -> Result<Pa
         return Ok(PathBuf::from(d));
     }
     state.host_path.clone().context(
-        "No host_path in workspace.json and no directory argument given.\n\
-         Provide a directory: coop push ./my-project",
+        "No host_path in workspace.json and no --dir given.\n\
+         Provide a directory: coop push --dir ./my-project",
     )
 }
 
@@ -658,8 +658,8 @@ fn resolve_host_dir_for_pull(explicit: Option<&str>, state: &WorkspaceState) -> 
         return Ok(hp.clone());
     }
     bail!(
-        "No host_path in workspace.json and no directory argument given.\n\
-         Provide a destination: coop pull ./my-project"
+        "No host_path in workspace.json and no --dir given.\n\
+         Provide a destination: coop pull --dir ./my-project"
     )
 }
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -126,7 +126,7 @@ guest_exec() {
 # Run the exec subcommand (captures stdout, propagates exit code).
 moat_exec() {
     local inst="${GUEST_INSTANCE:-$INSTANCE}"
-    RUST_LOG=off "$BINARY" exec --name "$inst" "$@" 2>"$tmpdir/guest_stderr"
+    RUST_LOG=off "$BINARY" exec "$inst" -- "$@" 2>"$tmpdir/guest_stderr"
 }
 
 # Return captured stderr from the last guest_exec/moat_exec call.
@@ -467,8 +467,8 @@ test_auto_resolve_running() {
         fail "shell auto-resolves single running instance" "exit code: $?"
     fi
 
-    # exec without --name should also auto-select
-    if output=$(RUST_LOG=off "$BINARY" exec echo "exec-auto" 2>/dev/null); then
+    # exec without an instance name should also auto-select
+    if output=$(RUST_LOG=off "$BINARY" exec -- echo "exec-auto" 2>/dev/null); then
         pass "exec auto-resolves single running instance"
         if echo "$output" | grep -q "exec-auto"; then
             pass "exec auto-resolve returns correct output"
@@ -675,7 +675,7 @@ except Exception:
 
     local token_out
     token_out=$(env GITHUB_TOKEN=test-leak-token RUST_LOG=off \
-        "$BINARY" exec --name "$INSTANCE" printenv GITHUB_TOKEN 2>/dev/null) || true
+        "$BINARY" exec "$INSTANCE" -- printenv GITHUB_TOKEN 2>/dev/null) || true
 
     if [[ "$github_setting" == "auto" || "$github_setting" == "env" ]]; then
         # Token should be forwarded
@@ -1242,7 +1242,7 @@ test_restart_stopped() {
     fi
 
     # Verify workspace survived the stop/start cycle
-    if coop exec --name "$INSTANCE" -- test -d /workspace; then
+    if coop exec "$INSTANCE" -- test -d /workspace; then
         pass "workspace persists across restart"
     else
         fail "workspace persists across restart" "exit code: $?"
@@ -1501,7 +1501,7 @@ test_workspace_sync() {
 
     local pull_dir
     pull_dir=$(mktemp -d)
-    if coop pull --name "$ws_instance" --force "$pull_dir"; then
+    if coop pull "$ws_instance" --force --dir "$pull_dir"; then
         pass "pull exits 0"
 
         local pulled
@@ -1518,7 +1518,7 @@ test_workspace_sync() {
 
     # Push: modify locally, push to guest, verify
     echo "pushed-from-host" > "$ws_tmpdir/hello.txt"
-    if coop push --name "$ws_instance" --force "$ws_tmpdir"; then
+    if coop push "$ws_instance" --force --dir "$ws_tmpdir"; then
         pass "push exits 0"
 
         local pushed_content
@@ -1649,7 +1649,7 @@ test_push_pull_no_workspace() {
     # Pull with explicit dir should work (no workspace.json exists)
     local pull_dir
     pull_dir=$(mktemp -d)
-    if coop pull --name "$nw_instance" --force "$pull_dir"; then
+    if coop pull "$nw_instance" --force --dir "$pull_dir"; then
         pass "pull with explicit dir (no workspace.json)"
     else
         fail "pull with explicit dir (no workspace.json)" "exit code: $?"
@@ -1660,7 +1660,7 @@ test_push_pull_no_workspace() {
     local push_dir
     push_dir=$(mktemp -d)
     echo "no-workspace-push-test" > "$push_dir/marker.txt"
-    if coop push --name "$nw_instance" --force "$push_dir"; then
+    if coop push "$nw_instance" --force --dir "$push_dir"; then
         pass "push with explicit dir (no workspace.json)"
 
         # Verify the file arrived in guest at /workspace
@@ -1677,14 +1677,14 @@ test_push_pull_no_workspace() {
     rm -rf "$push_dir"
 
     # Pull without dir and without workspace.json should fail
-    if moat_fails pull --name "$nw_instance"; then
+    if moat_fails pull "$nw_instance"; then
         pass "pull without dir or workspace.json fails"
     else
         fail "pull without dir or workspace.json fails" "should have failed"
     fi
 
     # Push without dir and without workspace.json should fail
-    if moat_fails push --name "$nw_instance"; then
+    if moat_fails push "$nw_instance"; then
         pass "push without dir or workspace.json fails"
     else
         fail "push without dir or workspace.json fails" "should have failed"
@@ -2347,7 +2347,7 @@ CFGEOF
     # coop claude uses run_interactive which needs a PTY — use exec instead
     # to verify the binary path is correct by invoking it directly.
     env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY RUST_LOG=off \
-        "$BINARY" --config "$cfg_file" exec --name "$mp_instance" \
+        "$BINARY" --config "$cfg_file" exec "$mp_instance" -- \
         /home/ubuntu/.local/bin/claude --help >/dev/null 2>/dev/null || true
 
     local post_log


### PR DESCRIPTION
## Summary

Fixes #90. `push`, `pull`, and `exec` previously took `--name <name>` while the other eleven subcommands took `name` positionally. This bundles them onto the majority convention.

- `coop push [NAME] [--dir DIR] [--force]`
- `coop pull [NAME] [--dir DIR] [--force]`
- `coop exec [NAME] -- COMMAND...`

The colliding positionals on these three commands move behind flags: `--dir` for `push`/`pull`, and clap's `last = true` (the `--` separator) for `exec`'s command. This is a breaking CLI change — there is no compatibility shim. CHANGELOG documents it under an `Unreleased` / `Breaking changes` section.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` — 293/293 pass (added 7 new clap parsing tests covering both `name` and `--dir`/`--` shapes plus `coop exec NAME` without `--` failing with `MissingRequiredArgument`)
- [x] CLI help and error paths exercised on the release binary: old `--name` form hard-rejects with `unexpected argument '--name' found`, `exec NAME` without `--` errors with the corrected usage line, parsing flows to runtime instance lookup
- [ ] `./tests/run-integration.sh` on macOS/Lima — needs to run on a host with the VM backend (this CI environment lacks `/dev/kvm`; halted at the `setup` phase). The pre-VM phases (`validate`, `invalid instance names`, `profiles list/show`) passed; the touched phases (workspace push/pull, exec auto-resolve at line 437) require a running VM
- [ ] `./tests/run-integration.sh --remote <linux-host>` against Firecracker/KVM

🤖 Generated with [Claude Code](https://claude.com/claude-code)