### PR TITLE
Refresh docs to reflect guest-side bypass settings (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ coop claude
 coop codex
 ```
 
-That gives you a Claude Code or Codex session running inside an isolated VM with your project synced in. By default, `coop claude` launches with `--dangerously-skip-permissions` since the VM is the isolation boundary. Pass `--ask` to prompt for permissions instead.
+That gives you a Claude Code or Codex session running inside an isolated VM with your project synced in. During `coop start`, coop writes `~/.claude/settings.json` in the guest with `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts — the VM itself is the isolation boundary. Pass `--ask` to `coop claude` to restore prompts for that session (`--permission-mode default`).
 
 ## Features
 

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -8,9 +8,9 @@ coop sets up Claude Code inside guest VMs and gives you a single command to laun
 coop claude [instance-name] [-- extra-args...]
 ```
 
-This SSHes into the guest and runs the `claude` CLI. By default, coop passes `--dangerously-skip-permissions` so Claude operates without confirmation prompts. The VM is the isolation boundary; permission prompts inside it are redundant.
+This SSHes into the guest and runs the `claude` CLI. The guest's managed `~/.claude/settings.json` (written during `coop start`) sets `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude operates without confirmation prompts. The VM is the isolation boundary; permission prompts inside it are redundant.
 
-To restore permission prompts:
+To restore permission prompts for a single session, pass `--ask`. coop then launches `claude` with `--permission-mode default`, overriding the guest default:
 
 ```bash
 coop claude --ask
@@ -186,11 +186,12 @@ When `coop start` runs (without `--no-agents`), it executes the following steps 
 
 1. **GitHub auth**: If a `GITHUB_TOKEN` is available, run `gh auth setup-git` in the guest.
 2. **User content**: Copy the allowlisted entries (`CLAUDE.md`, `rules/`, `commands/`) from `config_dir` to `~/.claude/` in the guest.
-3. **Marketplaces**: Register each marketplace source (local directories are copied to the guest first). On first boot, coop compares the configured marketplaces against those already baked into the golden image (from `coop setup --profile`) and only installs the ones that are missing.
-4. **Plugins**: Install each plugin from the registered marketplaces. Like marketplaces, coop computes the delta against plugins already present in the golden image and skips those that are already installed.
-5. **MCP servers**: Register each MCP server definition.
+3. **Managed permissions**: Write a coop-managed `~/.claude/settings.json` in the guest containing `permissions.defaultMode: bypassPermissions` and `permissions.skipDangerousModePermissionPrompt: true`. The setting must live in user scope — Claude Code ignores `skipDangerousModePermissionPrompt` from project settings. This file is overwritten on every `coop start`; per-VM customization belongs in coop's config, not in the guest file.
+4. **Marketplaces**: Register each marketplace source (local directories are copied to the guest first). On first boot, coop compares the configured marketplaces against those already baked into the golden image (from `coop setup --profile`) and only installs the ones that are missing.
+5. **Plugins**: Install each plugin from the registered marketplaces. Like marketplaces, coop computes the delta against plugins already present in the golden image and skips those that are already installed.
+6. **MCP servers**: Register each MCP server definition.
 
-On restart (`coop start` of a stopped instance), only ephemeral state is refreshed: GitHub auth (step 1) and config directory contents (step 2). Marketplaces, plugins, and MCP servers persist on the guest disk and are not re-installed.
+On restart (`coop start` of a stopped instance), only ephemeral state is refreshed: GitHub auth (step 1), config directory contents (step 2), and the managed `~/.claude/settings.json` (step 3). Marketplaces, plugins, and MCP servers persist on the guest disk and are not re-installed.
 
 ### Skipping bootstrap
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -128,7 +128,7 @@ coop shell my-project -- cat /etc/os-release
 
 ### `claude`
 
-Launch Claude Code inside the VM. By default, coop passes `--dangerously-skip-permissions` because the VM itself is the isolation boundary. Use `--ask` to restore the permissions prompt.
+Launch Claude Code inside the VM. The guest's `~/.claude/settings.json` (written during `coop start`) sets `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts — the VM itself is the isolation boundary. Use `--ask` to override the guest default for that session (coop passes `--permission-mode default`).
 
 ```
 coop claude [NAME] [FLAGS] [ARGS...]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,7 +163,7 @@ coop start my-project --no-agents
 coop claude
 ```
 
-This runs Claude Code with `--dangerously-skip-permissions` by default. The VM itself is the isolation boundary. For permission prompts:
+During `coop start`, coop writes `~/.claude/settings.json` in the guest with `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts by default. The VM itself is the isolation boundary. For permission prompts (coop launches `claude` with `--permission-mode default`):
 
 ```
 coop claude --ask


### PR DESCRIPTION
## Summary
- Replace stale `--dangerously-skip-permissions` claims in README.md, docs/commands.md, docs/claude-integration.md, and docs/getting-started.md with a description of the managed `~/.claude/settings.json` (`defaultMode: bypassPermissions`, `skipDangerousModePermissionPrompt: true`) that `coop start` injects into the guest.
- Add the settings.json injection as step 3 of the bootstrap sequence in docs/claude-integration.md, renumber the remaining steps, and update the restart note (the settings file is rewritten on every `coop start`).
- Document `coop claude --ask` as passing `--permission-mode default` to override the guest default for that session.

Closes #108.

## Test plan
- [x] `rg "dangerously-skip-permissions" README.md docs/` returns no matches (the only remaining occurrence is the in-guest `claude-yolo` shortcut in `src/lima.rs`, which is unrelated).
- [x] Pre-commit hooks pass (`trim trailing whitespace`, `fix end of files`, `check for added large files`, `check for merge conflicts`).
- [x] Docs-only change; no Rust source touched, so `cargo test` / `clippy` / integration tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)