### PR TITLE
Remove tmux session wrapping (closes #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Breaking changes
 
+- **tmux session wrapping removed** (#183) — `coop shell`, `coop claude`,
+  and `coop codex` no longer wrap the remote session in tmux, and the
+  `--session <name>` / `--no-tmux` flags are gone. `tmux` is no longer
+  installed in the guest image either. Users who want detachable sessions
+  can run `coop shell` and start tmux themselves, after installing it as
+  an extra package (`--extra-packages tmux` on `coop setup`) or via a
+  custom post-install script. Claude Code's background-agent daemon
+  (`coop claude-agents`) already provides session persistence without a
+  terminal multiplexer.
+
 - **`coop push` / `coop pull` / `coop exec` take the instance name as a
   positional argument** (#90) — these three commands previously accepted
   `--name <name>` while the other eleven subcommands took `name`
@@ -26,10 +36,10 @@
   an already-bound host port fails fast before the VM is created.
 
 - **`coop ca` / `coop claude-agents` shortcut** (#80, #82, #99, #100, #101) —
-  Runs `claude agents` inside the VM in one command. Defaults to no
-  tmux (Claude Code manages background-session lifetime itself);
-  `--session <name>` opts in. The guest is now bootstrapped with a
-  managed `~/.claude/settings.json` that pre-accepts
+  Runs `claude agents` inside the VM in one command. Claude Code's daemon
+  manages background-session lifetime itself, so closing the terminal
+  does not interrupt running agents. The guest is now bootstrapped with
+  a managed `~/.claude/settings.json` that pre-accepts
   `bypassPermissions`, so dispatched sessions no longer prompt for
   tool permissions; `coop claude --ask` explicitly opts back into the
   prompting default.

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -22,16 +22,6 @@ Trailing arguments go straight through to the `claude` CLI:
 coop claude -- --model sonnet --verbose
 ```
 
-### tmux session persistence
-
-`coop claude` runs inside a tmux session named `claude` by default. If the SSH connection drops, the Claude process survives in the guest. Running `coop claude` again reattaches to the existing session rather than starting a new one.
-
-To bypass tmux and get a raw SSH session:
-
-```bash
-coop claude --no-tmux
-```
-
 ## Managing background agents
 
 ```bash
@@ -48,11 +38,7 @@ This runs `claude agents` in the guest, which opens the agent view — an intera
 coop ca -- --cwd /workspace
 ```
 
-Unlike `coop claude`, this command does **not** run inside tmux by default — closing the TUI doesn't stop background sessions, so terminal-level persistence adds little. To opt into tmux, pass coop's `--session <name>` flag *before* the `--` separator (it's a coop flag, not a `claude agents` flag):
-
-```bash
-coop ca --session work
-```
+Closing the TUI does not stop background sessions; reopening `coop ca` reattaches to whatever Claude Code's daemon is still running.
 
 ## Configuration
 

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -16,16 +16,6 @@ Trailing arguments go straight through to the `codex` CLI:
 coop codex -- --model gpt-5
 ```
 
-### tmux session persistence
-
-`coop codex` runs inside a tmux session named `codex` by default. If the SSH connection drops, the Codex process survives in the guest. Running `coop codex` again reattaches to the existing session rather than starting a new one.
-
-To bypass tmux and get a raw SSH session:
-
-```bash
-coop codex --no-tmux
-```
-
 ## Configuration
 
 Codex-related settings live under the `[codex]` section in `config.toml`, except `github` which is a top-level field:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -128,18 +128,13 @@ coop shell [NAME] [FLAGS] [-- COMMAND...]
 | Flag | Description |
 |------|-------------|
 | `NAME` | Instance name (required if multiple instances exist) |
-| `--session <name>` | tmux session name (default: `main`) |
-| `--no-tmux` | Skip tmux session persistence (raw SSH connection) |
 | `-- COMMAND...` | Command to run non-interactively (no PTY allocated) |
 
-Without a trailing command, `shell` drops you into a tmux session named `main` (or the name given by `--session`). With a trailing command, it executes the command and returns its exit code.
-
-`--session` and `--no-tmux` are mutually exclusive.
+Without a trailing command, `shell` drops you into an interactive shell at `/workspace`. With a trailing command, it executes the command and returns its exit code.
 
 ```
 coop shell
-coop shell my-project --no-tmux
-coop shell my-project --session work
+coop shell my-project
 coop shell my-project -- cat /etc/os-release
 ```
 
@@ -155,11 +150,7 @@ coop claude [NAME] [FLAGS] [ARGS...]
 |------|-------------|
 | `NAME` | Instance name (required if multiple instances exist) |
 | `--ask` | Prompt for permissions instead of skipping them |
-| `--session <name>` | tmux session name (default: `claude`) |
-| `--no-tmux` | Skip tmux session persistence (raw SSH connection) |
 | `ARGS...` | Extra arguments passed through to `claude` |
-
-The session runs inside tmux under the name `claude` (or the name given by `--session`). `--session` and `--no-tmux` are mutually exclusive.
 
 ```
 coop claude
@@ -169,7 +160,7 @@ coop claude my-project -- --model sonnet
 
 ### `claude-agents`
 
-Open the Claude Code agent view (`claude agents`) inside the VM. Unlike `coop claude`, this command does **not** wrap the session in tmux by default — Claude Code's background agents are managed by its own daemon, so a tmux layer adds no persistence. Pass `--session <name>` to opt in to tmux if you want a re-attachable terminal.
+Open the Claude Code agent view (`claude agents`) inside the VM. Claude Code's background agents are managed by its own daemon, so closing the terminal does not stop in-flight sessions; reconnect with `coop claude-agents` to see them again.
 
 ```
 coop claude-agents [NAME] [FLAGS] [ARGS...]
@@ -179,16 +170,14 @@ coop ca [NAME] [FLAGS] [ARGS...]
 | Flag | Description |
 |------|-------------|
 | `NAME` | Instance name (required if multiple instances exist) |
-| `--session <name>` | tmux session name (opt-in; no default) |
-| `--no-tmux` | Skip tmux session persistence (raw SSH connection) |
 | `ARGS...` | Extra arguments passed through to `claude agents` |
 
-`--session` and `--no-tmux` are mutually exclusive. Alias: `ca`.
+Alias: `ca`.
 
 ```
 coop claude-agents
 coop ca my-project
-coop ca my-project --session agents-work
+coop ca my-project -- --cwd /workspace
 ```
 
 ### `codex`
@@ -202,11 +191,7 @@ coop codex [NAME] [FLAGS] [ARGS...]
 | Flag | Description |
 |------|-------------|
 | `NAME` | Instance name (required if multiple instances exist) |
-| `--session <name>` | tmux session name (default: `codex`) |
-| `--no-tmux` | Skip tmux session persistence (raw SSH connection) |
 | `ARGS...` | Extra arguments passed through to `codex` |
-
-The session runs inside tmux under the name `codex` (or the name given by `--session`). `--session` and `--no-tmux` are mutually exclusive.
 
 ```
 coop codex

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ coop picks up `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from your environment aut
 
 ### 1. Setup
 
-`coop setup` downloads the Firecracker binary and kernel (Linux) or configures Lima (macOS), then builds a template rootfs image. The template ships with base packages (git, curl, build-essential, Docker, tmux, and others), the GitHub CLI, Claude Code, and Codex.
+`coop setup` downloads the Firecracker binary and kernel (Linux) or configures Lima (macOS), then builds a template rootfs image. The template ships with base packages (git, curl, build-essential, Docker, and others), the GitHub CLI, Claude Code, and Codex.
 
 ```
 coop setup
@@ -192,8 +192,6 @@ coop codex -- --model gpt-5
 ```
 coop shell
 ```
-
-`coop shell`, `coop claude`, and `coop codex` attach to persistent tmux sessions. Use `--no-tmux` for a raw SSH connection, or `--session <name>` to pick a named session.
 
 **Run a command non-interactively:**
 

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -18,7 +18,7 @@ coop stores the result under `~/.coop/images/<name>/`. On `coop start`, it copie
 
 Every template installs these packages regardless of profile selection.
 
-**Base packages:** `openssh-server`, `curl`, `wget`, `git`, `build-essential`, `ca-certificates`, `gnupg`, `lsb-release`, `sudo`, `iproute2`, `iptables`, `kmod`, `procps`, `jq`, `rsync`, `tmux`, `unzip`, `zip`, `file`, `less`
+**Base packages:** `openssh-server`, `curl`, `wget`, `git`, `build-essential`, `ca-certificates`, `gnupg`, `lsb-release`, `sudo`, `iproute2`, `iptables`, `kmod`, `procps`, `jq`, `rsync`, `unzip`, `zip`, `file`, `less`
 
 **Docker:** `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-compose-plugin`
 

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -69,7 +69,6 @@ pub const BASE_PACKAGES: &[&str] = &[
     "procps",
     "jq",
     "rsync",
-    "tmux",
     "unzip",
     "zip",
     "file",

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,49 +66,6 @@ pub(crate) struct Cli {
     command: Commands,
 }
 
-#[derive(clap::Args)]
-struct SessionArgs {
-    /// Instance name (required if multiple instances exist)
-    #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-    name: Option<String>,
-    /// tmux session name (allowed: a-z, A-Z, 0-9, '_', '-')
-    #[arg(long, conflicts_with = "no_tmux", value_parser = parse_tmux_session)]
-    session: Option<ssh::TmuxSessionName>,
-    /// Skip tmux session persistence (raw SSH connection)
-    #[arg(long)]
-    no_tmux: bool,
-}
-
-fn parse_tmux_session(s: &str) -> Result<ssh::TmuxSessionName, String> {
-    ssh::TmuxSessionName::new(s).map_err(|e| e.to_string())
-}
-
-impl SessionArgs {
-    fn tmux_session(&self, default: &'static str) -> Option<ssh::TmuxSessionName> {
-        if self.no_tmux {
-            return None;
-        }
-        Some(self.session.clone().unwrap_or_else(|| {
-            #[expect(
-                clippy::expect_used,
-                reason = "static default literal matches TmuxSessionName charset"
-            )]
-            ssh::TmuxSessionName::new(default).expect("static default is a valid tmux name")
-        }))
-    }
-
-    /// Returns a tmux session name only when explicitly requested via
-    /// `--session`. Used by commands where tmux is opt-in (the wrapped
-    /// process manages its own persistence, e.g. `claude agents` whose
-    /// background sessions live in the daemon, not the terminal).
-    fn tmux_session_opt_in(&self) -> Option<ssh::TmuxSessionName> {
-        if self.no_tmux {
-            return None;
-        }
-        self.session.clone()
-    }
-}
-
 #[derive(Subcommand)]
 enum Commands {
     /// Check prerequisites, install Firecracker, fetch kernel and build template rootfs
@@ -244,16 +201,18 @@ enum Commands {
     /// Open an interactive shell in the VM (or run a command non-interactively)
     #[command(alias = "ssh")]
     Shell {
-        #[command(flatten)]
-        session: SessionArgs,
+        /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
+        name: Option<String>,
         /// Command to run (non-interactive, no PTY)
         #[arg(allow_hyphen_values = true, last = true)]
         command: Vec<String>,
     },
     /// Launch Claude Code inside the VM (skips permissions by default)
     Claude {
-        #[command(flatten)]
-        session: SessionArgs,
+        /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
+        name: Option<String>,
         /// Prompt for permissions instead of skipping them
         #[arg(long)]
         ask: bool,
@@ -264,16 +223,18 @@ enum Commands {
     /// Open the Claude Code agent view inside the VM (`claude agents`)
     #[command(alias = "ca")]
     ClaudeAgents {
-        #[command(flatten)]
-        session: SessionArgs,
+        /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
+        name: Option<String>,
         /// Extra arguments passed to `claude agents`
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
     /// Launch Codex inside the VM
     Codex {
-        #[command(flatten)]
-        session: SessionArgs,
+        /// Instance name (required if multiple instances exist)
+        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
+        name: Option<String>,
         /// Extra arguments passed to `codex`
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -801,35 +762,29 @@ fn main() -> Result<()> {
                 },
             )
         }
-        Commands::Shell { session, command } => {
-            let tmux = session.tmux_session("main");
-            cmd_shell(&be, &cfg, session.name.as_deref(), &command, tmux)
-        }
+        Commands::Shell { name, command } => cmd_shell(&be, &cfg, name.as_deref(), &command),
         Commands::Claude {
-            session,
+            name,
             ask,
             mut args,
         } => {
-            let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
+            let sess = open_ssh_session(&be, &cfg, name.as_deref())?;
             // Guest user settings set `defaultMode: bypassPermissions`. Opting in
             // to prompts means overriding that default explicitly.
             if ask {
                 args.insert(0, "default".to_string());
                 args.insert(0, "--permission-mode".to_string());
             }
-            let tmux = session.tmux_session("claude");
-            ssh::run_interactive(&sess, &build_remote(tmux, crate::guest::CLAUDE_BIN, args))
+            ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, args))
         }
-        Commands::ClaudeAgents { session, mut args } => {
-            let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
+        Commands::ClaudeAgents { name, mut args } => {
+            let sess = open_ssh_session(&be, &cfg, name.as_deref())?;
             args.insert(0, "agents".to_string());
-            let tmux = session.tmux_session_opt_in();
-            ssh::run_interactive(&sess, &build_remote(tmux, crate::guest::CLAUDE_BIN, args))
+            ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, args))
         }
-        Commands::Codex { session, args } => {
-            let sess = open_ssh_session(&be, &cfg, session.name.as_deref())?;
-            let tmux = session.tmux_session("codex");
-            ssh::run_interactive(&sess, &build_remote(tmux, crate::guest::CODEX_BIN, args))
+        Commands::Codex { name, args } => {
+            let sess = open_ssh_session(&be, &cfg, name.as_deref())?;
+            ssh::run_interactive(&sess, &prepend_binary(crate::guest::CODEX_BIN, args))
         }
         Commands::Stop { name } => {
             let inst = cfg.resolve_instance(name.as_deref())?;
@@ -1655,34 +1610,21 @@ fn cmd_shell(
     cfg: &config::CoopConfig,
     name: Option<&str>,
     command: &[String],
-    tmux_session: Option<ssh::TmuxSessionName>,
 ) -> Result<()> {
     let session = open_ssh_session(be, cfg, name)?;
     if command.is_empty() {
-        ssh::run_interactive(&session, &build_remote(tmux_session, "", Vec::new()))
+        ssh::run_interactive(&session, &[])
     } else {
         ssh::run_command(&session, command)
     }
 }
 
-/// Build a `RemoteCommand` from a tmux choice and a (binary, args) pair.
-///
-/// `binary` may be empty, meaning "no command" — opens a bare interactive
-/// shell (or attaches to tmux without launching anything).
-fn build_remote(
-    tmux: Option<ssh::TmuxSessionName>,
-    binary: &str,
-    args: Vec<String>,
-) -> ssh::RemoteCommand {
+/// Build a remote command by prepending `binary` to `args`.
+fn prepend_binary(binary: &str, args: Vec<String>) -> Vec<String> {
     let mut command = Vec::with_capacity(1 + args.len());
-    if !binary.is_empty() {
-        command.push(binary.to_string());
-    }
+    command.push(binary.to_string());
     command.extend(args);
-    match tmux {
-        Some(session) => ssh::RemoteCommand::Tmux { session, command },
-        None => ssh::RemoteCommand::Shell { command },
-    }
+    command
 }
 
 fn cmd_exec(
@@ -2348,65 +2290,13 @@ mod tests {
         assert!(matches!(cli.command, super::Commands::Shell { .. }));
     }
 
-    fn tmux(s: &str) -> super::ssh::TmuxSessionName {
-        super::ssh::TmuxSessionName::new(s).expect("valid tmux session name")
-    }
-
-    #[test]
-    fn shell_session_flag_parses() {
-        let cli = parse(&["shell", "--session", "work"]);
-        let super::Commands::Shell { session, .. } = cli.command else {
-            panic!("expected Shell variant");
-        };
-        assert_eq!(session.session, Some(tmux("work")));
-        assert_eq!(session.tmux_session("main"), Some(tmux("work")));
-    }
-
-    #[test]
-    fn shell_default_no_session() {
-        let cli = parse(&["shell"]);
-        let super::Commands::Shell { session, .. } = cli.command else {
-            panic!("expected Shell variant");
-        };
-        assert!(session.session.is_none());
-        assert_eq!(session.tmux_session("main"), Some(tmux("main")));
-    }
-
-    #[test]
-    fn shell_session_flag_rejects_invalid_name() {
-        let err = parse_err(&["shell", "--session", "bad name"]);
-        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
-    }
-
-    #[test]
-    fn shell_session_and_no_tmux_conflict() {
-        let err = parse_err(&["shell", "--session", "x", "--no-tmux"]);
-        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
-    }
-
-    #[test]
-    fn claude_session_flag_parses() {
-        let cli = parse(&["claude", "--session", "dev"]);
-        let super::Commands::Claude { session, .. } = cli.command else {
-            panic!("expected Claude variant");
-        };
-        assert_eq!(session.session, Some(tmux("dev")));
-        assert_eq!(session.tmux_session("claude"), Some(tmux("dev")));
-    }
-
-    #[test]
-    fn claude_session_and_no_tmux_conflict() {
-        let err = parse_err(&["claude", "--session", "x", "--no-tmux"]);
-        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
-    }
-
     #[test]
     fn claude_name_and_trailing_args_parse() {
         let cli = parse(&["claude", "myvm", "--", "--model", "opus"]);
-        let super::Commands::Claude { session, args, .. } = cli.command else {
+        let super::Commands::Claude { name, args, .. } = cli.command else {
             panic!("expected Claude variant");
         };
-        assert_eq!(session.name.as_deref(), Some("myvm"));
+        assert_eq!(name.as_deref(), Some("myvm"));
         assert_eq!(args, vec!["--model", "opus"]);
     }
 
@@ -2423,73 +2313,35 @@ mod tests {
     }
 
     #[test]
-    fn claude_agents_defaults_to_no_tmux() {
-        let cli = parse(&["claude-agents"]);
-        let super::Commands::ClaudeAgents { session, .. } = cli.command else {
-            panic!("expected ClaudeAgents variant");
-        };
-        assert!(session.tmux_session_opt_in().is_none());
-    }
-
-    #[test]
-    fn claude_agents_session_flag_opts_into_tmux() {
-        let cli = parse(&["claude-agents", "--session", "dev"]);
-        let super::Commands::ClaudeAgents { session, .. } = cli.command else {
-            panic!("expected ClaudeAgents variant");
-        };
-        assert_eq!(session.tmux_session_opt_in(), Some(tmux("dev")));
-    }
-
-    #[test]
-    fn claude_agents_no_tmux_stays_off() {
-        let cli = parse(&["claude-agents", "--no-tmux"]);
-        let super::Commands::ClaudeAgents { session, .. } = cli.command else {
-            panic!("expected ClaudeAgents variant");
-        };
-        assert!(session.no_tmux);
-        assert!(session.tmux_session_opt_in().is_none());
-    }
-
-    #[test]
-    fn claude_agents_session_and_no_tmux_conflict() {
-        let err = parse_err(&["claude-agents", "--session", "x", "--no-tmux"]);
-        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
-    }
-
-    #[test]
     fn claude_agents_name_and_trailing_args_parse() {
         let cli = parse(&["ca", "myvm", "--", "--cwd", "/workspace"]);
-        let super::Commands::ClaudeAgents { session, args, .. } = cli.command else {
+        let super::Commands::ClaudeAgents { name, args, .. } = cli.command else {
             panic!("expected ClaudeAgents variant");
         };
-        assert_eq!(session.name.as_deref(), Some("myvm"));
+        assert_eq!(name.as_deref(), Some("myvm"));
         assert_eq!(args, vec!["--cwd", "/workspace"]);
-    }
-
-    #[test]
-    fn codex_session_flag_parses() {
-        let cli = parse(&["codex", "--session", "dev"]);
-        let super::Commands::Codex { session, .. } = cli.command else {
-            panic!("expected Codex variant");
-        };
-        assert_eq!(session.session, Some(tmux("dev")));
-        assert_eq!(session.tmux_session("codex"), Some(tmux("dev")));
-    }
-
-    #[test]
-    fn codex_session_and_no_tmux_conflict() {
-        let err = parse_err(&["codex", "--session", "x", "--no-tmux"]);
-        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]
     fn codex_name_and_trailing_args_parse() {
         let cli = parse(&["codex", "myvm", "--", "--model", "gpt-5"]);
-        let super::Commands::Codex { session, args, .. } = cli.command else {
+        let super::Commands::Codex { name, args, .. } = cli.command else {
             panic!("expected Codex variant");
         };
-        assert_eq!(session.name.as_deref(), Some("myvm"));
+        assert_eq!(name.as_deref(), Some("myvm"));
         assert_eq!(args, vec!["--model", "gpt-5"]);
+    }
+
+    #[test]
+    fn prepend_binary_prefixes_command() {
+        let cmd = super::prepend_binary("/usr/bin/claude", vec!["--model".into(), "opus".into()]);
+        assert_eq!(cmd, vec!["/usr/bin/claude", "--model", "opus"]);
+    }
+
+    #[test]
+    fn prepend_binary_with_no_args() {
+        let cmd = super::prepend_binary("/usr/bin/codex", Vec::new());
+        assert_eq!(cmd, vec!["/usr/bin/codex"]);
     }
 
     #[test]
@@ -2736,16 +2588,6 @@ mod tests {
     fn exec_requires_command_after_separator() {
         let err = parse_err(&["exec", "myvm"]);
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
-    }
-
-    #[test]
-    fn shell_no_tmux_without_session() {
-        let cli = parse(&["shell", "--no-tmux"]);
-        let super::Commands::Shell { session, .. } = cli.command else {
-            panic!("expected Shell variant");
-        };
-        assert!(session.no_tmux);
-        assert!(session.tmux_session("main").is_none());
     }
 
     #[test]

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,107 +1,27 @@
-use std::fmt;
 use std::io::Write as _;
 use std::process::Command;
-use std::str::FromStr;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 
 use crate::backend::SshSession;
 use crate::shell::shell_escape;
-
-/// Validated tmux session name (matches `[a-zA-Z0-9_-]+`).
-///
-/// The constructor rejects empty strings and any character outside the
-/// allowed set, so callers that interpolate the name into a shell-built
-/// `tmux new-session` command can do so without defensive quoting.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TmuxSessionName(String);
-
-impl TmuxSessionName {
-    /// Parse and validate. The name must be non-empty and contain only
-    /// ASCII letters, digits, `_`, or `-`.
-    pub fn new(s: &str) -> Result<Self> {
-        if s.is_empty() {
-            bail!("tmux session name must not be empty");
-        }
-        for c in s.chars() {
-            if !(c.is_ascii_alphanumeric() || c == '_' || c == '-') {
-                bail!(
-                    "tmux session name '{s}' contains invalid character '{c}' \
-                     (allowed: a-z, A-Z, 0-9, '_', '-')"
-                );
-            }
-        }
-        Ok(Self(s.to_string()))
-    }
-}
-
-impl fmt::Display for TmuxSessionName {
-    #[mutants::skip] // equivalent: trivial forwarder; covered indirectly by RemoteCommand rendering tests
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl AsRef<str> for TmuxSessionName {
-    #[mutants::skip] // equivalent: trivial forwarder; covered indirectly by RemoteCommand rendering tests
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl FromStr for TmuxSessionName {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        Self::new(s)
-    }
-}
-
-/// How a remote command runs on the guest.
-///
-/// `Shell` runs directly in the user's login shell (empty `command`
-/// opens an interactive shell). `Tmux` wraps the run inside a named
-/// tmux session that survives SSH disconnects; reconnecting reattaches
-/// to the existing session.
-#[derive(Debug, Clone)]
-pub enum RemoteCommand {
-    Shell {
-        command: Vec<String>,
-    },
-    Tmux {
-        session: TmuxSessionName,
-        command: Vec<String>,
-    },
-}
-
-impl RemoteCommand {
-    /// Render to the single string passed to `ssh ... <cmd>`.
-    fn render(&self) -> String {
-        match self {
-            Self::Shell { command } if command.is_empty() => {
-                "cd /workspace && exec $SHELL -l".to_string()
-            }
-            Self::Shell { command } => {
-                format!("cd /workspace && {}", join_escaped(command))
-            }
-            Self::Tmux { session, command } if command.is_empty() => {
-                format!("tmux new-session -A -s {session} -c /workspace")
-            }
-            Self::Tmux { session, command } => {
-                format!(
-                    "tmux new-session -A -s {session} -c /workspace {}",
-                    shell_escape(&join_escaped(command)),
-                )
-            }
-        }
-    }
-}
 
 fn join_escaped(args: &[String]) -> String {
     args.iter()
         .map(|a| shell_escape(a))
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// Render the single string passed to `ssh ... <cmd>`.
+///
+/// Empty `command` opens a bare interactive shell at `/workspace`.
+fn render_remote(command: &[String]) -> String {
+    if command.is_empty() {
+        "cd /workspace && exec $SHELL -l".to_string()
+    } else {
+        format!("cd /workspace && {}", join_escaped(command))
+    }
 }
 
 /// Return a TERM value the guest is guaranteed to understand.
@@ -113,7 +33,7 @@ fn join_escaped(args: &[String]) -> String {
 /// Fall back to `xterm-256color` which is universally available.
 fn guest_term() -> String {
     let term = std::env::var("TERM").unwrap_or_default();
-    let safe = ["xterm", "xterm-256color", "screen", "tmux", "vt100"];
+    let safe = ["xterm", "xterm-256color", "screen", "vt100"];
     if safe.iter().any(|&s| term == s) {
         term
     } else {
@@ -121,13 +41,12 @@ fn guest_term() -> String {
     }
 }
 
-/// Run a `RemoteCommand` interactively over SSH with a PTY.
+/// Run a command interactively over SSH with a PTY.
 ///
-/// Used for both bare shell sessions and command launches (claude,
-/// codex). The tmux variant of `RemoteCommand` enables session
-/// persistence across disconnects.
-pub fn run_interactive(session: &SshSession, remote: &RemoteCommand) -> Result<()> {
-    let remote_cmd = remote.render();
+/// Empty `command` opens a bare interactive shell. Otherwise the
+/// arguments are shell-escaped and run inside the user's login shell.
+pub fn run_interactive(session: &SshSession, command: &[String]) -> Result<()> {
+    let remote_cmd = render_remote(command);
 
     tracing::info!(
         "Connecting via SSH to {}:{} ({remote_cmd})",
@@ -214,96 +133,26 @@ pub fn exec_command(session: &SshSession, command: &[String]) -> Result<()> {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, reason = "test code — panics are assertions")]
 mod tests {
     use super::*;
 
-    fn name(s: &str) -> TmuxSessionName {
-        TmuxSessionName::new(s).expect("valid tmux session name")
+    #[test]
+    fn empty_command_renders_interactive_shell() {
+        assert_eq!(render_remote(&[]), "cd /workspace && exec $SHELL -l");
     }
 
     #[test]
-    fn tmux_name_accepts_allowed_charset() {
-        for s in ["main", "claude", "codex", "a", "a_b", "a-b", "ABC_123-xyz"] {
-            assert!(
-                TmuxSessionName::new(s).is_ok(),
-                "expected '{s}' to be valid"
-            );
-        }
+    fn command_renders_with_cd_and_escaping() {
+        let cmd = vec!["echo".into(), "hi".into()];
+        assert_eq!(render_remote(&cmd), "cd /workspace && 'echo' 'hi'");
     }
 
     #[test]
-    fn tmux_name_rejects_empty() {
-        assert!(TmuxSessionName::new("").is_err());
-    }
-
-    #[test]
-    fn tmux_name_rejects_shell_metacharacters() {
-        for s in [
-            "a b", "a;b", "a$b", "a`b", "a\"b", "a'b", "a|b", "a&b", "a/b", "a.b", "a\\b", "a\nb",
-            "a*b", "a?b", "a(b", "a)b", "a{b", "a}b", "a[b", "a]b", "a<b", "a>b", "a#b", "a!b",
-            "a:b", "a=b", "a%b", "a@b", "a+b",
-        ] {
-            assert!(
-                TmuxSessionName::new(s).is_err(),
-                "expected '{s}' to be rejected",
-            );
-        }
-    }
-
-    #[test]
-    fn tmux_name_from_str() {
-        let parsed: TmuxSessionName = "dev".parse().expect("valid");
-        assert_eq!(parsed, name("dev"));
-        assert!("bad name".parse::<TmuxSessionName>().is_err());
-    }
-
-    #[test]
-    fn shell_empty_renders_interactive_shell() {
-        let rc = RemoteCommand::Shell { command: vec![] };
-        assert_eq!(rc.render(), "cd /workspace && exec $SHELL -l");
-    }
-
-    #[test]
-    fn shell_with_command_renders_with_cd() {
-        let rc = RemoteCommand::Shell {
-            command: vec!["echo".into(), "hi".into()],
-        };
-        assert_eq!(rc.render(), "cd /workspace && 'echo' 'hi'");
-    }
-
-    #[test]
-    fn tmux_empty_renders_attach() {
-        let rc = RemoteCommand::Tmux {
-            session: name("dev"),
-            command: vec![],
-        };
-        assert_eq!(rc.render(), "tmux new-session -A -s dev -c /workspace");
-    }
-
-    #[test]
-    fn tmux_with_command_renders_quoted_inner() {
-        let rc = RemoteCommand::Tmux {
-            session: name("dev"),
-            command: vec!["/usr/bin/foo".into(), "--bar".into()],
-        };
-        // Inner command is shell-escaped (per-arg) and the whole inner
-        // string is re-escaped so tmux sees one argument.
+    fn command_with_special_chars_is_escaped() {
+        let cmd = vec!["/usr/bin/foo".into(), "--bar".into()];
         assert_eq!(
-            rc.render(),
-            "tmux new-session -A -s dev -c /workspace ''\\''/usr/bin/foo'\\'' '\\''--bar'\\'''",
+            render_remote(&cmd),
+            "cd /workspace && '/usr/bin/foo' '--bar'",
         );
-    }
-
-    #[test]
-    fn tmux_session_name_not_escaped() {
-        // The session name is a TmuxSessionName, so the constructor has
-        // already rejected anything that would need escaping. The
-        // rendered output uses it verbatim.
-        let rc = RemoteCommand::Tmux {
-            session: name("My-Session_1"),
-            command: vec![],
-        };
-        assert!(rc.render().contains(" -s My-Session_1 "));
     }
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -573,23 +573,6 @@ test_ssh_alias() {
     fi
 }
 
-test_session_conflict() {
-    echo ""
-    echo "=== Phase: --session / --no-tmux conflict ==="
-
-    if moat_fails shell "$INSTANCE" --session main --no-tmux -- echo nope; then
-        pass "--session and --no-tmux conflict (shell)"
-    else
-        fail "--session and --no-tmux conflict (shell)" "should have failed"
-    fi
-
-    if moat_fails claude "$INSTANCE" --session main --no-tmux; then
-        pass "--session and --no-tmux conflict (claude)"
-    else
-        fail "--session and --no-tmux conflict (claude)" "should have failed"
-    fi
-}
-
 test_exec() {
     echo ""
     echo "=== Phase: exec ==="
@@ -1008,32 +991,6 @@ test_network() {
     else
         fail "HTTPS connectivity works" "curl failed"
     fi
-}
-
-test_tmux() {
-    echo ""
-    echo "=== Phase: tmux session persistence ==="
-
-    # tmux must be installed in the guest image
-    if guest_exec which tmux >/dev/null; then
-        pass "tmux is installed"
-    else
-        fail "tmux is installed" "stderr: $(guest_stderr)"
-        return
-    fi
-
-    # Create a detached tmux session running sleep (no quoting issues)
-    guest_exec tmux new-session -d -s test-persist sleep 300
-    if guest_exec tmux has-session -t test-persist; then
-        pass "tmux session created and persists"
-    else
-        fail "tmux session created and persists" "stderr: $(guest_stderr)"
-        guest_exec tmux kill-session -t test-persist || true
-        return
-    fi
-
-    # Clean up
-    guest_exec tmux kill-session -t test-persist || true
 }
 
 test_docker() {
@@ -3132,7 +3089,6 @@ main() {
     test_auto_resolve_running
     test_shell_connectivity
     test_ssh_alias
-    test_session_conflict
     test_exec
     test_claude_bin_path
     test_codex_bin_path
@@ -3141,7 +3097,6 @@ main() {
     test_guest_environment
     test_sudo
     test_network
-    test_tmux
     test_docker
     test_logs
     test_profiles


### PR DESCRIPTION
## Summary

- Removes the tmux wrapping that `coop shell`, `coop claude`, and `coop codex` previously applied to remote sessions. The `--session <name>` and `--no-tmux` flags are gone.
- Drops the `tmux` package from the guest base image.
- Deletes `TmuxSessionName` and the `RemoteCommand` enum — with the tmux variant gone, `ssh::run_interactive` now takes `&[String]` directly. `prepend_binary` replaces the old `build_remote` helper.
- Updates docs (commands, claude/codex integration, getting started, images-and-profiles) and CHANGELOG. The historic v0.4.4 `coop ca` changelog entry is reworded so it no longer references the removed default.

Per #183, Claude Code's `claude agents` daemon already provides background-session persistence, so the tmux layer adds nothing. Users who still want detachable terminals can install tmux themselves (`coop setup --extra-packages tmux`) and start it from `coop shell`.

## Test plan

- [x] `cargo build` and `cargo build --release`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features` (523 passing)
- [x] `prek run --all-files`
- [x] `coop shell --help` / `coop claude --help` / `coop claude-agents --help` / `coop codex --help` show no `--session` or `--no-tmux` flags
- [ ] Integration tests on both platforms (`./tests/run-integration.sh` locally and `--remote` for Firecracker) — not run in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)