### PR TITLE
Add post_start hook that runs after every VM boot

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -86,6 +86,7 @@ coop start [NAME] [FLAGS]
 | `--mount <spec>` | Mount host directory into guest (`HOST_PATH[:GUEST_PATH]`, repeatable). Conflicts with `--workspace` and `--git-repo`. |
 | `--exclude-git` | Skip the `.git/` directory when syncing the workspace (conflicts with `--git-repo`). |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
+| `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
 
 `--workspace` and `--git-repo` are mutually exclusive. Use `--workspace` to tar-pipe a local directory into the guest. Use `--git-repo` to clone a repository inside the VM at boot.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ Run `coop validate` to surface errors and warnings before anything touches a VM.
 | `ssh_port` | integer | `22` | SSH port on the guest VM. Must be > 0. |
 | `firecracker_bin` | string (path) | `~/.coop/firecracker` | Path to the Firecracker binary. Linux only; ignored on macOS (Lima backend). |
 | `github` | string or table | unset (treated as `"off"`) | GitHub authentication strategy. See [GitHub auth](#github-auth). |
+| `post_start` | string | unset | Shell command run in the guest after every successful boot, before any interactive `shell` / agent launch. Failure is logged at `WARN` and does not fail the start. Override per invocation with `coop start --post-start <cmd>`. |
 
 ## GitHub auth
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -976,6 +976,21 @@ pub fn prepare_env_forwarding(cfg: &CoopConfig, repo: Option<&str>) -> Result<En
     Ok(env)
 }
 
+/// Run a user-supplied post-start hook in the guest.
+///
+/// The command is sent to SSH as-is and evaluated by the guest's login
+/// shell, so pipes, `&&`, and redirects all work. Failures are logged at
+/// `WARN` and swallowed — a transient hook failure shouldn't strand the VM.
+pub fn run_post_start(session: &SshSession, command: &str) {
+    tracing::info!("Running post_start hook in guest");
+    tracing::debug!("post_start: {command}");
+
+    match session.exec(command) {
+        Ok(()) => tracing::debug!("post_start hook completed"),
+        Err(e) => tracing::warn!("post_start hook failed (continuing): {e}"),
+    }
+}
+
 /// Bootstrap configured guest agents in the guest declaratively.
 pub fn bootstrap_agents(
     session: &SshSession,

--- a/src/config.rs
+++ b/src/config.rs
@@ -340,6 +340,16 @@ pub struct CoopConfig {
     #[serde(default)]
     pub profiles: HashMap<String, CustomProfile>,
 
+    /// Shell command to run inside the guest after every successful boot.
+    ///
+    /// Executed after the VM is up and SSH is ready, before any interactive
+    /// `shell` / agent launch. A failure is logged at `WARN` and does not
+    /// fail the start — a transient hook failure shouldn't strand the VM.
+    ///
+    /// Maps to `postStartCommand` from `devcontainer.json`.
+    #[serde(default)]
+    pub post_start: Option<String>,
+
     /// Self-update behaviour
     #[serde(default)]
     pub updates: crate::update::UpdateConfig,
@@ -1244,6 +1254,7 @@ impl Default for CoopConfig {
             claude: ClaudeConfig::default(),
             codex: CodexConfig::default(),
             profiles: HashMap::new(),
+            post_start: None,
             updates: crate::update::UpdateConfig::default(),
         }
     }
@@ -2466,6 +2477,24 @@ token = "cmd:echo x"
     fn custom_profiles_default_empty() {
         let cfg = CoopConfig::default();
         assert!(cfg.profiles.is_empty());
+    }
+
+    // ── post_start ───────────────────────────────────────────
+
+    #[test]
+    fn post_start_deserializes() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, "post_start = \"touch /tmp/booted\"\n").unwrap();
+
+        let cfg = CoopConfig::load(&path).unwrap();
+        assert_eq!(cfg.post_start.as_deref(), Some("touch /tmp/booted"));
+    }
+
+    #[test]
+    fn post_start_default_none() {
+        let cfg = CoopConfig::default();
+        assert!(cfg.post_start.is_none());
     }
 
     // ── Named images ─────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,11 @@ enum Commands {
         /// when one is missing for the resolved repo.
         #[arg(long)]
         no_prompt: bool,
+        /// Shell command to run inside the guest after boot (overrides
+        /// `post_start` from `config.toml`). Failure is logged but does
+        /// not fail the start.
+        #[arg(long, value_name = "CMD")]
+        post_start: Option<String>,
     },
     /// Open an interactive shell in the VM (or run a command non-interactively)
     #[command(alias = "ssh")]
@@ -584,6 +589,7 @@ fn main() -> Result<()> {
             image,
             exclude_git,
             no_prompt,
+            post_start,
         } => {
             if raw_args_use_deprecated_no_claude(std::env::args()) {
                 tracing::warn!(
@@ -611,6 +617,7 @@ fn main() -> Result<()> {
                     mounts,
                     exclude_git,
                     config_path: &cli.config,
+                    post_start_override: post_start.as_deref(),
                 },
             )
         }
@@ -892,6 +899,9 @@ struct StartOpts<'a> {
     /// Path to the on-disk config file. Re-read after the auto-prompt
     /// in case the wizard added a new `[github.pat."..."]` entry.
     config_path: &'a Path,
+    /// CLI override for `post_start` from `config.toml`. `None` means
+    /// "use the configured value (if any)"; `Some` always wins.
+    post_start_override: Option<&'a str>,
 }
 
 fn cmd_start(
@@ -1072,11 +1082,19 @@ fn restart_instance(
 
     signal::check_shutdown()?;
 
-    if opts.no_agents {
+    let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
+    if opts.no_agents && post_start.is_none() {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
         let session = prepare_session_from_target(cfg, target.clone(), repo.as_deref())?;
-        backend::bootstrap_agents(&session, cfg, inst, true)?;
+        if opts.no_agents {
+            tracing::info!("Skipping guest agent bootstrap (--no-agents)");
+        } else {
+            backend::bootstrap_agents(&session, cfg, inst, true)?;
+        }
+        if let Some(cmd) = post_start {
+            backend::run_post_start(&session, cmd);
+        }
     }
 
     tracing::info!(
@@ -1142,11 +1160,19 @@ fn start_instance(
 
     signal::check_shutdown()?;
 
-    if opts.no_agents {
+    let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
+    if opts.no_agents && post_start.is_none() {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
         let session = prepare_session_from_target(cfg, target.clone(), repo.as_deref())?;
-        backend::bootstrap_agents(&session, cfg, inst, false)?;
+        if opts.no_agents {
+            tracing::info!("Skipping guest agent bootstrap (--no-agents)");
+        } else {
+            backend::bootstrap_agents(&session, cfg, inst, false)?;
+        }
+        if let Some(cmd) = post_start {
+            backend::run_post_start(&session, cmd);
+        }
     }
 
     signal::check_shutdown()?;
@@ -2090,6 +2116,15 @@ mod tests {
     }
 
     #[test]
+    fn start_post_start_flag_parses() {
+        let cli = parse(&["start", "--post-start", "touch /tmp/x"]);
+        let super::Commands::Start { post_start, .. } = cli.command else {
+            panic!("expected Start variant");
+        };
+        assert_eq!(post_start.as_deref(), Some("touch /tmp/x"));
+    }
+
+    #[test]
     fn start_no_claude_alias_parses() {
         let cli = parse(&["start", "--no-claude"]);
         let super::Commands::Start { no_agents, .. } = cli.command else {
@@ -2489,6 +2524,7 @@ mod tests {
             mounts,
             exclude_git: false,
             config_path,
+            post_start_override: None,
         }
     }
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2726,6 +2726,53 @@ test_interrupted_setup() {
     coop images --delete "$img" 2>/dev/null || true
 }
 
+# ── post_start hook (--full only) ──────────────────────────────
+
+test_post_start() {
+    echo ""
+    echo "=== Phase: post_start hook ==="
+
+    local inst_name="${INSTANCE}-poststart"
+    local marker="/tmp/coop-post-start-$$.marker"
+
+    # --post-start runs the command in the guest after SSH is ready.
+    # The marker file written by the hook is the assertion.
+    if coop start "$inst_name" --no-agents \
+        --post-start "echo hooked > $marker"; then
+        STARTED_INSTANCES+=("$inst_name")
+        pass "start --post-start exits 0"
+    else
+        fail "start --post-start exits 0" "exit code: $?"
+        return
+    fi
+
+    GUEST_INSTANCE="$inst_name"
+    local seen
+    seen=$(guest_exec cat "$marker" 2>/dev/null) || seen=""
+    unset GUEST_INSTANCE
+
+    if [[ "$seen" == *hooked* ]]; then
+        pass "--post-start hook ran in the guest"
+    else
+        fail "--post-start hook ran in the guest" "marker contents: '$seen'"
+    fi
+
+    # Verify a failing hook does not fail `coop start` (warn-and-continue).
+    local fail_inst="${INSTANCE}-poststart-fail"
+    if coop start "$fail_inst" --no-agents \
+        --post-start "false; exit 1"; then
+        STARTED_INSTANCES+=("$fail_inst")
+        pass "start succeeds when --post-start fails (warn-and-continue)"
+    else
+        fail "start succeeds when --post-start fails" "exit code: $?"
+    fi
+
+    coop destroy "$inst_name" 2>/dev/null || true
+    untrack_instance "$inst_name"
+    coop destroy "$fail_inst" 2>/dev/null || true
+    untrack_instance "$fail_inst"
+}
+
 # ── Provision failure test (--full only) ───────────────────────
 
 test_provision_failure() {
@@ -2840,6 +2887,7 @@ main() {
         test_named_images
         test_custom_profiles
         test_builtin_profiles
+        test_post_start
 
         # Local marketplace directory copy
         test_local_marketplace


### PR DESCRIPTION
Closes #123.

## Summary

- Adds `post_start: Option<String>` to `CoopConfig` and a matching `--post-start <CMD>` override on `coop start`. Runs the configured shell command in the guest after SSH is ready, before any interactive shell or agent launch — the missing per-boot counterpart to `CustomProfile.post_install` (which only runs at template-build time). Maps to `postStartCommand` from `devcontainer.json`.
- Failures are logged at `WARN` and swallowed — a transient hook problem shouldn't strand the VM.
- Wired into both the fresh-start and restart paths; when `--no-agents` is set, the agent bootstrap is still skipped but the hook still runs.
- Docs updated: `post_start` row in `docs/configuration.md` top-level table; `--post-start` row in the `coop start` flag table in `docs/commands.md`.

## Test plan

- [x] `cargo test` — 385 unit tests pass, including new `post_start_deserializes`, `post_start_default_none`, and `start_post_start_flag_parses`.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [ ] `./tests/run-integration.sh` (macOS / Lima) — new `test_post_start` phase under `--full` asserts the hook runs in the guest and that a failing hook does not fail `coop start`.
- [ ] `./tests/run-integration.sh --remote <linux-host>` (Linux / Firecracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)