### PR TITLE
Resolve profile names at the config boundary (closes #156)

### DIFF
--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
 use crate::config::{self, CoopConfig, GiB, MiB, Mount, PortForward};
-use crate::guest::BUILTIN_PROFILES;
+use crate::guest::{BuiltinProfile, builtin_for_feature};
 
 /// Default relative path coop looks for inside a workspace or mount root.
 pub const DEFAULT_DEVCONTAINER_REL_PATH: &str = ".devcontainer/devcontainer.json";
@@ -810,34 +810,35 @@ fn translate_features(
             );
             continue;
         };
+        let name = builtin.name;
         if stage == Stage::Start {
             t.report.push(
                 key,
                 ReportStatus::Unsupported,
                 ReportSource::Devcontainer,
-                builtin.to_string(),
+                name.to_string(),
                 "features are baked into the template at `coop setup` time, \
                  not selected per-start",
             );
             continue;
         }
-        if cli_profiles.contains(builtin) {
+        if cli_profiles.contains(&name) {
             t.report.push(
                 key,
                 ReportStatus::Overridden,
                 ReportSource::Cli,
-                builtin.to_string(),
+                name.to_string(),
                 "CLI --profile already includes this profile",
             );
             continue;
         }
-        t.profiles.push(builtin.to_string());
+        t.profiles.push(name.to_string());
         t.report.push(
             key,
             ReportStatus::Applied,
             ReportSource::Devcontainer,
-            builtin.to_string(),
-            format!("mapped to built-in profile '{builtin}'"),
+            name.to_string(),
+            format!("mapped to built-in profile '{name}'"),
         );
     }
 }
@@ -1093,10 +1094,10 @@ fn parse_mount_string(s: &str) -> Result<String> {
     Ok(format!("{source}:{target}"))
 }
 
-/// Map a devcontainer feature id (raw key) to a built-in coop profile name,
+/// Map a devcontainer feature id (raw key) to a built-in coop profile,
 /// or `None` if no match. We recognise both bare names (`rust`) and the
 /// fully-qualified registry form (`ghcr.io/devcontainers/features/rust:1`).
-fn map_feature_to_profile(raw: &str) -> Option<&'static str> {
+fn map_feature_to_profile(raw: &str) -> Option<&'static BuiltinProfile> {
     // Trim `ghcr.io/devcontainers/features/<name>[:version]` to `<name>`.
     let id = raw
         .rsplit('/')
@@ -1105,14 +1106,7 @@ fn map_feature_to_profile(raw: &str) -> Option<&'static str> {
         .split(':')
         .next()
         .unwrap_or(raw);
-    let known: &[&str] = &["python", "node", "rust", "go", "c", "fuzz"];
-    if known.contains(&id) && BUILTIN_PROFILES.iter().any(|bp| bp.name == id) {
-        return BUILTIN_PROFILES
-            .iter()
-            .find(|bp| bp.name == id)
-            .map(|bp| bp.name);
-    }
-    None
+    builtin_for_feature(id)
 }
 
 fn format_pf(p: &PortForward) -> String {

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -6,6 +6,22 @@ use anyhow::{Result, bail};
 
 use crate::config::{CoopConfig, CustomProfile};
 
+/// Devcontainer feature ids (bare names) that map to builtin profiles.
+/// The id is the same string as the builtin name; this slice acts as the
+/// allow-list so an unknown feature returns `None` rather than silently
+/// resolving against an unrelated builtin added later.
+const FEATURE_IDS: &[&str] = &["python", "node", "c", "fuzz", "rust", "go"];
+
+/// Look up a builtin profile by its devcontainer feature id (a bare
+/// name such as `rust`, after stripping any `ghcr.io/...:tag` prefix).
+pub fn builtin_for_feature(id: &str) -> Option<&'static BuiltinProfile> {
+    if FEATURE_IDS.contains(&id) {
+        lookup_builtin(id)
+    } else {
+        None
+    }
+}
+
 /// Username for the non-root guest user. Both backends ensure this user
 /// exists at uid 1000. On Firecracker's rootfs the `ubuntu` user already
 /// exists; on Lima, cloud-init may replace it with a host-mirror user,
@@ -83,9 +99,12 @@ pub struct BuiltinProfile {
     pub plugins: &'static [&'static str],
 }
 
