### PR TITLE
Redact secrets from Debug output

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -45,9 +45,33 @@ impl std::fmt::Display for GuestPath {
 /// Carries both variable names (for `-o SendEnv=`) and their values
 /// (for `Command::env()` on SSH child processes), avoiding unsafe
 /// mutation of the process-global environment.
-#[derive(Debug, Clone, Default)]
+///
+/// The whole struct is secret-bearing by construction (entries are
+/// `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GITHUB_TOKEN`, plus any
+/// user-configured `env_forward` values), so `Debug` redacts every
+/// value. Variable *names* are preserved because they are useful in
+/// diagnostics and are not themselves secret.
+#[derive(Clone, Default)]
 pub struct EnvForward {
     vars: IndexMap<String, String>,
+}
+
+impl std::fmt::Debug for EnvForward {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("EnvForward");
+        // `debug_map` would print keys without the `vars:` prefix; using
+        // a struct field with a map matches what `derive(Debug)` produced
+        // before, minus the redaction.
+        dbg.field(
+            "vars",
+            &self
+                .vars
+                .keys()
+                .map(|k| (k.as_str(), "<redacted>"))
+                .collect::<IndexMap<&str, &str>>(),
+        );
+        dbg.finish()
+    }
 }
 
 impl EnvForward {
@@ -910,8 +934,8 @@ pub fn prepare_env_forwarding(cfg: &CoopConfig, repo: Option<&str>) -> Result<En
 
     // ANTHROPIC_API_KEY: prefer config, fall back to process env
     if let Some(key) = &claude.api_key {
-        let resolved =
-            crate::config::resolve_cmd_value(key).context("Failed to resolve claude.api_key")?;
+        let resolved = crate::config::resolve_cmd_value(key.expose())
+            .context("Failed to resolve claude.api_key")?;
         env.set("ANTHROPIC_API_KEY", resolved);
     } else if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
         env.set("ANTHROPIC_API_KEY", key);
@@ -919,8 +943,8 @@ pub fn prepare_env_forwarding(cfg: &CoopConfig, repo: Option<&str>) -> Result<En
 
     // OPENAI_API_KEY: prefer config, fall back to process env
     if let Some(key) = &codex.api_key {
-        let resolved =
-            crate::config::resolve_cmd_value(key).context("Failed to resolve codex.api_key")?;
+        let resolved = crate::config::resolve_cmd_value(key.expose())
+            .context("Failed to resolve codex.api_key")?;
         env.set("OPENAI_API_KEY", resolved);
     } else if let Ok(key) = std::env::var("OPENAI_API_KEY") {
         env.set("OPENAI_API_KEY", key);
@@ -1170,7 +1194,7 @@ fn resolve_pat_token(strategy: Option<&GitHubAuth>, repo: &str) -> Result<String
     let entry = strategy
         .and_then(|s| s.pat_entry(repo))
         .with_context(|| crate::github_pat::missing_entry_error(repo))?;
-    let token = crate::config::resolve_cmd_value(&entry.token)
+    let token = crate::config::resolve_cmd_value(entry.token.expose())
         .with_context(|| format!("Failed to resolve token for [github.pat.\"{repo}\"]"))?;
     if !token.starts_with(crate::github_pat::TOKEN_PREFIX) {
         tracing::warn!(
@@ -2169,7 +2193,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             map.insert(
                 (*slug).to_string(),
                 crate::config::PatEntry {
-                    token: (*token).to_string(),
+                    token: crate::config::Secret::new((*token).to_string()),
                 },
             );
         }
@@ -2228,5 +2252,40 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         let auth = pat_auth_with(&[("owner/repo", "github_pat_literal")]);
         let token = resolve_clone_token(Some(&auth), "https://github.com/owner/repo.git").unwrap();
         assert_eq!(token.as_deref(), Some("github_pat_literal"));
+    }
+
+    // ── EnvForward Debug redaction ──────────────────────────
+
+    #[test]
+    fn env_forward_debug_redacts_all_values() {
+        let mut env = EnvForward::default();
+        env.set("ANTHROPIC_API_KEY", "sk-ant-secret-value");
+        env.set("GITHUB_TOKEN", "ghp_secret_value");
+        env.set("MYORG_INTERNAL", "internal-secret-blob");
+        let debug = format!("{env:?}");
+        for secret in [
+            "sk-ant-secret-value",
+            "ghp_secret_value",
+            "internal-secret-blob",
+        ] {
+            assert!(
+                !debug.contains(secret),
+                "EnvForward Debug leaked value '{secret}': {debug}"
+            );
+        }
+        // Keys are not secret — keep them in Debug output.
+        for key in ["ANTHROPIC_API_KEY", "GITHUB_TOKEN", "MYORG_INTERNAL"] {
+            assert!(
+                debug.contains(key),
+                "EnvForward Debug dropped key '{key}': {debug}"
+            );
+        }
+    }
+
+    #[test]
+    fn env_forward_debug_empty() {
+        let env = EnvForward::default();
+        let debug = format!("{env:?}");
+        assert!(debug.contains("EnvForward"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,6 +98,41 @@ pub(crate) fn resolve_cmd_value(value: &str) -> Result<String> {
     }
 }
 
+// ── Secret wrapper ───────────────────────────────────────────
+
+/// Generic wrapper for values that must not appear in `Debug` output.
+///
+/// `Debug` always prints `<redacted>`, so types embedded in error chains,
+/// `tracing` events, panic messages, or `dbg!` never leak the value.
+/// `Display` is intentionally **not** implemented — printing the secret
+/// must be an explicit `.expose()` call, which greps cleanly during review.
+///
+/// Round-trips through serde transparently: a config file with
+/// `api_key = "sk-…"` deserializes to `Secret(String::from("sk-…"))`,
+/// and re-serializing produces the same value. If a config-dump command
+/// is added later, redaction belongs at the formatter for that command,
+/// not on this type.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Secret<T>(T);
+
+impl<T> Secret<T> {
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    /// Borrow the underlying value. Named to flag every read at review time.
+    pub fn expose(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> fmt::Debug for Secret<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Secret(<redacted>)")
+    }
+}
+
 // ── Newtypes ─────────────────────────────────────────────────
 
 /// Memory size in mebibytes. Inner `NonZeroU32` rejects zero at
@@ -423,7 +458,7 @@ pub struct PatConfig {
 pub struct PatEntry {
     /// Token value. Accepts a literal token or a `cmd:`-prefixed shell
     /// command. Resolved via [`resolve_cmd_value`].
-    pub token: String,
+    pub token: Secret<String>,
 }
 
 /// Custom deserializer accepts either a string (legacy/simple) or a table.
@@ -618,7 +653,7 @@ impl<'de> serde::Deserialize<'de> for ConfigDir {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClaudeConfig {
     /// Anthropic API key (forwarded via `SendEnv`, never written to disk)
-    pub api_key: Option<String>,
+    pub api_key: Option<Secret<String>>,
 
     /// Additional env var names to forward from host to guest via SSH
     #[serde(default)]
@@ -667,7 +702,7 @@ fn default_prompt_for_pat() -> bool {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CodexConfig {
     /// `OpenAI` API key (forwarded via `SendEnv`, never written to disk)
-    pub api_key: Option<String>,
+    pub api_key: Option<Secret<String>>,
 
     /// Additional env var names to forward from host to guest via SSH
     #[serde(default)]
@@ -1231,7 +1266,7 @@ impl Default for NetworkConfig {
 impl Default for ClaudeConfig {
     fn default() -> Self {
         Self {
-            api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+            api_key: std::env::var("ANTHROPIC_API_KEY").ok().map(Secret::new),
             env_forward: Vec::new(),
             marketplaces: Vec::new(),
             plugins: Vec::new(),
@@ -1244,7 +1279,7 @@ impl Default for ClaudeConfig {
 impl Default for CodexConfig {
     fn default() -> Self {
         Self {
-            api_key: std::env::var("OPENAI_API_KEY").ok(),
+            api_key: std::env::var("OPENAI_API_KEY").ok().map(Secret::new),
             env_forward: Vec::new(),
             mcp_servers: HashMap::new(),
             config_dir: ConfigDir::Default,
@@ -1841,7 +1876,10 @@ mod tests {
             }
         }"#;
         let cfg: ClaudeConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(cfg.api_key.as_deref(), Some("sk-ant-test"));
+        assert_eq!(
+            cfg.api_key.as_ref().map(|s| s.expose().as_str()),
+            Some("sk-ant-test")
+        );
         assert_eq!(cfg.env_forward, vec!["MYORG_KEY"]);
         assert_eq!(cfg.marketplaces.len(), 1);
         assert_eq!(cfg.plugins, vec!["context7"]);
@@ -1873,7 +1911,10 @@ mod tests {
             }
         }"#;
         let cfg: CodexConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(cfg.api_key.as_deref(), Some("sk-openai-test"));
+        assert_eq!(
+            cfg.api_key.as_ref().map(|s| s.expose().as_str()),
+            Some("sk-openai-test")
+        );
         assert_eq!(cfg.env_forward, vec!["MYORG_KEY"]);
         assert_eq!(cfg.mcp_servers.len(), 1);
         assert!(cfg.mcp_servers.contains_key("sentry"));
@@ -1935,7 +1976,7 @@ token = "cmd:echo y"
         assert_eq!(
             pat.entries
                 .get("trailofbits/coop")
-                .map(|e| e.token.as_str()),
+                .map(|e| e.token.expose().as_str()),
             Some("cmd:echo x")
         );
         assert!(pat.skip.is_empty());
@@ -1967,7 +2008,7 @@ token = "cmd:echo x"
 "#;
         let auth: GitHubAuth = toml::from_str(toml_str).unwrap();
         let entry = auth.pat_entry("a/b").unwrap();
-        assert_eq!(entry.token, "cmd:echo x");
+        assert_eq!(entry.token.expose(), "cmd:echo x");
         assert!(auth.pat_entry("c/d").is_none());
     }
 
@@ -1989,7 +2030,7 @@ token = "cmd:echo x"
         entries.insert(
             "a/b".to_string(),
             PatEntry {
-                token: "cmd:echo x".to_string(),
+                token: Secret::new("cmd:echo x".to_string()),
             },
         );
         let auth = GitHubAuth::Pat(PatConfig {
@@ -2004,7 +2045,7 @@ token = "cmd:echo x"
         };
         assert_eq!(pat.skip, vec!["c/d".to_string()]);
         assert_eq!(
-            pat.entries.get("a/b").map(|e| e.token.as_str()),
+            pat.entries.get("a/b").map(|e| e.token.expose().as_str()),
             Some("cmd:echo x")
         );
     }
@@ -3067,5 +3108,70 @@ token = "cmd:echo x"
         // `cmd` (no colon) is a plain value, not a command substitution
         assert_eq!(resolve_cmd_value("cmd").unwrap(), "cmd");
         assert_eq!(resolve_cmd_value("cmdline").unwrap(), "cmdline");
+    }
+
+    // ── Secret redaction ─────────────────────────────────────
+
+    #[test]
+    fn secret_debug_does_not_leak_value() {
+        let s = Secret::new("real-token-value-do-not-leak".to_string());
+        let debug = format!("{s:?}");
+        assert!(
+            !debug.contains("real-token-value-do-not-leak"),
+            "Debug leaked secret value: {debug}"
+        );
+        assert!(
+            debug.contains("redacted"),
+            "Debug should mark redaction: {debug}"
+        );
+    }
+
+    #[test]
+    fn secret_expose_returns_underlying_value() {
+        let s = Secret::new("plaintext".to_string());
+        assert_eq!(s.expose(), "plaintext");
+    }
+
+    #[test]
+    fn secret_serde_round_trip_is_transparent() {
+        let json = r#""token-xyz""#;
+        let s: Secret<String> = serde_json::from_str(json).unwrap();
+        assert_eq!(s.expose(), "token-xyz");
+        let out = serde_json::to_string(&s).unwrap();
+        assert_eq!(out, json);
+    }
+
+    #[test]
+    fn claude_config_api_key_debug_redacts() {
+        let json = r#"{"api_key": "sk-ant-real-secret"}"#;
+        let cfg: ClaudeConfig = serde_json::from_str(json).unwrap();
+        let debug = format!("{cfg:?}");
+        assert!(
+            !debug.contains("sk-ant-real-secret"),
+            "ClaudeConfig Debug leaked api_key: {debug}"
+        );
+    }
+
+    #[test]
+    fn codex_config_api_key_debug_redacts() {
+        let json = r#"{"api_key": "sk-openai-real-secret"}"#;
+        let cfg: CodexConfig = serde_json::from_str(json).unwrap();
+        let debug = format!("{cfg:?}");
+        assert!(
+            !debug.contains("sk-openai-real-secret"),
+            "CodexConfig Debug leaked api_key: {debug}"
+        );
+    }
+
+    #[test]
+    fn pat_entry_token_debug_redacts() {
+        let entry = PatEntry {
+            token: Secret::new("github_pat_secret".to_string()),
+        };
+        let debug = format!("{entry:?}");
+        assert!(
+            !debug.contains("github_pat_secret"),
+            "PatEntry Debug leaked token: {debug}"
+        );
     }
 }

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -121,12 +121,12 @@ pub fn run_status(cfg: &CoopConfig, probe: bool) {
     println!("github mode: pat");
     println!("entries ({}):", pat.entries.len());
     for (repo, entry) in &pat.entries {
-        let backend_label = infer_backend(&entry.token)
+        let backend_label = infer_backend(entry.token.expose())
             .map_or_else(|| "unknown".to_string(), |b| b.label().to_string());
         println!("  {repo}");
         println!("    storage: {backend_label}");
         if probe {
-            let validity = match resolve_cmd_value(&entry.token) {
+            let validity = match resolve_cmd_value(entry.token.expose()) {
                 Ok(token) if token.starts_with(TOKEN_PREFIX) => "resolves, format ok",
                 Ok(_) => "resolves but unexpected format",
                 Err(_) => "FAILED to resolve",
@@ -153,7 +153,7 @@ pub fn run_forget_pat(cfg: &CoopConfig, repo: &str, config_path: &Path) -> Resul
         .with_context(|| {
             format!("No PAT entry for '{repo}' — nothing to forget. Run `coop github status`.")
         })?;
-    let backend = infer_backend(&entry.token);
+    let backend = infer_backend(entry.token.expose());
     let account = account_for_repo(repo);
     let state_dir = cfg.data_dir.join("state");
     if let Some(b) = backend {
@@ -586,7 +586,7 @@ mod tests {
         let cfg = pat_config_at(&path).unwrap().unwrap();
         assert_eq!(cfg.entries.len(), 1);
         let entry = cfg.entries.get("trailofbits/coop").unwrap();
-        assert_eq!(entry.token, "cmd:cat ./t.txt");
+        assert_eq!(entry.token.expose(), "cmd:cat ./t.txt");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -788,7 +788,7 @@ fn cmd_validate(
     // Per-repo PAT validation
     if let Some(config::GitHubAuth::Pat(pat)) = cfg.github.as_ref() {
         for (repo, entry) in &pat.entries {
-            match config::resolve_cmd_value(&entry.token) {
+            match config::resolve_cmd_value(entry.token.expose()) {
                 Ok(token) => {
                     if token.starts_with(github_pat::TOKEN_PREFIX) {
                         writeln!(

--- a/src/pat_prompt.rs
+++ b/src/pat_prompt.rs
@@ -240,7 +240,7 @@ mod tests {
         pc.entries.insert(
             "a/b".to_string(),
             PatEntry {
-                token: "cmd:echo x".to_string(),
+                token: crate::config::Secret::new("cmd:echo x".to_string()),
             },
         );
         let cfg = cfg_with(Some(GitHubAuth::Pat(pc)));


### PR DESCRIPTION
## Summary

- Add `Secret<T>` newtype in `src/config.rs` with redacting `Debug`, transparent serde, and an explicit `expose()` accessor — so any `{:?}` of a wrapped value emits `Secret(<redacted>)` instead of the plaintext.
- Apply to `ClaudeConfig.api_key`, `CodexConfig.api_key`, and `PatEntry.token`.
- Replace `derive(Debug)` on `EnvForward` with a bespoke impl that redacts every value and keeps variable names. The struct holds `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GITHUB_TOKEN`, and any user-configured `env_forward` entries, so wrapping each individually was more noise than signal.

Settles the open question from #79 in favour of transparent `Serialize`: a config file with `api_key = "sk-…"` still round-trips. If a `coop config show` command is ever added, redaction belongs at that formatter.

Closes #79.

## Test plan

- [x] `format!("{:?}", Secret::new("real-token"))` does not contain `"real-token"`
- [x] `format!("{:?}", env_forward_with_secrets)` does not contain any inserted value
- [x] Existing `ClaudeConfig` / `CodexConfig` / `PatEntry` deserialization tests still pass via `Secret::expose()`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 390 passing
- [x] Sweep: no other `Debug`-deriving structs in `src/` hold `key`/`token`/`secret`/`password`/`auth`/`cred` field values