### PR TITLE
Introduce `RepoSlug` newtype and return it from parsers (closes #149)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -896,7 +896,9 @@ pub type PlatformBackend = FirecrackerBackend;
 /// `mount` source has a host path we can scan for a `.git/config`
 /// `origin`. Returns `None` when no slug can be derived — pat-mode
 /// then falls back to a clear error.
-pub fn detect_instance_repo(inst: &crate::config::Instance) -> Option<String> {
+pub fn detect_instance_repo(
+    inst: &crate::config::Instance,
+) -> Option<crate::github_repo::RepoSlug> {
     use crate::workspace::WorkspaceSource;
 
     let state = crate::workspace::WorkspaceState::try_load(inst)
@@ -926,7 +928,10 @@ pub fn detect_instance_repo(inst: &crate::config::Instance) -> Option<String> {
 /// `git remote get-url origin` of the workspace. Pass `None` when no
 /// repo context is available; pat-mode then yields no token (the start
 /// flow surfaces a clearer error elsewhere).
-pub fn prepare_env_forwarding(cfg: &CoopConfig, repo: Option<&str>) -> Result<EnvForward> {
+pub fn prepare_env_forwarding(
+    cfg: &CoopConfig,
+    repo: Option<&crate::github_repo::RepoSlug>,
+) -> Result<EnvForward> {
     let claude = &cfg.claude;
     let codex = &cfg.codex;
     let mut env = EnvForward::default();
@@ -1167,7 +1172,7 @@ fn compute_plugin_delta(cfg: &CoopConfig, image: &str) -> (Vec<String>, Vec<Stri
 /// with an entry that fails to resolve).
 fn resolve_github_token(
     strategy: Option<&GitHubAuth>,
-    repo: Option<&str>,
+    repo: Option<&crate::github_repo::RepoSlug>,
 ) -> Result<Option<String>> {
     // Default to Off — never forward tokens without explicit opt-in.
     // Users must set `github = "auto"` / `"env"` / `"pat"` in
@@ -1215,7 +1220,10 @@ fn resolve_github_token(
 
 /// Look up a `[github.pat."repo"]` entry and resolve its `token` via
 /// the `cmd:` indirection.
-fn resolve_pat_token(strategy: Option<&GitHubAuth>, repo: &str) -> Result<String> {
+fn resolve_pat_token(
+    strategy: Option<&GitHubAuth>,
+    repo: &crate::github_repo::RepoSlug,
+) -> Result<String> {
     let entry = strategy
         .and_then(|s| s.pat_entry(repo))
         .with_context(|| crate::github_pat::missing_entry_error(repo))?;
@@ -1734,7 +1742,10 @@ pub fn clone_git_repo(
 /// Returning `None` directs [`resolve_clone_token`] to fall through to
 /// [`host_github_token`] — preserving the pre-PAT behaviour for `Auto`,
 /// `Env`, `Off`, and `Pat`-without-a-matching-entry.
-fn clone_pat_slug(strategy: Option<&GitHubAuth>, repo_url: &str) -> Option<String> {
+fn clone_pat_slug(
+    strategy: Option<&GitHubAuth>,
+    repo_url: &str,
+) -> Option<crate::github_repo::RepoSlug> {
     let strategy = strategy?;
     let GitHubAuth::Pat(_) = strategy else {
         return None;
@@ -2215,8 +2226,9 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
     fn pat_auth_with(entries: &[(&str, &str)]) -> GitHubAuth {
         let mut map = std::collections::BTreeMap::new();
         for (slug, token) in entries {
+            let slug = crate::github_repo::RepoSlug::new(slug).unwrap();
             map.insert(
-                (*slug).to_string(),
+                slug,
                 crate::config::PatEntry {
                     token: crate::config::Secret::new((*token).to_string()),
                 },
@@ -2231,9 +2243,10 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
     #[test]
     fn clone_pat_slug_matches_when_entry_exists() {
         let auth = pat_auth_with(&[("owner/repo", "github_pat_dummy")]);
+        let expected = crate::github_repo::RepoSlug::new("owner/repo").unwrap();
         assert_eq!(
-            clone_pat_slug(Some(&auth), "https://github.com/owner/repo.git").as_deref(),
-            Some("owner/repo")
+            clone_pat_slug(Some(&auth), "https://github.com/owner/repo.git"),
+            Some(expected)
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -638,7 +638,7 @@ impl GitHubAuth {
     /// Look up a `[github.pat."owner/repo"]` entry by repo slug.
     ///
     /// Returns `None` for non-pat modes or when no entry exists.
-    pub fn pat_entry(&self, repo: &str) -> Option<&PatEntry> {
+    pub fn pat_entry(&self, repo: &crate::github_repo::RepoSlug) -> Option<&PatEntry> {
         match self {
             Self::Pat(cfg) => cfg.entries.get(repo),
             _ => None,
@@ -652,11 +652,13 @@ pub struct PatConfig {
     /// Per-repo PAT entries, keyed by `owner/repo`.
     ///
     /// Uses `BTreeMap` so TOML serialization is stable across runs.
+    /// Invalid slugs are rejected at deserialization time by
+    /// [`RepoSlug`](crate::github_repo::RepoSlug).
     #[serde(default, rename = "pat")]
-    pub entries: std::collections::BTreeMap<String, PatEntry>,
+    pub entries: std::collections::BTreeMap<crate::github_repo::RepoSlug, PatEntry>,
     /// Repos for which the auto-prompt at `coop start` is suppressed.
     #[serde(default)]
-    pub skip: Vec<String>,
+    pub skip: Vec<crate::github_repo::RepoSlug>,
 }
 
 /// One per-repo PAT entry under `[github.pat."owner/repo"]`.
@@ -710,8 +712,10 @@ impl<'de> Deserialize<'de> for GitHubAuth {
                 }
 
                 let mut mode: Option<String> = None;
-                let mut entries: Option<std::collections::BTreeMap<String, PatEntry>> = None;
-                let mut skip: Option<Vec<String>> = None;
+                let mut entries: Option<
+                    std::collections::BTreeMap<crate::github_repo::RepoSlug, PatEntry>,
+                > = None;
+                let mut skip: Option<Vec<crate::github_repo::RepoSlug>> = None;
                 while let Some(field) = map.next_key::<Field>()? {
                     match field {
                         Field::Mode => mode = Some(map.next_value()?),
@@ -1193,22 +1197,9 @@ impl CoopConfig {
             }
         }
 
-        if let Some(GitHubAuth::Pat(pat)) = self.github.as_ref() {
-            for key in pat.entries.keys() {
-                if let Err(e) = crate::github_repo::validate_repo_slug(key) {
-                    errors.push(format!(
-                        "github.pat.\"{key}\" key is not a valid 'owner/repo' slug: {e}"
-                    ));
-                }
-            }
-            for slug in &pat.skip {
-                if let Err(e) = crate::github_repo::validate_repo_slug(slug) {
-                    errors.push(format!(
-                        "github.skip entry '{slug}' is not a valid 'owner/repo' slug: {e}"
-                    ));
-                }
-            }
-        }
+        // `[github.pat]` keys and `github.skip` entries are typed as
+        // `RepoSlug`; invalid values are rejected at config load time, so
+        // no per-key check is needed here.
 
         if errors.is_empty() {
             Ok(warnings)
@@ -2372,10 +2363,9 @@ token = "cmd:echo y"
             other => panic!("expected Pat variant, got {other:?}"),
         };
         assert_eq!(pat.entries.len(), 2);
+        let slug = crate::github_repo::RepoSlug::new("trailofbits/coop").unwrap();
         assert_eq!(
-            pat.entries
-                .get("trailofbits/coop")
-                .map(|e| e.token.expose().as_str()),
+            pat.entries.get(&slug).map(|e| e.token.expose().as_str()),
             Some("cmd:echo x")
         );
         assert!(pat.skip.is_empty());
@@ -2421,7 +2411,8 @@ skip = ["a/b"]
             GitHubAuth::Pat(p) => p,
             other => panic!("expected Pat variant, got {other:?}"),
         };
-        assert_eq!(pat.skip, vec!["a/b".to_string()]);
+        let ab = crate::github_repo::RepoSlug::new("a/b").unwrap();
+        assert_eq!(pat.skip, vec![ab]);
         assert!(pat.entries.is_empty());
     }
 
@@ -2434,35 +2425,66 @@ mode = "pat"
 token = "cmd:echo x"
 "#;
         let auth: GitHubAuth = toml::from_str(toml_str).unwrap();
-        let entry = auth.pat_entry("a/b").unwrap();
+        let ab = crate::github_repo::RepoSlug::new("a/b").unwrap();
+        let cd = crate::github_repo::RepoSlug::new("c/d").unwrap();
+        let entry = auth.pat_entry(&ab).unwrap();
         assert_eq!(entry.token.expose(), "cmd:echo x");
-        assert!(auth.pat_entry("c/d").is_none());
+        assert!(auth.pat_entry(&cd).is_none());
     }
 
     #[test]
     fn github_auth_lookup_returns_none_for_non_pat_modes() {
-        let auth = GitHubAuth::Auto;
-        assert!(auth.pat_entry("a/b").is_none());
-        let auth = GitHubAuth::Env;
-        assert!(auth.pat_entry("a/b").is_none());
-        let auth = GitHubAuth::Off;
-        assert!(auth.pat_entry("a/b").is_none());
+        let ab = crate::github_repo::RepoSlug::new("a/b").unwrap();
+        for auth in [GitHubAuth::Auto, GitHubAuth::Env, GitHubAuth::Off] {
+            assert!(auth.pat_entry(&ab).is_none());
+        }
+    }
+
+    #[test]
+    fn github_auth_table_form_rejects_invalid_pat_key() {
+        // Invalid slug as a `[github.pat."..."]` key fails at parse time.
+        let toml_str = r#"
+mode = "pat"
+
+[pat."not-a-slug"]
+token = "cmd:echo x"
+"#;
+        let err = toml::from_str::<GitHubAuth>(toml_str).unwrap_err();
+        assert!(
+            err.to_string().contains("owner/repo"),
+            "expected owner/repo error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn github_auth_table_form_rejects_invalid_skip_entry() {
+        let toml_str = r#"
+mode = "pat"
+skip = ["not-a-slug"]
+"#;
+        let err = toml::from_str::<GitHubAuth>(toml_str).unwrap_err();
+        assert!(
+            err.to_string().contains("owner/repo"),
+            "expected owner/repo error, got: {err}"
+        );
     }
 
     #[test]
     fn github_auth_serializes_round_trip_for_pat() {
         // pat-mode → table form; deserialize the serialized output and
         // confirm the entries survived.
+        let ab = crate::github_repo::RepoSlug::new("a/b").unwrap();
+        let cd = crate::github_repo::RepoSlug::new("c/d").unwrap();
         let mut entries = std::collections::BTreeMap::new();
         entries.insert(
-            "a/b".to_string(),
+            ab.clone(),
             PatEntry {
                 token: Secret::new("cmd:echo x".to_string()),
             },
         );
         let auth = GitHubAuth::Pat(PatConfig {
             entries,
-            skip: vec!["c/d".to_string()],
+            skip: vec![cd.clone()],
         });
         let serialized = toml::to_string(&auth).unwrap();
         let parsed: GitHubAuth = toml::from_str(&serialized).unwrap();
@@ -2470,9 +2492,9 @@ token = "cmd:echo x"
             GitHubAuth::Pat(p) => p,
             other => panic!("expected Pat variant after round-trip, got {other:?}"),
         };
-        assert_eq!(pat.skip, vec!["c/d".to_string()]);
+        assert_eq!(pat.skip, vec![cd]);
         assert_eq!(
-            pat.entries.get("a/b").map(|e| e.token.expose().as_str()),
+            pat.entries.get(&ab).map(|e| e.token.expose().as_str()),
             Some("cmd:echo x")
         );
     }

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -23,7 +23,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::cmd::Cmd;
 use crate::config::{CoopConfig, GitHubAuth, resolve_cmd_value};
-use crate::github_repo::{detect_workspace_repo, parse_repo_slug_from_url, validate_repo_slug};
+use crate::github_repo::{RepoSlug, detect_workspace_repo, parse_repo_slug_from_url};
 use crate::secret_store::{
     SERVICE, account_for_repo, available_backends, delete_secret, infer_backend, store_secret,
 };
@@ -46,7 +46,6 @@ pub struct SetupOpts<'a> {
 /// entry and any matching skip-marker is removed.
 pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
     let repo = resolve_target_repo(opts.repo, None)?;
-    validate_repo_slug(&repo)?;
 
     print_form_instructions(&repo);
     open_browser_best_effort(PAT_NEW_URL);
@@ -145,16 +144,16 @@ pub fn run_status(cfg: &CoopConfig, probe: bool) {
 /// `coop github forget-pat --repo owner/name` — remove the secret and
 /// the config entry. Does **not** add a skip marker.
 pub fn run_forget_pat(cfg: &CoopConfig, repo: &str, config_path: &Path) -> Result<()> {
-    validate_repo_slug(repo)?;
+    let repo = RepoSlug::new(repo)?;
     let entry = cfg
         .github
         .as_ref()
-        .and_then(|g| g.pat_entry(repo))
+        .and_then(|g| g.pat_entry(&repo))
         .with_context(|| {
             format!("No PAT entry for '{repo}' — nothing to forget. Run `coop github status`.")
         })?;
     let backend = infer_backend(entry.token.expose());
-    let account = account_for_repo(repo);
+    let account = account_for_repo(&repo);
     let state_dir = cfg.data_dir.join("state");
     if let Some(b) = backend {
         if let Err(e) = delete_secret(b, SERVICE, &account, &state_dir) {
@@ -166,7 +165,7 @@ pub fn run_forget_pat(cfg: &CoopConfig, repo: &str, config_path: &Path) -> Resul
              clean up the underlying secret manually if needed."
         );
     }
-    remove_pat_entry(config_path, repo)?;
+    remove_pat_entry(config_path, &repo)?;
     eprintln!("Removed PAT entry for {repo}.");
     eprintln!(
         "note: the token itself may still be live on GitHub — \
@@ -180,9 +179,9 @@ pub fn run_forget_pat(cfg: &CoopConfig, repo: &str, config_path: &Path) -> Resul
 
 /// Resolve the target repo from explicit `--repo`, fall back to a
 /// best-effort scan of the current working directory.
-fn resolve_target_repo(repo_arg: Option<&str>, git_repo_url: Option<&str>) -> Result<String> {
+fn resolve_target_repo(repo_arg: Option<&str>, git_repo_url: Option<&str>) -> Result<RepoSlug> {
     if let Some(repo) = repo_arg {
-        return Ok(repo.trim().to_string());
+        return RepoSlug::new(repo.trim());
     }
     if let Some(url) = git_repo_url
         && let Some(slug) = parse_repo_slug_from_url(url)
@@ -200,14 +199,11 @@ fn resolve_target_repo(repo_arg: Option<&str>, git_repo_url: Option<&str>) -> Re
     )
 }
 
-fn print_form_instructions(repo: &str) {
-    // Validation has already ensured repo is "owner/name".
-    let owner = repo.split('/').next().unwrap_or(repo);
-
+fn print_form_instructions(repo: &RepoSlug) {
     eprintln!("\nConfigure the form at {PAT_NEW_URL}:");
-    eprintln!("  Token name:        coop-{}", repo.replace('/', "-"));
+    eprintln!("  Token name:        coop-{}-{}", repo.owner(), repo.repo());
     eprintln!("  Expiration:        (your choice — 90 days is a reasonable default)");
-    eprintln!("  Resource owner:    {owner}");
+    eprintln!("  Resource owner:    {}", repo.owner());
     eprintln!("  Repository access: Only select repositories → {repo}");
     eprintln!("  Repository permissions:");
     eprintln!("    Contents:        Read and write");
@@ -309,7 +305,7 @@ fn probe_user(token: &str) -> Result<()> {
     Ok(())
 }
 
-fn probe_repo(token: &str, repo: &str) -> Result<()> {
+fn probe_repo(token: &str, repo: &RepoSlug) -> Result<()> {
     let url = format!("https://api.github.com/repos/{repo}");
     let (status, _body) = curl_with_token(token, &url)?;
     match status {
@@ -396,7 +392,7 @@ fn pick_backend() -> Result<crate::secret_store::Backend> {
 /// read-modify-write window so concurrent wizard invocations (e.g. two
 /// `coop start` auto-prompts firing at once) don't lose each other's
 /// writes.
-fn upsert_pat_entry(path: &Path, repo: &str, token_cmd: &str) -> Result<()> {
+fn upsert_pat_entry(path: &Path, repo: &RepoSlug, token_cmd: &str) -> Result<()> {
     let _lock = crate::fs_util::lock_sibling(path)?;
     let original = read_or_init_doc(path)?;
     let mut doc = original.clone();
@@ -433,13 +429,13 @@ fn upsert_pat_entry(path: &Path, repo: &str, token_cmd: &str) -> Result<()> {
         "token".to_string(),
         toml::Value::String(token_cmd.to_string()),
     );
-    pat_tbl.insert(repo.to_string(), toml::Value::Table(entry));
+    pat_tbl.insert(repo.as_str().to_string(), toml::Value::Table(entry));
 
     // Drop the repo from the skip list, if present.
     if let Some(skip) = github_tbl.get_mut("skip")
         && let Some(arr) = skip.as_array_mut()
     {
-        arr.retain(|v| v.as_str() != Some(repo));
+        arr.retain(|v| v.as_str() != Some(repo.as_str()));
     }
 
     // Skip the rewrite when the parsed result equals what's already on disk.
@@ -456,7 +452,7 @@ fn upsert_pat_entry(path: &Path, repo: &str, token_cmd: &str) -> Result<()> {
     write_doc(path, &doc)
 }
 
-fn remove_pat_entry(path: &Path, repo: &str) -> Result<()> {
+fn remove_pat_entry(path: &Path, repo: &RepoSlug) -> Result<()> {
     if !path.exists() {
         return Ok(());
     }
@@ -467,7 +463,7 @@ fn remove_pat_entry(path: &Path, repo: &str) -> Result<()> {
             .get_mut("pat")
             .and_then(toml::Value::as_table_mut)
     {
-        pat_tbl.remove(repo);
+        pat_tbl.remove(repo.as_str());
     }
     write_doc(path, &doc)
 }
@@ -482,8 +478,7 @@ fn remove_pat_entry(path: &Path, repo: &str) -> Result<()> {
 /// (with no entries) here is a no-op for token forwarding — pat-mode
 /// with no entries forwards no token, same as "off" — while making
 /// per-repo skip state survive a config reload.
-pub fn add_skip_marker(path: &Path, repo: &str) -> Result<()> {
-    validate_repo_slug(repo)?;
+pub fn add_skip_marker(path: &Path, repo: &RepoSlug) -> Result<()> {
     let _lock = crate::fs_util::lock_sibling(path)?;
     let mut doc = read_or_init_doc(path)?;
     let github = doc
@@ -505,8 +500,8 @@ pub fn add_skip_marker(path: &Path, repo: &str) -> Result<()> {
         *skip = toml::Value::Array(Vec::new());
     }
     let arr = skip.as_array_mut().context("github.skip is not an array")?;
-    if !arr.iter().any(|v| v.as_str() == Some(repo)) {
-        arr.push(toml::Value::String(repo.to_string()));
+    if !arr.iter().any(|v| v.as_str() == Some(repo.as_str())) {
+        arr.push(toml::Value::String(repo.as_str().to_string()));
     }
     write_doc(path, &doc)
 }
@@ -555,7 +550,7 @@ fn doc_contains_literal_token(doc: &toml::Value) -> bool {
 
 /// Hint helper used by `coop start` and other code paths to format the
 /// "no entry for this repo" error consistently.
-pub fn missing_entry_error(repo: &str) -> String {
+pub fn missing_entry_error(repo: &RepoSlug) -> String {
     format!(
         "No GitHub PAT configured for '{repo}'. \
          Run `coop github setup-pat --repo {repo}` to add one, \
@@ -578,14 +573,19 @@ pub(crate) fn pat_config_at(path: &Path) -> Result<Option<crate::config::PatConf
 mod tests {
     use super::*;
 
+    fn slug(s: &str) -> RepoSlug {
+        RepoSlug::new(s).unwrap()
+    }
+
     #[test]
     fn upsert_creates_new_file_with_entry() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
-        upsert_pat_entry(&path, "trailofbits/coop", "cmd:cat ./t.txt").unwrap();
+        let s = slug("trailofbits/coop");
+        upsert_pat_entry(&path, &s, "cmd:cat ./t.txt").unwrap();
         let cfg = pat_config_at(&path).unwrap().unwrap();
         assert_eq!(cfg.entries.len(), 1);
-        let entry = cfg.entries.get("trailofbits/coop").unwrap();
+        let entry = cfg.entries.get(&s).unwrap();
         assert_eq!(entry.token.expose(), "cmd:cat ./t.txt");
     }
 
@@ -600,7 +600,7 @@ mod tests {
              vcpu_count = 4\n",
         )
         .unwrap();
-        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        upsert_pat_entry(&path, &slug("a/b"), "cmd:echo x").unwrap();
         let s = std::fs::read_to_string(&path).unwrap();
         assert!(s.contains("ssh_port = 2222"));
         assert!(s.contains("vcpu_count = 4"));
@@ -612,7 +612,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, "github = \"off\"\n").unwrap();
-        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        upsert_pat_entry(&path, &slug("a/b"), "cmd:echo x").unwrap();
         let cfg = CoopConfig::load(&path).unwrap();
         assert!(matches!(cfg.github, Some(GitHubAuth::Pat(_))));
     }
@@ -627,7 +627,7 @@ mod tests {
         let path = tmp.path().join("config.toml");
         let original = "# user comment\n[github]\nmode = \"pat\"\n\n[github.pat.\"a/b\"]\ntoken = \"cmd:echo x\"\n";
         std::fs::write(&path, original).unwrap();
-        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        upsert_pat_entry(&path, &slug("a/b"), "cmd:echo x").unwrap();
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(
             after, original,
@@ -644,16 +644,16 @@ mod tests {
             "[github]\nmode = \"pat\"\nskip = [\"a/b\", \"c/d\"]\n",
         )
         .unwrap();
-        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        upsert_pat_entry(&path, &slug("a/b"), "cmd:echo x").unwrap();
         let cfg = pat_config_at(&path).unwrap().unwrap();
-        assert_eq!(cfg.skip, vec!["c/d".to_string()]);
+        assert_eq!(cfg.skip, vec![slug("c/d")]);
     }
 
     #[test]
     fn remove_pat_entry_is_idempotent_on_missing() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
-        remove_pat_entry(&path, "x/y").unwrap();
+        remove_pat_entry(&path, &slug("x/y")).unwrap();
         assert!(!path.exists());
     }
 
@@ -666,20 +666,20 @@ mod tests {
             "[github]\nmode = \"pat\"\n\n[github.pat.\"a/b\"]\ntoken = \"cmd:echo x\"\n\n[github.pat.\"c/d\"]\ntoken = \"cmd:echo y\"\n",
         )
         .unwrap();
-        remove_pat_entry(&path, "a/b").unwrap();
+        remove_pat_entry(&path, &slug("a/b")).unwrap();
         let cfg = pat_config_at(&path).unwrap().unwrap();
-        assert!(!cfg.entries.contains_key("a/b"));
-        assert!(cfg.entries.contains_key("c/d"));
+        assert!(!cfg.entries.contains_key(&slug("a/b")));
+        assert!(cfg.entries.contains_key(&slug("c/d")));
     }
 
     #[test]
     fn skip_marker_added_idempotent() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
-        add_skip_marker(&path, "a/b").unwrap();
-        add_skip_marker(&path, "a/b").unwrap();
+        add_skip_marker(&path, &slug("a/b")).unwrap();
+        add_skip_marker(&path, &slug("a/b")).unwrap();
         let cfg = pat_config_at(&path).unwrap().unwrap();
-        assert_eq!(cfg.skip, vec!["a/b".to_string()]);
+        assert_eq!(cfg.skip, vec![slug("a/b")]);
     }
 
     #[test]
@@ -689,9 +689,9 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, "github = \"off\"\n").unwrap();
-        add_skip_marker(&path, "a/b").unwrap();
+        add_skip_marker(&path, &slug("a/b")).unwrap();
         let cfg = pat_config_at(&path).unwrap().unwrap();
-        assert_eq!(cfg.skip, vec!["a/b".to_string()]);
+        assert_eq!(cfg.skip, vec![slug("a/b")]);
     }
 
     #[test]
@@ -702,16 +702,16 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, "github = \"off\"\n").unwrap();
-        add_skip_marker(&path, "a/b").unwrap();
-        upsert_pat_entry(&path, "a/b", "cmd:echo x").unwrap();
+        add_skip_marker(&path, &slug("a/b")).unwrap();
+        upsert_pat_entry(&path, &slug("a/b"), "cmd:echo x").unwrap();
         let cfg = pat_config_at(&path).unwrap().unwrap();
-        assert!(!cfg.skip.contains(&"a/b".to_string()));
-        assert!(cfg.entries.contains_key("a/b"));
+        assert!(!cfg.skip.contains(&slug("a/b")));
+        assert!(cfg.entries.contains_key(&slug("a/b")));
     }
 
     #[test]
     fn missing_entry_error_mentions_repo_and_command() {
-        let msg = missing_entry_error("trailofbits/coop");
+        let msg = missing_entry_error(&slug("trailofbits/coop"));
         assert!(msg.contains("trailofbits/coop"));
         assert!(msg.contains("setup-pat"));
     }

--- a/src/github_repo.rs
+++ b/src/github_repo.rs
@@ -1,39 +1,99 @@
 //! Helpers for parsing and validating GitHub repository identifiers.
 //!
 //! A *repo slug* is the canonical `owner/repo` form (e.g. `trailofbits/coop`).
-//! Used as the key for `[github.pat."owner/repo"]` entries.
+//! The [`RepoSlug`] newtype is the only constructor; once a value is held as
+//! `RepoSlug`, downstream code knows it is well-formed without re-validating.
 
+use std::fmt;
 use std::path::Path;
 use std::process::Command;
+use std::str::FromStr;
 
 use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
 
-/// Validate that `slug` matches `owner/repo` with GitHub-allowed characters.
+/// A validated `owner/repo` GitHub slug.
 ///
+/// The inner string is module-private — every value must come from
+/// [`RepoSlug::new`] (or [`FromStr`] / [`Deserialize`], both of which
+/// delegate to it). The constructor enforces:
+/// - exactly one `/` separator
+/// - non-empty owner and repo segments
+/// - GitHub-allowed characters only: ASCII alphanumerics plus `-`, `_`, `.`
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RepoSlug(String);
+
+impl RepoSlug {
+    /// Validate `s` and wrap it. Returns an error describing the violation.
+    pub fn new(s: &str) -> Result<Self> {
+        let (owner, repo) = s
+            .split_once('/')
+            .with_context(|| format!("Repo slug must be 'owner/repo', got '{s}'"))?;
+        if owner.is_empty() || repo.is_empty() {
+            bail!("Repo slug 'owner/repo' must have non-empty owner and repo: '{s}'");
+        }
+        if repo.contains('/') {
+            bail!("Repo slug must contain exactly one '/' separator: '{s}'");
+        }
+        if !is_valid_segment(owner) || !is_valid_segment(repo) {
+            bail!(
+                "Repo slug '{s}' contains invalid characters \
+                 (allowed: a-z, A-Z, 0-9, '-', '_', '.')"
+            );
+        }
+        Ok(Self(s.to_string()))
+    }
+
+    /// Borrow the slug as `&str` (for formatting / passing to `&str` APIs).
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Owner segment (left of the `/`).
+    pub fn owner(&self) -> &str {
+        // Constructor guarantees a single `/` with non-empty segments.
+        self.0.split_once('/').map_or(&self.0, |(o, _)| o)
+    }
+
+    /// Repository segment (right of the `/`).
+    pub fn repo(&self) -> &str {
+        self.0.split_once('/').map_or("", |(_, r)| r)
+    }
+}
+
 /// GitHub usernames and repo names allow ASCII letters, digits, `-`, `_`, `.`.
 /// Leading/trailing `.` or `-` is unusual but accepted by the API; we don't
 /// gate that here.
-pub fn validate_repo_slug(slug: &str) -> Result<()> {
-    let (owner, repo) = slug
-        .split_once('/')
-        .with_context(|| format!("Repo slug must be 'owner/repo', got '{slug}'"))?;
-    if owner.is_empty() || repo.is_empty() {
-        bail!("Repo slug 'owner/repo' must have non-empty owner and repo: '{slug}'");
+fn is_valid_segment(s: &str) -> bool {
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+impl fmt::Display for RepoSlug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
     }
-    if repo.contains('/') {
-        bail!("Repo slug must contain exactly one '/' separator: '{slug}'");
+}
+
+impl FromStr for RepoSlug {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
     }
-    let valid = |s: &str| {
-        s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
-    };
-    if !valid(owner) || !valid(repo) {
-        bail!(
-            "Repo slug '{slug}' contains invalid characters \
-             (allowed: a-z, A-Z, 0-9, '-', '_', '.')"
-        );
+}
+
+impl Serialize for RepoSlug {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
     }
-    Ok(())
+}
+
+impl<'de> Deserialize<'de> for RepoSlug {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::new(&s).map_err(serde::de::Error::custom)
+    }
 }
 
 /// Schemes recognised by [`parse_repo_slug_from_url`].
@@ -52,8 +112,9 @@ const GITHUB_URL_PREFIXES: &[&str] = &[
 /// - `git@github.com:owner/repo`
 /// - `ssh://git@github.com/owner/repo`
 ///
-/// Returns `None` for non-GitHub URLs or malformed input.
-pub fn parse_repo_slug_from_url(url: &str) -> Option<String> {
+/// Returns `None` for non-GitHub URLs, malformed input, or paths whose
+/// owner/repo segments are not valid GitHub identifiers.
+pub fn parse_repo_slug_from_url(url: &str) -> Option<RepoSlug> {
     let trimmed = url.trim();
     for prefix in GITHUB_URL_PREFIXES {
         if let Some(rest) = trimmed.strip_prefix(prefix) {
@@ -63,7 +124,7 @@ pub fn parse_repo_slug_from_url(url: &str) -> Option<String> {
     None
 }
 
-fn canonicalize(path: &str) -> Option<String> {
+fn canonicalize(path: &str) -> Option<RepoSlug> {
     let path = path.trim_end_matches('/');
     let path = path.strip_suffix(".git").unwrap_or(path);
     let (owner, repo) = path.split_once('/')?;
@@ -71,7 +132,7 @@ fn canonicalize(path: &str) -> Option<String> {
     if owner.is_empty() || repo.is_empty() || repo.contains('/') {
         return None;
     }
-    Some(format!("{owner}/{repo}"))
+    RepoSlug::new(&format!("{owner}/{repo}")).ok()
 }
 
 /// Detect the `owner/repo` slug for the GitHub remote of `git_dir`.
@@ -83,7 +144,7 @@ fn canonicalize(path: &str) -> Option<String> {
 /// `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` are stripped before
 /// invoking git so a parent hook context (e.g. a pre-commit running
 /// coop) can't redirect lookups to the wrong repository.
-pub fn detect_workspace_repo(git_dir: &Path) -> Result<Option<String>> {
+pub fn detect_workspace_repo(git_dir: &Path) -> Result<Option<RepoSlug>> {
     if !git_dir.exists() {
         return Ok(None);
     }
@@ -105,14 +166,19 @@ pub fn detect_workspace_repo(git_dir: &Path) -> Result<Option<String>> {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
+
+    fn slug(s: &str) -> RepoSlug {
+        RepoSlug::new(s).unwrap()
+    }
 
     #[test]
     fn parses_https_url() {
         assert_eq!(
             parse_repo_slug_from_url("https://github.com/trailofbits/coop"),
-            Some("trailofbits/coop".to_string())
+            Some(slug("trailofbits/coop"))
         );
     }
 
@@ -120,7 +186,7 @@ mod tests {
     fn parses_https_url_with_git_suffix() {
         assert_eq!(
             parse_repo_slug_from_url("https://github.com/trailofbits/coop.git"),
-            Some("trailofbits/coop".to_string())
+            Some(slug("trailofbits/coop"))
         );
     }
 
@@ -128,7 +194,7 @@ mod tests {
     fn parses_https_url_with_trailing_slash() {
         assert_eq!(
             parse_repo_slug_from_url("https://github.com/trailofbits/coop/"),
-            Some("trailofbits/coop".to_string())
+            Some(slug("trailofbits/coop"))
         );
     }
 
@@ -136,7 +202,7 @@ mod tests {
     fn parses_ssh_url() {
         assert_eq!(
             parse_repo_slug_from_url("git@github.com:trailofbits/coop"),
-            Some("trailofbits/coop".to_string())
+            Some(slug("trailofbits/coop"))
         );
     }
 
@@ -144,7 +210,7 @@ mod tests {
     fn parses_ssh_url_with_git_suffix() {
         assert_eq!(
             parse_repo_slug_from_url("git@github.com:trailofbits/coop.git"),
-            Some("trailofbits/coop".to_string())
+            Some(slug("trailofbits/coop"))
         );
     }
 
@@ -152,7 +218,7 @@ mod tests {
     fn parses_ssh_url_with_scheme() {
         assert_eq!(
             parse_repo_slug_from_url("ssh://git@github.com/trailofbits/coop.git"),
-            Some("trailofbits/coop".to_string())
+            Some(slug("trailofbits/coop"))
         );
     }
 
@@ -160,7 +226,7 @@ mod tests {
     fn parses_http_url() {
         assert_eq!(
             parse_repo_slug_from_url("http://github.com/trailofbits/coop"),
-            Some("trailofbits/coop".to_string())
+            Some(slug("trailofbits/coop"))
         );
     }
 
@@ -186,30 +252,81 @@ mod tests {
     }
 
     #[test]
-    fn validates_canonical_slug() {
-        assert!(validate_repo_slug("trailofbits/coop").is_ok());
-        assert!(validate_repo_slug("user-name/repo.name_v2").is_ok());
+    fn rejects_url_with_bad_chars() {
+        // Canonicalisation strips trailing slashes and `.git`, but the
+        // segment-level character check still rejects invalid characters.
+        assert_eq!(
+            parse_repo_slug_from_url("https://github.com/owner!/repo"),
+            None
+        );
+    }
+
+    #[test]
+    fn accepts_canonical_slug() {
+        assert!(RepoSlug::new("trailofbits/coop").is_ok());
+        assert!(RepoSlug::new("user-name/repo.name_v2").is_ok());
     }
 
     #[test]
     fn rejects_missing_slash() {
-        assert!(validate_repo_slug("trailofbits").is_err());
+        assert!(RepoSlug::new("trailofbits").is_err());
     }
 
     #[test]
     fn rejects_empty_segment() {
-        assert!(validate_repo_slug("/coop").is_err());
-        assert!(validate_repo_slug("trailofbits/").is_err());
+        assert!(RepoSlug::new("/coop").is_err());
+        assert!(RepoSlug::new("trailofbits/").is_err());
     }
 
     #[test]
     fn rejects_extra_slash() {
-        assert!(validate_repo_slug("a/b/c").is_err());
+        assert!(RepoSlug::new("a/b/c").is_err());
     }
 
     #[test]
     fn rejects_bad_chars() {
-        assert!(validate_repo_slug("owner!/repo").is_err());
-        assert!(validate_repo_slug("owner repo/x").is_err());
+        assert!(RepoSlug::new("owner!/repo").is_err());
+        assert!(RepoSlug::new("owner repo/x").is_err());
+    }
+
+    #[test]
+    fn accessors_split_at_slash() {
+        let s = slug("trailofbits/coop");
+        assert_eq!(s.owner(), "trailofbits");
+        assert_eq!(s.repo(), "coop");
+        assert_eq!(s.as_str(), "trailofbits/coop");
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        assert_eq!(format!("{}", slug("a/b")), "a/b");
+    }
+
+    #[test]
+    fn from_str_round_trips() {
+        let s: RepoSlug = "trailofbits/coop".parse().unwrap();
+        assert_eq!(s.as_str(), "trailofbits/coop");
+    }
+
+    #[test]
+    fn deserialize_accepts_valid_slug() {
+        let s: RepoSlug = serde_json::from_str("\"a/b\"").unwrap();
+        assert_eq!(s.as_str(), "a/b");
+    }
+
+    #[test]
+    fn deserialize_rejects_invalid_slug() {
+        let err = serde_json::from_str::<RepoSlug>("\"not-a-slug\"").unwrap_err();
+        assert!(
+            err.to_string().contains("owner/repo"),
+            "expected owner/repo error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn serialize_round_trips() {
+        let s = slug("a/b");
+        let json = serde_json::to_string(&s).unwrap();
+        assert_eq!(json, "\"a/b\"");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1323,7 +1323,7 @@ fn restart_instance(
     // Pre-flight: same auto-prompt as a fresh start. Uses the instance's
     // recorded workspace-state to recover the repo slug.
     let repo = backend::detect_instance_repo(inst);
-    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_deref(), opts.no_prompt)?;
+    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_ref(), opts.no_prompt)?;
 
     // Re-apply the forward set the instance was last started with.
     // CLI `--forward-port` on a restart appends/overrides; otherwise the
@@ -1375,7 +1375,7 @@ fn restart_instance(
     if opts.no_agents && post_start.is_none() {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
-        let session = prepare_session_from_target(cfg, None, target.clone(), repo.as_deref())?;
+        let session = prepare_session_from_target(cfg, None, target.clone(), repo.as_ref())?;
         if opts.no_agents {
             tracing::info!("Skipping guest agent bootstrap (--no-agents)");
         } else {
@@ -1404,7 +1404,7 @@ fn restart_instance(
 /// convention used by `push`/`pull`, so the slug a user sees here is the
 /// same one `detect_instance_repo` will recover on `coop shell` / `exec`
 /// / `restart`.
-fn resolve_start_repo(opts: &StartOpts<'_>) -> Result<Option<String>> {
+fn resolve_start_repo(opts: &StartOpts<'_>) -> Result<Option<github_repo::RepoSlug>> {
     if let Some(url) = opts.git_repo
         && let Some(slug) = github_repo::parse_repo_slug_from_url(url)
     {
@@ -1436,7 +1436,7 @@ fn start_instance(
     // can fire before any VM cost is incurred, and so pat-mode token
     // forwarding works at bootstrap time.
     let repo = resolve_start_repo(opts)?;
-    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_deref(), opts.no_prompt)?;
+    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_ref(), opts.no_prompt)?;
 
     // Forwards are checked up-front so an in-use host port fails fast,
     // before any VM cost is incurred. The actual `-L` tunnels are
@@ -1476,7 +1476,7 @@ fn start_instance(
     if opts.no_agents && post_start.is_none() {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
     } else {
-        let session = prepare_session_from_target(cfg, None, target.clone(), repo.as_deref())?;
+        let session = prepare_session_from_target(cfg, None, target.clone(), repo.as_ref())?;
         if opts.no_agents {
             tracing::info!("Skipping guest agent bootstrap (--no-agents)");
         } else {
@@ -1682,7 +1682,7 @@ fn open_ssh_session(
 ) -> Result<backend::SshSession> {
     let running = resolve_running(be, cfg, name)?;
     let repo = backend::detect_instance_repo(&running.inst);
-    prepare_session_from_target(cfg, Some(&running.inst), running.target, repo.as_deref())
+    prepare_session_from_target(cfg, Some(&running.inst), running.target, repo.as_ref())
 }
 
 /// Build an `SshSession` from an already-resolved target.
@@ -1704,7 +1704,7 @@ fn prepare_session_from_target(
     cfg: &config::CoopConfig,
     inst: Option<&config::Instance>,
     target: backend::SshTarget,
-    repo: Option<&str>,
+    repo: Option<&github_repo::RepoSlug>,
 ) -> Result<backend::SshSession> {
     let mut env = backend::prepare_env_forwarding(cfg, repo)?;
     if let Some(inst) = inst
@@ -2978,7 +2978,10 @@ mod tests {
         let cfg_path = tmp.path().join("config.toml");
         let opts = start_opts(vec![mount], &cfg_path);
         let slug = super::resolve_start_repo(&opts).expect("ok");
-        assert_eq!(slug.as_deref(), Some("trailofbits/coop"));
+        assert_eq!(
+            slug.as_ref().map(super::github_repo::RepoSlug::as_str),
+            Some("trailofbits/coop")
+        );
     }
 
     #[test]

--- a/src/pat_prompt.rs
+++ b/src/pat_prompt.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 
 use crate::config::{CoopConfig, GitHubAuth};
 use crate::github_pat::{self, SetupOpts};
+use crate::github_repo::RepoSlug;
 
 /// Effective answer to "should we offer the user a PAT wizard right now?"
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,7 +36,7 @@ impl Decision {
     /// `no_prompt_flag` reflects whether `--no-prompt` was passed.
     pub fn resolve(
         cfg: &CoopConfig,
-        repo: Option<&str>,
+        repo: Option<&RepoSlug>,
         tty: bool,
         ci: bool,
         no_prompt_flag: bool,
@@ -79,7 +80,7 @@ impl Decision {
 pub fn maybe_prompt(
     cfg: &mut CoopConfig,
     config_path: &Path,
-    repo: Option<&str>,
+    repo: Option<&RepoSlug>,
     no_prompt_flag: bool,
 ) -> Result<()> {
     let tty = std::io::stdin().is_terminal();
@@ -146,9 +147,9 @@ fn refresh_github_from_disk(cfg: &mut CoopConfig, config_path: &Path) -> Result<
     Ok(())
 }
 
-fn run_wizard_or_recover(cfg: &CoopConfig, config_path: &Path, repo: &str) -> Result<()> {
+fn run_wizard_or_recover(cfg: &CoopConfig, config_path: &Path, repo: &RepoSlug) -> Result<()> {
     let opts = SetupOpts {
-        repo: Some(repo),
+        repo: Some(repo.as_str()),
         config_path,
     };
     match github_pat::run_setup_pat(cfg, &opts) {
@@ -169,6 +170,7 @@ fn run_wizard_or_recover(cfg: &CoopConfig, config_path: &Path, repo: &str) -> Re
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
     use crate::config::{PatConfig, PatEntry};
@@ -178,6 +180,10 @@ mod tests {
             github,
             ..CoopConfig::default()
         }
+    }
+
+    fn slug(s: &str) -> RepoSlug {
+        RepoSlug::new(s).unwrap()
     }
 
     #[test]
@@ -193,7 +199,7 @@ mod tests {
     fn skips_when_no_tty() {
         let cfg = cfg_with(None);
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), false, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), false, false, false),
             Decision::Skip
         );
     }
@@ -202,7 +208,7 @@ mod tests {
     fn skips_when_ci() {
         let cfg = cfg_with(None);
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, true, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, true, false),
             Decision::Skip
         );
     }
@@ -211,7 +217,7 @@ mod tests {
     fn skips_when_no_prompt_flag() {
         let cfg = cfg_with(None);
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, false, true),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, true),
             Decision::Skip
         );
     }
@@ -220,7 +226,7 @@ mod tests {
     fn prompts_when_mode_off_and_interactive() {
         let cfg = cfg_with(Some(GitHubAuth::Off));
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
             Decision::Prompt
         );
     }
@@ -229,7 +235,7 @@ mod tests {
     fn prompts_when_pat_mode_but_no_entry() {
         let cfg = cfg_with(Some(GitHubAuth::Pat(PatConfig::default())));
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
             Decision::Prompt
         );
     }
@@ -238,14 +244,14 @@ mod tests {
     fn skips_when_pat_mode_has_entry() {
         let mut pc = PatConfig::default();
         pc.entries.insert(
-            "a/b".to_string(),
+            slug("a/b"),
             PatEntry {
                 token: crate::config::Secret::new("cmd:echo x".to_string()),
             },
         );
         let cfg = cfg_with(Some(GitHubAuth::Pat(pc)));
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
             Decision::Skip
         );
     }
@@ -253,10 +259,10 @@ mod tests {
     #[test]
     fn skips_when_repo_marked_skip() {
         let mut pc = PatConfig::default();
-        pc.skip.push("a/b".to_string());
+        pc.skip.push(slug("a/b"));
         let cfg = cfg_with(Some(GitHubAuth::Pat(pc)));
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
             Decision::Skip
         );
     }
@@ -265,7 +271,7 @@ mod tests {
     fn skips_when_mode_auto() {
         let cfg = cfg_with(Some(GitHubAuth::Auto));
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
             Decision::Skip
         );
     }
@@ -274,7 +280,7 @@ mod tests {
     fn skips_when_mode_env() {
         let cfg = cfg_with(Some(GitHubAuth::Env));
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
             Decision::Skip
         );
     }
@@ -284,7 +290,7 @@ mod tests {
         let mut cfg = cfg_with(Some(GitHubAuth::Off));
         cfg.setup.prompt_for_pat = false;
         assert_eq!(
-            Decision::resolve(&cfg, Some("a/b"), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
             Decision::Skip
         );
     }

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -357,8 +357,8 @@ fn shell_quote(s: &str) -> String {
 }
 
 /// Build the conventional account name for a repo's PAT entry.
-pub fn account_for_repo(repo: &str) -> String {
-    repo.replace('/', "-")
+pub fn account_for_repo(repo: &crate::github_repo::RepoSlug) -> String {
+    repo.as_str().replace('/', "-")
 }
 
 /// Conventional service name used across all backends.
@@ -383,10 +383,8 @@ mod tests {
 
     #[test]
     fn account_replaces_slash() {
-        assert_eq!(
-            account_for_repo("trailofbits/coop"),
-            "trailofbits-coop".to_string()
-        );
+        let slug = crate::github_repo::RepoSlug::new("trailofbits/coop").unwrap();
+        assert_eq!(account_for_repo(&slug), "trailofbits-coop".to_string());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces `validate_repo_slug(&str) -> Result<()>` plus four duplicate call sites with a single smart-constructor newtype. Once a value is held as `RepoSlug`, downstream code knows it is well-formed without re-validating.

- New `RepoSlug` in `src/github_repo.rs` with module-private field, smart constructor (`new`), accessors (`as_str` / `owner` / `repo`), and `FromStr` / `Display` / `Serialize` / `Deserialize`. `Eq` / `Ord` / `Hash` are derived so the type can key a `BTreeMap`.
- `parse_repo_slug_from_url` / `detect_workspace_repo` now return `Option<RepoSlug>` / `Result<Option<RepoSlug>>`.
- `PatConfig.entries` is now `BTreeMap<RepoSlug, PatEntry>` and `PatConfig.skip` is `Vec<RepoSlug>`. Invalid slugs in `[github.pat."..."]` keys or `github.skip` arrays are rejected at config load time via the `RepoSlug` deserializer, so the post-load `validate()` loop that re-checked them is removed.
- Downstream signatures (`pat_entry`, `account_for_repo`, `missing_entry_error`, `resolve_pat_token`, `resolve_github_token`, `prepare_env_forwarding`, `Decision::resolve`, `maybe_prompt`, `prepare_session_from_target`, `add_skip_marker`, `upsert_pat_entry`, `remove_pat_entry`, `probe_repo`, `print_form_instructions`) take `&RepoSlug` / `Option<&RepoSlug>`, so unvalidated strings can no longer reach them.
- `print_form_instructions` uses `repo.owner()` directly instead of the prior `split('/').next().unwrap_or(repo)` fallback.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 481 tests pass
- [x] Two new unit tests cover the load-time rejection of invalid `[github.pat]` keys and `github.skip` entries.
- [ ] Integration tests on both platforms before merge (`./tests/run-integration.sh` on macOS/Lima and `--remote` for Linux/Firecracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)