### PR TITLE
Fix SIGPIPE flake in bash completion integration check

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -219,11 +219,13 @@ test_completions() {
 
     if coop completions bash; then
         for sub in shell claude destroy completions; do
-            if echo "$HARNESS_OUT" | grep -q "coop,$sub"; then
+            # Here-string, not `echo | grep -q`: pipefail + early grep match
+            # SIGPIPE's bash's echo on this 48 KB script and turns matches into false misses.
+            if grep -q "coop,$sub" <<<"$HARNESS_OUT"; then
                 pass "bash completion script references \`$sub\`"
             else
                 fail "bash completion script references \`$sub\`" \
-                    "output (truncated): $(echo "$HARNESS_OUT" | head -c 400)"
+                    "output (truncated): $(head -c 400 <<<"$HARNESS_OUT")"
             fi
         done
     else


### PR DESCRIPTION
## Summary

- `tests/integration.sh` runs with `set -o pipefail` and the `=== Phase: shell completions ===` subtests check the ~48 KB completion script with `echo "$HARNESS_OUT" | grep -q "coop,$sub"`. When `grep -q` matches early it closes the pipe; bash's `echo` builtin then exits with SIGPIPE (141), and `pipefail` makes the whole pipeline 141, masking grep's success as a false miss.
- Reproduced ~60% miss rate over 120 trials on Linux 6.17 / bash 5.2.21. Switching to a here-string (`grep -q "..." <<<"$HARNESS_OUT"`) eliminates the pipe entirely and reduces misses to 0/120.

## Test plan

- [ ] `./tests/run-integration.sh --full` on Linux/Firecracker — bash-completion subtests pass deterministically across consecutive runs.
- [ ] `./tests/run-integration.sh --remote <macos-host> --full` on macOS/Lima — same subtests still pass (here-strings are equivalent there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)