### PR TITLE
Introduce `TmuxSessionName` newtype and `RemoteCommand` enum (closes #166)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,31 +71,41 @@ struct SessionArgs {
     /// Instance name (required if multiple instances exist)
     #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
     name: Option<String>,
-    /// tmux session name
-    #[arg(long, conflicts_with = "no_tmux")]
-    session: Option<String>,
+    /// tmux session name (allowed: a-z, A-Z, 0-9, '_', '-')
+    #[arg(long, conflicts_with = "no_tmux", value_parser = parse_tmux_session)]
+    session: Option<ssh::TmuxSessionName>,
     /// Skip tmux session persistence (raw SSH connection)
     #[arg(long)]
     no_tmux: bool,
 }
 
+fn parse_tmux_session(s: &str) -> Result<ssh::TmuxSessionName, String> {
+    ssh::TmuxSessionName::new(s).map_err(|e| e.to_string())
+}
+
 impl SessionArgs {
-    fn tmux_session<'a>(&'a self, default: &'a str) -> Option<&'a str> {
+    fn tmux_session(&self, default: &'static str) -> Option<ssh::TmuxSessionName> {
         if self.no_tmux {
             return None;
         }
-        Some(self.session.as_deref().unwrap_or(default))
+        Some(self.session.clone().unwrap_or_else(|| {
+            #[expect(
+                clippy::expect_used,
+                reason = "static default literal matches TmuxSessionName charset"
+            )]
+            ssh::TmuxSessionName::new(default).expect("static default is a valid tmux name")
+        }))
     }
 
     /// Returns a tmux session name only when explicitly requested via
     /// `--session`. Used by commands where tmux is opt-in (the wrapped
     /// process manages its own persistence, e.g. `claude agents` whose
     /// background sessions live in the daemon, not the terminal).
-    fn tmux_session_opt_in(&self) -> Option<&str> {
+    fn tmux_session_opt_in(&self) -> Option<ssh::TmuxSessionName> {
         if self.no_tmux {
             return None;
         }
-        self.session.as_deref()
+        self.session.clone()
     }
 }
 
@@ -808,18 +818,18 @@ fn main() -> Result<()> {
                 args.insert(0, "--permission-mode".to_string());
             }
             let tmux = session.tmux_session("claude");