-/// Owned profile definition produced by `lookup_profile`. Handles both
-/// builtin (converted from static data) and custom (cloned from config).
+/// Resolved profile definition. Carries the profile name alongside its
+/// effective contents so consumers don't need to re-look-up by name.
+/// Produced once at the config boundary by [`resolve_profiles`].
+#[derive(Debug, Clone)]
 pub struct ProfileDef {
+    pub name: String,
     pub apt_packages: Vec<String>,
     pub pre_install: Option<String>,
     pub post_install: Option<String>,
@@ -96,11 +115,25 @@ pub struct ProfileDef {
 impl From<&BuiltinProfile> for ProfileDef {
     fn from(bp: &BuiltinProfile) -> Self {
         Self {
+            name: bp.name.to_owned(),
             apt_packages: bp.apt_packages.iter().map(|s| (*s).to_owned()).collect(),
             pre_install: bp.pre_install.map(str::to_owned),
             post_install: bp.post_install.map(str::to_owned),
             marketplaces: bp.marketplaces.iter().map(|s| (*s).to_owned()).collect(),
             plugins: bp.plugins.iter().map(|s| (*s).to_owned()).collect(),
+        }
+    }
+}
+
+impl ProfileDef {
+    fn from_custom(name: &str, cp: &CustomProfile) -> Self {
+        Self {
+            name: name.to_owned(),
+            apt_packages: cp.apt_packages.clone(),
+            pre_install: cp.pre_install.clone(),
+            post_install: cp.post_install.clone(),
+            marketplaces: cp.marketplaces.clone(),
+            plugins: cp.plugins.clone(),
         }
     }
 }
@@ -160,47 +193,73 @@ fn lookup_builtin(name: &str) -> Option<&'static BuiltinProfile> {
     BUILTIN_PROFILES.iter().find(|bp| bp.name == name)
 }
 
-/// Look up a profile by name. Checks custom profiles first, then builtins.
-pub fn lookup_profile(name: &str, custom: &HashMap<String, CustomProfile>) -> Result<ProfileDef> {
+fn resolve_one(name: &str, custom: &HashMap<String, CustomProfile>) -> Option<ProfileDef> {
     if let Some(cp) = custom.get(name) {
-        return Ok(ProfileDef {
-            apt_packages: cp.apt_packages.clone(),
-            pre_install: cp.pre_install.clone(),
-            post_install: cp.post_install.clone(),
-            marketplaces: cp.marketplaces.clone(),
-            plugins: cp.plugins.clone(),
-        });
+        return Some(ProfileDef::from_custom(name, cp));
     }
+    lookup_builtin(name).map(ProfileDef::from)
+}
 
-    if let Some(bp) = lookup_builtin(name) {
-        return Ok(ProfileDef::from(bp));
-    }
-
+fn available_profiles(custom: &HashMap<String, CustomProfile>) -> Vec<&str> {
     let mut available: Vec<&str> = BUILTIN_PROFILES.iter().map(|bp| bp.name).collect();
     let mut custom_names: Vec<&str> = custom.keys().map(String::as_str).collect();
     custom_names.sort_unstable();
     available.extend(custom_names);
+    available
+}
 
-    bail!(
-        "Unknown profile: {name}\n\
-         Available profiles: {}",
-        available.join(", ")
-    )
+/// Resolve a list of profile names into [`ProfileDef`] values.
+///
+/// All unknown names are collected and reported in a single error so
+/// the caller sees every offender at once. Custom profiles shadow
+/// builtins with the same name.
+pub fn resolve_profiles(
+    names: &[String],
+    custom: &HashMap<String, CustomProfile>,
+) -> Result<Vec<ProfileDef>> {
+    let mut resolved = Vec::with_capacity(names.len());
+    let mut unknown: Vec<&str> = Vec::new();
+    for name in names {
+        match resolve_one(name, custom) {
+            Some(def) => resolved.push(def),
+            None => unknown.push(name.as_str()),
+        }
+    }
+    if !unknown.is_empty() {
+        bail!(
+            "Unknown profile(s): {}\n\
+             Available profiles: {}",
+            unknown.join(", "),
+            available_profiles(custom).join(", "),
+        );
+    }
+    Ok(resolved)
+}
+
+/// Look up a single profile by name. Convenience wrapper around
+/// [`resolve_profiles`] for the `coop profiles show <name>` path.
+pub fn lookup_profile(name: &str, custom: &HashMap<String, CustomProfile>) -> Result<ProfileDef> {
+    resolve_one(name, custom).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Unknown profile: {name}\n\
+             Available profiles: {}",
+            available_profiles(custom).join(", "),
+        )
+    })
 }
 
 /// Collect combined marketplace and plugin lists from global config
 /// and all active profiles. Results are sorted and deduplicated.
 pub fn collect_baked_lists(
     cfg: &CoopConfig,
-    profiles: &[String],
-) -> Result<(Vec<String>, Vec<String>)> {
+    profiles: &[ProfileDef],
+) -> (Vec<String>, Vec<String>) {
     let mut marketplaces = cfg.claude.marketplaces.clone();
     let mut plugins = cfg.claude.plugins.clone();
 
-    for name in profiles {
-        let def = lookup_profile(name, &cfg.profiles)?;
-        marketplaces.extend(def.marketplaces);
-        plugins.extend(def.plugins);
+    for def in profiles {
+        marketplaces.extend(def.marketplaces.iter().cloned());
+        plugins.extend(def.plugins.iter().cloned());
     }
 
     marketplaces.sort_unstable();
@@ -208,7 +267,7 @@ pub fn collect_baked_lists(
     plugins.sort_unstable();
     plugins.dedup();
 
-    Ok((marketplaces, plugins))
+    (marketplaces, plugins)
 }
 
 #[cfg(test)]
@@ -239,6 +298,7 @@ mod tests {
         for bp in BUILTIN_PROFILES {
             let def = lookup_profile(bp.name, &custom)
                 .unwrap_or_else(|_| panic!("builtin '{}' failed to resolve", bp.name));
+            assert_eq!(def.name, bp.name);
             assert_eq!(def.apt_packages.len(), bp.apt_packages.len());
         }
     }
@@ -263,6 +323,46 @@ mod tests {
             },
         );
         let def = lookup_profile("python", &custom).unwrap();
+        assert_eq!(def.name, "python");
         assert_eq!(def.apt_packages, vec!["custom-python"]);
+    }
+
+    #[test]
+    fn resolve_profiles_reports_all_unknowns() {
+        let custom = HashMap::new();
+        let names = vec!["rust".to_owned(), "bogus1".to_owned(), "bogus2".to_owned()];
+        let err = resolve_profiles(&names, &custom).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("bogus1"), "missing bogus1 in: {msg}");
+        assert!(msg.contains("bogus2"), "missing bogus2 in: {msg}");
+    }
+
+    #[test]
+    fn resolve_profiles_preserves_order_and_resolves_all() {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "data".to_owned(),
+            CustomProfile {
+                apt_packages: vec!["pandas".to_owned()],
+                pre_install: None,
+                post_install: None,
+                marketplaces: vec![],
+                plugins: vec![],
+            },
+        );
+        let names = vec!["rust".to_owned(), "data".to_owned(), "node".to_owned()];
+        let defs = resolve_profiles(&names, &custom).unwrap();
+        let resolved_names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(resolved_names, vec!["rust", "data", "node"]);
+    }
+
+    #[test]
+    fn builtin_for_feature_matches_known_ids() {
+        for id in FEATURE_IDS {
+            let bp = builtin_for_feature(id)
+                .unwrap_or_else(|| panic!("feature '{id}' should resolve to a builtin"));
+            assert_eq!(bp.name, *id);
+        }
+        assert!(builtin_for_feature("nonexistent").is_none());
     }
 }

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader, Write as _};
 use std::path::{Path, PathBuf};
