### PR TITLE
Add --forward-port for guest→host TCP forwarding (closes #125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
 
 ### New features
 
+- **`--forward-port` / `forward_ports` config** (#125) — Forward guest
+  TCP ports to the host for the lifetime of the VM. `coop start
+  --forward-port 3000` exposes guest 3000 on host 3000; `3000:18080`
+  remaps to a different host port. The flag is repeatable, supported
+  by a config-level `forward_ports = [...]` default, persisted across
+  `stop`/`start`, and torn down cleanly on `coop stop`. Collision with
+  an already-bound host port fails fast before the VM is created.
+
 - **`coop ca` / `coop claude-agents` shortcut** (#80, #82, #99, #100, #101) —
   Runs `claude agents` inside the VM in one command. Defaults to no
   tmux (Claude Code manages background-session lifetime itself);

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,6 +84,7 @@ coop start [NAME] [FLAGS]
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
 | `--image <name>` | Named image to use (default: `default`) |
 | `--mount <spec>` | Mount host directory into guest (`HOST_PATH[:GUEST_PATH]`, repeatable). Conflicts with `--workspace` and `--git-repo`. |
+| `--forward-port <spec>` | Forward a guest port to the host (`GUEST[:HOST]`, repeatable). Lives for the lifetime of the VM; torn down on `coop stop`. |
 | `--exclude-git` | Skip the `.git/` directory when syncing the workspace (conflicts with `--git-repo`). |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
@@ -99,6 +100,7 @@ coop start --git-repo https://github.com/org/repo.git --disk 50
 coop start --image ml-dev --no-agents
 coop start --mount ~/data:/mnt/data
 coop start --env RUST_LOG=info --env MY_FLAG=1
+coop start --forward-port 3000 --forward-port 8080:18080
 ```
 
 `--no-claude` is accepted as a deprecated alias for `--no-agents` and will be removed in a future release. Using it prints a deprecation warning.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,6 +220,30 @@ plugins = ["rust-analyzer-lsp@claude-plugins-official"]
 
 Custom profiles compose with built-in ones (`python`, `node`, `c`, `fuzz`, `rust`, `go`). Combine them with commas: `coop setup --profile python,node,my-tools`.
 
+## `forward_ports` field
+
+Default host-to-guest TCP port forwards applied to every `coop start`. Forwards are established as SSH `-L` tunnels after the VM is ready and torn down on `coop stop`.
+
+Each entry accepts a bare port (host and guest match), a `"GUEST:HOST"` string, or a table.
+
+```toml
+# Bare port: host 3000 ⇒ guest 3000
+forward_ports = [3000]
+
+# String form: host 18080 ⇒ guest 8080
+forward_ports = ["8080:18080"]
+
+# Table form (also supports an optional `label` for the user's own bookkeeping)
+[[forward_ports]]
+guest = 5432
+host = 15432
+label = "postgres"
+```
+
+`--forward-port` on `coop start` appends to (or overrides on guest-port collision) the entries from config; later entries win. Each instance remembers its forward set across `coop stop` / `coop start`, so a restart without `--forward-port` re-establishes the same tunnels.
+
+Collision with an in-use host port fails fast before the VM is created. The error names the offending port and suggests a `GUEST:HOST` override.
+
 ## `updates` section
 
 Background update-check behavior for `coop update`. Defaults are safe; most users do not need to set anything here.
@@ -303,4 +327,6 @@ args = ["-y", "@playwright/mcp@latest"]
 [profiles.my-tools]
 apt_packages = ["ripgrep", "fd-find"]
 post_install = "cargo install ast-grep"
+
+forward_ports = [3000, "8080:18080"]
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,6 +301,174 @@ impl Mount {
     }
 }
 
+/// A guest port to forward to the host for the lifetime of the VM.
+///
+/// Construction normalizes the spec so downstream code (SSH `-L` flags)
+/// sees a canonical `(guest, host)` pair where `host` defaults to
+/// `guest` when omitted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortForward {
+    pub guest: NonZeroU16,
+    pub host: NonZeroU16,
+    pub label: Option<String>,
+}
+
+impl PortForward {
+    /// Parse a CLI spec in the form `GUEST[:HOST]`.
+    ///
+    /// `--forward-port 3000` ⇒ guest=3000, host=3000.
+    /// `--forward-port 3000:3001` ⇒ guest=3000, host=3001.
+    pub fn parse(spec: &str) -> Result<Self> {
+        let (guest_str, host_str) = match spec.split_once(':') {
+            Some((g, h)) => (g.trim(), Some(h.trim())),
+            None => (spec.trim(), None),
+        };
+        let guest: u16 = guest_str.parse().with_context(|| {
+            format!("Invalid forward-port spec '{spec}': guest port must be a number 1..=65535")
+        })?;
+        let guest = NonZeroU16::new(guest).with_context(|| {
+            format!("Invalid forward-port spec '{spec}': guest port must be > 0")
+        })?;
+        let host = match host_str {
+            Some(s) => {
+                let h: u16 = s.parse().with_context(|| {
+                    format!(
+                        "Invalid forward-port spec '{spec}': host port must be a number 1..=65535"
+                    )
+                })?;
+                NonZeroU16::new(h).with_context(|| {
+                    format!("Invalid forward-port spec '{spec}': host port must be > 0")
+                })?
+            }
+            None => guest,
+        };
+        Ok(Self {
+            guest,
+            host,
+            label: None,
+        })
+    }
+}
+
+/// TOML deserializer for `PortForward`. Accepts:
+///
+/// - an integer: `3000` ⇒ guest=3000, host=3000
+/// - a string: `"3000"` or `"3000:3001"` (CLI form)
+/// - a table: `{ guest = 3000, host = 3001, label = "dev" }`
+impl<'de> Deserialize<'de> for PortForward {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::{Error, MapAccess, Visitor};
+
+        struct PortForwardVisitor;
+
+        impl<'de> Visitor<'de> for PortForwardVisitor {
+            type Value = PortForward;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(
+                    "a port number, a 'GUEST[:HOST]' string, or a { guest, host, label } table",
+                )
+            }
+
+            fn visit_u64<E: Error>(self, v: u64) -> Result<Self::Value, E> {
+                let port: u16 = v
+                    .try_into()
+                    .map_err(|_| E::custom(format!("port {v} out of range 1..=65535")))?;
+                let port = NonZeroU16::new(port).ok_or_else(|| E::custom("port must be > 0"))?;
+                Ok(PortForward {
+                    guest: port,
+                    host: port,
+                    label: None,
+                })
+            }
+
+            fn visit_i64<E: Error>(self, v: i64) -> Result<Self::Value, E> {
+                let v: u64 = v
+                    .try_into()
+                    .map_err(|_| E::custom(format!("port {v} must be > 0")))?;
+                self.visit_u64(v)
+            }
+
+            fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
+                PortForward::parse(v).map_err(E::custom)
+            }
+
+            fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
+                self.visit_str(&v)
+            }
+
+            fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+                #[derive(Deserialize)]
+                #[serde(field_identifier, rename_all = "snake_case")]
+                enum Field {
+                    Guest,
+                    Host,
+                    Label,
+                    #[serde(other)]
+                    Unknown,
+                }
+
+                let mut guest: Option<NonZeroU16> = None;
+                let mut host: Option<NonZeroU16> = None;
+                let mut label: Option<String> = None;
+                while let Some(field) = map.next_key::<Field>()? {
+                    match field {
+                        Field::Guest => guest = Some(map.next_value()?),
+                        Field::Host => host = Some(map.next_value()?),
+                        Field::Label => label = Some(map.next_value()?),
+                        Field::Unknown => {
+                            let _: serde::de::IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+                let guest =
+                    guest.ok_or_else(|| M::Error::custom("forward_ports entry missing 'guest'"))?;
+                Ok(PortForward {
+                    guest,
+                    host: host.unwrap_or(guest),
+                    label,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(PortForwardVisitor)
+    }
+}
+
+impl Serialize for PortForward {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("guest", &self.guest)?;
+        if self.host != self.guest {
+            map.serialize_entry("host", &self.host)?;
+        }
+        if let Some(label) = &self.label {
+            map.serialize_entry("label", label)?;
+        }
+        map.end()
+    }
+}
+
+/// Merge `[forward_ports]` from config with the CLI's `--forward-port` flag.
+///
+/// Walks both lists in order; on a duplicate guest port, the later entry wins.
+/// CLI entries are appended after config entries, so CLI overrides config.
+pub fn merge_forward_ports(
+    config_forwards: &[PortForward],
+    cli_forwards: &[PortForward],
+) -> Vec<PortForward> {
+    let mut out: Vec<PortForward> = Vec::new();
+    for f in config_forwards.iter().chain(cli_forwards.iter()) {
+        if let Some(existing) = out.iter_mut().find(|e| e.guest == f.guest) {
+            *existing = f.clone();
+        } else {
+            out.push(f.clone());
+        }
+    }
+    out
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CoopConfig {
     /// Directory for storing VM artifacts (images, sockets, logs)
@@ -359,6 +527,13 @@ pub struct CoopConfig {
     /// Maps to `postStartCommand` from `devcontainer.json`.
     #[serde(default)]
     pub post_start: Option<String>,
+
+    /// Default host:guest port forwards applied to every `coop start`.
+    ///
+    /// CLI `--forward-port` values are appended; later entries override
+    /// earlier ones with the same guest port.
+    #[serde(default)]
+    pub forward_ports: Vec<PortForward>,
 
     /// Self-update behaviour
     #[serde(default)]
@@ -1266,6 +1441,7 @@ impl Default for CoopConfig {
             guest_env: BTreeMap::new(),
             profiles: HashMap::new(),
             post_start: None,
+            forward_ports: Vec::new(),
             updates: crate::update::UpdateConfig::default(),
         }
     }
@@ -1376,6 +1552,10 @@ impl Instance {
 
     pub fn workspace_state_path(&self) -> PathBuf {
         self.dir.join("workspace.json")
+    }
+
+    pub fn forwards_state_path(&self) -> PathBuf {
+        self.dir.join("forwards.json")
     }
 
     pub fn tap_device(&self) -> String {
@@ -3246,5 +3426,138 @@ token = "cmd:echo x"
             !debug.contains("github_pat_secret"),
             "PatEntry Debug leaked token: {debug}"
         );
+    }
+
+    // ── PortForward parsing ──────────────────────────────────
+
+    #[test]
+    fn port_forward_parse_guest_only_defaults_host_to_guest() {
+        let f = PortForward::parse("3000").unwrap();
+        assert_eq!(f.guest.get(), 3000);
+        assert_eq!(f.host.get(), 3000);
+        assert!(f.label.is_none());
+    }
+
+    #[test]
+    fn port_forward_parse_guest_host() {
+        let f = PortForward::parse("3000:3001").unwrap();
+        assert_eq!(f.guest.get(), 3000);
+        assert_eq!(f.host.get(), 3001);
+    }
+
+    #[test]
+    fn port_forward_parse_rejects_zero() {
+        assert!(PortForward::parse("0").is_err());
+        assert!(PortForward::parse("3000:0").is_err());
+    }
+
+    #[test]
+    fn port_forward_parse_rejects_non_numeric() {
+        assert!(PortForward::parse("abc").is_err());
+        assert!(PortForward::parse("3000:abc").is_err());
+    }
+
+    #[test]
+    fn port_forward_parse_rejects_out_of_range() {
+        assert!(PortForward::parse("70000").is_err());
+    }
+
+    #[test]
+    fn port_forward_toml_integer_form() {
+        let toml_src = "forward_ports = [3000]";
+        let cfg: CoopConfig = toml::from_str(toml_src).unwrap();
+        assert_eq!(cfg.forward_ports.len(), 1);
+        assert_eq!(cfg.forward_ports[0].guest.get(), 3000);
+        assert_eq!(cfg.forward_ports[0].host.get(), 3000);
+    }
+
+    #[test]
+    fn port_forward_toml_string_form() {
+        let toml_src = r#"forward_ports = ["8080:8081"]"#;
+        let cfg: CoopConfig = toml::from_str(toml_src).unwrap();
+        assert_eq!(cfg.forward_ports[0].guest.get(), 8080);
+        assert_eq!(cfg.forward_ports[0].host.get(), 8081);
+    }
+
+    #[test]
+    fn port_forward_toml_table_form() {
+        let toml_src = "[[forward_ports]]\nguest = 3000\nhost = 13000\nlabel = \"dev\"\n";
+        let cfg: CoopConfig = toml::from_str(toml_src).unwrap();
+        assert_eq!(cfg.forward_ports[0].guest.get(), 3000);
+        assert_eq!(cfg.forward_ports[0].host.get(), 13000);
+        assert_eq!(cfg.forward_ports[0].label.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn port_forward_toml_table_omits_host_defaults_to_guest() {
+        let toml_src = "[[forward_ports]]\nguest = 3000\n";
+        let cfg: CoopConfig = toml::from_str(toml_src).unwrap();
+        assert_eq!(cfg.forward_ports[0].host.get(), 3000);
+    }
+
+    #[test]
+    fn port_forward_toml_table_missing_guest_errors() {
+        let toml_src = "[[forward_ports]]\nhost = 3000\n";
+        let err = match toml::from_str::<CoopConfig>(toml_src) {
+            Ok(cfg) => panic!("expected error, got: {cfg:?}"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("guest"), "err = {err}");
+    }
+
+    #[test]
+    fn port_forward_default_is_empty() {
+        let cfg: CoopConfig = toml::from_str("").unwrap();
+        assert!(cfg.forward_ports.is_empty());
+    }
+
+    #[test]
+    fn port_forward_serialize_round_trip() {
+        let original = PortForward {
+            guest: NonZeroU16::new(3000).unwrap(),
+            host: NonZeroU16::new(3001).unwrap(),
+            label: Some("dev".to_string()),
+        };
+        let toml_src = toml::to_string(&original).unwrap();
+        let parsed: PortForward = toml::from_str(&toml_src).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    // ── PortForward merge ────────────────────────────────────
+
+    fn pf(g: u16, h: u16) -> PortForward {
+        PortForward {
+            guest: NonZeroU16::new(g).unwrap(),
+            host: NonZeroU16::new(h).unwrap(),
+            label: None,
+        }
+    }
+
+    #[test]
+    fn merge_forward_ports_appends_cli() {
+        let cfg = vec![pf(3000, 3000)];
+        let cli = vec![pf(4000, 4000)];
+        let merged = merge_forward_ports(&cfg, &cli);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].guest.get(), 3000);
+        assert_eq!(merged[1].guest.get(), 4000);
+    }
+
+    #[test]
+    fn merge_forward_ports_cli_overrides_same_guest() {
+        let cfg = vec![pf(3000, 3000)];
+        let cli = vec![pf(3000, 13000)];
+        let merged = merge_forward_ports(&cfg, &cli);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].host.get(), 13000);
+    }
+
+    #[test]
+    fn merge_forward_ports_later_cli_overrides_earlier_cli() {
+        let cfg: Vec<PortForward> = Vec::new();
+        let cli = vec![pf(3000, 13000), pf(3000, 14000)];
+        let merged = merge_forward_ports(&cfg, &cli);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].host.get(), 14000);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod github_pat;
 mod github_repo;
 mod guest;
 mod pat_prompt;
+mod port_forward;
 mod secret_store;
 // Lima is an interactive CLI workflow — stderr output is intentional user communication.
 #[cfg_attr(not(target_os = "macos"), expect(dead_code, reason = "Lima-only"))]
@@ -163,6 +164,11 @@ enum Commands {
         /// Mount host directory into guest (`HOST_PATH[:GUEST_PATH]`, repeatable)
         #[arg(long, conflicts_with_all = ["workspace", "git_repo"])]
         mount: Vec<String>,
+        /// Forward a guest port to the host (`GUEST[:HOST]`, repeatable).
+        /// `--forward-port 3000` forwards guest 3000 to host 3000;
+        /// `--forward-port 3000:3001` forwards guest 3000 to host 3001.
+        #[arg(long)]
+        forward_port: Vec<String>,
         /// Named image to use (default: "default")
         #[arg(
             long,
@@ -596,6 +602,7 @@ fn main() -> Result<()> {
             no_prompt,
             post_start,
             guest_env,
+            forward_port,
         } => {
             if raw_args_use_deprecated_no_claude(std::env::args()) {
                 tracing::warn!(
@@ -607,6 +614,10 @@ fn main() -> Result<()> {
             let mounts = mount
                 .iter()
                 .map(|s| config::Mount::parse(s))
+                .collect::<Result<Vec<_>>>()?;
+            let forward_ports = forward_port
+                .iter()
+                .map(|s| config::PortForward::parse(s))
                 .collect::<Result<Vec<_>>>()?;
             cmd_start(
                 &be,
@@ -623,6 +634,7 @@ fn main() -> Result<()> {
                         .transpose()?,
                     mounts,
                     exclude_git,
+                    forward_ports,
                     config_path: &cli.config,
                     post_start_override: post_start.as_deref(),
                 },
@@ -920,6 +932,10 @@ struct StartOpts<'a> {
     disk: Option<config::GiB>,
     mounts: Vec<config::Mount>,
     exclude_git: bool,
+    /// Per-start forwards from `--forward-port`. Merged with
+    /// `cfg.forward_ports` at start time (CLI overrides on guest-port
+    /// collision).
+    forward_ports: Vec<config::PortForward>,
     /// Path to the on-disk config file. Re-read after the auto-prompt
     /// in case the wizard added a new `[github.pat."..."]` entry.
     config_path: &'a Path,
@@ -964,6 +980,9 @@ fn cmd_start(
 
     if let Err(e) = &result {
         tracing::error!("Failed to start instance '{}': {e}", inst.name);
+        if let Ok(target) = be.ssh_target(cfg, &inst) {
+            port_forward::teardown_ssh_forwards(&inst, &target);
+        }
         if let Err(cleanup_err) = be.destroy_instance(cfg, &inst) {
             tracing::debug!("Cleanup failed (non-fatal): {cleanup_err}");
         }
@@ -1095,6 +1114,15 @@ fn restart_instance(
     let repo = backend::detect_instance_repo(inst);
     pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_deref(), opts.no_prompt)?;
 
+    // Re-apply the forward set the instance was last started with.
+    // CLI `--forward-port` on a restart appends/overrides; otherwise the
+    // saved set carries forward untouched.
+    let saved = port_forward::ForwardsState::try_load(inst)?
+        .map(|s| s.forwards)
+        .unwrap_or_default();
+    let forwards = config::merge_forward_ports(&saved, &opts.forward_ports);
+    port_forward::check_host_port_collisions(&forwards)?;
+
     be.start_existing(cfg, inst)?;
 
     signal::check_shutdown()?;
@@ -1105,6 +1133,12 @@ fn restart_instance(
         .context("Guest booted but SSH is not accepting connections")?;
 
     signal::check_shutdown()?;
+
+    port_forward::ForwardsState {
+        forwards: forwards.clone(),
+    }
+    .save(inst)?;
+    port_forward::spawn_ssh_forwards(inst, &target, &forwards)?;
 
     let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
     if opts.no_agents && post_start.is_none() {
@@ -1173,6 +1207,12 @@ fn start_instance(
     let repo = resolve_start_repo(opts)?;
     pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_deref(), opts.no_prompt)?;
 
+    // Forwards are checked up-front so an in-use host port fails fast,
+    // before any VM cost is incurred. The actual `-L` tunnels are
+    // established after SSH is ready (below).
+    let forwards = config::merge_forward_ports(&cfg.forward_ports, &opts.forward_ports);
+    port_forward::check_host_port_collisions(&forwards)?;
+
     be.create_and_start(cfg, inst, opts.disk, &opts.mounts)?;
 
     signal::check_shutdown()?;
@@ -1183,6 +1223,12 @@ fn start_instance(
         .context("Guest booted but SSH is not accepting connections")?;
 
     signal::check_shutdown()?;
+
+    port_forward::ForwardsState {
+        forwards: forwards.clone(),
+    }
+    .save(inst)?;
+    port_forward::spawn_ssh_forwards(inst, &target, &forwards)?;
 
     let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
     if opts.no_agents && post_start.is_none() {
@@ -1418,6 +1464,13 @@ fn cmd_stop(
     inst: &config::Instance,
 ) -> Result<()> {
     tracing::info!("Stopping instance '{}'", inst.name);
+    // Tear down forwards before shutting down the VM so the control
+    // master can exit cleanly while SSH is still reachable.
+    if let Ok(target) = be.ssh_target(cfg, inst) {
+        port_forward::teardown_ssh_forwards(inst, &target);
+    } else {
+        tracing::debug!("Skipping forward teardown — no SSH target available");
+    }
     be.stop(cfg, inst)?;
     if let Err(e) = workspace::remove_ssh_config(inst) {
         tracing::debug!("SSH config cleanup failed (non-fatal): {e}");
@@ -1438,6 +1491,9 @@ fn cmd_destroy(
     } else {
         let inst = cfg.resolve_instance(name)?;
         tracing::info!("Destroying instance '{}'", inst.name);
+        if let Ok(target) = be.ssh_target(cfg, &inst) {
+            port_forward::teardown_ssh_forwards(&inst, &target);
+        }
         be.destroy_instance(cfg, &inst)?;
         workspace::remove_ssh_config(&inst)?;
         tracing::info!("Instance '{}' destroyed", inst.name);
@@ -1479,6 +1535,9 @@ fn purge_all_data(be: &backend::PlatformBackend, cfg: &config::CoopConfig) -> Re
     let instances = cfg.list_instances()?;
     for inst in &instances {
         tracing::info!("Destroying instance '{}'", inst.name);
+        if let Ok(target) = be.ssh_target(cfg, inst) {
+            port_forward::teardown_ssh_forwards(inst, &target);
+        }
         be.destroy_instance(cfg, inst)?;
         workspace::remove_ssh_config(inst)?;
     }
@@ -2618,6 +2677,7 @@ mod tests {
             disk: None,
             mounts,
             exclude_git: false,
+            forward_ports: Vec::new(),
             config_path,
             post_start_override: None,
         }

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -1,0 +1,320 @@
+//! Host-to-guest TCP port forwarding for the lifetime of a VM.
+//!
+//! Both backends use a backgrounded SSH session with `-L` forwards,
+//! parked under a per-instance control socket so `teardown_ssh_forwards`
+//! can tear it down cleanly with `ssh -O exit` (without touching the
+//! user's other SSH sessions). Lima exposes a normal SSH target via
+//! `limactl info`, so the same path works there.
+//!
+//! `check_host_port_collisions` runs before any state is created so an
+//! in-use host port fails fast — the error names the offending port
+//! and offers a copy-pasteable remediation flag.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
+use std::net::TcpListener;
+use std::num::NonZeroU16;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::backend::SshTarget;
+use crate::config::{Instance, PortForward};
+
+/// Persisted forward set written at `start` so `restart` can re-apply
+/// the same forwards without the user passing `--forward-port` again.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ForwardsState {
+    #[serde(default)]
+    pub forwards: Vec<PortForward>,
+}
+
+impl ForwardsState {
+    pub fn save(&self, inst: &Instance) -> Result<()> {
+        let path = inst.forwards_state_path();
+        if self.forwards.is_empty() {
+            // Don't litter the instance dir with empty state.
+            if path.exists()
+                && let Err(e) = fs::remove_file(&path)
+            {
+                tracing::debug!(
+                    "Failed to remove empty forwards state {} (non-fatal): {e}",
+                    path.display()
+                );
+            }
+            return Ok(());
+        }
+        let json =
+            serde_json::to_string_pretty(self).context("Failed to serialize forwards state")?;
+        crate::fs_util::atomic_write_json(&path, &json).context("Failed to write forwards.json")?;
+        tracing::debug!("Wrote forwards state to {}", path.display());
+        Ok(())
+    }
+
+    pub fn try_load(inst: &Instance) -> Result<Option<Self>> {
+        let path = inst.forwards_state_path();
+        match fs::read_to_string(&path) {
+            Ok(content) => {
+                let state =
+                    serde_json::from_str(&content).context("Failed to parse forwards.json")?;
+                Ok(Some(state))
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+            Err(e) => {
+                Err(anyhow::Error::new(e).context(format!("Failed to read {}", path.display())))
+            }
+        }
+    }
+}
+
+/// Probe each host port; bail with an actionable message on the first
+/// collision so we never partially apply a forward set.
+///
+/// Also flags duplicate host ports within `forwards` (two guests
+/// fighting for the same host port).
+pub fn check_host_port_collisions(forwards: &[PortForward]) -> Result<()> {
+    let mut seen: HashSet<NonZeroU16> = HashSet::new();
+    for f in forwards {
+        if !seen.insert(f.host) {
+            bail!(
+                "Duplicate host port {host} in forward set — \
+                 only one guest port can bind a given host port.\n\
+                 Pick distinct hosts, e.g. `--forward-port G:{alt}`.",
+                host = f.host,
+                alt = next_suggestion(f.host),
+            );
+        }
+
+        match TcpListener::bind(("127.0.0.1", f.host.get())) {
+            Ok(listener) => {
+                drop(listener);
+            }
+            Err(e) if e.kind() == ErrorKind::AddrInUse => {
+                bail!(
+                    "Host port {host} is already in use — \
+                     cannot forward guest port {guest}.\n\
+                     Pick another host port, e.g. \
+                     `--forward-port {guest}:{alt}`.",
+                    host = f.host,
+                    guest = f.guest,
+                    alt = next_suggestion(f.host),
+                );
+            }
+            Err(e) => {
+                bail!(
+                    "Failed to probe host port {host}: {e}.\n\
+                     Pick another host port, e.g. \
+                     `--forward-port {guest}:{alt}`.",
+                    host = f.host,
+                    guest = f.guest,
+                    alt = next_suggestion(f.host),
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Suggest the next port up, wrapping to `host - 1` when at `u16::MAX`.
+fn next_suggestion(host: NonZeroU16) -> u16 {
+    host.get().checked_add(1).unwrap_or(host.get() - 1)
+}
+
+/// Per-instance control socket for the port-forwarder SSH session.
+fn forwards_control_path(inst: &Instance) -> PathBuf {
+    inst.dir.join("forwards.sock")
+}
+
+/// Spawn a backgrounded SSH connection with `-L` forwards for every
+/// entry in `forwards`. The connection is owned by a dedicated control
+/// master at `<inst>/forwards.sock`, so `teardown_ssh_forwards` can
+/// terminate it cleanly without touching the user's own SSH sessions.
+///
+/// No-op when `forwards` is empty.
+///
+/// Caller must have already run [`check_host_port_collisions`] so we
+/// fail at allocation time rather than mid-bind.
+pub fn spawn_ssh_forwards(
+    inst: &Instance,
+    target: &SshTarget,
+    forwards: &[PortForward],
+) -> Result<()> {
+    if forwards.is_empty() {
+        return Ok(());
+    }
+
+    // A previous run may have crashed without stop cleanup; tear down
+    // any leftover master before binding so we don't race the old one
+    // for the same host ports.
+    teardown_ssh_forwards(inst, target);
+
+    let control_path = forwards_control_path(inst);
+    if let Some(parent) = control_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create instance dir {} for forward socket",
+                parent.display()
+            )
+        })?;
+    }
+
+    let mut args = target.ssh_opts();
+    // -f: fork to background after authentication. The parent exits 0
+    //     and the child holds the forwards.
+    // -N: no remote command — pure tunneling.
+    // -T: no PTY.
+    // ControlMaster=yes / ControlPath / ControlPersist=yes: park the
+    //     connection under a known socket so `ssh -O exit` can tear it
+    //     down without touching the user's other SSH sessions.
+    // ExitOnForwardFailure=yes: refuse to background if a -L fails to
+    //     bind — turns races with `check_host_port_collisions` into
+    //     loud errors rather than silently lost forwards.
+    // ServerAliveInterval=30: detect dead VMs so the forwarder doesn't
+    //     hang around eating descriptors after a hard reboot.
+    args.extend([
+        "-f".into(),
+        "-N".into(),
+        "-T".into(),
+        "-o".into(),
+        "ControlMaster=yes".into(),
+        "-o".into(),
+        format!("ControlPath={}", control_path.display()),
+        "-o".into(),
+        "ControlPersist=yes".into(),
+        "-o".into(),
+        "ExitOnForwardFailure=yes".into(),
+        "-o".into(),
+        "ServerAliveInterval=30".into(),
+    ]);
+
+    let mut spec_log: Vec<String> = Vec::new();
+    for f in forwards {
+        let spec = format!("127.0.0.1:{}:127.0.0.1:{}", f.host.get(), f.guest.get());
+        args.push("-L".into());
+        args.push(spec.clone());
+        spec_log.push(spec);
+    }
+    args.push(target.addr());
+
+    tracing::info!("Establishing SSH port forwards: {}", spec_log.join(", "));
+
+    let output = Command::new("ssh")
+        .args(&args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .context("Failed to launch ssh -L for port forwards")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "ssh -L for port forwards exited with status: {}.\n\
+             Forwards attempted: {}\n\
+             stderr: {}",
+            output.status,
+            spec_log.join(", "),
+            stderr.trim(),
+        );
+    }
+
+    Ok(())
+}
+
+/// Best-effort cleanup: tell the parked control master to exit via
+/// `ssh -O exit`, then remove the socket. Safe to call when no
+/// forwards were ever started.
+pub fn teardown_ssh_forwards(inst: &Instance, target: &SshTarget) {
+    let control_path = forwards_control_path(inst);
+    if !control_path.exists() {
+        return;
+    }
+
+    tracing::debug!(
+        "Tearing down SSH port forwards via control socket {}",
+        control_path.display()
+    );
+
+    let control_arg = format!("ControlPath={}", control_path.display());
+    let result = Command::new("ssh")
+        .args(["-O", "exit", "-o", &control_arg, &target.addr()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    match result {
+        Ok(s) if s.success() => {
+            tracing::debug!("SSH forwarder closed cleanly");
+        }
+        Ok(s) => {
+            tracing::debug!("ssh -O exit returned {s} (non-fatal)");
+        }
+        Err(e) => {
+            tracing::debug!("ssh -O exit failed: {e} (non-fatal)");
+        }
+    }
+
+    if control_path.exists()
+        && let Err(e) = fs::remove_file(&control_path)
+    {
+        tracing::debug!(
+            "Failed to remove forward control socket {} (non-fatal): {e}",
+            control_path.display()
+        );
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::expect_used, reason = "tests")]
+#[expect(clippy::panic, reason = "tests use panic! for unreachable arms")]
+mod tests {
+    use super::*;
+
+    fn pf(guest: u16, host: u16) -> PortForward {
+        PortForward {
+            guest: NonZeroU16::new(guest).expect("test inputs are non-zero"),
+            host: NonZeroU16::new(host).expect("test inputs are non-zero"),
+            label: None,
+        }
+    }
+
+    #[test]
+    fn collision_check_passes_when_ports_free() {
+        let l1 = TcpListener::bind("127.0.0.1:0").unwrap();
+        let l2 = TcpListener::bind("127.0.0.1:0").unwrap();
+        let p1 = l1.local_addr().unwrap().port();
+        let p2 = l2.local_addr().unwrap().port();
+        drop(l1);
+        drop(l2);
+        let forwards = vec![pf(3000, p1), pf(4000, p2)];
+        assert!(check_host_port_collisions(&forwards).is_ok());
+    }
+
+    #[test]
+    fn collision_check_flags_in_use_host_port() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let forwards = vec![pf(3000, port)];
+        let err = match check_host_port_collisions(&forwards) {
+            Ok(()) => panic!("expected collision error"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains(&port.to_string()), "msg = {msg}");
+        assert!(msg.contains("--forward-port"), "msg = {msg}");
+    }
+
+    #[test]
+    fn collision_check_flags_internal_duplicate_host() {
+        let forwards = vec![pf(3000, 9000), pf(3001, 9000)];
+        let err = match check_host_port_collisions(&forwards) {
+            Ok(()) => panic!("expected duplicate error"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("9000"), "msg = {msg}");
+        assert!(msg.contains("Duplicate host port"), "msg = {msg}");
+    }
+}

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2307,6 +2307,85 @@ test_host_mount_custom_guest_path() {
     rm -rf "$mount_dir"
 }
 
+# ── Port forward tests (--full only) ─────────────────────────
+
+test_port_forwards() {
+    echo ""
+    echo "=== Phase: port forwards ==="
+
+    local fwd_instance="${INSTANCE}-fwd"
+    # Pick a likely-free host port high in the ephemeral range to avoid
+    # clashes with anything the developer is already running.
+    local host_port=14573
+    local guest_port=8765
+    local content_file
+    content_file=$(mktemp)
+    echo "forward-test-payload" > "$content_file"
+
+    if coop start "$fwd_instance" --no-agents --forward-port "${guest_port}:${host_port}"; then
+        STARTED_INSTANCES+=("$fwd_instance")
+        pass "start with --forward-port exits 0"
+    else
+        fail "start with --forward-port exits 0" "exit code: $?"
+        rm -f "$content_file"
+        return
+    fi
+
+    GUEST_INSTANCE="$fwd_instance"
+
+    # Run a one-shot HTTP listener in the guest. `nc -l -p` is in the
+    # ubuntu-minimal CI image; pipe a canned HTTP response and exit.
+    # Backgrounded via nohup so the SSH exec returns immediately.
+    local payload
+    payload=$(cat "$content_file")
+    guest_exec sh -c "nohup sh -c 'printf \"HTTP/1.1 200 OK\\r\\nContent-Length: ${#payload}\\r\\n\\r\\n${payload}\" | nc -l -p ${guest_port} -q 1 > /tmp/fwd.log 2>&1' >/dev/null 2>&1 &" || true
+    sleep 1
+
+    if curl -fsS --max-time 3 "http://127.0.0.1:${host_port}/" > "$content_file.got"; then
+        local got
+        got=$(cat "$content_file.got")
+        if [[ "$got" == "$payload" ]]; then
+            pass "host curl reaches guest via forwarded port"
+        else
+            fail "host curl reaches guest via forwarded port" "got: $got"
+        fi
+    else
+        fail "host curl reaches guest via forwarded port" "curl failed"
+    fi
+
+    # Collision: starting another forward to the same host port should error.
+    local fwd_instance2="${INSTANCE}-fwd2"
+    if coop start "$fwd_instance2" --no-agents --forward-port "9999:${host_port}" 2>"$content_file.err"; then
+        STARTED_INSTANCES+=("$fwd_instance2")
+        fail "collision detection rejects in-use host port" "start unexpectedly succeeded"
+        coop destroy "$fwd_instance2" 2>/dev/null || true
+        untrack_instance "$fwd_instance2"
+    else
+        if grep -q "already in use" "$content_file.err"; then
+            pass "collision detection rejects in-use host port"
+        else
+            fail "collision detection rejects in-use host port" "stderr: $(cat "$content_file.err")"
+        fi
+    fi
+
+    unset GUEST_INSTANCE
+
+    coop stop "$fwd_instance" 2>/dev/null || true
+
+    # After stop, the host port must be free again so the next test can rebind.
+    if (exec 3<>/dev/tcp/127.0.0.1/"$host_port") 2>/dev/null; then
+        exec 3<&-
+        exec 3>&-
+        fail "host port released after stop" "still listening on $host_port"
+    else
+        pass "host port released after stop"
+    fi
+
+    coop destroy "$fwd_instance" 2>/dev/null || true
+    untrack_instance "$fwd_instance"
+    rm -f "$content_file" "$content_file.got" "$content_file.err"
+}
+
 test_mount_conflicts() {
     echo ""
     echo "=== Phase: mount CLI conflicts ==="
@@ -2898,6 +2977,7 @@ main() {
         test_mount_conflicts
         test_host_mount
         test_host_mount_custom_guest_path
+        test_port_forwards
         test_push_pull_no_workspace
         test_workspace_sync
         test_git_repo_private_clone


### PR DESCRIPTION
## Summary

- New `--forward-port GUEST[:HOST]` flag on `coop start` (repeatable). `--forward-port 3000` exposes guest 3000 on host 3000; `3000:18080` remaps to a different host port.
- Matching `forward_ports = [...]` config field as a default for every start. Accepts bare integer, `"GUEST:HOST"` string, or a `{ guest, host, label }` table.
- Forwards are established as SSH `-L` tunnels parked under a per-instance control socket (`<inst>/forwards.sock`), so they can be torn down cleanly with `ssh -O exit` on `coop stop` / `coop destroy` without disturbing other SSH sessions. Same code path on Firecracker and Lima — Lima exposes a normal SSH target via `limactl info`, so SSH `-L` traverses it the same way.
- Forwards are persisted in `<inst>/forwards.json` so a `coop stop` followed by `coop start` re-establishes the same set without re-passing the flag.
- Host-port collisions and intra-set duplicates fail fast with an actionable error that names the conflicting port and suggests a `GUEST:HOST` remediation, before any VM cost is incurred.

## Test plan

- [x] `cargo test` — 17 new unit tests across `src/config.rs` (parsing, TOML round-trip, merge) and `src/port_forward.rs` (collision detection)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `prek run --all-files` passes (fmt, clippy, test, whitespace, eof, large-files, merge-conflicts)
- [ ] `./tests/run-integration.sh --full` (Lima) — new `test_port_forwards` phase boots a guest, runs a `nc` listener, curls `127.0.0.1:<host_port>` from the host, verifies collision rejection and post-stop release
- [ ] `./tests/run-integration.sh --full --remote …` (Firecracker)