### PR TITLE
Replace bool params with BootMode/LogMode enums (closes #158)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -38,6 +38,26 @@ impl std::fmt::Display for GuestPath {
     }
 }
 
+// ── Operation modes ───────────────────────────────────────────
+
+/// Whether an agent bootstrap is running for the first boot of a new
+/// VM or for a restart of an existing one. On restart, marketplaces,
+/// plugins, and MCP servers are skipped because they persist on the
+/// guest disk across stop/start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootMode {
+    FirstBoot,
+    Restart,
+}
+
+/// Whether log streaming reads the existing log once and exits or
+/// tails it indefinitely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogMode {
+    Snapshot,
+    Follow,
+}
+
 // ── Environment forwarding ────────────────────────────────────
 
 /// Environment variables to forward to guest VMs via SSH `SendEnv`.
@@ -587,7 +607,7 @@ pub trait VmBackend: std::fmt::Display {
     ) -> Result<()>;
     fn is_running(&self, inst: &Instance) -> bool;
     fn status(&self, cfg: &CoopConfig, inst: &Instance) -> Result<String>;
-    fn stream_logs(&self, cfg: &CoopConfig, inst: &Instance, follow: bool) -> Result<()>;
+    fn stream_logs(&self, cfg: &CoopConfig, inst: &Instance, mode: LogMode) -> Result<()>;
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget>;
     fn disk_path(&self, inst: &Instance) -> Result<PathBuf>;
     /// Whether mounts use live filesystem sharing (Lima/virtiofs)
@@ -738,9 +758,9 @@ impl VmBackend for FirecrackerBackend {
         vm.status()
     }
 
