### PR TITLE
Extend `RunningInstance` proof across both backends (closes #153)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -123,12 +123,42 @@ impl EnvForward {
 
 // ── Running instance ──────────────────────────────────────────
 
-/// Instance that has been verified as running. Carries the SSH
-/// target so connection details are always available without
+/// Proof that an instance is currently running. Construct via
+/// [`VmBackend::as_running`] — the constructor is the single place
+/// that probes live state, so operations taking a `RunningInstance`
+/// can rely on the precondition without re-checking. Carries the
+/// SSH target so connection details are always available without
 /// further fallible lookups.
+///
+/// Fields are private so a `RunningInstance` cannot be forged; the
+/// only way to obtain one is through a backend method that verified
+/// the instance is alive.
 pub struct RunningInstance {
-    pub inst: Instance,
-    pub target: SshTarget,
+    inst: Instance,
+    target: SshTarget,
+}
+
+impl RunningInstance {
+    /// Mint a `RunningInstance` after a successful live-state probe.
+    ///
+    /// Crate-private so only backend impls can construct one. Callers
+    /// use [`VmBackend::as_running`] (which delegates here).
+    pub(crate) fn new(inst: Instance, target: SshTarget) -> Self {
+        Self { inst, target }
+    }
+
+    pub fn instance(&self) -> &Instance {
+        &self.inst
+    }
+
+    pub fn target(&self) -> &SshTarget {
+        &self.target
+    }
+
+    /// Consume the wrapper and return the inner `Instance` and SSH target.
+    pub fn into_parts(self) -> (Instance, SshTarget) {
+        (self.inst, self.target)
+    }
 }
 
 // ── SSH target ────────────────────────────────────────────────
@@ -595,7 +625,10 @@ pub trait VmBackend: std::fmt::Display {
         mounts: &[crate::config::Mount],
     ) -> Result<()>;
     fn start_existing(&self, cfg: &CoopConfig, inst: &Instance) -> Result<()>;
-    fn stop(&self, cfg: &CoopConfig, inst: &Instance) -> Result<()>;
+    /// Stop a running instance. Consumes the `RunningInstance` proof
+    /// so the type system witnesses that the precondition held when
+    /// the call was made.
+    fn stop(&self, cfg: &CoopConfig, running: RunningInstance) -> Result<()>;
     fn destroy_instance(&self, cfg: &CoopConfig, inst: &Instance) -> Result<()>;
     fn destroy_shared(&self, cfg: &CoopConfig);
     fn destroy_image(&self, cfg: &CoopConfig, image: &str) -> Result<()>;
@@ -606,8 +639,25 @@ pub trait VmBackend: std::fmt::Display {
         new_size: crate::config::GiB,
     ) -> Result<()>;
     fn is_running(&self, inst: &Instance) -> bool;
+    /// Probe the live state of `inst` and return a `RunningInstance`
+    /// if it is running. This is the single chokepoint for "is this
+    /// VM alive?" — call sites that need to operate on a running VM
+    /// should ask via this method rather than open-coding the check.
+    ///
+    /// Returns `Err` when the instance is not running or when the
+    /// backend lookup itself fails (e.g. `limactl list` errors). The
+    /// `Instance` is consumed; on `Err` callers can clone before
+    /// calling if they need to keep working with it.
+    fn as_running(&self, cfg: &CoopConfig, inst: Instance) -> Result<RunningInstance>;
     fn status(&self, cfg: &CoopConfig, inst: &Instance) -> Result<String>;
-    fn stream_logs(&self, cfg: &CoopConfig, inst: &Instance, mode: LogMode) -> Result<()>;
+    /// Stream logs from a running instance.
+    ///
+    /// Takes `&RunningInstance` so the running precondition is part
+    /// of the signature — Firecracker's log streaming asserts the
+    /// PID is alive, and `--follow` only makes sense while the VM
+    /// is producing new output.
+    fn stream_logs(&self, cfg: &CoopConfig, running: &RunningInstance, mode: LogMode)
+    -> Result<()>;
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget>;
     fn disk_path(&self, inst: &Instance) -> Result<PathBuf>;
     /// Whether mounts use live filesystem sharing (Lima/virtiofs)
@@ -666,12 +716,9 @@ impl VmBackend for FirecrackerBackend {
         running.wait_for_boot()
     }
 
-    fn stop(&self, cfg: &CoopConfig, inst: &Instance) -> Result<()> {
-        if !self.is_running(inst) {
-            tracing::debug!("Instance '{}' is not running — nothing to stop", inst.name);
-            return Ok(());
-        }
-        let vm = crate::vm::FirecrackerVm::from_running(cfg, inst)?;
+    fn stop(&self, cfg: &CoopConfig, running: RunningInstance) -> Result<()> {
+        let (inst, _target) = running.into_parts();
+        let vm = crate::vm::FirecrackerVm::from_running(cfg, &inst)?;
         vm.stop()
     }
 
@@ -753,13 +800,31 @@ impl VmBackend for FirecrackerBackend {
         inst.is_running()
     }
 
+    fn as_running(&self, cfg: &CoopConfig, inst: Instance) -> Result<RunningInstance> {
+        if !inst.is_running() {
+            bail!(
+                "Instance '{}' is not running (no live Firecracker process \
+                 for PID file {})",
+                inst.name,
+                inst.pid_file_path().display(),
+            );
+        }
+        let target = self.ssh_target(cfg, &inst)?;
+        Ok(RunningInstance::new(inst, target))
+    }
+
     fn status(&self, cfg: &CoopConfig, inst: &Instance) -> Result<String> {
         let vm = crate::vm::FirecrackerVm::from_running(cfg, inst)?;
         vm.status()
     }
 
-    fn stream_logs(&self, cfg: &CoopConfig, inst: &Instance, mode: LogMode) -> Result<()> {
-        let vm = crate::vm::FirecrackerVm::from_running(cfg, inst)?;
+    fn stream_logs(
+        &self,
+        cfg: &CoopConfig,
+        running: &RunningInstance,
+        mode: LogMode,
+    ) -> Result<()> {
+        let vm = crate::vm::FirecrackerVm::from_running(cfg, running.instance())?;
         vm.stream_logs(mode)
     }
 
@@ -820,8 +885,9 @@ impl VmBackend for LimaBackend {
         crate::lima::start_existing(cfg, inst)
     }
 
-    fn stop(&self, _cfg: &CoopConfig, inst: &Instance) -> Result<()> {
-        crate::lima::stop(inst)
+    fn stop(&self, _cfg: &CoopConfig, running: RunningInstance) -> Result<()> {
+        let (inst, _target) = running.into_parts();
+        crate::lima::stop_running(&inst)
     }
 
     fn destroy_instance(&self, _cfg: &CoopConfig, inst: &Instance) -> Result<()> {
@@ -878,12 +944,28 @@ impl VmBackend for LimaBackend {
         crate::lima::is_running(inst)
     }
 
+    fn as_running(&self, cfg: &CoopConfig, inst: Instance) -> Result<RunningInstance> {
+        if !crate::lima::is_running(&inst) {
+            bail!(
+                "Instance '{}' is not running (Lima reports state != Running)",
+                inst.name,
+            );
+        }
+        let target = crate::lima::ssh_target(cfg, &inst)?;
+        Ok(RunningInstance::new(inst, target))
+    }
+
     fn status(&self, cfg: &CoopConfig, inst: &Instance) -> Result<String> {
         crate::lima::status(cfg, inst)
     }
 
-    fn stream_logs(&self, _cfg: &CoopConfig, inst: &Instance, mode: LogMode) -> Result<()> {
-        crate::lima::stream_logs(inst, mode)
+    fn stream_logs(
+        &self,
+        _cfg: &CoopConfig,
+        running: &RunningInstance,
+        mode: LogMode,
+    ) -> Result<()> {
+        crate::lima::stream_logs(running.instance(), mode)
     }
 
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1771,7 +1771,7 @@ fn default_image_name() -> String {
     DEFAULT_IMAGE.to_string()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Instance {
     pub name: InstanceName,
     pub index: InstanceIndex,

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -180,14 +180,12 @@ pub fn start_existing(cfg: &CoopConfig, inst: &Instance) -> Result<()> {
     Ok(())
 }
 
-/// Stop a Lima instance.
-pub fn stop(inst: &Instance) -> Result<()> {
+/// Stop a Lima instance that has already been verified as running.
+///
+/// The caller's `RunningInstance` token proves the precondition, so
+/// this skips the live-state probe and only handles the shutdown.
+pub fn stop_running(inst: &Instance) -> Result<()> {
     let name = lima_name(inst);
-
-    if !is_running(inst) {
-        tracing::debug!("Lima instance '{name}' is not running — nothing to stop");
-        return Ok(());
-    }
 
     tracing::info!("Stopping Lima instance '{name}'");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -832,7 +832,7 @@ fn main() -> Result<()> {
             } else {
                 backend::LogMode::Snapshot
             };
-            be.stream_logs(&cfg, &running.inst, mode)
+            be.stream_logs(&cfg, &running, mode)
         }
         Commands::Push {
             name,
@@ -841,13 +841,7 @@ fn main() -> Result<()> {
             exclude_git,
         } => {
             let running = resolve_running(&be, &cfg, name.as_deref())?;
-            workspace::push(
-                &running.target,
-                &running.inst,
-                dir.as_deref(),
-                force,
-                exclude_git,
-            )
+            workspace::push(&running, dir.as_deref(), force, exclude_git)
         }
         Commands::Pull {
             name,
@@ -856,13 +850,7 @@ fn main() -> Result<()> {
             exclude_git,
         } => {
             let running = resolve_running(&be, &cfg, name.as_deref())?;
-            workspace::pull(
-                &running.target,
-                &running.inst,
-                dir.as_deref(),
-                force,
-                exclude_git,
-            )
+            workspace::pull(&running, dir.as_deref(), force, exclude_git)
         }
         Commands::Exec { name, command } => cmd_exec(&be, &cfg, name.as_deref(), &command),
         Commands::Vscode {
@@ -878,12 +866,7 @@ fn main() -> Result<()> {
                 return Ok(());
             }
             let running = resolve_running(&be, &cfg, name.as_deref())?;
-            workspace::vscode(
-                &running.target,
-                &running.inst,
-                Some(&project),
-                editor.as_deref(),
-            )
+            workspace::vscode(&running, Some(&project), editor.as_deref())
         }
         Commands::Images { delete } => cmd_images(&be, &cfg, delete.as_deref()),
         Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_deref(), &size),
@@ -1599,14 +1582,12 @@ fn resolve_running(
                      Create one with: coop start {name}"
                 )
             })?;
-        if !be.is_running(&inst) {
-            bail!(
+        return be.as_running(cfg, inst).with_context(|| {
+            format!(
                 "Instance '{name}' is not running.\n\
                  Start it with: coop start {name}"
-            );
-        }
-        let target = be.ssh_target(cfg, &inst)?;
-        return Ok(backend::RunningInstance { inst, target });
+            )
+        });
     }
 
     let (running, stopped): (Vec<_>, Vec<_>) =
@@ -1618,8 +1599,7 @@ fn resolve_running(
                 .into_iter()
                 .next()
                 .context("Instance list unexpectedly empty")?;
-            let target = be.ssh_target(cfg, &inst)?;
-            Ok(backend::RunningInstance { inst, target })
+            be.as_running(cfg, inst)
         }
         0 if stopped.len() == 1 => {
             let name = &stopped[0].name;
@@ -1690,8 +1670,9 @@ fn open_ssh_session(
     name: Option<&str>,
 ) -> Result<backend::SshSession> {
     let running = resolve_running(be, cfg, name)?;
-    let repo = backend::detect_instance_repo(&running.inst);
-    prepare_session_from_target(cfg, Some(&running.inst), running.target, repo.as_ref())
+    let repo = backend::detect_instance_repo(running.instance());
+    let (inst, target) = running.into_parts();
+    prepare_session_from_target(cfg, Some(&inst), target, repo.as_ref())
 }
 
 /// Build an `SshSession` from an already-resolved target.
@@ -1732,14 +1713,22 @@ fn cmd_stop(
     inst: &config::Instance,
 ) -> Result<()> {
     tracing::info!("Stopping instance '{}'", inst.name);
-    // Tear down forwards before shutting down the VM so the control
-    // master can exit cleanly while SSH is still reachable.
-    if let Ok(target) = be.ssh_target(cfg, inst) {
-        port_forward::teardown_ssh_forwards(inst, &target);
+    // Probe live state once. The `RunningInstance` proof flows into
+    // `be.stop`, so the type system witnesses that we only ask the
+    // backend to stop something that was actually running.
+    if let Ok(running) = be.as_running(cfg, inst.clone()) {
+        // Tear down forwards before shutting down the VM so the
+        // control master can exit cleanly while SSH is still
+        // reachable.
+        port_forward::teardown_ssh_forwards(running.instance(), running.target());
+        be.stop(cfg, running)?;
     } else {
-        tracing::debug!("Skipping forward teardown — no SSH target available");
+        tracing::debug!("Instance '{}' is not running — nothing to stop", inst.name);
+        // Stale forwards may still exist even when the VM is gone.
+        if let Ok(target) = be.ssh_target(cfg, inst) {
+            port_forward::teardown_ssh_forwards(inst, &target);
+        }
     }
-    be.stop(cfg, inst)?;
     if let Err(e) = workspace::remove_ssh_config(inst) {
         tracing::debug!("SSH config cleanup failed (non-fatal): {e}");
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Stdio};
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::backend::SshTarget;
+use crate::backend::{RunningInstance, SshTarget};
 use crate::config::Instance;
 
 const GUEST_WORKSPACE: &str = "/workspace";
@@ -329,13 +329,17 @@ fn load_or_default(inst: &Instance, dir: Option<&str>, cmd: &str) -> Result<Work
 }
 
 /// Push local directory to guest. Uses rsync if available, falls back to tar-pipe.
+///
+/// Takes a `RunningInstance` so the caller's proof of liveness is
+/// visible in the signature — no surprise SSH failure inside.
 pub fn push(
-    target: &SshTarget,
-    inst: &Instance,
+    running: &RunningInstance,
     dir: Option<&str>,
     force: bool,
     exclude_git: bool,
 ) -> Result<()> {
+    let inst = running.instance();
+    let target = running.target();
     let state = load_or_default(inst, dir, "push")?;
     let source_dir = resolve_host_dir(dir, &state, "push")?;
 
@@ -365,13 +369,17 @@ pub fn push(
 }
 
 /// Pull guest workspace to local directory. Uses rsync if available, falls back to tar-pipe.
+///
+/// Takes a `RunningInstance` so the caller's proof of liveness is
+/// visible in the signature — no surprise SSH failure inside.
 pub fn pull(
-    target: &SshTarget,
-    inst: &Instance,
+    running: &RunningInstance,
     dir: Option<&str>,
     force: bool,
     exclude_git: bool,
 ) -> Result<()> {
+    let inst = running.instance();
+    let target = running.target();
     let state = load_or_default(inst, dir, "pull")?;
     let dest_dir = resolve_host_dir(dir, &state, "pull")?;
 
@@ -448,12 +456,16 @@ pub fn record_mount_state(inst: &Instance, mounts: &[crate::config::Mount]) -> R
 }
 
 /// Generate SSH config and launch VS Code Remote SSH.
+///
+/// Takes a `RunningInstance` so the caller's proof of liveness is
+/// visible in the signature — VS Code needs a live SSH target.
 pub fn vscode(
-    target: &SshTarget,
-    inst: &Instance,
+    running: &RunningInstance,
     project: Option<&str>,
     editor: Option<&str>,
 ) -> Result<()> {
+    let inst = running.instance();
+    let target = running.target();
     let remote_path = project.unwrap_or(GUEST_WORKSPACE);
 
     update_ssh_config(target, inst)?;


### PR DESCRIPTION
## Summary

- `RunningInstance` now has private fields and is constructed only by `VmBackend::as_running`, the single chokepoint for "is this VM alive?" probing (PID/Firecracker on Linux, lima `Running` state on macOS).
- `VmBackend::stop` consumes a `RunningInstance`; `stream_logs` takes `&RunningInstance`. The internal bail-on-not-running paths in the Firecracker and Lima impls are gone — the precondition is in the type.
- `workspace::push`, `pull`, and `vscode` take `&RunningInstance` instead of `(SshTarget, Instance)` pairs.
- `resolve_running` and `cmd_stop` go through `as_running`; `lima::stop` is renamed to `lima::stop_running` to reflect that it no longer probes liveness.
- `Instance` derives `Clone` so `cmd_stop` can hand ownership to `as_running` while keeping a borrow for post-stop cleanup.

Extends the type-state idea already used in `src/vm.rs` (`FirecrackerVm<Configured>` / `FirecrackerVm<Running>`) up one level so call sites in `src/backend.rs` and `src/main.rs` benefit from the same compile-time enforcement.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — all 519 tests pass
- [ ] `./tests/run-integration.sh` (Lima, macOS) — requires real VM environment
- [ ] `./tests/run-integration.sh --remote <host>` (Firecracker, Linux) — requires real VM environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)