### PR TITLE
Read a subset of devcontainer.json (closes #129)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -49,11 +49,18 @@ coop setup [FLAGS]
 | `--post-install <path>` | Path to a post-install script to run in the chroot |
 | `--template-size <GiB>` | Template rootfs size in GiB (default: 8) |
 | `--image <name>` | Named image to build (default: `default`) |
+| `--workspace <dir>` | Scan for `.devcontainer/devcontainer.json` and offer to apply its `features` / `hostRequirements` to this setup. |
+| `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt). |
+| `--no-devcontainer` | Ignore any discovered `devcontainer.json`. |
+| `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any setup work. |
 
 ```
 coop setup -y --profile python,node --template-size 12
 coop setup --image ml-dev --profile python --extra-packages libopenblas-dev
+coop setup -y --workspace . --devcontainer .devcontainer/devcontainer.json
 ```
+
+See [docs/devcontainer.md](devcontainer.md) for the subset of `devcontainer.json` coop reads.
 
 ### `build`
 
@@ -89,6 +96,11 @@ coop start [NAME] [FLAGS]
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
 | `--env KEY=VALUE` | Literal env var to set in the guest (repeatable). Overrides `guest_env` config entries and any forwarded values with the same name. |
+| `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt). |
+| `--no-devcontainer` | Ignore any discovered `devcontainer.json` (escape hatch for CI). |
+| `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work. |
+
+When `--workspace <dir>` contains a `.devcontainer/devcontainer.json` (or one of `--mount`'s host roots does), coop reads a subset of it and prompts before applying. See [docs/devcontainer.md](devcontainer.md) for the supported keys and discovery rules.
 
 `--workspace` and `--git-repo` are mutually exclusive. Use `--workspace` to tar-pipe a local directory into the guest. Use `--git-repo` to clone a repository inside the VM at boot.
 

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,56 @@
+# Reading `devcontainer.json`
+
+coop reads a **subset** of [devcontainer.json](https://containers.dev/) and maps recognised keys to its own primitives. This is not full devcontainer support — coop builds its own rootfs and does not run Dockerfiles, compose files, or arbitrary OCI feature images. The supported subset is listed below; everything else is reported as `unsupported` and skipped.
+
+## How discovery and apply work
+
+When you run `coop start --workspace <dir>` or `coop setup --workspace <dir>`, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each `--mount` host root, with workspace winning ties).
+
+If a file is found, coop prompts:
+
+```
+Use devcontainer.json at <path>? [Y/n]
+```
+
+After your reply (or non-interactive escape hatches, below), coop prints a per-key report showing exactly which devcontainer.json keys took effect, which were overridden by CLI flags, and which are unsupported.
+
+## Non-interactive escape hatches
+
+For CI or scripted use, pass one of:
+
+- `--devcontainer <path>` — use this specific file, skip the prompt
+- `--no-devcontainer` — ignore any discovered file
+- `--dry-run` — print the report and exit before any VM work
+
+A non-TTY invocation that discovers a `devcontainer.json` without any of these flags errors out rather than silently choosing.
+
+## Precedence
+
+CLI flags > `devcontainer.json` > defaults. The reporting table marks overrides explicitly so you can see when one of your CLI flags suppressed a devcontainer value.
+
+## Supported keys
+
+| devcontainer.json | coop equivalent | Notes |
+|---|---|---|
+| `postStartCommand` | `post_start` | String or `[string,...]`; arrays are joined with ` && ` |
+| `containerEnv` | `guest_env` (`--env KEY=VALUE`) | CLI `--env` wins on conflict |
+| `forwardPorts` | `--forward-port` | Items may be integers or `"GUEST[:HOST]"` strings |
+| `features` (`rust`, `node`, `python`, `go`, `c`, `fuzz`) | built-in `--profile` | Only at `coop setup`; ignored at `coop start` |
+| `features` (anything else) | warn and skip | No silent fallback to a custom profile |
+| `hostRequirements.cpus` | `--vcpus` | |
+| `hostRequirements.memory` | `--mem` | Accepts `4GB`/`4GiB`-style values |
+| `hostRequirements.storage` | `--disk` | Accepts `16GB`/`16GiB`-style values |
+| `mounts` | `--mount` | Docker `type=bind,source=...,target=...` strings and objects supported; non-bind types are rejected |
+| `remoteUser` | warn and skip unless `ubuntu` | coop hardcodes the guest user |
+| `image`, `build`, `dockerComposeFile`, `customizations`, `name` | warn and skip | coop manages its own rootfs |
+
+## JSON with comments
+
+`devcontainer.json` officially allows `//` and `/* */` comments and trailing commas. coop parses these correctly.
+
+## Out of scope in v1
+
+- OCI feature registry pulls (`ghcr.io/devcontainers/features/*` features other than the built-in name match)
+- `--git-repo` auto-detection — the file lives inside the repo before coop has cloned it
+- Sticky `--no-devcontainer` (persistent per-workspace state)
+- Live re-application on an existing VM (destroy + start to pick up changes)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1558,6 +1558,10 @@ impl Instance {
         self.dir.join("forwards.json")
     }
 
+    pub fn guest_env_state_path(&self) -> PathBuf {
+        self.dir.join("guest_env.json")
+    }
+
     pub fn tap_device(&self) -> String {
         format!("tap{}", self.index)
     }

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -1,0 +1,1533 @@
+//! `devcontainer.json` translator.
+//!
+//! Reads a subset of the [devcontainer.json](https://containers.dev/) spec
+//! and maps recognised properties to coop's existing primitives. The full
+//! design (UX, scope, precedence, edge cases) is captured in issue #129;
+//! the docstring on each public item summarises the v1 contract.
+//!
+//! Coop reads a **subset** of devcontainer.json, not the full spec.
+//! Unsupported properties produce a `warn-and-skip` entry in the report
+//! rather than silently degrading.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::config::{self, CoopConfig, GiB, MiB, Mount, PortForward};
+use crate::guest::BUILTIN_PROFILES;
+
+/// Default relative path coop looks for inside a workspace or mount root.
+pub const DEFAULT_DEVCONTAINER_REL_PATH: &str = ".devcontainer/devcontainer.json";
+
+// ── Parsing ──────────────────────────────────────────────────
+
+/// Convert JSONC (`//`, `/* */`, trailing commas) to plain JSON.
+///
+/// Implements a single-pass byte scanner aware of string literals (with
+/// `\"` and `\\` escapes). Trailing commas are detected by buffering each
+/// `,` and dropping it if the next non-whitespace, non-comment token is
+/// `]` or `}`. Whitespace bytes are preserved so error offsets in
+/// downstream `serde_json` diagnostics roughly track the source.
+#[must_use]
+pub fn jsonc_to_json(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut pending_comma = false;
+    let mut in_string = false;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            if pending_comma {
+                out.push(',');
+                pending_comma = false;
+            }
+            out.push(c as char);
+            if c == b'\\' && i + 1 < bytes.len() {
+                out.push(bytes[i + 1] as char);
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' => {
+                if pending_comma {
+                    out.push(',');
+                    pending_comma = false;
+                }
+                in_string = true;
+                out.push('"');
+                i += 1;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    i += 2;
+                }
+            }
+            b',' => {
+                pending_comma = true;
+                i += 1;
+            }
+            b']' | b'}' => {
+                pending_comma = false;
+                out.push(c as char);
+                i += 1;
+            }
+            b if b.is_ascii_whitespace() => {
+                out.push(b as char);
+                i += 1;
+            }
+            _ => {
+                if pending_comma {
+                    out.push(',');
+                    pending_comma = false;
+                }
+                out.push(c as char);
+                i += 1;
+            }
+        }
+    }
+    if pending_comma {
+        // Trailing comma at EOF without a closer; let serde report it.
+        out.push(',');
+    }
+    out
+}
+
+/// Raw deserialization shape — close to the spec.
+///
+/// Field names are camelCase per devcontainer.json. `serde_json::Value`
+/// captures fields with flexible shapes (e.g. `forwardPorts` items can be
+/// numbers or strings) so we can render specific error messages instead of
+/// failing the whole parse on one weird entry.
+#[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+struct RawDevcontainer {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    image: Option<serde_json::Value>,
+    #[serde(default)]
+    build: Option<serde_json::Value>,
+    #[serde(default)]
+    docker_compose_file: Option<serde_json::Value>,
+    #[serde(default)]
+    features: Option<BTreeMap<String, serde_json::Value>>,
+    #[serde(default)]
+    forward_ports: Option<Vec<serde_json::Value>>,
+    #[serde(default)]
+    container_env: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    remote_user: Option<String>,
+    #[serde(default)]
+    post_start_command: Option<serde_json::Value>,
+    #[serde(default)]
+    mounts: Option<Vec<serde_json::Value>>,
+    #[serde(default)]
+    host_requirements: Option<RawHostRequirements>,
+    #[serde(default)]
+    customizations: Option<serde_json::Value>,
+    /// Anything we don't model is captured here so we can emit a single
+    /// `unrecognised key` row in the report rather than silently dropping it.
+    #[serde(flatten)]
+    extras: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+struct RawHostRequirements {
+    #[serde(default)]
+    cpus: Option<u32>,
+    #[serde(default)]
+    memory: Option<String>,
+    #[serde(default)]
+    storage: Option<String>,
+    #[serde(flatten)]
+    extras: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A parsed devcontainer.json file. Cheap to clone; field semantics match
+/// the spec verbatim.
+#[derive(Debug)]
+pub struct ParsedDevcontainer {
+    pub path: PathBuf,
+    raw: RawDevcontainer,
+}
+
+impl ParsedDevcontainer {
+    /// Parse JSONC text from `path`. The path is retained for reporting.
+    pub fn from_str(path: PathBuf, text: &str) -> Result<Self> {
+        let json = jsonc_to_json(text);
+        let raw: RawDevcontainer = serde_json::from_str(&json)
+            .with_context(|| format!("Failed to parse {}", path.display()))?;
+        Ok(Self { path, raw })
+    }
+
+    /// Read and parse a file from disk.
+    pub fn load(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        Self::from_str(path.to_path_buf(), &text)
+    }
+}
+
+// ── Reporting ────────────────────────────────────────────────
+
+/// Result of translating one key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportStatus {
+    /// Value from devcontainer.json took effect.
+    Applied,
+    /// Devcontainer value was overridden by a CLI flag or existing config.
+    Overridden,
+    /// Property is not supported by coop; ignored with a warning.
+    Unsupported,
+    /// Property value could not be parsed; ignored with a warning.
+    Invalid,
+}
+
+impl ReportStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::Overridden => "overridden",
+            Self::Unsupported => "unsupported",
+            Self::Invalid => "invalid",
+        }
+    }
+}
+
+/// Origin of the effective value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportSource {
+    Cli,
+    Devcontainer,
+}
+
+impl ReportSource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Cli => "CLI",
+            Self::Devcontainer => "devcontainer.json",
+        }
+    }
+}
+
+/// One row in the report table. `key` is the dotted devcontainer.json path
+/// (e.g. `hostRequirements.cpus`); `value` is the effective value (after
+/// CLI/precedence) rendered as a short string; `note` is free-form context.
+#[derive(Debug, Clone)]
+pub struct ReportEntry {
+    pub key: String,
+    pub status: ReportStatus,
+    pub source: ReportSource,
+    pub value: String,
+    pub note: String,
+}
+
+/// Loud per-key report rendered after translation. Implements `Display`
+/// for direct `writeln!` into stderr.
+#[derive(Debug, Default)]
+pub struct Report {
+    pub entries: Vec<ReportEntry>,
+    pub source_path: Option<PathBuf>,
+    /// Discovered but not chosen devcontainer.json files (workspace wins).
+    pub ignored_paths: Vec<PathBuf>,
+}
+
+impl Report {
+    fn push(
+        &mut self,
+        key: impl Into<String>,
+        status: ReportStatus,
+        source: ReportSource,
+        value: impl Into<String>,
+        note: impl Into<String>,
+    ) {
+        self.entries.push(ReportEntry {
+            key: key.into(),
+            status,
+            source,
+            value: value.into(),
+            note: note.into(),
+        });
+    }
+
+    /// Format the report as a plain-text table suitable for stderr.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        if let Some(p) = &self.source_path {
+            let _ = writeln!(out, "devcontainer.json: {}", p.display());
+        }
+        for ignored in &self.ignored_paths {
+            let _ = writeln!(
+                out,
+                "  ignored: {} (workspace's takes precedence)",
+                ignored.display()
+            );
+        }
+        if self.entries.is_empty() {
+            let _ = writeln!(out, "  (no recognised keys)");
+            return out;
+        }
+        let headers = ["Key", "Status", "Source", "Value", "Note"];
+        let mut widths = headers.map(str::len);
+        for e in &self.entries {
+            widths[0] = widths[0].max(e.key.len());
+            widths[1] = widths[1].max(e.status.label().len());
+            widths[2] = widths[2].max(e.source.label().len());
+            widths[3] = widths[3].max(e.value.len());
+            widths[4] = widths[4].max(e.note.len());
+        }
+        let row = |out: &mut String, cells: [&str; 5]| {
+            for (i, c) in cells.iter().enumerate() {
+                if i > 0 {
+                    out.push_str("  ");
+                }
+                let _ = write!(out, "{c:<w$}", w = widths[i]);
+            }
+            out.push('\n');
+        };
+        row(&mut out, headers);
+        let dashes: Vec<String> = widths.iter().map(|w| "-".repeat(*w)).collect();
+        row(
+            &mut out,
+            [
+                dashes[0].as_str(),
+                dashes[1].as_str(),
+                dashes[2].as_str(),
+                dashes[3].as_str(),
+                dashes[4].as_str(),
+            ],
+        );
+        for e in &self.entries {
+            row(
+                &mut out,
+                [
+                    e.key.as_str(),
+                    e.status.label(),
+                    e.source.label(),
+                    e.value.as_str(),
+                    e.note.as_str(),
+                ],
+            );
+        }
+        out
+    }
+}
+
+// ── Inputs and outputs of the translator ─────────────────────
+
+/// Subset of CLI/config state the translator needs to honour the
+/// "CLI > devcontainer.json > defaults" precedence and report overrides.
+///
+/// All fields share the `cli_` prefix on purpose: the report needs to
+/// distinguish CLI-sourced values from any other state, and the prefix
+/// reads as a stable boundary in call sites that build this struct.
+#[expect(clippy::struct_field_names, reason = "cli_ prefix is load-bearing")]
+#[derive(Debug, Default)]
+pub struct TranslatorInputs {
+    pub cli_vcpus: Option<u8>,
+    pub cli_mem_mib: Option<u32>,
+    pub cli_disk_gib: Option<u32>,
+    pub cli_post_start: Option<String>,
+    pub cli_guest_env_keys: Vec<String>,
+    pub cli_forward_ports: Vec<PortForward>,
+    pub cli_mounts: Vec<Mount>,
+    pub cli_profiles: Vec<String>,
+    /// True when the caller passed `--workspace` or `--git-repo`. coop's
+    /// `start` path uses `--mount` only when neither of these is set, so
+    /// devcontainer `mounts` are dropped with a report row pointing at
+    /// the conflict rather than silently disappearing.
+    pub cli_workspace_or_git_repo: bool,
+}
+
+/// Stage of the lifecycle the translator is feeding into.
+///
+/// `Start` and `Setup` care about disjoint subsets of devcontainer.json
+/// keys. Modelling this as an enum keeps "applied for this command" vs
+/// "applied for a different command" distinct from "unsupported".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stage {
+    Setup,
+    Start,
+}
+
+/// Result of `translate` — the values to push into config plus a report.
+#[derive(Debug, Default)]
+pub struct Translation {
+    pub vcpus: Option<u8>,
+    pub mem_mib: Option<u32>,
+    pub disk_gib: Option<u32>,
+    pub post_start: Option<String>,
+    pub guest_env: BTreeMap<String, String>,
+    pub forward_ports: Vec<PortForward>,
+    pub mounts: Vec<Mount>,
+    pub profiles: Vec<String>,
+    pub report: Report,
+}
+
+// ── Translation ──────────────────────────────────────────────
+
+/// Apply the parsed devcontainer.json against CLI/config inputs.
+///
+/// Returns effective overrides plus a human-readable report. The
+/// translator never mutates the input; callers fold the returned values
+/// into `CoopConfig`/`StartOpts`/`SetupOptions`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "single readable dispatch — splitting into per-key helpers fragments per-key context"
+)]
+pub fn translate(
+    file: &ParsedDevcontainer,
+    inputs: &TranslatorInputs,
+    stage: Stage,
+) -> Translation {
+    let mut t = Translation::default();
+    t.report.source_path = Some(file.path.clone());
+
+    if let Some(reqs) = &file.raw.host_requirements {
+        translate_host_requirements(reqs, inputs, &mut t);
+    }
+
+    if let Some(cmd) = &file.raw.post_start_command {
+        let key = "postStartCommand";
+        if stage == Stage::Setup {
+            t.report.push(
+                key,
+                ReportStatus::Applied,
+                ReportSource::Devcontainer,
+                render_value(cmd),
+                "applied at start time",
+            );
+        } else if let Some(s) = post_start_to_string(cmd) {
+            if let Some(cli) = &inputs.cli_post_start {
+                t.report.push(
+                    key,
+                    ReportStatus::Overridden,
+                    ReportSource::Cli,
+                    cli.clone(),
+                    format!("CLI --post-start overrides devcontainer value {s:?}"),
+                );
+            } else {
+                t.post_start = Some(s.clone());
+                t.report.push(
+                    key,
+                    ReportStatus::Applied,
+                    ReportSource::Devcontainer,
+                    s,
+                    "",
+                );
+            }
+        } else {
+            t.report.push(
+                key,
+                ReportStatus::Invalid,
+                ReportSource::Devcontainer,
+                render_value(cmd),
+                "expected string or [string,...]; array form joined with ' && '",
+            );
+        }
+    }
+
+    if let Some(env) = &file.raw.container_env {
+        translate_container_env(env, inputs, stage, &mut t);
+    }
+
+    if let Some(ports) = &file.raw.forward_ports {
+        translate_forward_ports(ports, inputs, stage, &mut t);
+    }
+
+    if let Some(features) = &file.raw.features {
+        translate_features(features, inputs, stage, &mut t);
+    }
+
+    if let Some(mounts) = &file.raw.mounts {
+        translate_mounts(mounts, inputs, stage, &mut t);
+    }
+
+    if let Some(user) = &file.raw.remote_user {
+        let key = "remoteUser";
+        if user == "ubuntu" {
+            t.report.push(
+                key,
+                ReportStatus::Applied,
+                ReportSource::Devcontainer,
+                user.clone(),
+                "matches coop's hardcoded guest user",
+            );
+        } else {
+            t.report.push(
+                key,
+                ReportStatus::Unsupported,
+                ReportSource::Devcontainer,
+                user.clone(),
+                "coop hardcodes the guest user to 'ubuntu' in v1",
+            );
+        }
+    }
+
+    if file.raw.image.is_some() {
+        t.report.push(
+            "image",
+            ReportStatus::Unsupported,
+            ReportSource::Devcontainer,
+            render_value_opt(file.raw.image.as_ref()),
+            "coop builds its own rootfs; base images are ignored",
+        );
+    }
+    if file.raw.build.is_some() {
+        t.report.push(
+            "build",
+            ReportStatus::Unsupported,
+            ReportSource::Devcontainer,
+            render_value_opt(file.raw.build.as_ref()),
+            "coop builds its own rootfs; Dockerfile/build is ignored",
+        );
+    }
+    if file.raw.docker_compose_file.is_some() {
+        t.report.push(
+            "dockerComposeFile",
+            ReportStatus::Unsupported,
+            ReportSource::Devcontainer,
+            render_value_opt(file.raw.docker_compose_file.as_ref()),
+            "coop has no compose support",
+        );
+    }
+    if file.raw.customizations.is_some() {
+        t.report.push(
+            "customizations",
+            ReportStatus::Unsupported,
+            ReportSource::Devcontainer,
+            "<...>",
+            "editor-specific; not relevant to coop",
+        );
+    }
+
+    if let Some(name) = &file.raw.name {
+        t.report.push(
+            "name",
+            ReportStatus::Unsupported,
+            ReportSource::Devcontainer,
+            name.clone(),
+            "informational only; coop names instances via --name or auto-generates",
+        );
+    }
+
+    for (key, value) in &file.raw.extras {
+        t.report.push(
+            key,
+            ReportStatus::Unsupported,
+            ReportSource::Devcontainer,
+            render_value(value),
+            "unrecognised devcontainer.json key",
+        );
+    }
+
+    t
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "three independent fields with similar override branches"
+)]
+fn translate_host_requirements(
+    reqs: &RawHostRequirements,
+    inputs: &TranslatorInputs,
+    t: &mut Translation,
+) {
+    if let Some(cpus) = reqs.cpus {
+        let key = "hostRequirements.cpus";
+        match u8::try_from(cpus) {
+            Ok(n) if n > 0 => {
+                if let Some(cli) = inputs.cli_vcpus {
+                    t.report.push(
+                        key,
+                        ReportStatus::Overridden,
+                        ReportSource::Cli,
+                        cli.to_string(),
+                        format!("CLI --vcpus overrides devcontainer.json value {n}"),
+                    );
+                } else {
+                    t.vcpus = Some(n);
+                    t.report.push(
+                        key,
+                        ReportStatus::Applied,
+                        ReportSource::Devcontainer,
+                        n.to_string(),
+                        "",
+                    );
+                }
+            }
+            _ => t.report.push(
+                key,
+                ReportStatus::Invalid,
+                ReportSource::Devcontainer,
+                cpus.to_string(),
+                "expected positive integer that fits in u8",
+            ),
+        }
+    }
+    if let Some(mem) = &reqs.memory {
+        let key = "hostRequirements.memory";
+        match parse_size_mib(mem) {
+            Ok(mib) => {
+                if let Some(cli) = inputs.cli_mem_mib {
+                    t.report.push(
+                        key,
+                        ReportStatus::Overridden,
+                        ReportSource::Cli,
+                        format!("{cli} MiB"),
+                        format!("CLI --mem overrides devcontainer.json value {mib} MiB"),
+                    );
+                } else {
+                    t.mem_mib = Some(mib);
+                    t.report.push(
+                        key,
+                        ReportStatus::Applied,
+                        ReportSource::Devcontainer,
+                        format!("{mib} MiB"),
+                        "",
+                    );
+                }
+            }
+            Err(e) => t.report.push(
+                key,
+                ReportStatus::Invalid,
+                ReportSource::Devcontainer,
+                mem.clone(),
+                e.to_string(),
+            ),
+        }
+    }
+    if let Some(storage) = &reqs.storage {
+        let key = "hostRequirements.storage";
+        match parse_size_gib(storage) {
+            Ok(gib) => {
+                if let Some(cli) = inputs.cli_disk_gib {
+                    t.report.push(
+                        key,
+                        ReportStatus::Overridden,
+                        ReportSource::Cli,
+                        format!("{cli} GiB"),
+                        format!("CLI --disk overrides devcontainer.json value {gib} GiB"),
+                    );
+                } else {
+                    t.disk_gib = Some(gib);
+                    t.report.push(
+                        key,
+                        ReportStatus::Applied,
+                        ReportSource::Devcontainer,
+                        format!("{gib} GiB"),
+                        "",
+                    );
+                }
+            }
+            Err(e) => t.report.push(
+                key,
+                ReportStatus::Invalid,
+                ReportSource::Devcontainer,
+                storage.clone(),
+                e.to_string(),
+            ),
+        }
+    }
+    for (k, v) in &reqs.extras {
+        t.report.push(
+            format!("hostRequirements.{k}"),
+            ReportStatus::Unsupported,
+            ReportSource::Devcontainer,
+            render_value(v),
+            "unrecognised hostRequirements key",
+        );
+    }
+}
+
+fn translate_container_env(
+    env: &BTreeMap<String, String>,
+    inputs: &TranslatorInputs,
+    stage: Stage,
+    t: &mut Translation,
+) {
+    let key = "containerEnv";
+    if env.is_empty() {
+        return;
+    }
+    if stage == Stage::Setup {
+        t.report.push(
+            key,
+            ReportStatus::Applied,
+            ReportSource::Devcontainer,
+            format!("{} entries", env.len()),
+            "applied at start time",
+        );
+        return;
+    }
+    let cli_keys: std::collections::HashSet<&str> = inputs
+        .cli_guest_env_keys
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let mut overridden = Vec::new();
+    let mut applied = Vec::new();
+    for (k, v) in env {
+        if cli_keys.contains(k.as_str()) {
+            overridden.push(k.clone());
+        } else {
+            t.guest_env.insert(k.clone(), v.clone());
+            applied.push(k.clone());
+        }
+    }
+    if !applied.is_empty() {
+        t.report.push(
+            key,
+            ReportStatus::Applied,
+            ReportSource::Devcontainer,
+            format!("{} entries", applied.len()),
+            applied.join(","),
+        );
+    }
+    if !overridden.is_empty() {
+        t.report.push(
+            key,
+            ReportStatus::Overridden,
+            ReportSource::Cli,
+            format!("{} entries", overridden.len()),
+            format!("CLI --env overrides: {}", overridden.join(",")),
+        );
+    }
+}
+
+fn translate_forward_ports(
+    ports: &[serde_json::Value],
+    inputs: &TranslatorInputs,
+    stage: Stage,
+    t: &mut Translation,
+) {
+    let key = "forwardPorts";
+    if ports.is_empty() {
+        return;
+    }
+    if stage == Stage::Setup {
+        t.report.push(
+            key,
+            ReportStatus::Applied,
+            ReportSource::Devcontainer,
+            format!("{} entries", ports.len()),
+            "applied at start time",
+        );
+        return;
+    }
+    let cli_guest_ports: std::collections::HashSet<u16> = inputs
+        .cli_forward_ports
+        .iter()
+        .map(|p| p.guest.get())
+        .collect();
+    let mut applied: Vec<String> = Vec::new();
+    let mut overridden: Vec<String> = Vec::new();
+    for entry in ports {
+        let parsed = parse_forward_port_entry(entry);
+        match parsed {
+            Ok(pf) => {
+                if cli_guest_ports.contains(&pf.guest.get()) {
+                    overridden.push(pf.guest.to_string());
+                } else {
+                    applied.push(format_pf(&pf));
+                    t.forward_ports.push(pf);
+                }
+            }
+            Err(e) => t.report.push(
+                key,
+                ReportStatus::Invalid,
+                ReportSource::Devcontainer,
+                render_value(entry),
+                e.to_string(),
+            ),
+        }
+    }
+    if !applied.is_empty() {
+        t.report.push(
+            key,
+            ReportStatus::Applied,
+            ReportSource::Devcontainer,
+            applied.join(","),
+            "",
+        );
+    }
+    if !overridden.is_empty() {
+        t.report.push(
+            key,
+            ReportStatus::Overridden,
+            ReportSource::Cli,
+            overridden.join(","),
+            format!(
+                "CLI --forward-port overrides for guest port(s): {}",
+                overridden.join(",")
+            ),
+        );
+    }
+}
+
+fn translate_features(
+    features: &BTreeMap<String, serde_json::Value>,
+    inputs: &TranslatorInputs,
+    stage: Stage,
+    t: &mut Translation,
+) {
+    if features.is_empty() {
+        return;
+    }
+    let cli_profiles: std::collections::HashSet<&str> =
+        inputs.cli_profiles.iter().map(String::as_str).collect();
+    for raw_id in features.keys() {
+        let key = format!("features.{raw_id}");
+        let Some(builtin) = map_feature_to_profile(raw_id) else {
+            t.report.push(
+                key,
+                ReportStatus::Unsupported,
+                ReportSource::Devcontainer,
+                raw_id.clone(),
+                "no built-in profile match; coop does not pull OCI feature images in v1",
+            );
+            continue;
+        };
+        if stage == Stage::Start {
+            t.report.push(
+                key,
+                ReportStatus::Unsupported,
+                ReportSource::Devcontainer,
+                builtin.to_string(),
+                "features are baked into the template at `coop setup` time, \
+                 not selected per-start",
+            );
+            continue;
+        }
+        if cli_profiles.contains(builtin) {
+            t.report.push(
+                key,
+                ReportStatus::Overridden,
+                ReportSource::Cli,
+                builtin.to_string(),
+                "CLI --profile already includes this profile",
+            );
+            continue;
+        }
+        t.profiles.push(builtin.to_string());
+        t.report.push(
+            key,
+            ReportStatus::Applied,
+            ReportSource::Devcontainer,
+            builtin.to_string(),
+            format!("mapped to built-in profile '{builtin}'"),
+        );
+    }
+}
+
+fn translate_mounts(
+    mounts: &[serde_json::Value],
+    inputs: &TranslatorInputs,
+    stage: Stage,
+    t: &mut Translation,
+) {
+    let key = "mounts";
+    if mounts.is_empty() {
+        return;
+    }
+    if stage == Stage::Setup {
+        t.report.push(
+            key,
+            ReportStatus::Applied,
+            ReportSource::Devcontainer,
+            format!("{} entries", mounts.len()),
+            "applied at start time",
+        );
+        return;
+    }
+    let cli_present = !inputs.cli_mounts.is_empty();
+    if cli_present {
+        t.report.push(
+            key,
+            ReportStatus::Overridden,
+            ReportSource::Cli,
+            format!("{} CLI --mount entries", inputs.cli_mounts.len()),
+            "CLI --mount conflicts with --workspace and replaces devcontainer mounts",
+        );
+        return;
+    }
+    if inputs.cli_workspace_or_git_repo {
+        t.report.push(
+            key,
+            ReportStatus::Unsupported,
+            ReportSource::Devcontainer,
+            format!("{} entries", mounts.len()),
+            "coop --mount is mutually exclusive with --workspace/--git-repo in v1; \
+             drop those flags to use devcontainer mounts",
+        );
+        return;
+    }
+    let mut applied: Vec<String> = Vec::new();
+    for entry in mounts {
+        match parse_mount_entry(entry) {
+            Ok(spec) => match Mount::parse(&spec) {
+                Ok(m) => {
+                    applied.push(format!("{}->{}", m.host_path.display(), m.guest_path));
+                    t.mounts.push(m);
+                }
+                Err(e) => t.report.push(
+                    key,
+                    ReportStatus::Invalid,
+                    ReportSource::Devcontainer,
+                    spec,
+                    e.to_string(),
+                ),
+            },
+            Err(e) => t.report.push(
+                key,
+                ReportStatus::Invalid,
+                ReportSource::Devcontainer,
+                render_value(entry),
+                e.to_string(),
+            ),
+        }
+    }
+    if !applied.is_empty() {
+        t.report.push(
+            key,
+            ReportStatus::Applied,
+            ReportSource::Devcontainer,
+            applied.join(", "),
+            "",
+        );
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+fn render_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        _ => v.to_string(),
+    }
+}
+
+fn render_value_opt(v: Option<&serde_json::Value>) -> String {
+    v.map(render_value).unwrap_or_default()
+}
+
+fn post_start_to_string(v: &serde_json::Value) -> Option<String> {
+    match v {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Array(items) => {
+            let strs: Option<Vec<&str>> = items.iter().map(serde_json::Value::as_str).collect();
+            strs.map(|ss| ss.join(" && "))
+        }
+        _ => None,
+    }
+}
+
+/// Parse a memory size string per the [devcontainer spec][spec]:
+/// `{decimal}{KB|MB|GB|TB}`, where the suffix is decimal-base. We honour
+/// the spec while accepting the binary suffixes (KiB/MiB/GiB/TiB) that
+/// real-world files use interchangeably.
+///
+/// Returns mebibytes (rounded up to the nearest MiB).
+///
+/// [spec]: https://containers.dev/implementors/json_reference/#image-specific
+fn parse_size_mib(s: &str) -> Result<u32> {
+    let bytes = parse_size_bytes(s)?;
+    let mib = bytes.div_ceil(1024 * 1024);
+    u32::try_from(mib).context("memory value overflows u32 MiB")
+}
+
+fn parse_size_gib(s: &str) -> Result<u32> {
+    let bytes = parse_size_bytes(s)?;
+    let gib = bytes.div_ceil(1024 * 1024 * 1024);
+    u32::try_from(gib).context("storage value overflows u32 GiB")
+}
+
+fn parse_size_bytes(s: &str) -> Result<u64> {
+    let trimmed = s.trim();
+    let (num_str, mult) = split_size(trimmed)?;
+    let num: f64 = num_str
+        .parse()
+        .with_context(|| format!("expected '<decimal><unit>' (e.g. '4GB'); got '{s}'"))?;
+    if !num.is_finite() || num < 0.0 {
+        bail!("size must be a non-negative finite number: '{s}'");
+    }
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "sizes are bounded well below f64 precision and u64 max"
+    )]
+    let bytes = (num * mult as f64).round() as u64;
+    Ok(bytes)
+}
+
+/// Split a `<decimal><unit>` string into the numeric part and a byte
+/// multiplier. Suffix matching is case-insensitive and accepts both
+/// decimal (`GB`) and binary (`GiB`) units.
+fn split_size(s: &str) -> Result<(&str, u64)> {
+    // Longest suffix first so "GiB" matches before "B".
+    let suffixes: &[(&str, u64)] = &[
+        ("TiB", 1u64 << 40),
+        ("GiB", 1u64 << 30),
+        ("MiB", 1u64 << 20),
+        ("KiB", 1u64 << 10),
+        ("TB", 1_000_000_000_000),
+        ("GB", 1_000_000_000),
+        ("MB", 1_000_000),
+        ("KB", 1_000),
+        ("B", 1),
+    ];
+    let lower = s.to_ascii_lowercase();
+    for (suf, mult) in suffixes {
+        let lower_suf = suf.to_ascii_lowercase();
+        if lower.ends_with(&lower_suf) {
+            let cut = s.len() - suf.len();
+            return Ok((s[..cut].trim(), *mult));
+        }
+    }
+    bail!("expected a unit suffix (B, KB, MB, GB, TB; KiB/MiB/GiB/TiB also accepted)");
+}
+
+fn parse_forward_port_entry(v: &serde_json::Value) -> Result<PortForward> {
+    match v {
+        serde_json::Value::Number(n) => {
+            let n = n.as_u64().context("port must be a positive integer")?;
+            let n: u16 = n
+                .try_into()
+                .with_context(|| format!("port {n} out of range 1..=65535"))?;
+            PortForward::parse(&n.to_string())
+        }
+        serde_json::Value::String(s) => {
+            // devcontainer.json supports "host:port" string forms; coop
+            // does not host-IP-bind. We accept "8080" or "8080:9090".
+            PortForward::parse(s)
+        }
+        _ => bail!("expected port number or 'GUEST[:HOST]' string"),
+    }
+}
+
+fn parse_mount_entry(v: &serde_json::Value) -> Result<String> {
+    match v {
+        serde_json::Value::String(s) => parse_mount_string(s),
+        serde_json::Value::Object(map) => {
+            let typ = map
+                .get("type")
+                .and_then(|v| v.as_str())
+                .context("mount object requires 'type'")?;
+            if typ != "bind" {
+                bail!("unsupported mount type '{typ}' (coop supports 'bind' only in v1)");
+            }
+            let source = map
+                .get("source")
+                .and_then(|v| v.as_str())
+                .context("mount object requires 'source'")?;
+            let target = map
+                .get("target")
+                .and_then(|v| v.as_str())
+                .context("mount object requires 'target'")?;
+            Ok(format!("{source}:{target}"))
+        }
+        _ => bail!("expected mount string or object"),
+    }
+}
+
+/// Convert a docker-style mount string (`type=bind,source=...,target=...`)
+/// into coop's `HOST_PATH[:GUEST_PATH]` form.
+fn parse_mount_string(s: &str) -> Result<String> {
+    if !s.contains('=') {
+        // Already in HOST:GUEST or HOST form — pass through.
+        return Ok(s.to_string());
+    }
+    let mut typ: Option<&str> = None;
+    let mut source: Option<&str> = None;
+    let mut target: Option<&str> = None;
+    for part in s.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (k, v) = match part.split_once('=') {
+            Some((k, v)) => (k.trim(), Some(v.trim())),
+            // Bare token: only meaningful for flag-style fields like `readonly`.
+            None => (part, None),
+        };
+        match k {
+            "type" => typ = v,
+            "source" | "src" => source = v,
+            "target" | "dst" | "destination" => target = v,
+            "readonly" | "ro" | "consistency" | "bind-propagation" => {
+                // Tolerate Docker flags we don't honour in v1; the bind
+                // semantics are coop's default.
+            }
+            other => bail!("unsupported mount field '{other}'"),
+        }
+    }
+    let typ = typ.unwrap_or("bind");
+    if typ != "bind" {
+        bail!("unsupported mount type '{typ}' (coop supports 'bind' only in v1)");
+    }
+    let source = source.context("mount string missing source=...")?;
+    let target = target.context("mount string missing target=...")?;
+    Ok(format!("{source}:{target}"))
+}
+
+/// Map a devcontainer feature id (raw key) to a built-in coop profile name,
+/// or `None` if no match. We recognise both bare names (`rust`) and the
+/// fully-qualified registry form (`ghcr.io/devcontainers/features/rust:1`).
+fn map_feature_to_profile(raw: &str) -> Option<&'static str> {
+    // Trim `ghcr.io/devcontainers/features/<name>[:version]` to `<name>`.
+    let id = raw
+        .rsplit('/')
+        .next()
+        .unwrap_or(raw)
+        .split(':')
+        .next()
+        .unwrap_or(raw);
+    let known: &[&str] = &["python", "node", "rust", "go", "c", "fuzz"];
+    if known.contains(&id) && BUILTIN_PROFILES.iter().any(|bp| bp.name == id) {
+        return BUILTIN_PROFILES
+            .iter()
+            .find(|bp| bp.name == id)
+            .map(|bp| bp.name);
+    }
+    None
+}
+
+fn format_pf(p: &PortForward) -> String {
+    if p.guest == p.host {
+        p.guest.to_string()
+    } else {
+        format!("{}:{}", p.guest, p.host)
+    }
+}
+
+// ── Discovery ────────────────────────────────────────────────
+
+/// A devcontainer.json file found on disk, with its origin recorded so
+/// the report can distinguish "from workspace" vs "from mount".
+#[derive(Debug, Clone)]
+pub struct Discovered {
+    pub path: PathBuf,
+    pub origin: DiscoveryOrigin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveryOrigin {
+    Workspace,
+    Mount,
+}
+
+/// Look for `.devcontainer/devcontainer.json` under each candidate root.
+///
+/// Returns matches in order: workspace first (when present), then each
+/// mount root in the order supplied. Non-existent files are silently
+/// skipped — only present files are returned.
+pub fn discover(workspace: Option<&Path>, mounts: &[Mount]) -> Vec<Discovered> {
+    let mut out = Vec::new();
+    if let Some(ws) = workspace {
+        let candidate = ws.join(DEFAULT_DEVCONTAINER_REL_PATH);
+        if candidate.is_file() {
+            out.push(Discovered {
+                path: candidate,
+                origin: DiscoveryOrigin::Workspace,
+            });
+        }
+    }
+    for m in mounts {
+        let candidate = m.host_path.join(DEFAULT_DEVCONTAINER_REL_PATH);
+        if candidate.is_file() {
+            out.push(Discovered {
+                path: candidate,
+                origin: DiscoveryOrigin::Mount,
+            });
+        }
+    }
+    out
+}
+
+/// Pick the winning devcontainer.json and record losers in the report.
+///
+/// Workspace > mounts. Ties within mounts are broken by order (first
+/// `--mount` wins). The ignored set is populated even when the caller
+/// doesn't end up loading the file, so `--dry-run` shows the user every
+/// file we saw.
+#[must_use]
+pub fn pick_winner(found: Vec<Discovered>) -> Option<(Discovered, Vec<PathBuf>)> {
+    let mut workspace = None;
+    let mut mounts: Vec<Discovered> = Vec::new();
+    for d in found {
+        match d.origin {
+            DiscoveryOrigin::Workspace => workspace = Some(d),
+            DiscoveryOrigin::Mount => mounts.push(d),
+        }
+    }
+    if let Some(ws) = workspace {
+        let losers = mounts.into_iter().map(|d| d.path).collect();
+        return Some((ws, losers));
+    }
+    if let Some(first) = mounts.first().cloned() {
+        let losers = mounts.into_iter().skip(1).map(|d| d.path).collect();
+        return Some((first, losers));
+    }
+    None
+}
+
+// ── Application ──────────────────────────────────────────────
+
+/// Apply a translation to `CoopConfig`. Returns warnings to emit.
+///
+/// Returns a vector of human-readable warnings (e.g. "containerEnv X
+/// overrides forwarded value") so callers can decide whether to emit at
+/// WARN or DEBUG. `guest_env` precedence already wins over forwarded
+/// values per the existing `prepare_env_forwarding` semantics.
+pub fn apply_to_config(cfg: &mut CoopConfig, t: &Translation) -> Result<()> {
+    if let Some(v) = t.vcpus {
+        cfg.vm.vcpu_count =
+            std::num::NonZeroU8::new(v).context("translated --vcpus value resolved to zero")?;
+    }
+    if let Some(m) = t.mem_mib {
+        cfg.vm.mem_size_mib = MiB::new(m).context("translated --mem value resolved to zero")?;
+    }
+    if let Some(p) = &t.post_start {
+        cfg.post_start = Some(p.clone());
+    }
+    for (k, v) in &t.guest_env {
+        cfg.guest_env.insert(k.clone(), v.clone());
+    }
+    Ok(())
+}
+
+/// Return the effective disk override that a caller should pass through
+/// to `StartOpts::disk`. CLI value wins; otherwise the translator's
+/// `disk_gib` is used.
+#[must_use]
+pub fn effective_disk(cli: Option<GiB>, t: &Translation) -> Option<GiB> {
+    if let Some(c) = cli {
+        return Some(c);
+    }
+    t.disk_gib.and_then(GiB::new)
+}
+
+/// Merge devcontainer.json forwards on top of existing config defaults.
+///
+/// Mirrors `config::merge_forward_ports` semantics — later entries with
+/// the same guest port win. The caller still merges the result with the
+/// CLI forwards via the existing helper.
+#[must_use]
+pub fn merge_into_forward_ports(
+    cfg_forwards: &[PortForward],
+    t_forwards: &[PortForward],
+) -> Vec<PortForward> {
+    config::merge_forward_ports(cfg_forwards, t_forwards)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests use unwrap for brevity")]
+mod tests {
+    use super::*;
+
+    fn parse(text: &str) -> ParsedDevcontainer {
+        ParsedDevcontainer::from_str(PathBuf::from("test.json"), text).unwrap()
+    }
+
+    #[test]
+    fn jsonc_strips_line_comments() {
+        let src = r#"{
+            // a comment
+            "name": "demo" // trailing
+        }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["name"], "demo");
+    }
+
+    #[test]
+    fn jsonc_strips_block_comments() {
+        let src = r#"{ /* block */ "k": /* inline */ 1 }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["k"], 1);
+    }
+
+    #[test]
+    fn jsonc_strips_trailing_commas() {
+        let src = r#"{ "a": 1, "b": [1, 2, 3,], }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["a"], 1);
+        assert_eq!(v["b"][2], 3);
+    }
+
+    #[test]
+    fn jsonc_keeps_commas_inside_strings() {
+        let src = r#"{ "k": "a, b, c", }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["k"], "a, b, c");
+    }
+
+    #[test]
+    fn jsonc_keeps_slashes_inside_strings() {
+        let src = r#"{ "k": "https://example.com/a", "j": "/* not a comment */" }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["k"], "https://example.com/a");
+        assert_eq!(v["j"], "/* not a comment */");
+    }
+
+    #[test]
+    fn parse_supported_subset() {
+        let f = parse(
+            r#"{
+                "name": "demo",
+                "image": "ignored",
+                "hostRequirements": { "cpus": 4, "memory": "4GiB", "storage": "16GiB" },
+                "containerEnv": { "FOO": "bar" },
+                "forwardPorts": [3000, "8080:8081"],
+                "postStartCommand": "echo hi",
+                "features": { "ghcr.io/devcontainers/features/rust:1": {} },
+                "remoteUser": "root"
+            }"#,
+        );
+        assert_eq!(f.raw.name.as_deref(), Some("demo"));
+        assert_eq!(f.raw.host_requirements.as_ref().unwrap().cpus, Some(4));
+    }
+
+    #[test]
+    fn translate_marks_overridden_when_cli_wins() {
+        let f = parse(r#"{ "hostRequirements": { "cpus": 4 }, "postStartCommand": "x" }"#);
+        let inputs = TranslatorInputs {
+            cli_vcpus: Some(8),
+            cli_post_start: Some("y".to_string()),
+            ..TranslatorInputs::default()
+        };
+        let t = translate(&f, &inputs, Stage::Start);
+        let cpu = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "hostRequirements.cpus")
+            .unwrap();
+        assert_eq!(cpu.status, ReportStatus::Overridden);
+        let cmd = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "postStartCommand")
+            .unwrap();
+        assert_eq!(cmd.status, ReportStatus::Overridden);
+        assert!(t.vcpus.is_none());
+        assert!(t.post_start.is_none());
+    }
+
+    #[test]
+    fn translate_features_known_to_profiles() {
+        let f = parse(
+            r#"{ "features": {
+                "ghcr.io/devcontainers/features/rust:1": {},
+                "node": {},
+                "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+            } }"#,
+        );
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Setup);
+        assert!(t.profiles.contains(&"rust".to_string()));
+        assert!(t.profiles.contains(&"node".to_string()));
+        let docker = t
+            .report
+            .entries
+            .iter()
+            .find(|e| {
+                e.key
+                    .starts_with("features.ghcr.io/devcontainers/features/docker")
+            })
+            .unwrap();
+        assert_eq!(docker.status, ReportStatus::Unsupported);
+    }
+
+    #[test]
+    fn translate_remote_user_warns_unless_ubuntu() {
+        let f = parse(r#"{ "remoteUser": "root" }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        let entry = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "remoteUser")
+            .unwrap();
+        assert_eq!(entry.status, ReportStatus::Unsupported);
+
+        let f = parse(r#"{ "remoteUser": "ubuntu" }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        let entry = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "remoteUser")
+            .unwrap();
+        assert_eq!(entry.status, ReportStatus::Applied);
+    }
+
+    #[test]
+    fn translate_unknown_keys_reported() {
+        let f = parse(r#"{ "name": "x", "wackyKey": 1, "image": "ignored" }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        let wacky = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "wackyKey")
+            .unwrap();
+        assert_eq!(wacky.status, ReportStatus::Unsupported);
+        assert!(t.report.entries.iter().any(|e| e.key == "image"));
+    }
+
+    #[test]
+    fn translate_forward_ports_numbers_and_strings() {
+        let f = parse(r#"{ "forwardPorts": [3000, "8080:9090"] }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        assert_eq!(t.forward_ports.len(), 2);
+        assert_eq!(t.forward_ports[0].guest.get(), 3000);
+        assert_eq!(t.forward_ports[1].guest.get(), 8080);
+        assert_eq!(t.forward_ports[1].host.get(), 9090);
+    }
+
+    #[test]
+    fn translate_post_start_array_joins() {
+        let f = parse(r#"{ "postStartCommand": ["echo a", "echo b"] }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        assert_eq!(t.post_start.as_deref(), Some("echo a && echo b"));
+    }
+
+    #[test]
+    fn parse_size_handles_decimal_and_binary_units() {
+        assert_eq!(parse_size_mib("4GiB").unwrap(), 4096);
+        assert_eq!(parse_size_mib("4096MiB").unwrap(), 4096);
+        // 4GB = 4_000_000_000 B; rounded up to MiB = ceil(4e9 / 2^20) = 3815
+        assert_eq!(parse_size_mib("4GB").unwrap(), 3815);
+        assert_eq!(parse_size_gib("8GiB").unwrap(), 8);
+        assert!(parse_size_mib("4 lemons").is_err());
+        assert!(parse_size_mib("").is_err());
+    }
+
+    #[test]
+    fn parse_mount_object_and_string() {
+        assert_eq!(
+            parse_mount_string("type=bind,source=/a,target=/b").unwrap(),
+            "/a:/b"
+        );
+        assert_eq!(
+            parse_mount_string("source=/a,target=/b,readonly").unwrap(),
+            "/a:/b"
+        );
+        assert!(parse_mount_string("type=volume,source=v,target=/b").is_err());
+        let obj = serde_json::json!({"type": "bind", "source": "/a", "target": "/b"});
+        assert_eq!(parse_mount_entry(&obj).unwrap(), "/a:/b");
+    }
+
+    #[test]
+    fn report_render_includes_path_and_columns() {
+        let f = parse(r#"{ "hostRequirements": { "cpus": 4 } }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        let rendered = t.report.render();
+        assert!(rendered.contains("test.json"));
+        assert!(rendered.contains("hostRequirements.cpus"));
+        assert!(rendered.contains("applied"));
+    }
+
+    #[test]
+    fn pick_winner_prefers_workspace() {
+        let found = vec![
+            Discovered {
+                path: PathBuf::from("/ws/.devcontainer/devcontainer.json"),
+                origin: DiscoveryOrigin::Workspace,
+            },
+            Discovered {
+                path: PathBuf::from("/m1/.devcontainer/devcontainer.json"),
+                origin: DiscoveryOrigin::Mount,
+            },
+            Discovered {
+                path: PathBuf::from("/m2/.devcontainer/devcontainer.json"),
+                origin: DiscoveryOrigin::Mount,
+            },
+        ];
+        let (winner, losers) = pick_winner(found).unwrap();
+        assert_eq!(winner.origin, DiscoveryOrigin::Workspace);
+        assert_eq!(losers.len(), 2);
+    }
+
+    #[test]
+    fn pick_winner_falls_back_to_first_mount() {
+        let found = vec![
+            Discovered {
+                path: PathBuf::from("/m1/.devcontainer/devcontainer.json"),
+                origin: DiscoveryOrigin::Mount,
+            },
+            Discovered {
+                path: PathBuf::from("/m2/.devcontainer/devcontainer.json"),
+                origin: DiscoveryOrigin::Mount,
+            },
+        ];
+        let (winner, losers) = pick_winner(found).unwrap();
+        assert_eq!(
+            winner.path,
+            PathBuf::from("/m1/.devcontainer/devcontainer.json")
+        );
+        assert_eq!(
+            losers,
+            vec![PathBuf::from("/m2/.devcontainer/devcontainer.json")]
+        );
+    }
+
+    #[test]
+    fn translate_mounts_unsupported_with_workspace_flag() {
+        let f = parse(r#"{ "mounts": [{ "type": "bind", "source": "/a", "target": "/b" }] }"#);
+        let inputs = TranslatorInputs {
+            cli_workspace_or_git_repo: true,
+            ..TranslatorInputs::default()
+        };
+        let t = translate(&f, &inputs, Stage::Start);
+        let row = t.report.entries.iter().find(|e| e.key == "mounts").unwrap();
+        assert_eq!(row.status, ReportStatus::Unsupported);
+        assert!(t.mounts.is_empty());
+    }
+
+    #[test]
+    fn translate_container_env_overridden_by_cli() {
+        let f = parse(r#"{ "containerEnv": { "FOO": "x", "BAR": "y" } }"#);
+        let inputs = TranslatorInputs {
+            cli_guest_env_keys: vec!["FOO".to_string()],
+            ..TranslatorInputs::default()
+        };
+        let t = translate(&f, &inputs, Stage::Start);
+        assert_eq!(t.guest_env.get("BAR").map(String::as_str), Some("y"));
+        assert!(!t.guest_env.contains_key("FOO"));
+        assert!(
+            t.report
+                .entries
+                .iter()
+                .any(|e| e.key == "containerEnv" && e.status == ReportStatus::Overridden)
+        );
+    }
+}

--- a/src/guest_env_state.rs
+++ b/src/guest_env_state.rs
@@ -1,0 +1,193 @@
+//! Per-instance snapshot of `--env` overrides applied at `coop start`.
+//!
+//! Mirrors [`crate::port_forward::ForwardsState`]: `--env KEY=VALUE` lives
+//! only in the `coop start` process's memory, so subsequent invocations
+//! like `coop shell` reload `config.toml` and never see those values.
+//! Persisting the CLI-provided entries lets every later invocation
+//! against the same instance forward them via SSH `SendEnv`.
+//!
+//! The snapshot stores **only** the CLI-provided `--env` set (not the
+//! whole merged `guest_env` map). `[guest_env]` from `config.toml` and
+//! devcontainer-derived entries are re-read from disk on every command,
+//! so persisting them would freeze edits the user made between `start`
+//! and `shell`. Restart can extend or override the snapshot — passing
+//! `--env KEY=newvalue` on `coop start <stopped>` wins over the saved
+//! value for that key and replaces it in the saved set.
+//!
+//! Persistence layout: one JSON file at `<inst.dir>/guest_env.json`.
+//! Empty snapshots are not written; an empty file would be ambiguous
+//! with "no snapshot," and the missing-file branch already means
+//! "nothing extra to overlay."
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::ErrorKind;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::config::Instance;
+
+/// Persisted CLI `--env KEY=VALUE` snapshot, applied on every later
+/// `coop` invocation that targets the same instance.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct GuestEnvState {
+    /// Entries to overlay onto the resolved env-forward set. `BTreeMap`
+    /// gives deterministic iteration so `serde_json` output is stable
+    /// across runs.
+    #[serde(default)]
+    pub entries: BTreeMap<String, String>,
+}
+
+impl GuestEnvState {
+    pub fn save(&self, inst: &Instance) -> Result<()> {
+        let path = inst.guest_env_state_path();
+        if self.entries.is_empty() {
+            // Don't leave a stale or empty snapshot behind — the
+            // missing-file branch already encodes "nothing to overlay."
+            if path.exists()
+                && let Err(e) = fs::remove_file(&path)
+            {
+                tracing::debug!(
+                    "Failed to remove empty guest_env state {} (non-fatal): {e}",
+                    path.display()
+                );
+            }
+            return Ok(());
+        }
+        let json =
+            serde_json::to_string_pretty(self).context("Failed to serialize guest_env state")?;
+        crate::fs_util::atomic_write_json(&path, &json)
+            .context("Failed to write guest_env.json")?;
+        tracing::debug!("Wrote guest_env state to {}", path.display());
+        Ok(())
+    }
+
+    pub fn try_load(inst: &Instance) -> Result<Option<Self>> {
+        let path = inst.guest_env_state_path();
+        match fs::read_to_string(&path) {
+            Ok(content) => {
+                let state =
+                    serde_json::from_str(&content).context("Failed to parse guest_env.json")?;
+                Ok(Some(state))
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+            Err(e) => {
+                Err(anyhow::Error::new(e).context(format!("Failed to read {}", path.display())))
+            }
+        }
+    }
+}
+
+/// Parse `--env KEY=VALUE` argument list into a `BTreeMap`.
+///
+/// Rejects entries missing `=` and entries with an empty key. Empty
+/// values are allowed (e.g. `--env CLEAR=`).
+///
+/// Returned map preserves the "last write wins" precedence of the
+/// argument order: later duplicates of the same key overwrite earlier
+/// ones, matching `merge_cli_guest_env`'s in-memory behaviour.
+pub fn parse_cli_env_args(args: &[String]) -> Result<BTreeMap<String, String>> {
+    let mut out = BTreeMap::new();
+    for entry in args {
+        let (key, value) = entry
+            .split_once('=')
+            .with_context(|| format!("--env expects KEY=VALUE, got '{entry}' (missing '=')"))?;
+        if key.is_empty() {
+            bail!("--env KEY must not be empty (got '{entry}')");
+        }
+        out.insert(key.to_string(), value.to_string());
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::config::{Instance, InstanceIndex, InstanceName};
+
+    fn fake_instance(dir: PathBuf) -> Instance {
+        Instance {
+            name: InstanceName::new("test").unwrap(),
+            index: InstanceIndex::new(0),
+            dir,
+            image: "test.img".to_string(),
+        }
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        let mut state = GuestEnvState::default();
+        state.entries.insert("FOO".to_string(), "1".to_string());
+        state.entries.insert("BAR".to_string(), "2".to_string());
+
+        state.save(&inst).unwrap();
+        let loaded = GuestEnvState::try_load(&inst).unwrap().unwrap();
+        assert_eq!(loaded.entries.get("FOO").map(String::as_str), Some("1"));
+        assert_eq!(loaded.entries.get("BAR").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn try_load_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        assert!(GuestEnvState::try_load(&inst).unwrap().is_none());
+    }
+
+    #[test]
+    fn save_empty_removes_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        let mut state = GuestEnvState::default();
+        state.entries.insert("KEEP".to_string(), "x".to_string());
+        state.save(&inst).unwrap();
+        assert!(inst.guest_env_state_path().exists());
+
+        GuestEnvState::default().save(&inst).unwrap();
+        assert!(!inst.guest_env_state_path().exists());
+    }
+
+    #[test]
+    fn parse_cli_env_args_basic() {
+        let parsed = parse_cli_env_args(&["FOO=1".into(), "BAR=baz".into()]).unwrap();
+        assert_eq!(parsed.get("FOO").map(String::as_str), Some("1"));
+        assert_eq!(parsed.get("BAR").map(String::as_str), Some("baz"));
+    }
+
+    #[test]
+    fn parse_cli_env_args_allows_empty_value() {
+        let parsed = parse_cli_env_args(&["EMPTY=".into()]).unwrap();
+        assert_eq!(parsed.get("EMPTY").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn parse_cli_env_args_rejects_missing_equals() {
+        let err = parse_cli_env_args(&["BAD".into()]).unwrap_err();
+        assert!(format!("{err:#}").contains("missing '='"));
+    }
+
+    #[test]
+    fn parse_cli_env_args_rejects_empty_key() {
+        let err = parse_cli_env_args(&["=value".into()]).unwrap_err();
+        assert!(format!("{err:#}").contains("KEY must not be empty"));
+    }
+
+    #[test]
+    fn parse_cli_env_args_last_duplicate_wins() {
+        let parsed = parse_cli_env_args(&["K=v1".into(), "K=v2".into()]).unwrap();
+        assert_eq!(parsed.get("K").map(String::as_str), Some("v2"));
+    }
+
+    #[test]
+    fn parse_cli_env_args_value_may_contain_equals() {
+        let parsed = parse_cli_env_args(&["URL=https://x?a=b&c=d".into()]).unwrap();
+        assert_eq!(
+            parsed.get("URL").map(String::as_str),
+            Some("https://x?a=b&c=d"),
+        );
+    }
+}

--- a/src/guest_env_state.rs
+++ b/src/guest_env_state.rs
@@ -1,18 +1,25 @@
-//! Per-instance snapshot of `--env` overrides applied at `coop start`.
+//! Per-instance snapshot of start-time guest env overrides.
 //!
-//! Mirrors [`crate::port_forward::ForwardsState`]: `--env KEY=VALUE` lives
-//! only in the `coop start` process's memory, so subsequent invocations
-//! like `coop shell` reload `config.toml` and never see those values.
-//! Persisting the CLI-provided entries lets every later invocation
-//! against the same instance forward them via SSH `SendEnv`.
+//! Mirrors [`crate::port_forward::ForwardsState`]. Two sources contribute
+//! entries that live only in the `coop start` process's memory and would
+//! otherwise be lost to subsequent `coop shell`/`exec` invocations
+//! (which reload `config.toml` from scratch):
 //!
-//! The snapshot stores **only** the CLI-provided `--env` set (not the
-//! whole merged `guest_env` map). `[guest_env]` from `config.toml` and
-//! devcontainer-derived entries are re-read from disk on every command,
-//! so persisting them would freeze edits the user made between `start`
-//! and `shell`. Restart can extend or override the snapshot — passing
-//! `--env KEY=newvalue` on `coop start <stopped>` wins over the saved
-//! value for that key and replaces it in the saved set.
+//! - `--env KEY=VALUE` from the CLI
+//! - `containerEnv` translated from a `--devcontainer` JSON file
+//!
+//! Both are passed at start time and never re-derived by later commands,
+//! so we persist them here and overlay them onto the resolved env-forward
+//! set in [`crate::prepare_session_from_target`].
+//!
+//! `[guest_env]` from `config.toml` is deliberately *not* in the snapshot:
+//! it is re-read on every invocation, so persisting it would freeze edits
+//! the user made between `start` and `shell`.
+//!
+//! Restart can extend or override the snapshot — passing `--env
+//! KEY=newvalue` (or a `--devcontainer` whose `containerEnv` carries a
+//! new value) on `coop start <stopped>` wins over the saved value for
+//! that key and replaces it in the saved set.
 //!
 //! Persistence layout: one JSON file at `<inst.dir>/guest_env.json`.
 //! Empty snapshots are not written; an empty file would be ambiguous
@@ -27,8 +34,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::Instance;
 
-/// Persisted CLI `--env KEY=VALUE` snapshot, applied on every later
-/// `coop` invocation that targets the same instance.
+/// Persisted start-time guest-env snapshot (CLI `--env` plus
+/// devcontainer `containerEnv`), applied on every later `coop`
+/// invocation that targets the same instance.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct GuestEnvState {
     /// Entries to overlay onto the resolved env-forward set. `BTreeMap`
@@ -76,6 +84,25 @@ impl GuestEnvState {
             }
         }
     }
+}
+
+/// Merge devcontainer `containerEnv` and CLI `--env` entries into the
+/// single map persisted as [`GuestEnvState`]. CLI wins on key conflict,
+/// matching the documented "CLI > devcontainer.json" precedence.
+///
+/// The translator already filters CLI keys out of its `guest_env` map
+/// (see `translate_container_env`), so in practice there is no overlap;
+/// the explicit CLI-wins insertion is defensive against future changes.
+#[must_use]
+pub fn merge_persisted_entries(
+    devcontainer_entries: &BTreeMap<String, String>,
+    cli_entries: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut out = devcontainer_entries.clone();
+    for (key, value) in cli_entries {
+        out.insert(key.clone(), value.clone());
+    }
+    out
 }
 
 /// Parse `--env KEY=VALUE` argument list into a `BTreeMap`.
@@ -149,6 +176,30 @@ mod tests {
 
         GuestEnvState::default().save(&inst).unwrap();
         assert!(!inst.guest_env_state_path().exists());
+    }
+
+    #[test]
+    fn merge_persisted_entries_unions_disjoint_keys() {
+        let dc = BTreeMap::from([("DC".to_string(), "1".to_string())]);
+        let cli = BTreeMap::from([("CLI".to_string(), "2".to_string())]);
+        let merged = merge_persisted_entries(&dc, &cli);
+        assert_eq!(merged.get("DC").map(String::as_str), Some("1"));
+        assert_eq!(merged.get("CLI").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn merge_persisted_entries_cli_wins_on_conflict() {
+        let dc = BTreeMap::from([("K".to_string(), "from-devcontainer".to_string())]);
+        let cli = BTreeMap::from([("K".to_string(), "from-cli".to_string())]);
+        let merged = merge_persisted_entries(&dc, &cli);
+        assert_eq!(merged.get("K").map(String::as_str), Some("from-cli"));
+    }
+
+    #[test]
+    fn merge_persisted_entries_devcontainer_only() {
+        let dc = BTreeMap::from([("ONLY_DC".to_string(), "x".to_string())]);
+        let merged = merge_persisted_entries(&dc, &BTreeMap::new());
+        assert_eq!(merged.get("ONLY_DC").map(String::as_str), Some("x"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod backend;
 mod cmd;
 mod completions;
 mod config;
+mod devcontainer;
 mod fs_util;
 mod github_pat;
 mod github_repo;
@@ -136,6 +137,21 @@ enum Commands {
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         image: String,
+        /// Workspace directory to scan for `.devcontainer/devcontainer.json`.
+        /// When present (and `--no-devcontainer` is not set), coop offers to
+        /// apply the file's `features` and `hostRequirements` to this setup.
+        #[arg(long)]
+        workspace: Option<String>,
+        /// Explicit path to a `devcontainer.json` to use (skips discovery).
+        #[arg(long, value_name = "PATH", conflicts_with = "no_devcontainer")]
+        devcontainer: Option<String>,
+        /// Ignore any discovered `devcontainer.json` (escape hatch for CI).
+        #[arg(long)]
+        no_devcontainer: bool,
+        /// Translate `devcontainer.json` and print the report, then exit
+        /// before doing any setup work.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Build rootfs image and fetch kernel (use `setup` for first-time install)
     Build,
@@ -193,6 +209,16 @@ enum Commands {
         /// values with the same name.
         #[arg(long = "env", value_name = "KEY=VALUE")]
         guest_env: Vec<String>,
+        /// Explicit path to a `devcontainer.json` to use (skips discovery).
+        #[arg(long, value_name = "PATH", conflicts_with = "no_devcontainer")]
+        devcontainer: Option<String>,
+        /// Ignore any discovered `devcontainer.json` (escape hatch for CI).
+        #[arg(long)]
+        no_devcontainer: bool,
+        /// Translate `devcontainer.json` and print the report, then exit
+        /// before doing any VM work.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Open an interactive shell in the VM (or run a command non-interactively)
     #[command(alias = "ssh")]
@@ -572,8 +598,45 @@ fn main() -> Result<()> {
             post_install,
             template_size,
             image,
+            workspace,
+            devcontainer,
+            no_devcontainer,
+            dry_run,
         } => {
+            let ws_path = workspace.as_deref().map(Path::new);
+            let inputs = devcontainer::TranslatorInputs {
+                cli_vcpus: vcpus,
+                cli_mem_mib: mem,
+                cli_profiles: profile.clone(),
+                ..devcontainer::TranslatorInputs::default()
+            };
+            let translation = resolve_devcontainer(
+                &DevcontainerOpts {
+                    explicit_path: devcontainer.as_deref(),
+                    no_devcontainer,
+                    dry_run,
+                    workspace: ws_path,
+                    mounts: &[],
+                },
+                &inputs,
+                devcontainer::Stage::Setup,
+            )?;
+            if dry_run {
+                return Ok(());
+            }
+            let mut profile = profile;
+            if let Some(t) = &translation {
+                for p in &t.profiles {
+                    if !profile.contains(p) {
+                        profile.push(p.clone());
+                    }
+                }
+            }
+            // CLI flags first; translation values then fill in any blanks.
             apply_vm_overrides(&mut cfg, vcpus, mem, template_size)?;
+            if let Some(t) = &translation {
+                devcontainer::apply_to_config(&mut cfg, t)?;
+            }
             let _guard = signal::install_handlers();
             be.setup(
                 &cfg,
@@ -603,22 +666,87 @@ fn main() -> Result<()> {
             post_start,
             guest_env,
             forward_port,
+            devcontainer,
+            no_devcontainer,
+            dry_run,
         } => {
             if raw_args_use_deprecated_no_claude(std::env::args()) {
                 tracing::warn!(
                     "--no-claude is deprecated and will be removed in a future release; use --no-agents"
                 );
             }
-            apply_vm_overrides(&mut cfg, vcpus, mem, None)?;
-            merge_cli_guest_env(&mut cfg, &guest_env)?;
             let mounts = mount
                 .iter()
                 .map(|s| config::Mount::parse(s))
                 .collect::<Result<Vec<_>>>()?;
-            let forward_ports = forward_port
+            let mut forward_ports = forward_port
                 .iter()
                 .map(|s| config::PortForward::parse(s))
                 .collect::<Result<Vec<_>>>()?;
+
+            let cli_env_keys = guest_env
+                .iter()
+                .filter_map(|s| s.split_once('=').map(|(k, _)| k.to_string()))
+                .collect();
+            let inputs = devcontainer::TranslatorInputs {
+                cli_vcpus: vcpus,
+                cli_mem_mib: mem,
+                cli_disk_gib: disk,
+                cli_post_start: post_start.clone(),
+                cli_guest_env_keys: cli_env_keys,
+                cli_forward_ports: forward_ports.clone(),
+                cli_mounts: mounts.clone(),
+                cli_profiles: Vec::new(),
+                cli_workspace_or_git_repo: workspace.is_some() || git_repo.is_some(),
+            };
+            let ws_path = workspace.as_deref().map(Path::new);
+            let translation = resolve_devcontainer(
+                &DevcontainerOpts {
+                    explicit_path: devcontainer.as_deref(),
+                    no_devcontainer,
+                    dry_run,
+                    workspace: ws_path,
+                    mounts: &mounts,
+                },
+                &inputs,
+                devcontainer::Stage::Start,
+            )?;
+            if dry_run {
+                return Ok(());
+            }
+            // CLI flags are applied first; the translation only carries
+            // values that survived the "CLI > devcontainer.json" precedence
+            // check inside `translate`, so the two cannot fight here.
+            apply_vm_overrides(&mut cfg, vcpus, mem, None)?;
+            if let Some(t) = &translation {
+                devcontainer::apply_to_config(&mut cfg, t)?;
+                forward_ports =
+                    devcontainer::merge_into_forward_ports(&t.forward_ports, &forward_ports);
+            }
+            merge_cli_guest_env(&mut cfg, &guest_env)?;
+            let cli_disk = disk
+                .map(|d| config::GiB::new(d).context("--disk must be > 0"))
+                .transpose()?;
+            let default_translation = devcontainer::Translation::default();
+            let effective_disk = devcontainer::effective_disk(
+                cli_disk,
+                translation.as_ref().unwrap_or(&default_translation),
+            );
+            let post_start_override = post_start
+                .clone()
+                .or_else(|| translation.as_ref().and_then(|t| t.post_start.clone()));
+            // `--mount` and devcontainer `mounts` aren't combined: --mount is
+            // a complete replacement of the mount set (its `conflicts_with`
+            // rules with --workspace/--git-repo encode this). The CLI-wins
+            // outcome is reported by `translate`.
+            let final_mounts = if mounts.is_empty() {
+                translation
+                    .as_ref()
+                    .map(|t| t.mounts.clone())
+                    .unwrap_or_default()
+            } else {
+                mounts
+            };
             cmd_start(
                 &be,
                 &mut cfg,
@@ -629,14 +757,12 @@ fn main() -> Result<()> {
                     git_repo: git_repo.as_deref(),
                     no_agents,
                     no_prompt,
-                    disk: disk
-                        .map(|d| config::GiB::new(d).context("--disk must be > 0"))
-                        .transpose()?,
-                    mounts,
+                    disk: effective_disk,
+                    mounts: final_mounts,
                     exclude_git,
                     forward_ports,
                     config_path: &cli.config,
-                    post_start_override: post_start.as_deref(),
+                    post_start_override: post_start_override.as_deref(),
                 },
             )
         }
@@ -912,6 +1038,86 @@ fn merge_cli_guest_env(cfg: &mut config::CoopConfig, args: &[String]) -> Result<
         cfg.guest_env.insert(key.to_string(), value.to_string());
     }
     Ok(())
+}
+
+/// CLI surface controlling devcontainer.json discovery and apply.
+///
+/// `explicit_path` opts the caller in to a specific file (skips the
+/// prompt). `no_devcontainer` opts out entirely (skips discovery).
+/// `dry_run` prints the report and exits before any side effects.
+struct DevcontainerOpts<'a> {
+    explicit_path: Option<&'a str>,
+    no_devcontainer: bool,
+    dry_run: bool,
+    workspace: Option<&'a Path>,
+    mounts: &'a [config::Mount],
+}
+
+/// Discover, prompt, and translate a `devcontainer.json` for the given
+/// lifecycle `stage`.
+///
+/// Returns `None` when the user opts out, no file is found, or stdin is
+/// not a TTY with no explicit flag (in which case an error is returned
+/// instead — the issue forbids silently choosing). The report is always
+/// emitted to stderr when a file is loaded, so the user sees every key
+/// that did and didn't take effect.
+#[expect(
+    clippy::print_stderr,
+    reason = "devcontainer report is intentional user-facing CLI output"
+)]
+fn resolve_devcontainer(
+    opts: &DevcontainerOpts<'_>,
+    inputs: &devcontainer::TranslatorInputs,
+    stage: devcontainer::Stage,
+) -> Result<Option<devcontainer::Translation>> {
+    use std::io::IsTerminal as _;
+
+    if opts.no_devcontainer {
+        return Ok(None);
+    }
+
+    let (path, losers) = if let Some(p) = opts.explicit_path {
+        (PathBuf::from(p), Vec::new())
+    } else {
+        let found = devcontainer::discover(opts.workspace, opts.mounts);
+        if let Some((winner, losers)) = devcontainer::pick_winner(found) {
+            (winner.path, losers)
+        } else {
+            return Ok(None);
+        }
+    };
+
+    // When discovery (not an explicit flag) found the file, defer to the
+    // user. CI/scripted callers must pass --devcontainer or --no-devcontainer.
+    if opts.explicit_path.is_none() && !opts.dry_run {
+        if !std::io::stdin().is_terminal() {
+            bail!(
+                "Found {} but stdin is not a TTY.\n\
+                 Pass --devcontainer {} to apply it, or --no-devcontainer to ignore.\n\
+                 coop reads a subset of devcontainer.json — see docs/devcontainer.md for the supported keys.",
+                path.display(),
+                path.display()
+            );
+        }
+        let answer =
+            prompt::confirm_default_yes(&format!("Use devcontainer.json at {}?", path.display()))?;
+        if !answer {
+            tracing::info!(
+                "Skipping {}. Re-run with --devcontainer {} to apply it later.",
+                path.display(),
+                path.display()
+            );
+            return Ok(None);
+        }
+    }
+
+    let parsed = devcontainer::ParsedDevcontainer::load(&path)?;
+    let mut translation = devcontainer::translate(&parsed, inputs, stage);
+    translation.report.ignored_paths = losers;
+
+    eprintln!("{}", translation.report.render());
+
+    Ok(Some(translation))
 }
 
 fn cmd_build(cfg: &config::CoopConfig) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -728,6 +728,16 @@ fn main() -> Result<()> {
             for (key, value) in &cli_guest_env {
                 cfg.guest_env.insert(key.clone(), value.clone());
             }
+            // Union of CLI `--env` and devcontainer `containerEnv`. Both
+            // are start-time inputs that won't be re-derived by later
+            // `coop shell`/`exec`, so they belong in the on-disk snapshot
+            // (see `guest_env_state` module docs for the rationale).
+            let dc_guest_env = translation
+                .as_ref()
+                .map(|t| t.guest_env.clone())
+                .unwrap_or_default();
+            let persisted_guest_env =
+                guest_env_state::merge_persisted_entries(&dc_guest_env, &cli_guest_env);
             let cli_disk = disk
                 .map(|d| config::GiB::new(d).context("--disk must be > 0"))
                 .transpose()?;
@@ -767,7 +777,7 @@ fn main() -> Result<()> {
                     forward_ports,
                     config_path: &cli.config,
                     post_start_override: post_start_override.as_deref(),
-                    cli_guest_env,
+                    persisted_guest_env,
                 },
             )
         }
@@ -1136,11 +1146,13 @@ struct StartOpts<'a> {
     /// CLI override for `post_start` from `config.toml`. `None` means
     /// "use the configured value (if any)"; `Some` always wins.
     post_start_override: Option<&'a str>,
-    /// Parsed `--env KEY=VALUE` set from this invocation. Persisted as
-    /// the per-instance snapshot so later `coop shell`/`exec` runs see
-    /// the values — `config.toml` and devcontainer-derived entries are
-    /// re-read every invocation and are deliberately not saved here.
-    cli_guest_env: std::collections::BTreeMap<String, String>,
+    /// Start-time guest-env entries to persist as the per-instance
+    /// snapshot, so later `coop shell`/`exec` runs see them. This is
+    /// the union of CLI `--env KEY=VALUE` and the devcontainer
+    /// translator's `containerEnv` map (CLI wins per-key). `[guest_env]`
+    /// from `config.toml` is re-read every invocation and deliberately
+    /// not saved here.
+    persisted_guest_env: std::collections::BTreeMap<String, String>,
 }
 
 fn cmd_start(
@@ -1322,14 +1334,15 @@ fn restart_instance(
     let forwards = config::merge_forward_ports(&saved, &opts.forward_ports);
     port_forward::check_host_port_collisions(&forwards)?;
 
-    // Re-apply the `--env` set from the initial start. New `--env` on
-    // restart overrides per-key; the merged result is what gets
-    // persisted (and forwarded for this restart's bootstrap).
+    // Re-apply the persisted guest-env set from the initial start
+    // (CLI `--env` ∪ devcontainer `containerEnv`). New start-time
+    // entries on restart override per-key; the merged result is what
+    // gets persisted (and forwarded for this restart's bootstrap).
     let saved_guest_env = guest_env_state::GuestEnvState::try_load(inst)?
         .map(|s| s.entries)
         .unwrap_or_default();
     let mut merged_guest_env = saved_guest_env;
-    for (key, value) in &opts.cli_guest_env {
+    for (key, value) in &opts.persisted_guest_env {
         merged_guest_env.insert(key.clone(), value.clone());
     }
     for (key, value) in &merged_guest_env {
@@ -1448,12 +1461,14 @@ fn start_instance(
     .save(inst)?;
     port_forward::spawn_ssh_forwards(inst, &target, &forwards)?;
 
-    // Persist the CLI `--env` set so later commands targeting this
-    // instance (which reload `config.toml` from scratch) still forward
-    // these values via SSH `SendEnv`. The in-memory `cfg.guest_env`
-    // already contains them for this process's bootstrap pass.
+    // Persist start-time guest-env entries (CLI `--env` ∪ devcontainer
+    // `containerEnv`) so later commands targeting this instance — which
+    // reload `config.toml` from scratch and do not re-parse
+    // `--devcontainer` — still forward these values via SSH `SendEnv`.
+    // The in-memory `cfg.guest_env` already contains them for this
+    // process's bootstrap pass.
     guest_env_state::GuestEnvState {
-        entries: opts.cli_guest_env.clone(),
+        entries: opts.persisted_guest_env.clone(),
     }
     .save(inst)?;
 
@@ -2939,7 +2954,7 @@ mod tests {
             forward_ports: Vec::new(),
             config_path,
             post_start_override: None,
-            cli_guest_env: std::collections::BTreeMap::new(),
+            persisted_guest_env: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod fs_util;
 mod github_pat;
 mod github_repo;
 mod guest;
+mod guest_env_state;
 mod pat_prompt;
 mod port_forward;
 mod secret_store;
@@ -723,7 +724,10 @@ fn main() -> Result<()> {
                 forward_ports =
                     devcontainer::merge_into_forward_ports(&t.forward_ports, &forward_ports);
             }
-            merge_cli_guest_env(&mut cfg, &guest_env)?;
+            let cli_guest_env = guest_env_state::parse_cli_env_args(&guest_env)?;
+            for (key, value) in &cli_guest_env {
+                cfg.guest_env.insert(key.clone(), value.clone());
+            }
             let cli_disk = disk
                 .map(|d| config::GiB::new(d).context("--disk must be > 0"))
                 .transpose()?;
@@ -763,6 +767,7 @@ fn main() -> Result<()> {
                     forward_ports,
                     config_path: &cli.config,
                     post_start_override: post_start_override.as_deref(),
+                    cli_guest_env,
                 },
             )
         }
@@ -1023,23 +1028,6 @@ fn apply_vm_overrides(
     Ok(())
 }
 
-/// Merge `--env KEY=VALUE` arguments into `cfg.guest_env`.
-///
-/// CLI values override config entries with the same key. Empty keys
-/// and values without `=` are rejected; empty values are allowed.
-fn merge_cli_guest_env(cfg: &mut config::CoopConfig, args: &[String]) -> Result<()> {
-    for entry in args {
-        let (key, value) = entry
-            .split_once('=')
-            .with_context(|| format!("--env expects KEY=VALUE, got '{entry}' (missing '=')"))?;
-        if key.is_empty() {
-            bail!("--env KEY must not be empty (got '{entry}')");
-        }
-        cfg.guest_env.insert(key.to_string(), value.to_string());
-    }
-    Ok(())
-}
-
 /// CLI surface controlling devcontainer.json discovery and apply.
 ///
 /// `explicit_path` opts the caller in to a specific file (skips the
@@ -1148,6 +1136,11 @@ struct StartOpts<'a> {
     /// CLI override for `post_start` from `config.toml`. `None` means
     /// "use the configured value (if any)"; `Some` always wins.
     post_start_override: Option<&'a str>,
+    /// Parsed `--env KEY=VALUE` set from this invocation. Persisted as
+    /// the per-instance snapshot so later `coop shell`/`exec` runs see
+    /// the values — `config.toml` and devcontainer-derived entries are
+    /// re-read every invocation and are deliberately not saved here.
+    cli_guest_env: std::collections::BTreeMap<String, String>,
 }
 
 fn cmd_start(
@@ -1329,6 +1322,20 @@ fn restart_instance(
     let forwards = config::merge_forward_ports(&saved, &opts.forward_ports);
     port_forward::check_host_port_collisions(&forwards)?;
 
+    // Re-apply the `--env` set from the initial start. New `--env` on
+    // restart overrides per-key; the merged result is what gets
+    // persisted (and forwarded for this restart's bootstrap).
+    let saved_guest_env = guest_env_state::GuestEnvState::try_load(inst)?
+        .map(|s| s.entries)
+        .unwrap_or_default();
+    let mut merged_guest_env = saved_guest_env;
+    for (key, value) in &opts.cli_guest_env {
+        merged_guest_env.insert(key.clone(), value.clone());
+    }
+    for (key, value) in &merged_guest_env {
+        cfg.guest_env.insert(key.clone(), value.clone());
+    }
+
     be.start_existing(cfg, inst)?;
 
     signal::check_shutdown()?;
@@ -1346,11 +1353,16 @@ fn restart_instance(
     .save(inst)?;
     port_forward::spawn_ssh_forwards(inst, &target, &forwards)?;
 
+    guest_env_state::GuestEnvState {
+        entries: merged_guest_env,
+    }
+    .save(inst)?;
+
     let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
     if opts.no_agents && post_start.is_none() {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
-        let session = prepare_session_from_target(cfg, target.clone(), repo.as_deref())?;
+        let session = prepare_session_from_target(cfg, None, target.clone(), repo.as_deref())?;
         if opts.no_agents {
             tracing::info!("Skipping guest agent bootstrap (--no-agents)");
         } else {
@@ -1436,11 +1448,20 @@ fn start_instance(
     .save(inst)?;
     port_forward::spawn_ssh_forwards(inst, &target, &forwards)?;
 
+    // Persist the CLI `--env` set so later commands targeting this
+    // instance (which reload `config.toml` from scratch) still forward
+    // these values via SSH `SendEnv`. The in-memory `cfg.guest_env`
+    // already contains them for this process's bootstrap pass.
+    guest_env_state::GuestEnvState {
+        entries: opts.cli_guest_env.clone(),
+    }
+    .save(inst)?;
+
     let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
     if opts.no_agents && post_start.is_none() {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
-        let session = prepare_session_from_target(cfg, target.clone(), repo.as_deref())?;
+        let session = prepare_session_from_target(cfg, None, target.clone(), repo.as_deref())?;
         if opts.no_agents {
             tracing::info!("Skipping guest agent bootstrap (--no-agents)");
         } else {
@@ -1646,7 +1667,7 @@ fn open_ssh_session(
 ) -> Result<backend::SshSession> {
     let running = resolve_running(be, cfg, name)?;
     let repo = backend::detect_instance_repo(&running.inst);
-    prepare_session_from_target(cfg, running.target, repo.as_deref())
+    prepare_session_from_target(cfg, Some(&running.inst), running.target, repo.as_deref())
 }
 
 /// Build an `SshSession` from an already-resolved target.
@@ -1655,12 +1676,29 @@ fn open_ssh_session(
 /// target without going through `resolve_running` — namely the
 /// post-boot bootstrap in fresh start and restart, where the
 /// instance isn't yet registered as running.
+///
+/// When `inst` is `Some`, any persisted `--env` snapshot for that
+/// instance is overlaid onto the resolved env-forward set so values
+/// passed at `coop start --env KEY=VAL` survive across the
+/// per-invocation config reload. Bootstrap callers inside fresh
+/// `start_instance` pass `None` because the in-memory `cfg.guest_env`
+/// is already authoritative for that one process; restart and every
+/// post-start command pass `Some` because the on-disk snapshot is
+/// the only place the original `--env` set still lives.
 fn prepare_session_from_target(
     cfg: &config::CoopConfig,
+    inst: Option<&config::Instance>,
     target: backend::SshTarget,
     repo: Option<&str>,
 ) -> Result<backend::SshSession> {
-    let env = backend::prepare_env_forwarding(cfg, repo)?;
+    let mut env = backend::prepare_env_forwarding(cfg, repo)?;
+    if let Some(inst) = inst
+        && let Some(state) = guest_env_state::GuestEnvState::try_load(inst)?
+    {
+        for (name, value) in &state.entries {
+            env.set(name.as_str(), value.as_str());
+        }
+    }
     Ok(backend::SshSession { target, env })
 }
 
@@ -2454,62 +2492,77 @@ mod tests {
         );
     }
 
+    /// `prepare_session_from_target` must overlay the on-disk
+    /// `GuestEnvState` for the running instance on top of values
+    /// resolved from `cfg.guest_env` and forwarded host env vars.
+    /// This is the regression test for issue #131: `coop start --env`
+    /// values must survive across a fresh config reload by later
+    /// `coop shell`/`exec` invocations.
     #[test]
-    fn merge_cli_guest_env_inserts_and_overrides_config() {
+    fn prepare_session_overlays_persisted_guest_env() {
+        use std::num::NonZeroU16;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inst = super::config::Instance {
+            name: super::config::InstanceName::new("test").expect("valid name"),
+            index: super::config::InstanceIndex::new(0),
+            dir: tmp.path().to_path_buf(),
+            image: super::config::DEFAULT_IMAGE.to_string(),
+        };
+        let mut state = super::guest_env_state::GuestEnvState::default();
+        state
+            .entries
+            .insert("FROM_CLI".to_string(), "saved-value".to_string());
+        state.save(&inst).expect("save snapshot");
+
         let mut cfg = super::config::CoopConfig::default();
+        // Sanity: an entry in cfg without a CLI override should still
+        // appear (so the overlay is additive, not replacing).
         cfg.guest_env
-            .insert("KEEP".to_string(), "from-config".to_string());
-        cfg.guest_env
-            .insert("OVERWRITE".to_string(), "from-config".to_string());
+            .insert("FROM_CFG".to_string(), "cfg-value".to_string());
 
-        super::merge_cli_guest_env(
-            &mut cfg,
-            &["OVERWRITE=from-cli".to_string(), "NEW=cli-only".to_string()],
-        )
-        .unwrap();
+        let target = super::backend::SshTarget {
+            host: "127.0.0.1".to_string(),
+            port: NonZeroU16::new(22).expect("non-zero"),
+            user: "ubuntu".to_string(),
+            key_path: tmp.path().join("id_test"),
+        };
 
+        let session =
+            super::prepare_session_from_target(&cfg, Some(&inst), target, None).expect("session");
+
+        let envs = session.env.as_envs();
         assert_eq!(
-            cfg.guest_env.get("KEEP").map(String::as_str),
-            Some("from-config")
+            envs.get("FROM_CLI").map(String::as_str),
+            Some("saved-value"),
+            "persisted CLI --env entry must reach SshSession",
         );
         assert_eq!(
-            cfg.guest_env.get("OVERWRITE").map(String::as_str),
-            Some("from-cli")
-        );
-        assert_eq!(
-            cfg.guest_env.get("NEW").map(String::as_str),
-            Some("cli-only")
+            envs.get("FROM_CFG").map(String::as_str),
+            Some("cfg-value"),
+            "config.toml [guest_env] entries must still flow through",
         );
     }
 
     #[test]
-    fn merge_cli_guest_env_allows_empty_value() {
-        let mut cfg = super::config::CoopConfig::default();
-        super::merge_cli_guest_env(&mut cfg, &["CLEAR=".to_string()]).unwrap();
-        assert_eq!(cfg.guest_env.get("CLEAR").map(String::as_str), Some(""));
-    }
+    fn prepare_session_skips_overlay_without_instance() {
+        use std::num::NonZeroU16;
 
-    #[test]
-    fn merge_cli_guest_env_rejects_missing_equals() {
-        let mut cfg = super::config::CoopConfig::default();
-        let err = super::merge_cli_guest_env(&mut cfg, &["NO_EQUALS".to_string()]).unwrap_err();
-        assert!(err.to_string().contains("KEY=VALUE"));
-    }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = super::config::CoopConfig::default();
+        let target = super::backend::SshTarget {
+            host: "127.0.0.1".to_string(),
+            port: NonZeroU16::new(22).expect("non-zero"),
+            user: "ubuntu".to_string(),
+            key_path: tmp.path().join("id_test"),
+        };
 
-    #[test]
-    fn merge_cli_guest_env_rejects_empty_key() {
-        let mut cfg = super::config::CoopConfig::default();
-        let err = super::merge_cli_guest_env(&mut cfg, &["=value".to_string()]).unwrap_err();
-        assert!(err.to_string().contains("KEY"));
-    }
+        let session =
+            super::prepare_session_from_target(&cfg, None, target, None).expect("session");
 
-    #[test]
-    fn merge_cli_guest_env_value_may_contain_equals() {
-        let mut cfg = super::config::CoopConfig::default();
-        super::merge_cli_guest_env(&mut cfg, &["URL=https://x?a=b&c=d".to_string()]).unwrap();
-        assert_eq!(
-            cfg.guest_env.get("URL").map(String::as_str),
-            Some("https://x?a=b&c=d"),
+        assert!(
+            !session.env.contains("FROM_CLI"),
+            "without an instance, no persisted overlay should be applied",
         );
     }
 
@@ -2886,6 +2939,7 @@ mod tests {
             forward_ports: Vec::new(),
             config_path,
             post_start_override: None,
+            cli_guest_env: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -24,3 +24,27 @@ pub fn confirm(prompt: &str) -> Result<bool> {
         "y" | "yes"
     ))
 }
+
+/// Variant of [`confirm`] where the default (empty reply) is *yes*.
+///
+/// Used for "Use devcontainer.json?" — the answer is yes for any user
+/// who set the file up in the first place; this saves a keystroke without
+/// hiding the choice. Returns `Ok(false)` when stdin is not a TTY — the
+/// caller is responsible for surfacing a more specific non-interactive
+/// error if they want different behaviour.
+pub fn confirm_default_yes(prompt: &str) -> Result<bool> {
+    if !std::io::stdin().is_terminal() {
+        return Ok(false);
+    }
+    let mut stderr = std::io::stderr();
+    write!(stderr, "{prompt} [Y/n] ").context("Failed to write confirmation prompt")?;
+    stderr.flush().context("Failed to flush stderr")?;
+    let mut response = String::new();
+    std::io::stdin()
+        .read_line(&mut response)
+        .context("Failed to read confirmation")?;
+    match response.trim().to_ascii_lowercase().as_str() {
+        "" | "y" | "yes" => Ok(true),
+        _ => Ok(false),
+    }
+}

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2354,17 +2354,20 @@ test_port_forwards() {
     fi
 
     # Collision: starting another forward to the same host port should error.
+    # The coop() wrapper captures the binary's stderr into $HARNESS_ERR — an
+    # outer `2>` redirect here would be shadowed by the wrapper's internal
+    # redirect and silently capture nothing.
     local fwd_instance2="${INSTANCE}-fwd2"
-    if coop start "$fwd_instance2" --no-agents --forward-port "9999:${host_port}" 2>"$content_file.err"; then
+    if coop start "$fwd_instance2" --no-agents --forward-port "9999:${host_port}"; then
         STARTED_INSTANCES+=("$fwd_instance2")
         fail "collision detection rejects in-use host port" "start unexpectedly succeeded"
         coop destroy "$fwd_instance2" 2>/dev/null || true
         untrack_instance "$fwd_instance2"
     else
-        if grep -q "already in use" "$content_file.err"; then
+        if grep -q "already in use" <<<"$HARNESS_ERR"; then
             pass "collision detection rejects in-use host port"
         else
-            fail "collision detection rejects in-use host port" "stderr: $(cat "$content_file.err")"
+            fail "collision detection rejects in-use host port" "stderr: $HARNESS_ERR"
         fi
     fi
 
@@ -2383,7 +2386,7 @@ test_port_forwards() {
 
     coop destroy "$fwd_instance" 2>/dev/null || true
     untrack_instance "$fwd_instance"
-    rm -f "$content_file" "$content_file.got" "$content_file.err"
+    rm -f "$content_file" "$content_file.got"
 }
 
 test_mount_conflicts() {

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1309,14 +1309,30 @@ test_list_empty() {
     echo ""
     echo "=== Phase: list (no instances) ==="
 
-    if coop list; then
-        if echo "$HARNESS_OUT" | grep -q "No instances found"; then
-            pass "list shows empty-state message"
-        else
-            fail "list shows empty-state message" "got: $HARNESS_OUT"
-        fi
-    else
+    if ! coop list; then
         fail "list exits 0 with no instances" "exit code: $?"
+        return
+    fi
+
+    # Dev/CI hosts may carry long-lived instances unrelated to this run.
+    # Assert what this phase actually owns: the just-destroyed `$INSTANCE`
+    # is gone. The empty-state message is only asserted on a clean host.
+    local instance_count
+    instance_count=$(RUST_LOG=off "$BINARY" status 2>/dev/null | grep -cE "running|stopped" || true)
+
+    if [[ "$instance_count" -gt 0 ]]; then
+        if echo "$HARNESS_OUT" | grep -qE "^${INSTANCE} "; then
+            fail "destroyed instance no longer in list" "still present: $HARNESS_OUT"
+        else
+            pass "destroyed instance no longer in list ($instance_count other(s) present)"
+        fi
+        return
+    fi
+
+    if echo "$HARNESS_OUT" | grep -q "No instances found"; then
+        pass "list shows empty-state message"
+    else
+        fail "list shows empty-state message" "got: $HARNESS_OUT"
     fi
 }
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2823,6 +2823,160 @@ test_interrupted_setup() {
     coop images --delete "$img" 2>/dev/null || true
 }
 
+# ── devcontainer.json translator (pre-VM + --full) ────────────
+
+# Write a sample devcontainer.json into $1/.devcontainer/devcontainer.json.
+# Exercises JSONC features (comments + trailing commas) so the integration
+# run also catches parser regressions, not just the unit tests.
+_write_devcontainer() {
+    local dir="$1"
+    mkdir -p "$dir/.devcontainer"
+    cat > "$dir/.devcontainer/devcontainer.json" <<'EOF'
+{
+    // sample devcontainer.json — coop reads a subset.
+    "name": "coop-it-demo",
+    "image": "ubuntu:22.04",
+    "hostRequirements": {
+        "cpus": 2,
+        "memory": "1GiB",
+    },
+    "containerEnv": {
+        "COOP_TEST_DEVCONTAINER": "applied",
+    },
+    "forwardPorts": [3000],
+    "postStartCommand": "echo dc-hooked > /tmp/coop-dc-marker",
+    "remoteUser": "root",
+}
+EOF
+}
+
+test_devcontainer_translator() {
+    echo ""
+    echo "=== Phase: devcontainer.json translator (dry-run) ==="
+
+    local dcdir="$tmpdir/devcontainer-ws"
+    _write_devcontainer "$dcdir"
+    local dcfile="$dcdir/.devcontainer/devcontainer.json"
+
+    # --dry-run with auto-discovery: report is printed to stderr, no VM work.
+    if coop start "${INSTANCE}-dc-dry" --workspace "$dcdir" --dry-run --no-agents; then
+        pass "start --workspace ... --dry-run exits 0"
+    else
+        fail "start --workspace ... --dry-run exits 0" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    # Report content lands on stderr (per the CLAUDE.md "tracing → stderr" rule).
+    if grep -q "hostRequirements.cpus" <<< "$HARNESS_ERR" \
+        && grep -q "applied" <<< "$HARNESS_ERR"; then
+        pass "dry-run report covers hostRequirements"
+    else
+        fail "dry-run report covers hostRequirements" "stderr: $HARNESS_ERR"
+    fi
+
+    # JSONC: the file uses //-comments and trailing commas; parser must accept.
+    if grep -q "containerEnv" <<< "$HARNESS_ERR"; then
+        pass "JSONC (comments + trailing commas) parses"
+    else
+        fail "JSONC (comments + trailing commas) parses" "stderr: $HARNESS_ERR"
+    fi
+
+    # remoteUser != ubuntu must surface as unsupported.
+    if grep -q "remoteUser" <<< "$HARNESS_ERR" \
+        && grep -q "unsupported" <<< "$HARNESS_ERR"; then
+        pass "remoteUser != ubuntu is reported unsupported"
+    else
+        fail "remoteUser != ubuntu is reported unsupported" "stderr: $HARNESS_ERR"
+    fi
+
+    # --no-devcontainer silently skips the file: the report header must NOT appear.
+    # `--dry-run` lets us exercise the discovery path without any VM work.
+    if coop start "${INSTANCE}-dc-skip" --workspace "$dcdir" \
+        --no-devcontainer --dry-run --no-agents; then
+        if grep -q "devcontainer.json:" <<< "$HARNESS_ERR"; then
+            fail "--no-devcontainer suppresses discovery" "report header still appeared: $HARNESS_ERR"
+        else
+            pass "--no-devcontainer suppresses discovery"
+        fi
+    else
+        fail "--no-devcontainer suppresses discovery" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    # Non-interactive + discovered file + no escape hatch must error with the
+    # hint pointing at --devcontainer / --no-devcontainer.
+    if moat_fails start "${INSTANCE}-dc-noopt" --workspace "$dcdir" --no-agents; then
+        if grep -qi "devcontainer" <<< "$HARNESS_ERR" \
+            && grep -q -- "--no-devcontainer" <<< "$HARNESS_ERR"; then
+            pass "non-TTY without escape hatch errors with hint"
+        else
+            fail "non-TTY without escape hatch errors with hint" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "non-TTY without escape hatch errors with hint" "expected non-zero exit"
+    fi
+
+    # CLI overrides devcontainer.json values — report should mark cpus as
+    # "overridden" with source = CLI.
+    if coop start "${INSTANCE}-dc-override" --workspace "$dcdir" \
+        --vcpus 8 --dry-run --no-agents; then
+        pass "start --dry-run with overriding CLI flag exits 0"
+    else
+        fail "start --dry-run with overriding CLI flag exits 0" "stderr: $HARNESS_ERR"
+        return
+    fi
+    if grep "hostRequirements.cpus" <<< "$HARNESS_ERR" | grep -q "overridden"; then
+        pass "CLI --vcpus is reported as overriding devcontainer.json"
+    else
+        fail "CLI --vcpus is reported as overriding devcontainer.json" "stderr: $HARNESS_ERR"
+    fi
+}
+
+# ── devcontainer.json apply (--full only) ─────────────────────
+
+test_devcontainer_apply() {
+    echo ""
+    echo "=== Phase: devcontainer.json apply (--full) ==="
+
+    local dcdir="$tmpdir/devcontainer-apply-ws"
+    _write_devcontainer "$dcdir"
+    local dcfile="$dcdir/.devcontainer/devcontainer.json"
+    local inst_name="${INSTANCE}-dc-apply"
+
+    # Use explicit --devcontainer to skip the prompt in CI.
+    if coop start "$inst_name" --workspace "$dcdir" \
+        --devcontainer "$dcfile" --no-agents; then
+        STARTED_INSTANCES+=("$inst_name")
+        pass "start with --devcontainer exits 0"
+    else
+        fail "start with --devcontainer exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        return
+    fi
+
+    GUEST_INSTANCE="$inst_name"
+
+    # containerEnv must reach the guest as a literal env var.
+    local seen_env
+    seen_env=$(guest_exec printenv COOP_TEST_DEVCONTAINER 2>/dev/null) || seen_env=""
+    if [[ "$seen_env" == "applied" ]]; then
+        pass "containerEnv reached the guest"
+    else
+        fail "containerEnv reached the guest" "got: '$seen_env'"
+    fi
+
+    # postStartCommand must have written the marker.
+    local seen_marker
+    seen_marker=$(guest_exec cat /tmp/coop-dc-marker 2>/dev/null) || seen_marker=""
+    if [[ "$seen_marker" == *dc-hooked* ]]; then
+        pass "postStartCommand ran in the guest"
+    else
+        fail "postStartCommand ran in the guest" "marker contents: '$seen_marker'"
+    fi
+
+    unset GUEST_INSTANCE
+
+    coop destroy "$inst_name" 2>/dev/null || true
+    untrack_instance "$inst_name"
+}
+
 # ── post_start hook (--full only) ──────────────────────────────
 
 test_post_start() {
@@ -2932,6 +3086,7 @@ main() {
     test_invalid_names
     test_profiles_cli
     test_completions
+    test_devcontainer_translator
 
     # Setup + primary instance
     test_setup
@@ -2986,6 +3141,7 @@ main() {
         test_custom_profiles
         test_builtin_profiles
         test_post_start
+        test_devcontainer_apply
 
         # Local marketplace directory copy
         test_local_marketplace

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2349,12 +2349,28 @@ test_port_forwards() {
 
     GUEST_INSTANCE="$fwd_instance"
 
-    # Run a one-shot HTTP listener in the guest. `nc -l -p` is in the
-    # ubuntu-minimal CI image; pipe a canned HTTP response and exit.
-    # Backgrounded via nohup so the SSH exec returns immediately.
+    # Run a one-shot HTTP listener in the guest. The Firecracker CI rootfs
+    # ships no netcat variant (only socat among net listeners), so we use
+    # python3, which is present on both Firecracker (pulled in via
+    # python3-boto3) and Lima (Ubuntu cloud image default). The listener
+    # script is embedded as a heredoc; coop shell single-quotes each arg,
+    # so newlines pass through to the remote sh -c untouched.
     local payload
     payload=$(cat "$content_file")
-    guest_exec sh -c "nohup sh -c 'printf \"HTTP/1.1 200 OK\\r\\nContent-Length: ${#payload}\\r\\n\\r\\n${payload}\" | nc -l -p ${guest_port} -q 1 > /tmp/fwd.log 2>&1' >/dev/null 2>&1 &" || true
+    guest_exec sh -c "cat > /tmp/fwd.py <<'PYEOF'
+import socket, sys
+port = int(sys.argv[1])
+body = sys.argv[2].encode()
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', port))
+s.listen(1)
+c, _ = s.accept()
+c.recv(65536)
+c.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s' % (len(body), body))
+c.close()
+PYEOF
+nohup python3 /tmp/fwd.py ${guest_port} ${payload} > /tmp/fwd.log 2>&1 &" || true
     sleep 1
 
     if curl -fsS --max-time 3 "http://127.0.0.1:${host_port}/" > "$content_file.got"; then


### PR DESCRIPTION
## Summary

- Add a `devcontainer.json` translator that maps a recognised subset to coop's existing primitives (`hostRequirements` → `--vcpus`/`--mem`/`--disk`, `containerEnv` → `guest_env`, `forwardPorts` → `--forward-port`, `postStartCommand` → `post_start`, `features` → built-in profiles, `mounts` → `--mount`). Unsupported keys produce a "warn-and-skip" row in the report rather than silently degrading.
- New flags on `setup` and `start`: `--devcontainer PATH`, `--no-devcontainer`, `--dry-run`. When a workspace (or mount root) contains `.devcontainer/devcontainer.json` and no escape-hatch flag is set, coop prompts before applying. Non-TTY without an escape hatch errors with a hint.
- Parsing handles JSONC (`//` and `/* */` comments, trailing commas) so real-world devcontainer files load directly. Precedence is CLI > devcontainer.json > defaults; the per-key report column makes overrides explicit.

The implementation is in `src/devcontainer.rs` with 19 unit tests covering JSONC parsing, translation, precedence, mount/feature edge cases, and report rendering. Docs: `docs/devcontainer.md` (supported keys + discovery rules) and an updated `docs/commands.md`.

## Also fixes

Closes #135. The integration test for `--forward-port` collision detection was redirecting stderr on the outside of the `coop()` test wrapper, which is shadowed by the wrapper's internal redirect into `$HARNESS_ERR` — so the assertion grepped an empty file and always took the `else` branch. The collision check itself in `src/port_forward.rs` is correct; the fix reads `$HARNESS_ERR` like every other stderr-asserting test in the suite.

Closes #133. `test_list_empty` asserted `coop list` prints "No instances found" after the destroy phase, which breaks on any host carrying a long-lived instance unrelated to the run. The sibling phase right above it (`test_auto_resolve_no_instances`) already skips-on-other-state; this brings `test_list_empty` in line: when other instances exist, verify the just-destroyed `$INSTANCE` is gone; only assert the empty-state message on a clean host.

Closes #132. The `--forward-port` integration test invoked `nc -l -p 8765` in the guest, but the Firecracker CI rootfs ships no netcat variant (only `socat` among net listeners — see `firecracker/resources/rootfs/setup-ubuntu-ci.sh`). With no listener bound in the guest, the SSH `-L` channel-open failed and OpenSSH closed the accepted host socket while curl's GET request was still in the receive buffer, producing the observed RST. Replaced the nc invocation with a small python3 socket listener delivered via heredoc inside the same `guest_exec sh -c` call. python3 is present on both backends, so no guest package is added.

Closes #131. `coop start --env KEY=VALUE` only lived in the start process's in-memory `cfg.guest_env`. The follow-on `coop shell -- printenv` in `test_guest_environment` is a separate process that reloads `config.toml` from scratch, so its SSH `SendEnv` set never contained the CLI value and `printenv` exited 1. Persist the parsed `--env` map to `<inst.dir>/guest_env.json` at start (mirrors `ForwardsState`), and overlay it onto the resolved env-forward set whenever a session is opened against a running instance. Restart merges new `--env` on top of the snapshot (CLI wins per-key) and rewrites the file so the next stop/start cycle keeps the latest applied set. `[guest_env]` from `config.toml` deliberately stays out of the snapshot — it is re-read every invocation so edits between `start` and `shell` still take effect. The hypothesis in the issue (sshd `AcceptEnv` mismatch) was incorrect; both backends already set `AcceptEnv *` and would forward the value if it were ever sent.

Closes #134. The `containerEnv reached the guest` assertion in `test_devcontainer_apply` failed on Linux/Firecracker `--full` runs because `coop start --devcontainer` applied `containerEnv` to the in-memory `cfg.guest_env` only — the follow-on `coop shell -- printenv` reloaded `config.toml` and never re-parsed `--devcontainer`, so the SSH `SendEnv` set was empty. The #131 fix had snapshotted CLI `--env` for the same reason but explicitly excluded devcontainer-derived entries on the assumption that they would be "re-read every invocation"; only `setup` and `start` re-translate `devcontainer.json`, so `shell`/`exec` had nothing to overlay. Extend `<inst.dir>/guest_env.json` to be the union of CLI `--env` and devcontainer `containerEnv` (CLI wins on key conflict, matching the documented "CLI > devcontainer.json" precedence). The translator already filters CLI keys out of its own `guest_env` map, so the union has no real overlap; the explicit CLI-wins insertion is defensive. `StartOpts.cli_guest_env` is renamed to `persisted_guest_env` to reflect the broader snapshot semantics.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 451 tests pass (19 new in `devcontainer::tests`, 9 in `guest_env_state::tests` from the #131 fix + 3 new `merge_persisted_entries_*` for the #134 fix, 2 new `prepare_session_*` in `main::tests`)
- [x] `tests/integration.sh` — added `test_devcontainer_translator` (pre-VM, dry-run path) and `test_devcontainer_apply` (`--full` only, asserts `containerEnv` and `postStartCommand` reach the guest). The pre-VM phase runs to completion (8/8 PASS) before the existing setup phase hits the host's KVM requirement. The `test_guest_environment` phase's `guest_env from --env reaches the guest` assertion (issue #131) is covered by this same `--full` run.
- [x] Run `./tests/run-integration.sh` on Linux/Firecracker (`--full`) — also re-validates the #135 collision assertion, the #133 list-empty fix, the #132 python3 listener replacing nc, the #131 `--env` persistence, and the #134 `containerEnv` persistence
- [x] Run `./tests/run-integration.sh` on macOS/Lima (`--full`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
