### PR TITLE
Pass --dangerously-skip-permissions to `coop ca`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -583,6 +583,8 @@ fn main() -> Result<()> {
         }
         Commands::ClaudeAgents { session, mut args } => {
             let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
+            // Subcommand flag: defaults dispatched sessions to bypassPermissions.
+            args.insert(0, "--dangerously-skip-permissions".to_string());
             args.insert(0, "agents".to_string());
             let tmux = session.tmux_session_opt_in();
             ssh::run_interactive(&sess, crate::guest::CLAUDE_BIN, &args, tmux)


### PR DESCRIPTION
## Summary
- `coop ca` (alias for `coop claude-agents`) launched the agent view without `--dangerously-skip-permissions`, so sessions dispatched from it kept hitting tool-permission prompts.
- The `agents` subcommand has its own `--dangerously-skip-permissions` flag — an alias for `--permission-mode bypassPermissions`, documented as the *default permission mode for sessions dispatched from agent view*. There is no settings.json equivalent: `permissions.defaultMode` in claude's schema is restricted to `default | plan | acceptEdits | dontAsk`, and `bypassPermissions` requires the session to be launched with the CLI flag.
- Insert the flag *after* `agents` (subcommand-level, not top-level) so the dispatched-session default is bypass.

Fixes #99.

## Test plan
- [x] `cargo test claude_agents` — parse tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: `coop ca`, dispatch an agent, confirm no tool-permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)