### PR TITLE
Add shell completion for bash, zsh, fish, powershell, elvish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -111,6 +111,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +158,7 @@ version = "0.4.3"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "dirs",
  "hex",
  "indexmap",
@@ -207,7 +220,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -223,7 +236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -317,6 +330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,7 +410,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -487,7 +509,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -569,6 +591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,7 +629,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -829,12 +857,86 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Isolated VM environment for running Claude Code"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = { version = "4", features = ["unstable-dynamic"] }
 dirs = "6.0.0"
 indexmap = "2"
 libc = "0.2.186"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 | `resize` | Grow a stopped instance's disk |
 | `validate` | Check config and prerequisites |
 | `update` | Self-update coop to the latest GitHub release |
+| `completions` | Print a shell completion script (bash/zsh/fish/powershell/elvish) |
+
+## Shell completion
+
+`coop completions <bash|zsh|fish|powershell|elvish>` prints a static completion script. Adding `source <(COMPLETE=<shell> coop)` to your rc additionally completes instance, image, and profile names live. Full setup recipes are in [docs/shell-completion.md](docs/shell-completion.md).
 
 ## Updating
 
@@ -158,3 +163,4 @@ Tested on macOS arm64 (Apple Silicon) and Linux x86_64. Linux arm64 builds are a
 - [VS Code integration](docs/vscode.md)
 - [Multi-instance](docs/multi-instance.md)
 - [Platform backends](docs/backends.md)