-    fn stream_logs(&self, cfg: &CoopConfig, inst: &Instance, follow: bool) -> Result<()> {
+    fn stream_logs(&self, cfg: &CoopConfig, inst: &Instance, mode: LogMode) -> Result<()> {
         let vm = crate::vm::FirecrackerVm::from_running(cfg, inst)?;
-        vm.stream_logs(follow)
+        vm.stream_logs(mode)
     }
 
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {
@@ -862,8 +882,8 @@ impl VmBackend for LimaBackend {
         crate::lima::status(cfg, inst)
     }
 
-    fn stream_logs(&self, _cfg: &CoopConfig, inst: &Instance, follow: bool) -> Result<()> {
-        crate::lima::stream_logs(inst, follow)
+    fn stream_logs(&self, _cfg: &CoopConfig, inst: &Instance, mode: LogMode) -> Result<()> {
+        crate::lima::stream_logs(inst, mode)
     }
 
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {
@@ -1011,7 +1031,7 @@ pub fn bootstrap_agents(
     session: &SshSession,
     cfg: &CoopConfig,
     inst: &crate::config::Instance,
-    restart: bool,
+    mode: BootMode,
 ) -> Result<()> {
     // GitHub auth is guest-global state. Refresh it once before either
     // agent bootstrap if a token is available.
@@ -1020,8 +1040,8 @@ pub fn bootstrap_agents(
         setup_github_auth(session)?;
     }
 
-    bootstrap_claude(session, cfg, inst, restart)?;
-    bootstrap_codex(session, cfg, restart)?;
+    bootstrap_claude(session, cfg, inst, mode)?;
+    bootstrap_codex(session, cfg, mode)?;
 
     Ok(())
 }
@@ -1031,7 +1051,7 @@ pub fn bootstrap_agents(
 /// Runs the bootstrap sequence: GitHub auth, user content
 /// (CLAUDE.md, rules), marketplaces, plugins, MCP servers.
 ///
-/// On restart (`restart=true`), only refreshes ephemeral state
+/// On `BootMode::Restart`, only refreshes ephemeral state
 /// (GitHub auth, CLAUDE.md, rules). Marketplaces, plugins, and
 /// MCP servers persist on the guest disk across stop/start.
 ///
@@ -1043,11 +1063,11 @@ fn bootstrap_claude(
     session: &SshSession,
     cfg: &CoopConfig,
     inst: &crate::config::Instance,
-    restart: bool,
+    mode: BootMode,
 ) -> Result<()> {
     let claude = &cfg.claude;
 
-    if !restart {
+    if let BootMode::FirstBoot = mode {
         let needs_claude_cli = !claude.marketplaces.is_empty()
             || !claude.plugins.is_empty()
             || !claude.mcp_servers.is_empty();
@@ -1075,7 +1095,7 @@ fn bootstrap_claude(
 
     // Marketplaces, plugins, MCP servers — persisted on guest disk,
     // only install on first boot
-    if !restart {
+    if let BootMode::FirstBoot = mode {
         // Compute delta: only install marketplaces/plugins not already
         // baked into the golden image
         let (missing_marketplaces, missing_plugins) = compute_plugin_delta(cfg, &inst.image);
@@ -1102,7 +1122,7 @@ fn bootstrap_claude(
 /// Codex uses `~/.codex/config.toml` for MCP registration and related
 /// settings, so bootstrap writes allowlisted user config files and a
 /// managed MCP section there when configured.
-fn bootstrap_codex(session: &SshSession, cfg: &CoopConfig, restart: bool) -> Result<()> {
+fn bootstrap_codex(session: &SshSession, cfg: &CoopConfig, mode: BootMode) -> Result<()> {
     let codex = &cfg.codex;
     let source_dir = resolve_config_source_dir(&codex.config_dir, ".codex", "codex.config_dir");
     let needs_codex = codex_bootstrap_needed(source_dir.as_deref(), &codex.mcp_servers);
@@ -1120,10 +1140,9 @@ fn bootstrap_codex(session: &SshSession, cfg: &CoopConfig, restart: bool) -> Res
 
     copy_codex_config(&session.target, source_dir.as_deref(), codex)?;
 
-    if restart {
-        tracing::info!("Codex bootstrap refreshed");
-    } else {
-        tracing::info!("Codex bootstrap complete");
+    match mode {
+        BootMode::Restart => tracing::info!("Codex bootstrap refreshed"),
+        BootMode::FirstBoot => tracing::info!("Codex bootstrap complete"),
     }
 
     Ok(())

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 
-use crate::backend::SshTarget;
+use crate::backend::{LogMode, SshTarget};
 use crate::config::{CoopConfig, GiB, Instance};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
@@ -358,7 +358,7 @@ pub fn status(cfg: &CoopConfig, inst: &Instance) -> Result<String> {
 }
 
 /// Stream Lima instance logs.
-pub fn stream_logs(inst: &Instance, follow: bool) -> Result<()> {
+pub fn stream_logs(inst: &Instance, mode: LogMode) -> Result<()> {
     let name = lima_name(inst);
 
     // Lima logs are in ~/.lima/<name>/serial.log
@@ -379,19 +379,22 @@ pub fn stream_logs(inst: &Instance, follow: bool) -> Result<()> {
         );
     };
 
-    if follow {
-        let mut child = Command::new("tail")
-            .arg("-f")
-            .arg(&log_path)
-            .spawn()
-            .context("Failed to tail log file")?;
-        child.wait().context("Log streaming interrupted")?;
-    } else {
-        let file = fs::File::open(&log_path).context("Failed to open log file")?;
-        let reader = BufReader::new(file);
-        for line in reader.lines() {
-            let line = line.context("Failed to read log line")?;
-            writeln!(std::io::stdout(), "{line}").context("Failed to write log line")?;
+    match mode {
+        LogMode::Follow => {
+            let mut child = Command::new("tail")
+                .arg("-f")
+                .arg(&log_path)
+                .spawn()
+                .context("Failed to tail log file")?;
+            child.wait().context("Log streaming interrupted")?;
+        }
+        LogMode::Snapshot => {
+            let file = fs::File::open(&log_path).context("Failed to open log file")?;
+            let reader = BufReader::new(file);
+            for line in reader.lines() {
+                let line = line.context("Failed to read log line")?;
+                writeln!(std::io::stdout(), "{line}").context("Failed to write log line")?;
+            }
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -825,7 +825,12 @@ fn main() -> Result<()> {
         Commands::Status { name } => cmd_status(&be, &cfg, name.as_deref()),
         Commands::Logs { name, follow } => {
             let running = resolve_running(&be, &cfg, name.as_deref())?;
-            be.stream_logs(&cfg, &running.inst, follow)
+            let mode = if follow {
+                backend::LogMode::Follow
+            } else {
+                backend::LogMode::Snapshot
+            };
+            be.stream_logs(&cfg, &running.inst, mode)
         }
         Commands::Push {
             name,
@@ -1381,7 +1386,7 @@ fn restart_instance(
         if opts.no_agents {
             tracing::info!("Skipping guest agent bootstrap (--no-agents)");
         } else {
-            backend::bootstrap_agents(&session, cfg, inst, true)?;
+            backend::bootstrap_agents(&session, cfg, inst, backend::BootMode::Restart)?;
         }
         if let Some(cmd) = post_start {
             backend::run_post_start(&session, cmd);
@@ -1482,7 +1487,7 @@ fn start_instance(
         if opts.no_agents {
             tracing::info!("Skipping guest agent bootstrap (--no-agents)");
         } else {
-            backend::bootstrap_agents(&session, cfg, inst, false)?;
+            backend::bootstrap_agents(&session, cfg, inst, backend::BootMode::FirstBoot)?;
         }
         if let Some(cmd) = post_start {
             backend::run_post_start(&session, cmd);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 
+use crate::backend::LogMode;
 use crate::cmd::Cmd;
 use crate::config::{CoopConfig, Instance};
 
@@ -380,25 +381,28 @@ impl<'a> FirecrackerVm<'a, Running> {
     }
 
     /// Stream the Firecracker log file to stdout.
-    pub fn stream_logs(&self, follow: bool) -> Result<()> {
+    pub fn stream_logs(&self, mode: LogMode) -> Result<()> {
         let log_path = self.inst.log_path();
         if !log_path.exists() {
             bail!("No log file found at {}", log_path.display());
         }
 
-        if follow {
-            let mut child = Command::new("tail")
-                .arg("-f")
-                .arg(&log_path)
-                .spawn()
-                .context("Failed to tail log file")?;
-            child.wait().context("Log streaming interrupted")?;
-        } else {
-            let file = fs::File::open(&log_path).context("Failed to open log file")?;
-            let reader = BufReader::new(file);
-            for line in reader.lines() {
-                let line = line.context("Failed to read log line")?;
-                writeln!(std::io::stdout(), "{line}").context("Failed to write log line")?;
+        match mode {
+            LogMode::Follow => {
+                let mut child = Command::new("tail")
+                    .arg("-f")
+                    .arg(&log_path)
+                    .spawn()
+                    .context("Failed to tail log file")?;
+                child.wait().context("Log streaming interrupted")?;
+            }
+            LogMode::Snapshot => {
+                let file = fs::File::open(&log_path).context("Failed to open log file")?;
+                let reader = BufReader::new(file);
+                for line in reader.lines() {
+                    let line = line.context("Failed to read log line")?;
+                    writeln!(std::io::stdout(), "{line}").context("Failed to write log line")?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

- Add `BootMode { FirstBoot, Restart }` and `LogMode { Snapshot, Follow }` in `src/backend.rs`.
- Thread them through `bootstrap_agents` / `bootstrap_claude` / `bootstrap_codex` and `stream_logs` (trait + Firecracker + Lima + `vm::FirecrackerVm`) in place of `restart: bool` / `follow: bool`.
- Translate `--follow` at the CLI boundary in `main.rs`; pass `BootMode::FirstBoot` / `BootMode::Restart` from `start_instance` / `restart_instance`.

Call sites now read as `backend::BootMode::Restart` / `backend::LogMode::Follow`, so the intent is visible at the call site instead of an opaque positional `true`/`false`. Closes #158.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (485 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual integration check (`./tests/run-integration.sh` on Lima/Firecracker) — mechanical rename, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)