### PR TITLE
Document the @{u}..HEAD unpushed-commits check in workspaces.md

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -69,7 +69,12 @@ coop push my-instance                        # target a specific instance
 coop push my-instance --dir ./src --force    # combined
 ```
 
-Before overwriting guest files, `push` runs `git status --porcelain` inside the guest workspace. If there are uncommitted changes, push prints them and exits. `--force` overrides this.
+Before overwriting guest files, `push` checks for in-guest work the host doesn't yet know about. Two signals are inspected:
+
+- `git status --porcelain --untracked-files=no` — modifications to tracked files. Untracked files are skipped because they're usually host-side build artifacts that were copied into the guest at start time, not work done by an in-guest agent.
+- `git rev-list --count '@{u}..HEAD'` — commits on the current branch that are ahead of its upstream. Catches in-guest commits that a host push would otherwise silently overwrite.
+
+If either signal finds anything, push prints it and exits. `--force` overrides both.
 
 Transfer method selection is automatic:
 
@@ -86,7 +91,7 @@ coop pull my-instance                           # target a specific instance
 coop pull my-instance --dir ./local-copy        # combined
 ```
 
-Same dirty-check logic as push, applied to the local destination. If the local directory has a `.git` and uncommitted changes, pull refuses unless you pass `--force`.
+Before overwriting the local destination, `pull` runs `git status --porcelain` against it. If the directory has a `.git` and any uncommitted changes (tracked or untracked), pull refuses unless you pass `--force`. Unlike push's guest-side check, the local check does not inspect unpushed commits — committing your local work first is enough to satisfy it.
 
 The destination directory is created if absent. Transport selection follows the same rsync-then-tar-pipe order. The tar-pipe fallback verifies SHA-256 checksums end-to-end.
 


### PR DESCRIPTION
## Summary

- The push section of `docs/workspaces.md` described the dirty-check as a plain `git status --porcelain`, but PR #95 changed the guest-side check to ignore untracked files and to also flag commits ahead of upstream (`@{u}..HEAD`). Spell out both signals.
- The pull section claimed "Same dirty-check logic as push", which is no longer true — `check_local_dirty` is still a plain `git status --porcelain`, with no upstream-ahead check. Reword to describe what pull actually does and call out the asymmetry.

Fixes #111.

## Test plan

- [x] Re-read against `src/workspace.rs::check_guest_dirty` and `check_local_dirty` to confirm the prose matches the code.
- [x] `prek run` on the modified file (trailing-whitespace, end-of-file, large-files, merge-conflict checks; cargo hooks skipped — no Rust touched).