### PR TITLE
Parse `--mount`, `--env`, `--forward-port` at the clap boundary (closes #152)

### DIFF
--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -906,19 +906,10 @@ fn translate_mounts(
     let mut applied: Vec<String> = Vec::new();
     for entry in mounts {
         match parse_mount_entry(entry) {
-            Ok(spec) => match Mount::parse(&spec) {
-                Ok(m) => {
-                    applied.push(format!("{}->{}", m.host_path.display(), m.guest_path));
-                    t.mounts.push(m);
-                }
-                Err(e) => t.report.push(
-                    key,
-                    ReportStatus::Invalid,
-                    ReportSource::Devcontainer,
-                    spec,
-                    e.to_string(),
-                ),
-            },
+            Ok(m) => {
+                applied.push(format!("{}->{}", m.host_path.display(), m.guest_path));
+                t.mounts.push(m);
+            }
             Err(e) => t.report.push(
                 key,
                 ReportStatus::Invalid,
@@ -1047,9 +1038,9 @@ fn parse_forward_port_entry(v: &serde_json::Value) -> Result<PortForward> {
     }
 }
 
-fn parse_mount_entry(v: &serde_json::Value) -> Result<String> {
-    match v {
-        serde_json::Value::String(s) => parse_mount_string(s),
+fn parse_mount_entry(v: &serde_json::Value) -> Result<Mount> {
+    let spec = match v {
+        serde_json::Value::String(s) => normalize_mount_string(s)?,
         serde_json::Value::Object(map) => {
             let typ = map
                 .get("type")
@@ -1066,15 +1057,16 @@ fn parse_mount_entry(v: &serde_json::Value) -> Result<String> {
                 .get("target")
                 .and_then(|v| v.as_str())
                 .context("mount object requires 'target'")?;
-            Ok(format!("{source}:{target}"))
+            format!("{source}:{target}")
         }
         _ => bail!("expected mount string or object"),
-    }
+    };
+    Mount::parse(&spec)
 }
 
 /// Convert a docker-style mount string (`type=bind,source=...,target=...`)
 /// into coop's `HOST_PATH[:GUEST_PATH]` form.
-fn parse_mount_string(s: &str) -> Result<String> {
+fn normalize_mount_string(s: &str) -> Result<String> {
     if !s.contains('=') {
         // Already in HOST:GUEST or HOST form — pass through.
         return Ok(s.to_string());
@@ -1444,18 +1436,32 @@ mod tests {
     }
 
     #[test]
-    fn parse_mount_object_and_string() {
+    fn normalize_mount_string_handles_docker_form() {
         assert_eq!(
-            parse_mount_string("type=bind,source=/a,target=/b").unwrap(),
+            normalize_mount_string("type=bind,source=/a,target=/b").unwrap(),
             "/a:/b"
         );
         assert_eq!(
-            parse_mount_string("source=/a,target=/b,readonly").unwrap(),
+            normalize_mount_string("source=/a,target=/b,readonly").unwrap(),
             "/a:/b"
         );
-        assert!(parse_mount_string("type=volume,source=v,target=/b").is_err());
-        let obj = serde_json::json!({"type": "bind", "source": "/a", "target": "/b"});
-        assert_eq!(parse_mount_entry(&obj).unwrap(), "/a:/b");
+        assert!(normalize_mount_string("type=volume,source=v,target=/b").is_err());
+    }
+
+    #[test]
+    fn parse_mount_entry_object_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let host = tmp.path().to_str().unwrap();
+        let obj = serde_json::json!({"type": "bind", "source": host, "target": "/b"});
+        let m = parse_mount_entry(&obj).unwrap();
+        assert_eq!(m.guest_path, "/b");
+    }
+
+    #[test]
+    fn parse_mount_entry_rejects_unsupported_type() {
+        let obj = serde_json::json!({"type": "volume", "source": "/v", "target": "/b"});
+        let err = parse_mount_entry(&obj).unwrap_err();
+        assert!(format!("{err:#}").contains("unsupported mount type"));
     }
 
     #[test]

--- a/src/guest_env_state.rs
+++ b/src/guest_env_state.rs
@@ -178,26 +178,19 @@ pub fn merge_persisted_entries(
     out
 }
 
-/// Parse `--env KEY=VALUE` argument list into a `BTreeMap`.
+/// Parse a single `--env KEY=VALUE` entry. Suitable for clap
+/// `value_parser`, so invalid keys fail before any VM lifecycle work.
 ///
 /// Rejects entries missing `=` and entries whose key fails
 /// [`EnvVarName`] validation. Empty values are allowed (e.g.
 /// `--env CLEAR=`).
-///
-/// Returned map preserves the "last write wins" precedence of the
-/// argument order: later duplicates of the same key overwrite earlier
-/// ones, matching `merge_cli_guest_env`'s in-memory behaviour.
-pub fn parse_cli_env_args(args: &[String]) -> Result<BTreeMap<EnvVarName, String>> {
-    let mut out = BTreeMap::new();
-    for entry in args {
-        let (key, value) = entry
-            .split_once('=')
-            .with_context(|| format!("--env expects KEY=VALUE, got '{entry}' (missing '=')"))?;
-        let name = EnvVarName::new(key)
-            .with_context(|| format!("--env KEY is invalid (got '{entry}')"))?;
-        out.insert(name, value.to_string());
-    }
-    Ok(out)
+pub fn parse_cli_env_arg(entry: &str) -> Result<(EnvVarName, String)> {
+    let (key, value) = entry
+        .split_once('=')
+        .with_context(|| format!("--env expects KEY=VALUE, got '{entry}' (missing '=')"))?;
+    let name =
+        EnvVarName::new(key).with_context(|| format!("--env KEY is invalid (got '{entry}')"))?;
+    Ok((name, value.to_string()))
 }
 
 #[cfg(test)]
@@ -314,33 +307,34 @@ mod tests {
         assert_eq!(merged.get(&env("K")).map(String::as_str), Some("from-cli"));
     }
 
-    // ── parse_cli_env_args ───────────────────────────────────
+    // ── parse_cli_env_arg ────────────────────────────────────
 
     #[test]
-    fn parse_cli_env_args_basic() {
-        let parsed = parse_cli_env_args(&["FOO=1".into(), "BAR=baz".into()]).unwrap();
-        assert_eq!(parsed.get(&env("FOO")).map(String::as_str), Some("1"));
-        assert_eq!(parsed.get(&env("BAR")).map(String::as_str), Some("baz"));
+    fn parse_cli_env_arg_basic() {
+        let (k, v) = parse_cli_env_arg("FOO=1").unwrap();
+        assert_eq!(k, env("FOO"));
+        assert_eq!(v, "1");
     }
 
     #[test]
-    fn parse_cli_env_args_allows_empty_value() {
-        let parsed = parse_cli_env_args(&["EMPTY=".into()]).unwrap();
-        assert_eq!(parsed.get(&env("EMPTY")).map(String::as_str), Some(""));
+    fn parse_cli_env_arg_allows_empty_value() {
+        let (k, v) = parse_cli_env_arg("EMPTY=").unwrap();
+        assert_eq!(k, env("EMPTY"));
+        assert_eq!(v, "");
     }
 
     #[test]
-    fn parse_cli_env_args_rejects_missing_equals() {
-        let err = parse_cli_env_args(&["BAD".into()]).unwrap_err();
+    fn parse_cli_env_arg_rejects_missing_equals() {
+        let err = parse_cli_env_arg("BAD").unwrap_err();
         assert!(format!("{err:#}").contains("missing '='"));
     }
 
     #[test]
-    fn parse_cli_env_args_rejects_invalid_key() {
+    fn parse_cli_env_arg_rejects_invalid_key() {
         // Empty key, leading digit, embedded space, embedded '=' in key
         // all funnel through `EnvVarName::new`, so one test covers them.
         for bad in ["=value", "1FOO=v", "FOO BAR=v"] {
-            let err = parse_cli_env_args(&[bad.into()]).unwrap_err();
+            let err = parse_cli_env_arg(bad).unwrap_err();
             assert!(
                 format!("{err:#}").contains("--env KEY is invalid"),
                 "expected validation error for '{bad}', got: {err:#}",
@@ -349,17 +343,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_cli_env_args_last_duplicate_wins() {
-        let parsed = parse_cli_env_args(&["K=v1".into(), "K=v2".into()]).unwrap();
-        assert_eq!(parsed.get(&env("K")).map(String::as_str), Some("v2"));
-    }
-
-    #[test]
-    fn parse_cli_env_args_value_may_contain_equals() {
-        let parsed = parse_cli_env_args(&["URL=https://x?a=b&c=d".into()]).unwrap();
-        assert_eq!(
-            parsed.get(&env("URL")).map(String::as_str),
-            Some("https://x?a=b&c=d"),
-        );
+    fn parse_cli_env_arg_value_may_contain_equals() {
+        let (k, v) = parse_cli_env_arg("URL=https://x?a=b&c=d").unwrap();
+        assert_eq!(k, env("URL"));
+        assert_eq!(v, "https://x?a=b&c=d");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,13 +179,17 @@ enum Commands {
         #[arg(long, alias = "no-claude")]
         no_agents: bool,
         /// Mount host directory into guest (`HOST_PATH[:GUEST_PATH]`, repeatable)
-        #[arg(long, conflicts_with_all = ["workspace", "git_repo"])]
-        mount: Vec<String>,
+        #[arg(
+            long,
+            conflicts_with_all = ["workspace", "git_repo"],
+            value_parser = config::Mount::parse,
+        )]
+        mount: Vec<config::Mount>,
         /// Forward a guest port to the host (`GUEST[:HOST]`, repeatable).
         /// `--forward-port 3000` forwards guest 3000 to host 3000;
         /// `--forward-port 3000:3001` forwards guest 3000 to host 3001.
-        #[arg(long)]
-        forward_port: Vec<String>,
+        #[arg(long, value_parser = config::PortForward::parse)]
+        forward_port: Vec<config::PortForward>,
         /// Named image to use (default: "default")
         #[arg(
             long,
@@ -208,8 +212,12 @@ enum Commands {
         /// Literal env var to set in the guest (`KEY=VALUE`, repeatable).
         /// Overrides `guest_env` entries from config and any forwarded
         /// values with the same name.
-        #[arg(long = "env", value_name = "KEY=VALUE")]
-        guest_env: Vec<String>,
+        #[arg(
+            long = "env",
+            value_name = "KEY=VALUE",
+            value_parser = guest_env_state::parse_cli_env_arg,
+        )]
+        guest_env: Vec<(guest_env_state::EnvVarName, String)>,
         /// Explicit path to a `devcontainer.json` to use (skips discovery).
         #[arg(long, value_name = "PATH", conflicts_with = "no_devcontainer")]
         devcontainer: Option<String>,
@@ -662,13 +670,13 @@ fn main() -> Result<()> {
             mem,
             disk,
             no_agents,
-            mount,
+            mount: mounts,
             image,
             exclude_git,
             no_prompt,
             post_start,
             guest_env,
-            forward_port,
+            forward_port: mut forward_ports,
             devcontainer,
             no_devcontainer,
             dry_run,
@@ -678,18 +686,9 @@ fn main() -> Result<()> {
                     "--no-claude is deprecated and will be removed in a future release; use --no-agents"
                 );
             }
-            let mounts = mount
-                .iter()
-                .map(|s| config::Mount::parse(s))
-                .collect::<Result<Vec<_>>>()?;
-            let mut forward_ports = forward_port
-                .iter()
-                .map(|s| config::PortForward::parse(s))
-                .collect::<Result<Vec<_>>>()?;
-
             let cli_env_keys = guest_env
                 .iter()
-                .filter_map(|s| s.split_once('=').map(|(k, _)| k.to_string()))
+                .map(|(k, _)| k.as_str().to_string())
                 .collect();
             let inputs = devcontainer::TranslatorInputs {
                 cli_vcpus: vcpus,
@@ -726,7 +725,10 @@ fn main() -> Result<()> {
                 forward_ports =
                     devcontainer::merge_into_forward_ports(&t.forward_ports, &forward_ports);
             }
-            let cli_guest_env = guest_env_state::parse_cli_env_args(&guest_env)?;
+            // `BTreeMap::from_iter` keeps the last value for a repeated
+            // key, matching the documented "last `--env` wins" semantics.
+            let cli_guest_env: std::collections::BTreeMap<_, _> =
+                guest_env.iter().cloned().collect();
             for (key, value) in &cli_guest_env {
                 cfg.guest_env.insert(key.clone(), value.clone());
             }
@@ -2508,10 +2510,37 @@ mod tests {
         let super::Commands::Start { guest_env, .. } = cli.command else {
             panic!("expected Start variant");
         };
+        let pairs: Vec<(String, String)> = guest_env
+            .into_iter()
+            .map(|(k, v)| (k.as_str().to_string(), v))
+            .collect();
         assert_eq!(
-            guest_env,
-            vec!["FOO=bar".to_string(), "BAZ=qux".to_string()]
+            pairs,
+            vec![
+                ("FOO".to_string(), "bar".to_string()),
+                ("BAZ".to_string(), "qux".to_string()),
+            ]
         );
+    }
+
+    #[test]
+    fn start_env_flag_rejects_invalid_key_at_clap_time() {
+        use clap::Parser as _;
+        let argv = ["coop", "start", "--env", "1BAD=value"];
+        let Err(err) = super::Cli::try_parse_from(argv) else {
+            panic!("expected --env to reject invalid KEY");
+        };
+        assert!(format!("{err}").contains("--env KEY is invalid"));
+    }
+
+    #[test]
+    fn start_forward_port_rejects_invalid_spec_at_clap_time() {
+        use clap::Parser as _;
+        let argv = ["coop", "start", "--forward-port", "abc"];
+        let Err(err) = super::Cli::try_parse_from(argv) else {
+            panic!("expected --forward-port to reject invalid spec");
+        };
+        assert!(format!("{err}").contains("forward-port"));
     }
 
     /// `prepare_session_from_target` must overlay the on-disk


### PR DESCRIPTION
## Summary

Use clap `value_parser` so each `Vec<String>` CLI argument is parsed
into its strong type at parse time. Malformed specs now fail before
any VM lifecycle work, instead of after SSH setup begins.

- `--mount` parses into `Vec<Mount>` via `Mount::parse`
- `--forward-port` parses into `Vec<PortForward>` via `PortForward::parse`
- `--env` parses into `Vec<(EnvVarName, String)>` via a new
  `parse_cli_env_arg` (replaces the post-clap `parse_cli_env_args` loop)

Devcontainer cleanup follows naturally: `parse_mount_entry` now
returns `Mount` directly (no intermediate `String`), collapsing the
nested error match in `translate_mounts`. The docker-style normalizer
is renamed `normalize_mount_string` to reflect its narrower scope.

Closes #152.

## Test plan

- [x] `cargo test` — 506 passing, including new tests that exercise
  the clap-time failure paths for `--env` and `--forward-port`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] Smoke-tested at the CLI:
  - `coop start --mount /no/such/path/xyz` → fails at clap with
    `Mount host path does not exist: /no/such/path/xyz`
  - `coop start --forward-port abc` → fails at clap with
    `guest port must be a number 1..=65535`
  - `coop start --env 1BAD=value` → fails at clap with
    `--env KEY is invalid`
- [ ] Integration tests on both platforms (per `CLAUDE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)