@@ -8,10 +7,10 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 
 use crate::backend::SshTarget;
-use crate::config::{CoopConfig, CustomProfile, GiB, Instance};
+use crate::config::{CoopConfig, GiB, Instance};
 use crate::guest::{
-    BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
-    SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, lookup_profile,
+    BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
+    SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
 };
 use crate::setup::{SetupOptions, TEMPLATE_VERSION, TemplateConfig, hash_string, utc_timestamp};
 
@@ -466,10 +465,10 @@ fn ensure_ssh_key(cfg: &CoopConfig) -> Result<()> {
     Ok(())
 }
 
-fn provision_script_hash(cfg: &CoopConfig, profiles: &[String]) -> String {
+fn provision_script_hash(cfg: &CoopConfig, profiles: &[ProfileDef]) -> String {
     let pubkey_path = cfg.ssh_key_path().with_extension("pub");
     let pubkey = fs::read_to_string(&pubkey_path).unwrap_or_default();
-    let script = compose_provision_script(pubkey.trim(), profiles, &cfg.profiles);
+    let script = compose_provision_script(pubkey.trim(), profiles);
     hash_string(&script)
 }
 
@@ -478,7 +477,7 @@ fn provision_script_hash(cfg: &CoopConfig, profiles: &[String]) -> String {
 /// A rebuild is needed when the config file is missing (orphaned
 /// image), the provision-script hash has changed, or the baked
 /// marketplace/plugin lists have changed.
-fn needs_rebuild(cfg: &CoopConfig, image: &str, profiles: &[String]) -> bool {
+fn needs_rebuild(cfg: &CoopConfig, image: &str, profiles: &[ProfileDef]) -> bool {
     let current_hash = provision_script_hash(cfg, profiles);
     let Ok(existing) = TemplateConfig::load_for(cfg, image) else {
         tracing::info!("Template config missing — treating golden image as stale");
@@ -489,15 +488,11 @@ fn needs_rebuild(cfg: &CoopConfig, image: &str, profiles: &[String]) -> bool {
         return true;
     }
 
-    // Check if marketplace/plugin lists have changed
-    let Ok((wanted_m, wanted_p)) = crate::guest::collect_baked_lists(cfg, profiles) else {
-        return true;
-    };
-
+    let (wanted_m, wanted_p) = crate::guest::collect_baked_lists(cfg, profiles);
     existing.marketplaces != wanted_m || existing.plugins != wanted_p
 }
 
-fn build_golden_image(cfg: &CoopConfig, image: &str, profiles: &[String]) -> Result<()> {
+fn build_golden_image(cfg: &CoopConfig, image: &str, profiles: &[ProfileDef]) -> Result<()> {
     eprintln!(
         "\n=> Building golden VM image \
          (this takes a few minutes on first run)"
@@ -526,7 +521,7 @@ fn build_golden_image(cfg: &CoopConfig, image: &str, profiles: &[String]) -> Res
 
     // Generate builder template with full provisioning
     let builder_template = cfg.data_dir.join("lima-builder.yaml");
-    let provision_script = compose_provision_script(pubkey.trim(), profiles, &cfg.profiles);
+    let provision_script = compose_provision_script(pubkey.trim(), profiles);
     let yaml = compose_template_yaml(cfg, &provision_script);
     fs::write(&builder_template, &yaml).with_context(|| {
         format!(
@@ -536,7 +531,8 @@ fn build_golden_image(cfg: &CoopConfig, image: &str, profiles: &[String]) -> Res
     })?;
 
     if !profiles.is_empty() {
-        eprintln!("  Profiles: {}", profiles.join(", "));
+        let names: Vec<&str> = profiles.iter().map(|p| p.name.as_str()).collect();
+        eprintln!("  Profiles: {}", names.join(", "));
     }
 
     // Build to staging path — old image is never touched
@@ -585,7 +581,7 @@ fn build_golden_image(cfg: &CoopConfig, image: &str, profiles: &[String]) -> Res
         version: TEMPLATE_VERSION,
         created: utc_timestamp(),
         install_script_hash: provision_script_hash(cfg, profiles),
-        profiles: profiles.to_vec(),
+        profiles: profiles.iter().map(|p| p.name.clone()).collect(),
         extra_packages: Vec::new(),
         post_install_hash: None,
         marketplaces,
@@ -600,7 +596,7 @@ fn build_golden_image(cfg: &CoopConfig, image: &str, profiles: &[String]) -> Res
 /// cloud-init, stop it, and extract the disk image to `output_path`.
 fn run_builder_vm(
     cfg: &CoopConfig,
-    profiles: &[String],
+    profiles: &[ProfileDef],
     output_path: &std::path::Path,
     builder_template: &std::path::Path,
 ) -> Result<(Vec<String>, Vec<String>)> {
@@ -722,9 +718,9 @@ fn builder_ssh_target(cfg: &CoopConfig) -> Result<SshTarget> {
 /// `TemplateConfig`).
 fn install_builder_plugins(
     cfg: &CoopConfig,
-    profiles: &[String],
+    profiles: &[ProfileDef],
 ) -> Result<(Vec<String>, Vec<String>)> {
-    let (marketplaces, plugins) = crate::guest::collect_baked_lists(cfg, profiles)?;
+    let (marketplaces, plugins) = crate::guest::collect_baked_lists(cfg, profiles);
 
     if marketplaces.is_empty() && plugins.is_empty() {
         return Ok((marketplaces, plugins));
@@ -1083,11 +1079,7 @@ provision:
     )
 }
 
-fn compose_provision_script(
-    ssh_pubkey: &str,
-    profiles: &[String],
-    custom: &HashMap<String, CustomProfile>,
-) -> String {
+fn compose_provision_script(ssh_pubkey: &str, profiles: &[ProfileDef]) -> String {
     let mut s = String::with_capacity(8192);
 
     // Preamble
@@ -1103,23 +1095,19 @@ fn compose_provision_script(
     s.push_str(SCRIPT_DOCKER_REPO);
     s.push('\n');
 
-    // Resolve profile definitions (validates names, collects packages/scripts)
-    let mut profile_apt: Vec<String> = Vec::new();
-    let mut pre_scripts: Vec<String> = Vec::new();
-    let mut post_scripts: Vec<String> = Vec::new();
-    for name in profiles {
-        if let Ok(def) = lookup_profile(name, custom) {
-            profile_apt.extend(def.apt_packages);
-            if let Some(pre) = def.pre_install {
-                pre_scripts.push(pre);
-            }
-            if let Some(post) = def.post_install {
-                post_scripts.push(post);
-            }
-        } else {
-            tracing::warn!("Unknown profile '{name}', skipping");
-        }
-    }
+    // Collect packages/scripts from already-resolved profiles
+    let profile_apt: Vec<&str> = profiles
+        .iter()
+        .flat_map(|d| d.apt_packages.iter().map(String::as_str))
+        .collect();
+    let pre_scripts: Vec<&str> = profiles
+        .iter()
+        .filter_map(|d| d.pre_install.as_deref())
+        .collect();
+    let post_scripts: Vec<&str> = profiles
+        .iter()
+        .filter_map(|d| d.post_install.as_deref())
+        .collect();
 
     // Profile pre-scripts (may add repos, e.g. NodeSource)
     for pre in &pre_scripts {
@@ -1140,7 +1128,7 @@ fn compose_provision_script(
         .chain(GH_PACKAGES)
         .chain(DOCKER_PACKAGES)
         .copied()
-        .chain(profile_apt.iter().map(String::as_str))
+        .chain(profile_apt.iter().copied())
         .collect();
 
     s.push_str("echo '  [guest] Installing all packages...'\n");
@@ -1531,8 +1519,9 @@ mod tests {
         assert!(result.is_err());
     }
 
-    fn custom_profile(apt: &[&str], pre: Option<&str>, post: Option<&str>) -> CustomProfile {
-        CustomProfile {
+    fn profile(name: &str, apt: &[&str], pre: Option<&str>, post: Option<&str>) -> ProfileDef {
+        ProfileDef {
+            name: name.into(),
             apt_packages: apt.iter().map(|s| (*s).into()).collect(),
             pre_install: pre.map(Into::into),
             post_install: post.map(Into::into),
@@ -1553,13 +1542,8 @@ mod tests {
 
     #[test]
     fn provision_script_post_install_without_trailing_newline() {
-        let mut custom = HashMap::new();
-        custom.insert(
-            "test".into(),
-            custom_profile(&["curl"], None, Some("echo done")),
-        );
-        let script =
-            compose_provision_script("ssh-ed25519 AAAA test@test", &["test".into()], &custom);
+        let profiles = vec![profile("test", &["curl"], None, Some("echo done"))];
+        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &profiles);
 
         assert!(
             script.contains("echo done\n"),
@@ -1570,13 +1554,13 @@ mod tests {
 
     #[test]
     fn provision_script_pre_install_without_trailing_newline() {
-        let mut custom = HashMap::new();
-        custom.insert(
-            "test".into(),
-            custom_profile(&[], Some("curl -fsSL https://example.com | bash"), None),
-        );
-        let script =
-            compose_provision_script("ssh-ed25519 AAAA test@test", &["test".into()], &custom);
+        let profiles = vec![profile(
+            "test",
+            &[],
+            Some("curl -fsSL https://example.com | bash"),
+            None,
+        )];
+        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &profiles);
 
         assert!(
             script.contains("| bash\n"),
@@ -1587,14 +1571,11 @@ mod tests {
 
     #[test]
     fn provision_script_multiple_profiles_separated() {
-        let mut custom = HashMap::new();
-        custom.insert("a".into(), custom_profile(&[], None, Some("echo a-done")));
-        custom.insert("b".into(), custom_profile(&[], None, Some("echo b-done")));
-        let script = compose_provision_script(
-            "ssh-ed25519 AAAA test@test",
-            &["a".into(), "b".into()],
-            &custom,
-        );
+        let profiles = vec![
+            profile("a", &[], None, Some("echo a-done")),
+            profile("b", &[], None, Some("echo b-done")),
+        ];
+        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &profiles);
 
         assert!(script.contains("echo a-done\n"));
         assert!(script.contains("echo b-done\n"));
@@ -1608,8 +1589,7 @@ mod tests {
 
     #[test]
     fn provision_script_installs_codex() {
-        let custom = HashMap::new();
-        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &[], &custom);
+        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &[]);
 
         assert!(
             script.contains("Installing Codex CLI"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,13 +638,15 @@ fn main() -> Result<()> {
             if let Some(t) = &translation {
                 devcontainer::apply_to_config(&mut cfg, t)?;
             }
+            // Resolve profile names once at the CLI boundary.
+            let resolved_profiles = guest::resolve_profiles(&profile, &cfg.profiles)?;
             let _guard = signal::install_handlers();
             be.setup(
                 &cfg,
                 &setup::SetupOptions {
                     skip_confirm: yes,
                     rebuild,
-                    profiles: profile,
+                    profiles: resolved_profiles,
                     extra_packages,
                     post_install: post_install.map(PathBuf::from),
                     image,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
@@ -9,10 +8,10 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::cmd::Cmd;
-use crate::config::{CoopConfig, CustomProfile, Instance};
+use crate::config::{CoopConfig, Instance};
 use crate::guest::{
-    BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
-    SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, lookup_profile,
+    BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
+    SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, resolve_profiles,
 };
 
 const S3_BUCKET: &str = "https://s3.amazonaws.com/spec.ccfc.min";
@@ -28,7 +27,7 @@ pub const TEMPLATE_VERSION: u32 = 1;
 pub struct SetupOptions {
     pub skip_confirm: bool,
     pub rebuild: bool,
-    pub profiles: Vec<String>,
+    pub profiles: Vec<ProfileDef>,
     pub extra_packages: Vec<String>,
     pub post_install: Option<PathBuf>,
     pub image: String,
@@ -290,15 +289,10 @@ fn patch_guest_network(inst: &Instance) -> Result<()> {
 fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
     let image = &opts.image;
     let template = cfg.template_path_for(image);
-    let (profiles, extra_packages) = resolve_template_config(cfg, opts);
-
-    // Validate all profiles upfront
-    for name in &profiles {
-        lookup_profile(name, &cfg.profiles)?;
-    }
+    let (profiles, extra_packages) = resolve_template_config(cfg, opts)?;
 
     // Compose recipe and compute hashes
-    let recipe = compose_recipe(&profiles, &extra_packages, &cfg.profiles)?;
+    let recipe = compose_recipe(&profiles, &extra_packages);
     let script_hash = hash_string(&recipe);
     let post_install_content = load_post_install(opts.post_install.as_ref())?;
     let post_install_hash = post_install_content.as_ref().map(|s| hash_string(s));
@@ -360,7 +354,7 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
         version: TEMPLATE_VERSION,
         created: utc_timestamp(),
         install_script_hash: script_hash,
-        profiles,
+        profiles: profile_names(&profiles),
         extra_packages,
         post_install_hash,
         marketplaces: Vec::new(),
@@ -369,6 +363,10 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
     template_config.save_for(cfg, image)?;
 
     Ok(())
+}
+
+fn profile_names(profiles: &[ProfileDef]) -> Vec<String> {
+    profiles.iter().map(|p| p.name.clone()).collect()
 }
 
 /// Returns `true` if the template needs rebuilding.
@@ -394,7 +392,7 @@ fn build_template(
     cfg: &CoopConfig,
     opts: &SetupOptions,
     image: &str,
-    profiles: &[String],
+    profiles: &[ProfileDef],
     extra_packages: &[String],
     recipe: &str,
     script_hash: &str,
@@ -410,7 +408,7 @@ fn build_template(
     eprintln!("  Found rootfs: {rootfs_name}");
     eprintln!("  URL: {rootfs_url}");
     if !profiles.is_empty() {
-        eprintln!("  Profiles: {}", profiles.join(", "));
+        eprintln!("  Profiles: {}", profile_names(profiles).join(", "));
     }
     if !extra_packages.is_empty() {
         eprintln!("  Extra packages: {}", extra_packages.join(", "));
@@ -448,7 +446,7 @@ fn build_template(
         version: TEMPLATE_VERSION,
         created: utc_timestamp(),
         install_script_hash: script_hash.to_string(),
-        profiles: profiles.to_vec(),
+        profiles: profile_names(profiles),
         extra_packages: extra_packages.to_vec(),
         post_install_hash: post_install_hash.map(String::from),
         marketplaces: Vec::new(),
@@ -479,17 +477,22 @@ fn build_template(
 /// Resolve effective profiles and extra packages.
 ///
 /// If CLI flags provide profiles or packages, use those.
-/// Otherwise, reuse the previous template config.
-fn resolve_template_config(cfg: &CoopConfig, opts: &SetupOptions) -> (Vec<String>, Vec<String>) {
+/// Otherwise, reuse the previous template config (resolving the persisted
+/// profile names against the current builtin/custom set).
+fn resolve_template_config(
+    cfg: &CoopConfig,
+    opts: &SetupOptions,
+) -> Result<(Vec<ProfileDef>, Vec<String>)> {
     if !opts.profiles.is_empty() || !opts.extra_packages.is_empty() {
-        return (opts.profiles.clone(), opts.extra_packages.clone());
+        return Ok((opts.profiles.clone(), opts.extra_packages.clone()));
     }
 
     if let Ok(existing) = TemplateConfig::load_for(cfg, &opts.image) {
-        return (existing.profiles, existing.extra_packages);
+        let profiles = resolve_profiles(&existing.profiles, &cfg.profiles)?;
+        return Ok((profiles, existing.extra_packages));
     }
 
-    (Vec::new(), Vec::new())
+    Ok((Vec::new(), Vec::new()))
 }
 
 fn load_post_install(path: Option<&PathBuf>) -> Result<Option<String>> {
@@ -509,18 +512,9 @@ fn load_post_install(path: Option<&PathBuf>) -> Result<Option<String>> {
 ///
 /// This portion is hashed for staleness detection.
 /// Does NOT include version marker, post-install script, or cleanup.
-fn compose_recipe(
-    profiles: &[String],
-    extra_packages: &[String],
-    custom: &HashMap<String, CustomProfile>,
-) -> Result<String> {
-    let profile_defs: Vec<_> = profiles
-        .iter()
-        .map(|name| lookup_profile(name, custom))
-        .collect::<Result<_>>()?;
-
+fn compose_recipe(profiles: &[ProfileDef], extra_packages: &[String]) -> String {
     // Collect and deduplicate profile + extra apt packages
-    let mut extra_apt: Vec<&str> = profile_defs
+    let mut extra_apt: Vec<&str> = profiles
         .iter()
         .flat_map(|def| &def.apt_packages)
         .map(String::as_str)
@@ -529,11 +523,11 @@ fn compose_recipe(
     extra_apt.sort_unstable();
     extra_apt.dedup();
 
-    let pre_installs: Vec<&str> = profile_defs
+    let pre_installs: Vec<&str> = profiles
         .iter()
         .filter_map(|d| d.pre_install.as_deref())
         .collect();
-    let post_installs: Vec<&str> = profile_defs
+    let post_installs: Vec<&str> = profiles
         .iter()
         .filter_map(|d| d.post_install.as_deref())
         .collect();
@@ -615,7 +609,7 @@ fn compose_recipe(
     // Codex installs as a standalone binary under /usr/local/bin.
     s.push_str(SCRIPT_CODEX);
 
-    Ok(s)
+    s
 }
 
 /// Compose the full chroot script from recipe + marker + post-install + cleanup.
@@ -1302,12 +1296,12 @@ fn confirm(action: &str, skip: bool) -> Result<bool> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code — panics are assertions")]
 mod tests {
     use super::*;
 
-    fn custom_profile(apt: &[&str], pre: Option<&str>, post: Option<&str>) -> CustomProfile {
-        CustomProfile {
+    fn profile(name: &str, apt: &[&str], pre: Option<&str>, post: Option<&str>) -> ProfileDef {
+        ProfileDef {
+            name: name.into(),
             apt_packages: apt.iter().map(|s| (*s).into()).collect(),
             pre_install: pre.map(Into::into),
             post_install: post.map(Into::into),
@@ -1328,10 +1322,7 @@ mod tests {
 
     #[test]
     fn compose_recipe_no_profiles_succeeds() {
-        let custom = HashMap::new();
-        let result = compose_recipe(&[], &[], &custom);
-        assert!(result.is_ok());
-        let script = result.unwrap();
+        let script = compose_recipe(&[], &[]);
         assert!(script.contains("apt-get"));
         assert!(
             script.contains("Installing Codex CLI"),
@@ -1342,12 +1333,8 @@ mod tests {
 
     #[test]
     fn compose_recipe_post_install_without_trailing_newline() {
-        let mut custom = HashMap::new();
-        custom.insert(
-            "test".into(),
-            custom_profile(&["curl"], None, Some("echo done")),
-        );
-        let script = compose_recipe(&["test".into()], &[], &custom).unwrap();
+        let profiles = vec![profile("test", &["curl"], None, Some("echo done"))];
+        let script = compose_recipe(&profiles, &[]);
 
         // The post_install "echo done" must be on its own line
         assert!(
@@ -1359,12 +1346,13 @@ mod tests {
 
     #[test]
     fn compose_recipe_pre_install_without_trailing_newline() {
-        let mut custom = HashMap::new();
-        custom.insert(
-            "test".into(),
-            custom_profile(&[], Some("curl -fsSL https://example.com | bash"), None),
-        );
-        let script = compose_recipe(&["test".into()], &[], &custom).unwrap();
+        let profiles = vec![profile(
+            "test",
+            &[],
+            Some("curl -fsSL https://example.com | bash"),
+            None,
+        )];
+        let script = compose_recipe(&profiles, &[]);
 
         assert!(
             script.contains("| bash\n"),
@@ -1375,12 +1363,8 @@ mod tests {
 
     #[test]
     fn compose_recipe_scripts_with_trailing_newline_no_double() {
-        let mut custom = HashMap::new();
-        custom.insert(
-            "test".into(),
-            custom_profile(&[], Some("pre-cmd\n"), Some("post-cmd\n")),
-        );
-        let script = compose_recipe(&["test".into()], &[], &custom).unwrap();
+        let profiles = vec![profile("test", &[], Some("pre-cmd\n"), Some("post-cmd\n"))];
+        let script = compose_recipe(&profiles, &[]);
 
         // Should not produce triple+ newlines from double-adding
         assert!(
@@ -1392,10 +1376,11 @@ mod tests {
 
     #[test]
     fn compose_recipe_multiple_profiles_separated() {
-        let mut custom = HashMap::new();
-        custom.insert("a".into(), custom_profile(&[], None, Some("echo a-done")));
-        custom.insert("b".into(), custom_profile(&[], None, Some("echo b-done")));
-        let script = compose_recipe(&["a".into(), "b".into()], &[], &custom).unwrap();
+        let profiles = vec![
+            profile("a", &[], None, Some("echo a-done")),
+            profile("b", &[], None, Some("echo b-done")),
+        ];
+        let script = compose_recipe(&profiles, &[]);
 
         // Each post_install must be on its own line
         assert!(script.contains("echo a-done\n"));


### PR DESCRIPTION
## Summary

- Resolve profile names once at the CLI boundary into `Vec<ProfileDef>`
  instead of re-looking them up at every consumer.
- Batch all unknown-profile errors into a single message so the user
  sees every offender at once, not just the first.
- Replace `map_feature_to_profile`'s two-scan string-search with a
  static `FEATURE_IDS` allow-list returning `&'static BuiltinProfile`.

## Notes

`ProfileDef` now carries the profile name alongside its contents, so
downstream functions (`compose_recipe`, `compose_provision_script`,
`collect_baked_lists`) take `&[ProfileDef]` and never re-resolve.
`TemplateConfig.profiles` stays `Vec<String>` for persistence;
`resolve_template_config` re-resolves the persisted names when
reusing an existing template config — so a custom profile deleted
from `config.toml` since the image was built reports cleanly at
`coop setup` time.

`lookup_profile` is retained as a single-name convenience wrapper
for the `coop profiles show <name>` path.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 476 passed, including 3 new tests covering
  batched unknown-profile errors, ordering preservation in
  `resolve_profiles`, and the `FEATURE_IDS` allow-list.
- [ ] Integration tests on both Lima (macOS) and Firecracker (Linux)
  per CLAUDE.md — not run here; please run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)