### PR TITLE
Gate `destroy --all` integration phase behind COOP_TEST_DESTRUCTIVE

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -16,10 +16,14 @@ set -euo pipefail
 #   --full           Run extended tests (workspace sync, multi-instance)
 #
 # Environment variables (override flags):
-#   TEST_BINARY   — Path to pre-built binary
-#   TEST_PROFILES — Comma-separated profiles to install
-#   TEST_INSTANCE — Instance name prefix
-#   TEST_FULL     — Set to 1 for extended tests
+#   TEST_BINARY            — Path to pre-built binary
+#   TEST_PROFILES          — Comma-separated profiles to install
+#   TEST_INSTANCE          — Instance name prefix
+#   TEST_FULL              — Set to 1 for extended tests
+#   COOP_TEST_DESTRUCTIVE  — Set to 1 to run the `coop destroy --all` phase.
+#                            Off by default because it wipes every coop-managed
+#                            instance on the host, including ones not owned by
+#                            this test run. Enable only on clean/CI hosts.
 
 # ── Defaults ──────────────────────────────────────────────────
 
@@ -2838,12 +2842,20 @@ main() {
         # destroy --all which removes it entirely.
         test_provision_failure
 
-        # destroy --all removes the golden image, so run it last.
-        # After this test, `coop setup` must be re-run.
-        test_destroy_all
-        echo ""
-        echo "NOTE: destroy --all removed the golden image."
-        echo "      Run 'coop setup -y' before next use."
+        # destroy --all wipes every coop-managed instance on the host,
+        # not just ones this run created. Gate behind an opt-in env var
+        # so dev machines aren't silently cleared. Run last because it
+        # also removes the golden image.
+        if [[ "${COOP_TEST_DESTRUCTIVE:-0}" == "1" ]]; then
+            test_destroy_all
+            echo ""
+            echo "NOTE: destroy --all removed the golden image."
+            echo "      Run 'coop setup -y' before next use."
+        else
+            echo ""
+            echo "=== Phase: destroy --all ==="
+            skip "destroy --all (set COOP_TEST_DESTRUCTIVE=1 to enable)"
+        fi
     fi
 
     summary

--- a/tests/run-integration.sh
+++ b/tests/run-integration.sh
@@ -62,8 +62,13 @@ trap 'ssh "$REMOTE_HOST" rm -rf "$REMOTE_DIR"' EXIT
 echo "Copying binary and test script to $REMOTE_HOST:$REMOTE_DIR..."
 scp -q "$LOCAL_BINARY" "$TEST_SCRIPT" "$REMOTE_HOST:$REMOTE_DIR/"
 
-# Build the remote command as an array, then printf %q to safely quote for ssh
-REMOTE_CMD=("$REMOTE_DIR/integration.sh" --binary "$REMOTE_DIR/coop"
+# Build the remote command as an array, then printf %q to safely quote for ssh.
+# ssh doesn't forward arbitrary env vars, so pass opt-in flags explicitly.
+REMOTE_CMD=()
+if [[ -n "${COOP_TEST_DESTRUCTIVE:-}" ]]; then
+    REMOTE_CMD+=("COOP_TEST_DESTRUCTIVE=$COOP_TEST_DESTRUCTIVE")
+fi
+REMOTE_CMD+=("$REMOTE_DIR/integration.sh" --binary "$REMOTE_DIR/coop"
     "${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}")
 
 echo "Running tests on $REMOTE_HOST..."


### PR DESCRIPTION
## Summary

- `coop destroy --all` wipes every coop-managed instance on the host, not just ones the test run created. Running `./tests/run-integration.sh --full` on a dev machine silently removed pre-existing Lima instances.
- Skip the `destroy --all` phase by default; require `COOP_TEST_DESTRUCTIVE=1` to opt in. A `SKIP` line is printed when the gate is off so the omission is visible.
- Forward `COOP_TEST_DESTRUCTIVE` explicitly to the remote shell in `run-integration.sh`, since ssh does not pass arbitrary environment variables.

## Test plan

- [ ] `./tests/run-integration.sh --full` on macOS/Lima — confirm `destroy --all` is skipped and no pre-existing instances are touched.
- [ ] `COOP_TEST_DESTRUCTIVE=1 ./tests/run-integration.sh --full` on a clean host — confirm the phase still runs and passes.
- [ ] `COOP_TEST_DESTRUCTIVE=1 ./tests/run-integration.sh --remote user@host --full` — confirm the env var reaches the remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)