### PR TITLE
docs: fix stale --name syntax in shell-completion.md

### DIFF
--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -79,6 +79,6 @@ Dynamic and static completion can coexist — static fills in subcommand and fla
 
 | Argument | Source |
 |----------|--------|
-| Instance name (`shell`, `claude`, `claude-agents`, `codex`, `stop`, `destroy`, `status`, `logs`, `push --name`, `pull --name`, `exec --name`, `vscode`, `resize`) | `~/.coop/instances/` |
+| Instance name (`shell`, `claude`, `claude-agents`, `codex`, `stop`, `destroy`, `status`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`) | `~/.coop/instances/` |
 | `--image` (`start`, `setup`), `images --delete` | `~/.coop/images/` |
 | `--profile` (`setup`), `profiles show <name>` | builtin profiles plus `[profiles.*]` from `~/.coop/config.toml` |


### PR DESCRIPTION
## Summary

- `docs/shell-completion.md:82` listed `push --name`, `pull --name`, `exec --name` in the completion-source table. PR #97 changed those commands to take the instance name as a positional argument; the doc was the last reference still using the old `--name` syntax.
- Drop the `--name` qualifiers so the entry matches the bare-command convention used for `shell`, `claude`, `stop`, etc. on the same line. The completion engine itself was already correct — this is doc-only.

Closes #110

## Test plan

- [x] `grep -rn -- --name docs/` shows no remaining references
- [x] Other docs (`commands.md`, `workspaces.md`, `getting-started.md`) already use the new positional form, so the table is now consistent with them

🤖 Generated with [Claude Code](https://claude.com/claude-code)