+- [Shell completion](docs/shell-completion.md)

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -1,0 +1,84 @@
+# Shell completion
+
+`coop` ships with both static and dynamic shell completion via `clap_complete`. Static completion handles subcommand and flag names; dynamic completion additionally fills in live values for instance names, image names, and profile names by reading `~/.coop`.
+
+## Static completion
+
+Generate a script once and drop it where your shell looks for completions.
+
+### bash
+
+```sh
+mkdir -p ~/.local/share/bash-completion/completions
+coop completions bash > ~/.local/share/bash-completion/completions/coop
+```
+
+System-wide variant:
+
+```sh
+coop completions bash | sudo tee /etc/bash_completion.d/coop > /dev/null
+```
+
+### zsh
+
+The completion file must live on `$fpath`. If you don't already have a directory for it:
+
+```sh
+mkdir -p ~/.zfunc
+echo 'fpath=(~/.zfunc $fpath)' >> ~/.zshrc
+echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
+coop completions zsh > ~/.zfunc/_coop
+```
+
+### fish
+
+```sh
+coop completions fish > ~/.config/fish/completions/coop.fish
+```
+
+### PowerShell
+
+```powershell
+coop completions powershell | Out-String | Invoke-Expression
+```
+
+Add the same line to your `$PROFILE` to load it on every shell start.
+
+### elvish
+
+```sh
+coop completions elvish > ~/.config/elvish/lib/coop-completion.elv
+echo 'use coop-completion' >> ~/.config/elvish/rc.elv
+```
+
+Restart the shell (or `source` your rc) after the first install.
+
+## Dynamic completion
+
+Dynamic completion lets `coop` itself compute candidates on TAB — so `coop shell <TAB>` lists your running instances, `coop start --image <TAB>` lists existing images, and `coop setup --profile <TAB>` lists builtin and custom profiles.
+
+Add one line to your shell rc:
+
+```sh
+# bash
+echo 'source <(COMPLETE=bash coop)' >> ~/.bashrc
+
+# zsh
+echo 'source <(COMPLETE=zsh coop)' >> ~/.zshrc
+
+# fish
+echo 'source (COMPLETE=fish coop | psub)' >> ~/.config/fish/config.fish
+
+# elvish
+echo 'eval (COMPLETE=elvish coop | slurp)' >> ~/.config/elvish/rc.elv
+```
+
+Dynamic and static completion can coexist — static fills in subcommand and flag names even without `COMPLETE=…` set up.
+
+## What completes where
+
+| Argument | Source |
+|----------|--------|
+| Instance name (`shell`, `claude`, `claude-agents`, `codex`, `stop`, `destroy`, `status`, `logs`, `push --name`, `pull --name`, `exec --name`, `vscode`, `resize`) | `~/.coop/instances/` |
+| `--image` (`start`, `setup`), `images --delete` | `~/.coop/images/` |
+| `--profile` (`setup`), `profiles show <name>` | builtin profiles plus `[profiles.*]` from `~/.coop/config.toml` |

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,83 @@
+//! Shell completion support.
+//!
+//! Two pieces:
+//!
+//! * Static generation via `coop completions <shell>` — emits a completion
+//!   script the user can source from their shell rc.
+//! * Dynamic completion via `clap_complete::CompleteEnv` — when the binary
+//!   is invoked with `COMPLETE=<shell>`, it computes candidates at runtime
+//!   so things like instance names and image names get real values.
+//!
+//! Each `complete_*` function must be infallible and fast: shells call into
+//! the binary on every TAB. We swallow all errors and return an empty list
+//! rather than printing diagnostics or panicking.
+
+use std::io;
+
+use clap::CommandFactory as _;
+use clap_complete::engine::CompletionCandidate;
+use clap_complete::{Shell, generate};
+
+use crate::config::CoopConfig;
+use crate::guest::BUILTIN_PROFILES;
+
+/// Write a static completion script for `shell` to stdout.
+pub fn emit_static(shell: Shell) {
+    let mut cmd = crate::Cli::command();
+    let name = cmd.get_name().to_string();
+    generate(shell, &mut cmd, name, &mut io::stdout());
+}
+
+/// Candidate list for instance-name arguments.
+///
+/// Reads the default config (ignoring `--config` — completion fires before
+/// argument parsing) and returns the names of any registered instances.
+///
+/// `CoopConfig::list_instances` emits `tracing::warn!` for corrupted instance
+/// dirs. Today the completion path runs before `init_tracing`, so the global
+/// subscriber is the no-op default and nothing leaks into the user's shell.
+/// If tracing is ever wired up earlier, those warnings would surface here.
+#[must_use]
+pub fn instance_candidates() -> Vec<CompletionCandidate> {
+    let Ok(cfg) = CoopConfig::load(&CoopConfig::default_path()) else {
+        return Vec::new();
+    };
+    let Ok(instances) = cfg.list_instances() else {
+        return Vec::new();
+    };
+    instances
+        .into_iter()
+        .map(|i| CompletionCandidate::new(i.name.as_str()))
+        .collect()
+}
+
+/// Candidate list for `--image` arguments.
+#[must_use]
+pub fn image_candidates() -> Vec<CompletionCandidate> {
+    let Ok(cfg) = CoopConfig::load(&CoopConfig::default_path()) else {
+        return Vec::new();
+    };
+    let Ok(images) = cfg.list_images() else {
+        return Vec::new();
+    };
+    images
+        .into_iter()
+        .map(|i| CompletionCandidate::new(i.name))
+        .collect()
+}
+
+/// Candidate list for `--profile` and `profiles show <name>` arguments.
+///
+/// Combines compile-time builtin profiles with any custom profiles defined
+/// in the user's config.
+#[must_use]
+pub fn profile_candidates() -> Vec<CompletionCandidate> {
+    let builtins = BUILTIN_PROFILES
+        .iter()
+        .map(|p| CompletionCandidate::new(p.name));
+    let custom = CoopConfig::load(&CoopConfig::default_path())
+        .ok()
+        .into_iter()
+        .flat_map(|cfg| cfg.profiles.into_keys().map(CompletionCandidate::new));
+    builtins.chain(custom).collect()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod backend;
 mod cmd;
+mod completions;
 mod config;
 mod fs_util;
 mod guest;
@@ -37,6 +38,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
+use clap_complete::engine::ArgValueCandidates;
 
 use backend::VmBackend as _;
 use cmd::Cmd;
@@ -44,7 +46,7 @@ use cmd::Cmd;
 #[derive(Parser)]
 #[command(name = "coop", version = env!("COOP_VERSION_STR"))]
 #[command(about = "Isolated VM environment for running Claude Code and Codex")]
-struct Cli {
+pub(crate) struct Cli {
     /// Path to coop config file
     #[arg(long, default_value_os_t = config::CoopConfig::default_path())]
     config: PathBuf,
@@ -60,6 +62,7 @@ struct Cli {
 #[derive(clap::Args)]
 struct SessionArgs {
     /// Instance name (required if multiple instances exist)
+    #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
     name: Option<String>,
     /// tmux session name
     #[arg(long, conflicts_with = "no_tmux")]
@@ -106,7 +109,11 @@ enum Commands {
         #[arg(long)]
         rebuild: bool,
         /// Install profiles (comma-separated: python,node,c,fuzz,rust,go)
-        #[arg(long, value_delimiter = ',')]
+        #[arg(
+            long,
+            value_delimiter = ',',
+            add = ArgValueCandidates::new(completions::profile_candidates),
+        )]
         profile: Vec<String>,
         /// Extra apt packages to install (comma-separated)
         #[arg(long, value_delimiter = ',')]
@@ -118,7 +125,11 @@ enum Commands {
         #[arg(long)]
         template_size: Option<u32>,
         /// Named image to build (default: "default")
-        #[arg(long, default_value = config::DEFAULT_IMAGE)]
+        #[arg(
+            long,
+            default_value = config::DEFAULT_IMAGE,
+            add = ArgValueCandidates::new(completions::image_candidates),
+        )]
         image: String,
     },
     /// Build rootfs image and fetch kernel (use `setup` for first-time install)
@@ -149,7 +160,11 @@ enum Commands {
         #[arg(long, conflicts_with_all = ["workspace", "git_repo"])]
         mount: Vec<String>,
         /// Named image to use (default: "default")
-        #[arg(long, default_value = config::DEFAULT_IMAGE)]
+        #[arg(
+            long,
+            default_value = config::DEFAULT_IMAGE,
+            add = ArgValueCandidates::new(completions::image_candidates),
+        )]
         image: String,
         /// Skip the `.git` directory when syncing the workspace
         #[arg(long, conflicts_with = "git_repo")]
@@ -195,11 +210,13 @@ enum Commands {
     /// Gracefully stop the VM
     Stop {
         /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
     },
     /// Stop and clean up instance resources (keeps template)
     Destroy {
         /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
         /// Also remove template, kernel, and Firecracker binary
         #[arg(long)]
@@ -211,11 +228,13 @@ enum Commands {
     /// Show VM status
     Status {
         /// Instance name (shows all if omitted)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
     },
     /// Stream VM serial console logs
     Logs {
         /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
         /// Follow log output
         #[arg(short, long)]
@@ -224,6 +243,7 @@ enum Commands {
     /// Push local workspace into the running VM
     Push {
         /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
         /// Local directory to push (defaults to `workspace.json` `host_path`)
         #[arg(long)]
@@ -238,6 +258,7 @@ enum Commands {
     /// Pull guest workspace to local directory
     Pull {
         /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
         /// Local directory to pull into (defaults to `workspace.json` `host_path`)
         #[arg(long)]
@@ -256,6 +277,7 @@ enum Commands {
     /// `coop exec my-vm -- ls -la` or `coop exec -- ls -la`.
     Exec {
         /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
         /// Command and arguments to run (after `--`)
         #[arg(required = true, last = true, allow_hyphen_values = true)]
@@ -264,6 +286,7 @@ enum Commands {
     /// Open VS Code connected to the guest VM
     Vscode {
         /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
         /// Remote path to open in VS Code
         #[arg(long, default_value = "/workspace")]
@@ -278,12 +301,13 @@ enum Commands {
     /// List or manage golden images
     Images {
         /// Delete a named image
-        #[arg(long)]
+        #[arg(long, add = ArgValueCandidates::new(completions::image_candidates))]
         delete: Option<String>,
     },
     /// Resize a stopped instance's disk
     Resize {
         /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
         name: Option<String>,
         /// New size: absolute GiB (e.g. 150, 150G) or relative (e.g. +20, +20G)
         #[arg(long, required = true)]
@@ -325,7 +349,35 @@ enum Commands {
         #[arg(long, conflicts_with = "keep_data")]
         purge: bool,
     },
+    /// Print a shell completion script (run `coop completions --help` for setup)
+    #[command(after_help = COMPLETIONS_AFTER_HELP)]
+    Completions {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
+    },
 }
+
+const COMPLETIONS_AFTER_HELP: &str = "\
+Examples:
+  # bash — system-wide
+  coop completions bash | sudo tee /etc/bash_completion.d/coop > /dev/null
+
+  # bash — user
+  coop completions bash > ~/.local/share/bash-completion/completions/coop
+
+  # zsh — user (ensure dir is on $fpath; restart shell)
+  coop completions zsh > ~/.zfunc/_coop
+
+  # fish — user
+  coop completions fish > ~/.config/fish/completions/coop.fish
+
+Dynamic completion (live instance / image / profile names) requires one
+extra line in your shell rc:
+
+  bash:  source <(COMPLETE=bash coop)
+  zsh:   source <(COMPLETE=zsh coop)
+  fish:  source (COMPLETE=fish coop | psub)
+";
 
 #[derive(Subcommand)]
 enum ProfilesAction {
@@ -334,6 +386,7 @@ enum ProfilesAction {
     /// Show the full definition of a profile
     Show {
         /// Profile name to inspect
+        #[arg(add = ArgValueCandidates::new(completions::profile_candidates))]
         name: String,
     },
 }
@@ -375,9 +428,18 @@ where
 
 #[expect(clippy::too_many_lines, reason = "CLI dispatch — flat match arms")]
 fn main() -> Result<()> {
+    // Dynamic shell completion: when invoked with COMPLETE=<shell>, compute
+    // candidates and exit before doing anything else (no tracing init, no
+    // config load — completion is expected to be cheap).
+    clap_complete::CompleteEnv::with_factory(<Cli as clap::CommandFactory>::command).complete();
+
     let cli = Cli::parse();
     init_tracing(cli.verbose);
 
+    if let Commands::Completions { shell } = cli.command {
+        completions::emit_static(shell);
+        return Ok(());
+    }
     if matches!(cli.command, Commands::Init) {
         return cmd_init(&cli.config);
     }
@@ -601,7 +663,10 @@ fn main() -> Result<()> {
             cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
         }
         Commands::Validate => cmd_validate(&cfg, &be),
-        Commands::Init | Commands::Update { .. } | Commands::Uninstall { .. } => {
+        Commands::Init
+        | Commands::Update { .. }
+        | Commands::Uninstall { .. }
+        | Commands::Completions { .. } => {
             unreachable!("handled before config loading")
         }
     }
@@ -2140,5 +2205,36 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let config = std::path::Path::new("/nonexistent/path/config.toml");
         assert!(super::config_path_is_under_data_dir(config, tmp.path()));
+    }
+
+    #[test]
+    fn completions_subcommand_parses_each_shell() {
+        for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+            let cli = parse(&["completions", shell]);
+            let super::Commands::Completions { shell: parsed } = cli.command else {
+                panic!("expected Completions variant for {shell}");
+            };
+            assert_eq!(parsed.to_string(), shell);
+        }
+    }
+
+    #[test]
+    fn completions_subcommand_requires_shell() {
+        let err = parse_err(&["completions"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn completions_emit_static_includes_subcommands() {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut cmd = <super::Cli as clap::CommandFactory>::command();
+        let name = cmd.get_name().to_string();
+        clap_complete::generate(clap_complete::Shell::Bash, &mut cmd, name, &mut buf);
+        let Ok(script) = String::from_utf8(buf) else {
+            panic!("bash completion script is not valid utf-8");
+        };
+        for sub in ["shell", "claude", "destroy", "completions"] {
+            assert!(script.contains(sub), "completion script missing `{sub}`");
+        }
     }
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -199,6 +199,52 @@ test_validate() {
     fi
 }
 
+test_completions() {
+    echo ""
+    echo "=== Phase: shell completions ==="
+
+    # Static script generation — must succeed for each supported shell and
+    # the bash script must reference our subcommands.
+    for shell in bash zsh fish powershell elvish; do
+        if coop completions "$shell" >/dev/null; then
+            pass "completions $shell exits 0"
+        else
+            fail "completions $shell exits 0" "exit code: $?"
+        fi
+    done
+
+    if coop completions bash; then
+        for sub in shell claude destroy completions; do
+            if echo "$HARNESS_OUT" | grep -q "coop,$sub"; then
+                pass "bash completion script references \`$sub\`"
+            else
+                fail "bash completion script references \`$sub\`" \
+                    "output (truncated): $(echo "$HARNESS_OUT" | head -c 400)"
+            fi
+        done
+    else
+        fail "bash completion script content check" \
+             "completions bash exited non-zero: $?, stderr: $HARNESS_ERR"
+    fi
+
+    # Dynamic completion: the engine must return a usable subcommand list
+    # when called via the CompleteEnv protocol.
+    local dyn_out
+    if dyn_out=$(_CLAP_COMPLETE_INDEX=1 _CLAP_IFS=$'\013' \
+                 COMPLETE=bash "$BINARY" -- coop "" 2>&1); then
+        for sub in shell claude destroy completions; do
+            if echo "$dyn_out" | tr $'\013' '\n' | grep -qx "$sub"; then
+                pass "dynamic completion offers \`$sub\`"
+            else
+                fail "dynamic completion offers \`$sub\`" \
+                    "got: $(echo "$dyn_out" | tr $'\013' '\n')"
+            fi
+        done
+    else
+        fail "dynamic completion request exits 0" "exit code: $?, output: $dyn_out"
+    fi
+}
+
 test_invalid_names() {
     echo ""
     echo "=== Phase: invalid instance names ==="
@@ -2624,6 +2670,7 @@ main() {
     test_validate
     test_invalid_names
     test_profiles_cli
+    test_completions
 
     # Setup + primary instance
     test_setup


### PR DESCRIPTION
## Summary

- `coop completions <shell>` prints a static completion script (bash / zsh / fish / powershell / elvish).
- Adding `source <(COMPLETE=<shell> coop)` to a shell rc additionally fills in **live values** via `clap_complete`'s dynamic engine — instance names, image names, and profile names are read from `~/.coop` on each TAB.
- Static completion alone handles subcommand names, aliases (`ssh`, `ca`, `ls`), and flag names; the dynamic line is opt-in.

`ArgValueCandidates` is wired to:

- every `name: Option<String>` referring to an existing instance (`shell`, `claude`, `claude-agents`, `codex`, `stop`, `destroy`, `status`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`) → reads `config.list_instances()`,
- `--image` (`start`, `setup`) and `images --delete` → reads `config.list_images()`,
- `--profile` (`setup`) and `profiles show <name>` → builtin profiles + custom profiles from config.

Dynamic completion uses `clap_complete`'s `unstable-dynamic` feature. Detailed install recipes per shell are in [`docs/shell-completion.md`](docs/shell-completion.md).

Closes #92.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (316 pass — 313 upstream + 3 new)
- [x] New integration phase `test_completions` in `tests/integration.sh` covers static script generation per shell and the dynamic `COMPLETE=bash` protocol — 13/13 PASS against the freshly-built debug binary
- [x] Manual smoke: `coop shell <TAB>`, `coop start --image <TAB>`, `coop setup --profile <TAB>`, `coop push <TAB>`, `coop exec <TAB>`, `coop profiles show <TAB>` all return the expected candidates against a synthetic `~/.coop` tree
- [ ] Run `./tests/run-integration.sh` locally (macOS / Lima)
- [ ] Run `./tests/run-integration.sh --remote ...` (Linux / Firecracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)