### PR TITLE
Introduce `Hostname` and `SshUser` newtypes (closes #154)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -163,12 +163,118 @@ impl RunningInstance {
 
 // ── SSH target ────────────────────────────────────────────────
 
+const MAX_HOSTNAME_LEN: usize = 253;
+
+fn validate_hostname(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("Hostname must not be empty");
+    }
+    if name.len() > MAX_HOSTNAME_LEN {
+        bail!(
+            "Hostname too long ({} chars, max {MAX_HOSTNAME_LEN})",
+            name.len()
+        );
+    }
+    if let Some(c) = name
+        .chars()
+        .find(|c| c.is_whitespace() || c.is_control() || !c.is_ascii_graphic())
+    {
+        bail!("Hostname contains invalid character {c:?} (must be printable ASCII, no whitespace)");
+    }
+    Ok(())
+}
+
+/// Validated SSH hostname or IP literal. Construction enforces a
+/// non-empty, printable ASCII string with no whitespace, so downstream
+/// code (shell-escaped SSH args, `user@host` formatting, SSH config
+/// blocks) can use it without re-checking.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Hostname(String);
+
+impl Hostname {
+    pub fn new(name: impl Into<String>) -> Result<Self> {
+        let name = name.into();
+        validate_hostname(&name)?;
+        Ok(Self(name))
+    }
+}
+
+impl std::fmt::Display for Hostname {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for Hostname {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+const MAX_SSH_USER_LEN: usize = 32;
+
+fn validate_ssh_user(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("SSH user must not be empty");
+    }
+    if name.len() > MAX_SSH_USER_LEN {
+        bail!(
+            "SSH user too long ({} chars, max {MAX_SSH_USER_LEN})",
+            name.len()
+        );
+    }
+    for (i, c) in name.chars().enumerate() {
+        let ok = if i == 0 {
+            matches!(c, 'a'..='z' | '_')
+        } else {
+            matches!(c, 'a'..='z' | '0'..='9' | '_' | '-')
+        };
+        if !ok {
+            if i == 0 {
+                bail!("SSH user must start with [a-z_], got {c:?}");
+            }
+            bail!("SSH user contains invalid character {c:?} (allowed: a-z, 0-9, '_', '-')");
+        }
+    }
+    Ok(())
+}
+
+/// Validated SSH username. Construction enforces the portable POSIX
+/// pattern `[a-z_][a-z0-9_-]{0,31}`, so downstream code (SSH addr
+/// formatting, SSH config blocks) can use it without re-checking.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SshUser(String);
+
+impl SshUser {
+    pub fn new(name: impl Into<String>) -> Result<Self> {
+        let name = name.into();
+        validate_ssh_user(&name)?;
+        Ok(Self(name))
+    }
+}
+
+impl std::fmt::Display for SshUser {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for SshUser {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// SSH connection details for reaching a guest VM.
 #[derive(Debug, Clone)]
 pub struct SshTarget {
-    pub host: String,
+    pub host: Hostname,
     pub port: NonZeroU16,
-    pub user: String,
+    pub user: SshUser,
     pub key_path: PathBuf,
 }
 
@@ -830,9 +936,9 @@ impl VmBackend for FirecrackerBackend {
 
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {
         Ok(SshTarget {
-            host: inst.guest_ip(),
+            host: Hostname::new(inst.guest_ip())?,
             port: cfg.ssh_port,
-            user: crate::guest::GUEST_USER.to_string(),
+            user: SshUser::new(crate::guest::GUEST_USER)?,
             key_path: cfg.ssh_key_path(),
         })
     }
@@ -1967,6 +2073,77 @@ Buffers:          128000 kB
 Filesystem     1M-blocks  Used Available Use% Mounted on
 /dev/vda1          20480  3200     16000  17% /
 ";
+
+    #[test]
+    fn hostname_accepts_valid_inputs() {
+        for s in [
+            "127.0.0.1",
+            "172.16.0.2",
+            "example.com",
+            "host-1.local",
+            "::1",
+        ] {
+            let h = Hostname::new(s).unwrap();
+            assert_eq!(h.to_string(), s);
+            assert_eq!(<Hostname as AsRef<str>>::as_ref(&h), s);
+        }
+    }
+
+    #[test]
+    fn hostname_rejects_empty() {
+        assert!(Hostname::new("").is_err());
+    }
+
+    #[test]
+    fn hostname_rejects_whitespace_and_control() {
+        for s in ["host name", "host\tname", "host\nname", "name\0"] {
+            assert!(Hostname::new(s).is_err(), "should reject {s:?}");
+        }
+    }
+
+    #[test]
+    fn hostname_rejects_non_ascii() {
+        assert!(Hostname::new("hôst").is_err());
+    }
+
+    #[test]
+    fn hostname_rejects_too_long() {
+        let long = "a".repeat(MAX_HOSTNAME_LEN + 1);
+        assert!(Hostname::new(long).is_err());
+    }
+
+    #[test]
+    fn ssh_user_accepts_valid_inputs() {
+        for s in ["ubuntu", "_user", "ec2-user", "u", "user_1", "a0"] {
+            let u = SshUser::new(s).unwrap();
+            assert_eq!(u.to_string(), s);
+            assert_eq!(<SshUser as AsRef<str>>::as_ref(&u), s);
+        }
+    }
+
+    #[test]
+    fn ssh_user_rejects_empty() {
+        assert!(SshUser::new("").is_err());
+    }
+
+    #[test]
+    fn ssh_user_rejects_leading_digit_or_dash() {
+        assert!(SshUser::new("0user").is_err());
+        assert!(SshUser::new("-user").is_err());
+    }
+
+    #[test]
+    fn ssh_user_rejects_uppercase_and_special() {
+        for s in ["Ubuntu", "user!", "user.name", "user name"] {
+            assert!(SshUser::new(s).is_err(), "should reject {s:?}");
+        }
+    }
+
+    #[test]
+    fn ssh_user_rejects_too_long() {
+        let long = "a".repeat(MAX_SSH_USER_LEN + 1);
+        assert!(SshUser::new(long).is_err());
+    }
 
     #[test]
     fn parse_resource_usage_typical_output() {

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 
-use crate::backend::{LogMode, SshTarget};
+use crate::backend::{Hostname, LogMode, SshTarget, SshUser};
 use crate::config::{CoopConfig, GiB, ImageName, Instance};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
@@ -410,9 +410,9 @@ pub fn ssh_target(cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {
     let port = std::num::NonZeroU16::new(port).context("Lima SSH port is 0")?;
 
     Ok(SshTarget {
-        host: "127.0.0.1".to_string(),
+        host: Hostname::new("127.0.0.1")?,
         port,
-        user: crate::guest::GUEST_USER.to_string(),
+        user: SshUser::new(crate::guest::GUEST_USER)?,
         key_path: cfg.ssh_key_path(),
     })
 }
@@ -707,9 +707,9 @@ fn builder_ssh_target(cfg: &CoopConfig) -> Result<SshTarget> {
     let port = u16::try_from(port).context("SSH port out of range")?;
     let port = std::num::NonZeroU16::new(port).context("Builder SSH port is 0")?;
     Ok(SshTarget {
-        host: "127.0.0.1".to_string(),
+        host: Hostname::new("127.0.0.1")?,
         port,
-        user: crate::guest::GUEST_USER.to_string(),
+        user: SshUser::new(crate::guest::GUEST_USER)?,
         key_path: cfg.ssh_key_path(),
     })
 }
@@ -1291,9 +1291,9 @@ fn wait_for_lima_ssh(
     // sshd isn't ready for several seconds. Auth probing detects
     // true readiness so the caller's wait_until_ready is instant.
     let target = SshTarget {
-        host: "127.0.0.1".to_string(),
+        host: Hostname::new("127.0.0.1")?,
         port: std::num::NonZeroU16::new(port).context("Lima assigned SSH port 0")?,
-        user: crate::guest::GUEST_USER.to_string(),
+        user: SshUser::new(crate::guest::GUEST_USER)?,
         key_path: cfg.ssh_key_path(),
     };
     let mut delay = Duration::from_millis(500);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2464,9 +2464,9 @@ mod tests {
         );
 
         let target = super::backend::SshTarget {
-            host: "127.0.0.1".to_string(),
+            host: super::backend::Hostname::new("127.0.0.1").expect("valid host"),
             port: NonZeroU16::new(22).expect("non-zero"),
-            user: "ubuntu".to_string(),
+            user: super::backend::SshUser::new("ubuntu").expect("valid user"),
             key_path: tmp.path().join("id_test"),
         };
 
@@ -2493,9 +2493,9 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let cfg = super::config::CoopConfig::default();
         let target = super::backend::SshTarget {
-            host: "127.0.0.1".to_string(),
+            host: super::backend::Hostname::new("127.0.0.1").expect("valid host"),
             port: NonZeroU16::new(22).expect("non-zero"),
-            user: "ubuntu".to_string(),
+            user: super::backend::SshUser::new("ubuntu").expect("valid user"),
             key_path: tmp.path().join("id_test"),
         };
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -368,9 +368,9 @@ impl<'a> FirecrackerVm<'a, Running> {
         );
 
         let target = crate::backend::SshTarget {
-            host: self.inst.guest_ip(),
+            host: crate::backend::Hostname::new(self.inst.guest_ip())?,
             port: self.cfg.ssh_port,
-            user: crate::guest::GUEST_USER.to_string(),
+            user: crate::backend::SshUser::new(crate::guest::GUEST_USER)?,
             key_path: self.cfg.ssh_key_path(),
         };
         if let Some(usage) = crate::backend::query_resource_usage(&target) {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1235,10 +1235,11 @@ Host coop-0\n\
     // ── exclude_git policy ────────────────────────────────────
 
     fn fake_ssh_target() -> SshTarget {
+        use crate::backend::{Hostname, SshUser};
         SshTarget {
-            host: "127.0.0.1".to_string(),
+            host: Hostname::new("127.0.0.1").expect("valid host"),
             port: std::num::NonZeroU16::new(2222).unwrap(),
-            user: "ubuntu".to_string(),
+            user: SshUser::new("ubuntu").expect("valid user"),
             key_path: PathBuf::from("/tmp/key"),
         }
     }


### PR DESCRIPTION
## Summary

`SshTarget` (src/backend.rs) held `host: String` and `user: String` side by side, so a constructor could silently swap them. This adds two newtypes with smart constructors so the compiler catches the mistake:

- `Hostname` — non-empty, printable ASCII, no whitespace, ≤253 chars
- `SshUser` — POSIX `[a-z_][a-z0-9_-]{0,31}`

Both expose `Display` and `AsRef<str>`. Validation lives in the constructors; the call sites that read the fields use `{}` formatting, so no other code changed. Construction sites in `backend.rs`, `vm.rs`, `lima.rs`, and the two `main.rs` / `workspace.rs` test fixtures were updated to call `Hostname::new(..)` / `SshUser::new(..)`.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 547 passed, 0 failed; new tests for both validators cover accept / empty / whitespace / non-ASCII / too-long / leading-digit-or-dash / uppercase-or-special cases
- [x] `prek run --all-files`
- [ ] `./tests/run-integration.sh` (local Lima) — not run; no behavior change, only field types
- [ ] `./tests/run-integration.sh --remote ...` (Firecracker) — not run; same reason