-            ssh::run_interactive(&sess, crate::guest::CLAUDE_BIN, &args, tmux)
+            ssh::run_interactive(&sess, &build_remote(tmux, crate::guest::CLAUDE_BIN, args))
         }
         Commands::ClaudeAgents { session, mut args } => {
             let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
             args.insert(0, "agents".to_string());
             let tmux = session.tmux_session_opt_in();
-            ssh::run_interactive(&sess, crate::guest::CLAUDE_BIN, &args, tmux)
+            ssh::run_interactive(&sess, &build_remote(tmux, crate::guest::CLAUDE_BIN, args))
         }
         Commands::Codex { session, args } => {
             let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
             let tmux = session.tmux_session("codex");
-            ssh::run_interactive(&sess, crate::guest::CODEX_BIN, &args, tmux)
+            ssh::run_interactive(&sess, &build_remote(tmux, crate::guest::CODEX_BIN, args))
         }
         Commands::Stop { name } => {
             let inst = cfg.resolve_instance(name.as_deref())?;
@@ -1645,13 +1655,33 @@ fn cmd_shell(
     cfg: &config::CoopConfig,
     name: Option<&str>,
     command: &[String],
-    tmux_session: Option<&str>,
+    tmux_session: Option<ssh::TmuxSessionName>,
 ) -> Result<()> {
     let session = open_ssh_session(be, cfg, name)?;
     if command.is_empty() {
-        ssh::connect(&session, tmux_session)
+        ssh::run_interactive(&session, &build_remote(tmux_session, "", Vec::new()))
     } else {
         ssh::run_command(&session, command)
+    }
+}
+
+/// Build a `RemoteCommand` from a tmux choice and a (binary, args) pair.
+///
+/// `binary` may be empty, meaning "no command" — opens a bare interactive
+/// shell (or attaches to tmux without launching anything).
+fn build_remote(
+    tmux: Option<ssh::TmuxSessionName>,
+    binary: &str,
+    args: Vec<String>,
+) -> ssh::RemoteCommand {
+    let mut command = Vec::with_capacity(1 + args.len());
+    if !binary.is_empty() {
+        command.push(binary.to_string());
+    }
+    command.extend(args);
+    match tmux {
+        Some(session) => ssh::RemoteCommand::Tmux { session, command },
+        None => ssh::RemoteCommand::Shell { command },
     }
 }
 
@@ -2318,14 +2348,18 @@ mod tests {
         assert!(matches!(cli.command, super::Commands::Shell { .. }));
     }
 
+    fn tmux(s: &str) -> super::ssh::TmuxSessionName {
+        super::ssh::TmuxSessionName::new(s).expect("valid tmux session name")
+    }
+
     #[test]
     fn shell_session_flag_parses() {
         let cli = parse(&["shell", "--session", "work"]);
         let super::Commands::Shell { session, .. } = cli.command else {
             panic!("expected Shell variant");
         };
-        assert_eq!(session.session.as_deref(), Some("work"));
-        assert_eq!(session.tmux_session("main"), Some("work"));
+        assert_eq!(session.session, Some(tmux("work")));
+        assert_eq!(session.tmux_session("main"), Some(tmux("work")));
     }
 
     #[test]
@@ -2335,7 +2369,13 @@ mod tests {
             panic!("expected Shell variant");
         };
         assert!(session.session.is_none());
-        assert_eq!(session.tmux_session("main"), Some("main"));
+        assert_eq!(session.tmux_session("main"), Some(tmux("main")));
+    }
+
+    #[test]
+    fn shell_session_flag_rejects_invalid_name() {
+        let err = parse_err(&["shell", "--session", "bad name"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
     }
 
     #[test]
@@ -2350,8 +2390,8 @@ mod tests {
         let super::Commands::Claude { session, .. } = cli.command else {
             panic!("expected Claude variant");
         };
-        assert_eq!(session.session.as_deref(), Some("dev"));
-        assert_eq!(session.tmux_session("claude"), Some("dev"));
+        assert_eq!(session.session, Some(tmux("dev")));
+        assert_eq!(session.tmux_session("claude"), Some(tmux("dev")));
     }
 
     #[test]
@@ -2397,7 +2437,7 @@ mod tests {
         let super::Commands::ClaudeAgents { session, .. } = cli.command else {
             panic!("expected ClaudeAgents variant");
         };
-        assert_eq!(session.tmux_session_opt_in(), Some("dev"));
+        assert_eq!(session.tmux_session_opt_in(), Some(tmux("dev")));
     }
 
     #[test]
@@ -2432,8 +2472,8 @@ mod tests {
         let super::Commands::Codex { session, .. } = cli.command else {
             panic!("expected Codex variant");
         };
-        assert_eq!(session.session.as_deref(), Some("dev"));
-        assert_eq!(session.tmux_session("codex"), Some("dev"));
+        assert_eq!(session.session, Some(tmux("dev")));
+        assert_eq!(session.tmux_session("codex"), Some(tmux("dev")));
     }
 
     #[test]

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,10 +1,108 @@
+use std::fmt;
 use std::io::Write as _;
 use std::process::Command;
+use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::backend::SshSession;
 use crate::shell::shell_escape;
+
+/// Validated tmux session name (matches `[a-zA-Z0-9_-]+`).
+///
+/// The constructor rejects empty strings and any character outside the
+/// allowed set, so callers that interpolate the name into a shell-built
+/// `tmux new-session` command can do so without defensive quoting.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TmuxSessionName(String);
+
+impl TmuxSessionName {
+    /// Parse and validate. The name must be non-empty and contain only
+    /// ASCII letters, digits, `_`, or `-`.
+    pub fn new(s: &str) -> Result<Self> {
+        if s.is_empty() {
+            bail!("tmux session name must not be empty");
+        }
+        for c in s.chars() {
+            if !(c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+                bail!(
+                    "tmux session name '{s}' contains invalid character '{c}' \
+                     (allowed: a-z, A-Z, 0-9, '_', '-')"
+                );
+            }
+        }
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl fmt::Display for TmuxSessionName {
+    #[mutants::skip] // equivalent: trivial forwarder; covered indirectly by RemoteCommand rendering tests
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for TmuxSessionName {
+    #[mutants::skip] // equivalent: trivial forwarder; covered indirectly by RemoteCommand rendering tests
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for TmuxSessionName {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::new(s)
+    }
+}
+
+/// How a remote command runs on the guest.
+///
+/// `Shell` runs directly in the user's login shell (empty `command`
+/// opens an interactive shell). `Tmux` wraps the run inside a named
+/// tmux session that survives SSH disconnects; reconnecting reattaches
+/// to the existing session.
+#[derive(Debug, Clone)]
+pub enum RemoteCommand {
+    Shell {
+        command: Vec<String>,
+    },
+    Tmux {
+        session: TmuxSessionName,
+        command: Vec<String>,
+    },
+}
+
+impl RemoteCommand {
+    /// Render to the single string passed to `ssh ... <cmd>`.
+    fn render(&self) -> String {
+        match self {
+            Self::Shell { command } if command.is_empty() => {
+                "cd /workspace && exec $SHELL -l".to_string()
+            }
+            Self::Shell { command } => {
+                format!("cd /workspace && {}", join_escaped(command))
+            }
+            Self::Tmux { session, command } if command.is_empty() => {
+                format!("tmux new-session -A -s {session} -c /workspace")
+            }
+            Self::Tmux { session, command } => {
+                format!(
+                    "tmux new-session -A -s {session} -c /workspace {}",
+                    shell_escape(&join_escaped(command)),
+                )
+            }
+        }
+    }
+}
+
+fn join_escaped(args: &[String]) -> String {
+    args.iter()
+        .map(|a| shell_escape(a))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
 
 /// Return a TERM value the guest is guaranteed to understand.
 ///
@@ -23,28 +121,22 @@ fn guest_term() -> String {
     }
 }
 
-/// Open an interactive SSH session to the guest VM.
+/// Run a `RemoteCommand` interactively over SSH with a PTY.
 ///
-/// When `tmux_session` is `Some`, the session runs inside a named
-/// tmux session that survives SSH disconnects. Reconnecting
-/// reattaches to the existing session.
-pub fn connect(session: &SshSession, tmux_session: Option<&str>) -> Result<()> {
+/// Used for both bare shell sessions and command launches (claude,
+/// codex). The tmux variant of `RemoteCommand` enables session
+/// persistence across disconnects.
+pub fn run_interactive(session: &SshSession, remote: &RemoteCommand) -> Result<()> {
+    let remote_cmd = remote.render();
+
     tracing::info!(
-        "Connecting via SSH to {}:{}",
+        "Connecting via SSH to {}:{} ({remote_cmd})",
         session.target.host,
-        session.target.port
+        session.target.port,
     );
 
     let mut args = session.ssh_opts();
     args.push(session.target.addr());
-
-    let remote_cmd = match tmux_session {
-        Some(name) => format!(
-            "tmux new-session -A -s {} -c /workspace",
-            shell_escape(name),
-        ),
-        None => "cd /workspace && exec $SHELL -l".to_string(),
-    };
     args.extend(["-t".to_string(), remote_cmd]);
 
     let status = Command::new("ssh")
@@ -65,11 +157,7 @@ pub fn connect(session: &SshSession, tmux_session: Option<&str>) -> Result<()> {
 ///
 /// Propagates the remote command's exit code via the process exit code.
 pub fn run_command(session: &SshSession, command: &[String]) -> Result<()> {
-    let remote_cmd = command
-        .iter()
-        .map(|a| shell_escape(a))
-        .collect::<Vec<_>>()
-        .join(" ");
+    let remote_cmd = join_escaped(command);
 
     tracing::info!("Running (non-interactive): {remote_cmd}");
 
@@ -90,65 +178,13 @@ pub fn run_command(session: &SshSession, command: &[String]) -> Result<()> {
     Ok(())
 }
 
-/// Run a command interactively over SSH with a PTY.
-///
-/// When `tmux_session` is `Some`, the command runs inside a named
-/// tmux session. If the session already exists, it reattaches
-/// (the command argument is ignored by tmux on reattach).
-pub fn run_interactive(
-    session: &SshSession,
-    cmd: &str,
-    extra_args: &[String],
-    tmux_session: Option<&str>,
-) -> Result<()> {
-    let mut inner_cmd = cmd.to_string();
-    for arg in extra_args {
-        inner_cmd.push(' ');
-        inner_cmd.push_str(&shell_escape(arg));
-    }
-
-    let remote_cmd = match tmux_session {
-        Some(name) => {
-            format!(
-                "tmux new-session -A -s {} -c /workspace {}",
-                shell_escape(name),
-                shell_escape(&inner_cmd),
-            )
-        }
-        None => format!("cd /workspace && {inner_cmd}"),
-    };
-
-    tracing::info!("Running: {remote_cmd}");
-
-    let mut args = session.ssh_opts();
-    args.push(session.target.addr());
-    args.extend(["-t".to_string(), remote_cmd]);
-
-    let status = Command::new("ssh")
-        .args(&args)
-        .envs(session.env.as_envs())
-        .env("TERM", guest_term())
-        .status()
-        .context("Failed to launch SSH")?;
-
-    if !status.success() {
-        tracing::warn!("SSH session exited with status: {status}");
-    }
-
-    Ok(())
-}
-
 /// Run a command in the VM, capture output, and exit with the remote's code.
 ///
 /// Stdout and stderr from the remote command are written to the local
 /// stdout/stderr respectively. The process exits with the remote
 /// command's exit code, making this suitable for scripting and CI.
 pub fn exec_command(session: &SshSession, command: &[String]) -> Result<()> {
-    let remote_cmd = command
-        .iter()
-        .map(|a| shell_escape(a))
-        .collect::<Vec<_>>()
-        .join(" ");
+    let remote_cmd = join_escaped(command);
 
     tracing::debug!("exec: {remote_cmd}");
 
@@ -175,4 +211,99 @@ pub fn exec_command(session: &SshSession, command: &[String]) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code — panics are assertions")]
+mod tests {
+    use super::*;
+
+    fn name(s: &str) -> TmuxSessionName {
+        TmuxSessionName::new(s).expect("valid tmux session name")
+    }
+
+    #[test]
+    fn tmux_name_accepts_allowed_charset() {
+        for s in ["main", "claude", "codex", "a", "a_b", "a-b", "ABC_123-xyz"] {
+            assert!(
+                TmuxSessionName::new(s).is_ok(),
+                "expected '{s}' to be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn tmux_name_rejects_empty() {
+        assert!(TmuxSessionName::new("").is_err());
+    }
+
+    #[test]
+    fn tmux_name_rejects_shell_metacharacters() {
+        for s in [
+            "a b", "a;b", "a$b", "a`b", "a\"b", "a'b", "a|b", "a&b", "a/b", "a.b", "a\\b", "a\nb",
+            "a*b", "a?b", "a(b", "a)b", "a{b", "a}b", "a[b", "a]b", "a<b", "a>b", "a#b", "a!b",
+            "a:b", "a=b", "a%b", "a@b", "a+b",
+        ] {
+            assert!(
+                TmuxSessionName::new(s).is_err(),
+                "expected '{s}' to be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn tmux_name_from_str() {
+        let parsed: TmuxSessionName = "dev".parse().expect("valid");
+        assert_eq!(parsed, name("dev"));
+        assert!("bad name".parse::<TmuxSessionName>().is_err());
+    }
+
+    #[test]
+    fn shell_empty_renders_interactive_shell() {
+        let rc = RemoteCommand::Shell { command: vec![] };
+        assert_eq!(rc.render(), "cd /workspace && exec $SHELL -l");
+    }
+
+    #[test]
+    fn shell_with_command_renders_with_cd() {
+        let rc = RemoteCommand::Shell {
+            command: vec!["echo".into(), "hi".into()],
+        };
+        assert_eq!(rc.render(), "cd /workspace && 'echo' 'hi'");
+    }
+
+    #[test]
+    fn tmux_empty_renders_attach() {
+        let rc = RemoteCommand::Tmux {
+            session: name("dev"),
+            command: vec![],
+        };
+        assert_eq!(rc.render(), "tmux new-session -A -s dev -c /workspace");
+    }
+
+    #[test]
+    fn tmux_with_command_renders_quoted_inner() {
+        let rc = RemoteCommand::Tmux {
+            session: name("dev"),
+            command: vec!["/usr/bin/foo".into(), "--bar".into()],
+        };
+        // Inner command is shell-escaped (per-arg) and the whole inner
+        // string is re-escaped so tmux sees one argument.
+        assert_eq!(
+            rc.render(),
+            "tmux new-session -A -s dev -c /workspace ''\\''/usr/bin/foo'\\'' '\\''--bar'\\'''",
+        );
+    }
+
+    #[test]
+    fn tmux_session_name_not_escaped() {
+        // The session name is a TmuxSessionName, so the constructor has
+        // already rejected anything that would need escaping. The
+        // rendered output uses it verbatim.
+        let rc = RemoteCommand::Tmux {
+            session: name("My-Session_1"),
+            command: vec![],
+        };
+        assert!(rc.render().contains(" -s My-Session_1 "));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `TmuxSessionName(String)` newtype in `src/ssh.rs` with a smart constructor that enforces `[a-zA-Z0-9_-]+` (non-empty). Validation runs at the clap boundary via `value_parser`, so downstream code never sees an invalid name.
- Adds `RemoteCommand` enum (`Shell { command }` / `Tmux { session, command }`). Empty `command` means "bare interactive shell" / "attach without launching."
- Collapses `ssh::connect` into `ssh::run_interactive` — both functions differed only in the `RemoteCommand` they built. The single function now takes `&RemoteCommand`.
- Drops the defensive `shell_escape(name)` calls — `TmuxSessionName`'s constructor has already rejected any character that would need escaping.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` — all clean (529 tests pass).
- [x] New `ssh::tests`: 9 tests cover charset validation (accepts allowed, rejects empty, rejects 29 shell metacharacters), `FromStr`, and `RemoteCommand::render` output for all four variants.
- [x] New `main::tests::shell_session_flag_rejects_invalid_name` confirms clap rejects bad names at parse time.
- [ ] Integration tests (`./tests/run-integration.sh`) on Lima + Firecracker — not run here (no VM tooling in this environment); please run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)