### PR TITLE
Add guest_env: set literal env vars in the guest

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -38,6 +38,13 @@
 # subnet_mask = "/24"
 # host_iface = "auto"           # "auto" detects at runtime
 
+# [guest_env]                   # Literal env vars to set in the guest.
+#                               # Overrides forwarded values on key
+#                               # collision (warning logged). Avoid for
+#                               # secrets — use `env_forward` instead.
+# RUST_LOG = "info"
+# MY_FLAG = "1"
+
 # [claude]
 # config_dir = "~/.claude"  # path to copy CLAUDE.md, rules/, commands/ from (false to disable)
 # env_forward = ["CUSTOM_TOKEN"]  # Extra env vars to forward to guest

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -87,6 +87,7 @@ coop start [NAME] [FLAGS]
 | `--exclude-git` | Skip the `.git/` directory when syncing the workspace (conflicts with `--git-repo`). |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
+| `--env KEY=VALUE` | Literal env var to set in the guest (repeatable). Overrides `guest_env` config entries and any forwarded values with the same name. |
 
 `--workspace` and `--git-repo` are mutually exclusive. Use `--workspace` to tar-pipe a local directory into the guest. Use `--git-repo` to clone a repository inside the VM at boot.
 
@@ -97,6 +98,7 @@ coop start my-project --workspace ./src --vcpus 4 --mem 8192
 coop start --git-repo https://github.com/org/repo.git --disk 50
 coop start --image ml-dev --no-agents
 coop start --mount ~/data:/mnt/data
+coop start --env RUST_LOG=info --env MY_FLAG=1
 ```
 
 `--no-claude` is accepted as a deprecated alias for `--no-agents` and will be removed in a future release. Using it prints a deprecation warning.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,22 @@ Firecracker TAP networking. These fields apply to Linux only. The Lima backend o
 | `subnet_mask` | string (CIDR) | `/24` | Subnet mask in CIDR notation. Must be `/0` through `/32`. |
 | `host_iface` | string | `auto` | Host network interface for NAT (e.g., `eth0`, `ens5`). `auto` detects it at runtime. |
 
+## `guest_env` section
+
+Literal environment variables to set inside the guest, independent of the host process environment. Use this when you want a value that isn't (or shouldn't be) on the host — `env_forward` covers the inherit-from-host case.
+
+```toml
+[guest_env]
+RUST_LOG = "info"
+MY_FLAG = "1"
+```
+
+Keys are env var names; values are the literals to inject. Entries here **override** any value resolved through other mechanisms for the same name (forwarded host env, `claude.api_key`, etc.), and the override is logged at `WARN`.
+
+**Secrets:** values land in the guest's process environment in plain text and may be visible via `ps`/`/proc` to guest users. For credentials, prefer `env_forward` (host process env stays the source of truth) or one of the `cmd:` integrations on the structured fields (`claude.api_key`, etc.).
+
+Override or extend per-invocation with `coop start --env KEY=VALUE` (repeatable).
+
 ## `claude` section
 
 Claude Code configuration injected into the guest VM at start time. Every field is optional.
@@ -230,6 +246,7 @@ Several config values accept per-invocation overrides via flags:
 | `--mem <MiB>` | `setup`, `start` | `vm.mem_size_mib` |
 | `--template-size <GiB>` | `setup` | `vm.template_size_gib` |
 | `--disk <GiB>` | `start` | Per-instance disk size (grows from template if larger) |
+| `--env KEY=VALUE` | `start` | Adds or overrides a `guest_env` entry (repeatable) |
 | `--config <path>` | all commands | Config file path (default: `~/.coop/config.toml`) |
 
 ## Examples
@@ -257,6 +274,9 @@ boot_args = "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw"
 host_ip = "172.16.0.1"
 subnet_mask = "/24"
 host_iface = "auto"
+
+[guest_env]
+RUST_LOG = "info"
 
 [claude]
 config_dir = "~/.claude"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -973,6 +973,17 @@ pub fn prepare_env_forwarding(cfg: &CoopConfig, repo: Option<&str>) -> Result<En
         }
     }
 
+    // `guest_env` literals override anything resolved above (forwarded
+    // host env vars, `claude.api_key`, etc.) so an explicit value beats
+    // an inherited one. Warn on collision so the override is visible —
+    // values are not logged (they may be secrets).
+    for (name, value) in &cfg.guest_env {
+        if env.contains(name) {
+            tracing::warn!("guest_env entry '{name}' overrides a previously resolved value");
+        }
+        env.set(name.as_str(), value.as_str());
+    }
+
     Ok(env)
 }
 
@@ -2302,5 +2313,59 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         let env = EnvForward::default();
         let debug = format!("{env:?}");
         assert!(debug.contains("EnvForward"));
+    }
+
+    // ── guest_env merge precedence ──────────────────────────
+
+    /// Build a `CoopConfig` whose env-resolving inputs are all empty
+    /// except `guest_env`. Defaults read `ANTHROPIC_API_KEY` /
+    /// `OPENAI_API_KEY` from the process environment, which would make
+    /// these tests flaky; clearing them keeps the assertions about
+    /// `guest_env` precise.
+    fn cfg_with_guest_env(entries: &[(&str, &str)]) -> CoopConfig {
+        let mut cfg = CoopConfig::default();
+        cfg.claude.api_key = None;
+        cfg.claude.env_forward = Vec::new();
+        cfg.codex.api_key = None;
+        cfg.codex.env_forward = Vec::new();
+        cfg.github = None;
+        for (k, v) in entries {
+            cfg.guest_env.insert((*k).to_string(), (*v).to_string());
+        }
+        cfg
+    }
+
+    #[test]
+    fn guest_env_entries_are_forwarded() {
+        let cfg = cfg_with_guest_env(&[("RUST_LOG", "info"), ("MY_FLAG", "1")]);
+        let env = prepare_env_forwarding(&cfg, None).unwrap();
+        assert_eq!(
+            env.as_envs().get("RUST_LOG").map(String::as_str),
+            Some("info")
+        );
+        assert_eq!(env.as_envs().get("MY_FLAG").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn guest_env_overrides_configured_api_key() {
+        // Configured claude.api_key gets inserted first; guest_env with
+        // the same name should win on conflict.
+        let mut cfg = cfg_with_guest_env(&[("ANTHROPIC_API_KEY", "guest-env-wins")]);
+        cfg.claude.api_key = Some(crate::config::Secret::new("from-claude-config".to_string()));
+
+        let env = prepare_env_forwarding(&cfg, None).unwrap();
+        assert_eq!(
+            env.as_envs().get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("guest-env-wins"),
+        );
+    }
+
+    #[test]
+    fn guest_env_empty_value_is_preserved() {
+        // Empty string is a legitimate value — distinguish "unset" from
+        // "set to empty" so users can intentionally clear inherited vars.
+        let cfg = cfg_with_guest_env(&[("EMPTY", "")]);
+        let env = prepare_env_forwarding(&cfg, None).unwrap();
+        assert_eq!(env.as_envs().get("EMPTY").map(String::as_str), Some(""));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, File};
@@ -335,6 +335,16 @@ pub struct CoopConfig {
     /// Codex config forwarding settings
     #[serde(default)]
     pub codex: CodexConfig,
+
+    /// Literal env vars to set in the guest, independent of the host
+    /// process environment. Merged with `env_forward` results during
+    /// SSH setup; entries here override forwarded values (with a
+    /// `tracing::warn!`).
+    ///
+    /// `BTreeMap` for deterministic iteration order — useful for
+    /// snapshot/diagnostic stability.
+    #[serde(default)]
+    pub guest_env: BTreeMap<String, String>,
 
     /// User-defined profiles (name -> definition)
     #[serde(default)]
@@ -1253,6 +1263,7 @@ impl Default for CoopConfig {
             setup: SetupConfig::default(),
             claude: ClaudeConfig::default(),
             codex: CodexConfig::default(),
+            guest_env: BTreeMap::new(),
             profiles: HashMap::new(),
             post_start: None,
             updates: crate::update::UpdateConfig::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,11 @@ enum Commands {
         /// not fail the start.
         #[arg(long, value_name = "CMD")]
         post_start: Option<String>,
+        /// Literal env var to set in the guest (`KEY=VALUE`, repeatable).
+        /// Overrides `guest_env` entries from config and any forwarded
+        /// values with the same name.
+        #[arg(long = "env", value_name = "KEY=VALUE")]
+        guest_env: Vec<String>,
     },
     /// Open an interactive shell in the VM (or run a command non-interactively)
     #[command(alias = "ssh")]
@@ -590,6 +595,7 @@ fn main() -> Result<()> {
             exclude_git,
             no_prompt,
             post_start,
+            guest_env,
         } => {
             if raw_args_use_deprecated_no_claude(std::env::args()) {
                 tracing::warn!(
@@ -597,6 +603,7 @@ fn main() -> Result<()> {
                 );
             }
             apply_vm_overrides(&mut cfg, vcpus, mem, None)?;
+            merge_cli_guest_env(&mut cfg, &guest_env)?;
             let mounts = mount
                 .iter()
                 .map(|s| config::Mount::parse(s))
@@ -874,6 +881,23 @@ fn apply_vm_overrides(
     }
     if let Some(ts) = template_size {
         cfg.vm.template_size_gib = config::GiB::new(ts).context("--template-size must be > 0")?;
+    }
+    Ok(())
+}
+
+/// Merge `--env KEY=VALUE` arguments into `cfg.guest_env`.
+///
+/// CLI values override config entries with the same key. Empty keys
+/// and values without `=` are rejected; empty values are allowed.
+fn merge_cli_guest_env(cfg: &mut config::CoopConfig, args: &[String]) -> Result<()> {
+    for entry in args {
+        let (key, value) = entry
+            .split_once('=')
+            .with_context(|| format!("--env expects KEY=VALUE, got '{entry}' (missing '=')"))?;
+        if key.is_empty() {
+            bail!("--env KEY must not be empty (got '{entry}')");
+        }
+        cfg.guest_env.insert(key.to_string(), value.to_string());
     }
     Ok(())
 }
@@ -2151,6 +2175,77 @@ mod tests {
             "--name",
             "--no-claude-work"
         ]));
+    }
+
+    #[test]
+    fn start_env_flag_parses_repeatable() {
+        let cli = parse(&["start", "--env", "FOO=bar", "--env", "BAZ=qux"]);
+        let super::Commands::Start { guest_env, .. } = cli.command else {
+            panic!("expected Start variant");
+        };
+        assert_eq!(
+            guest_env,
+            vec!["FOO=bar".to_string(), "BAZ=qux".to_string()]
+        );
+    }
+
+    #[test]
+    fn merge_cli_guest_env_inserts_and_overrides_config() {
+        let mut cfg = super::config::CoopConfig::default();
+        cfg.guest_env
+            .insert("KEEP".to_string(), "from-config".to_string());
+        cfg.guest_env
+            .insert("OVERWRITE".to_string(), "from-config".to_string());
+
+        super::merge_cli_guest_env(
+            &mut cfg,
+            &["OVERWRITE=from-cli".to_string(), "NEW=cli-only".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            cfg.guest_env.get("KEEP").map(String::as_str),
+            Some("from-config")
+        );
+        assert_eq!(
+            cfg.guest_env.get("OVERWRITE").map(String::as_str),
+            Some("from-cli")
+        );
+        assert_eq!(
+            cfg.guest_env.get("NEW").map(String::as_str),
+            Some("cli-only")
+        );
+    }
+
+    #[test]
+    fn merge_cli_guest_env_allows_empty_value() {
+        let mut cfg = super::config::CoopConfig::default();
+        super::merge_cli_guest_env(&mut cfg, &["CLEAR=".to_string()]).unwrap();
+        assert_eq!(cfg.guest_env.get("CLEAR").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn merge_cli_guest_env_rejects_missing_equals() {
+        let mut cfg = super::config::CoopConfig::default();
+        let err = super::merge_cli_guest_env(&mut cfg, &["NO_EQUALS".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("KEY=VALUE"));
+    }
+
+    #[test]
+    fn merge_cli_guest_env_rejects_empty_key() {
+        let mut cfg = super::config::CoopConfig::default();
+        let err = super::merge_cli_guest_env(&mut cfg, &["=value".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("KEY"));
+    }
+
+    #[test]
+    fn merge_cli_guest_env_value_may_contain_equals() {
+        let mut cfg = super::config::CoopConfig::default();
+        super::merge_cli_guest_env(&mut cfg, &["URL=https://x?a=b&c=d".to_string()]).unwrap();
+        assert_eq!(
+            cfg.guest_env.get("URL").map(String::as_str),
+            Some("https://x?a=b&c=d"),
+        );
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -367,7 +367,13 @@ test_start() {
     echo ""
     echo "=== Phase: start ==="
 
-    local args=(start "$INSTANCE" --no-agents)
+    # `--env` exercises the guest_env CLI -> config -> SendEnv path
+    # end-to-end. `test_guest_environment` verifies the value is
+    # visible inside the guest via `printenv`.
+    local args=(
+        start "$INSTANCE" --no-agents
+        --env "COOP_TEST_GUEST_ENV=hello-from-cli"
+    )
     if coop "${args[@]}"; then
         STARTED_INSTANCES+=("$INSTANCE")
         pass "start exits 0"
@@ -938,6 +944,18 @@ test_guest_environment() {
         fi
     else
         fail "HOME is /home/ubuntu" "printenv failed"
+    fi
+
+    # Verify `--env` from test_start landed in the guest process env.
+    local guest_env_val
+    if guest_env_val=$(guest_exec printenv COOP_TEST_GUEST_ENV); then
+        if [[ "$guest_env_val" == "hello-from-cli" ]]; then
+            pass "guest_env from --env reaches the guest"
+        else
+            fail "guest_env from --env reaches the guest" "got: $guest_env_val"
+        fi
+    else
+        fail "guest_env from --env reaches the guest" "printenv failed; stderr: $(guest_stderr)"
     fi
 }
 


### PR DESCRIPTION
## Summary

- Adds `[guest_env]` (`BTreeMap<String, String>`, top-level on `CoopConfig`) so users can set arbitrary env vars inside the guest without first exporting them on the host or baking them into `post_install`. Maps to devcontainer.json `containerEnv` for the future translator (#27).
- `prepare_env_forwarding` merges `guest_env` after the existing forwarded values; collisions resolve in favour of `guest_env` with a `tracing::warn!` so the override is visible. `BTreeMap` keeps iteration deterministic for snapshot/diagnostic stability.
- `coop start --env KEY=VALUE` (repeatable) extends or overrides the configured map per-invocation. Empty values are accepted (so users can intentionally blank an inherited var); empty keys and missing `=` are rejected at parse time.
- Documents the field in `docs/configuration.md`, the flag in `docs/commands.md`, and adds an example to `config.example.toml`. Secrets guidance stays pointed at `env_forward` / `cmd:` since `guest_env` values land in the guest's process env in plain text.

## Scope notes

- Per-profile `guest_env` was mentioned in the issue but punted: `CustomProfile` has no env-related fields today, and the top-level field covers the reported gap. A follow-up can add it if a real use case appears.
- Devcontainer.json translation is left for #27.

## Test plan

- [x] `cargo test` — 399 pass, including 3 new `prepare_env_forwarding` tests covering insertion, override of a configured `claude.api_key`, and empty-value preservation, plus 5 `--env` parser tests (parsing, override, empty value, missing `=`, empty key, `=`-containing value)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `prek run --all-files`
- [x] `coop start --help` shows the new flag with a clear description
- [ ] Manual integration check on Lima/Firecracker — left to maintainers since the test runners aren't available in this environment

Closes #124