### PR TITLE
Introduce `Sha256Hash` newtype (closes #161)

### DIFF
--- a/src/lima.rs
+++ b/src/lima.rs
@@ -12,7 +12,8 @@ use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
     SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
 };
-use crate::setup::{SetupOptions, TEMPLATE_VERSION, TemplateConfig, hash_string, utc_timestamp};
+use crate::setup::{SetupOptions, TEMPLATE_VERSION, TemplateConfig, utc_timestamp};
+use crate::sha256_hash::Sha256Hash;
 
 const LIMA_PREFIX: &str = "coop-";
 const BUILDER_NAME: &str = "coop-builder";
@@ -466,11 +467,11 @@ fn ensure_ssh_key(cfg: &CoopConfig) -> Result<()> {
     Ok(())
 }
 
-fn provision_script_hash(cfg: &CoopConfig, profiles: &[ProfileDef]) -> String {
+fn provision_script_hash(cfg: &CoopConfig, profiles: &[ProfileDef]) -> Sha256Hash {
     let pubkey_path = cfg.ssh_key_path().with_extension("pub");
     let pubkey = fs::read_to_string(&pubkey_path).unwrap_or_default();
     let script = compose_provision_script(pubkey.trim(), profiles);
-    hash_string(&script)
+    Sha256Hash::of(&script)
 }
 
 /// Returns `true` if the golden image needs rebuilding.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod guest_env_state;
 mod pat_prompt;
 mod port_forward;
 mod secret_store;
+mod sha256_hash;
 // Lima is an interactive CLI workflow — stderr output is intentional user communication.
 #[cfg_attr(not(target_os = "macos"), expect(dead_code, reason = "Lima-only"))]
 #[expect(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -6,7 +6,6 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::cmd::Cmd;
 use crate::config::{CoopConfig, ImageName, Instance};
@@ -14,6 +13,7 @@ use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
     SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, resolve_profiles,
 };
+use crate::sha256_hash::Sha256Hash;
 
 const S3_BUCKET: &str = "https://s3.amazonaws.com/spec.ccfc.min";
 const S3_LIST: &str = "http://spec.ccfc.min.s3.amazonaws.com";
@@ -39,10 +39,10 @@ pub struct SetupOptions {
 pub struct TemplateConfig {
     pub version: u32,
     pub created: String,
-    pub install_script_hash: String,
+    pub install_script_hash: Sha256Hash,
     pub profiles: Vec<String>,
     pub extra_packages: Vec<String>,
-    pub post_install_hash: Option<String>,
+    pub post_install_hash: Option<Sha256Hash>,
     #[serde(default)]
     pub marketplaces: Vec<String>,
     #[serde(default)]
@@ -294,13 +294,13 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
 
     // Compose recipe and compute hashes
     let recipe = compose_recipe(&profiles, &extra_packages);
-    let script_hash = hash_string(&recipe);
+    let script_hash = Sha256Hash::of(&recipe);
     let post_install_content = load_post_install(opts.post_install.as_ref())?;
-    let post_install_hash = post_install_content.as_ref().map(|s| hash_string(s));
+    let post_install_hash = post_install_content.as_ref().map(Sha256Hash::of);
 
     // Check existing template — rebuild automatically if stale
     if template.exists() && !opts.rebuild {
-        if !needs_rebuild(cfg, image, &script_hash, post_install_hash.as_deref()) {
+        if !needs_rebuild(cfg, image, script_hash, post_install_hash) {
             step("Template rootfs: up to date");
             return Ok(());
         }
@@ -326,9 +326,9 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
         &profiles,
         &extra_packages,
         &recipe,
-        &script_hash,
+        script_hash,
         post_install_content.as_deref(),
-        post_install_hash.as_deref(),
+        post_install_hash,
         &staging,
     );
 
@@ -377,15 +377,14 @@ fn profile_names(profiles: &[ProfileDef]) -> Vec<String> {
 fn needs_rebuild(
     cfg: &CoopConfig,
     image: &ImageName,
-    current_hash: &str,
-    current_post_hash: Option<&str>,
+    current_hash: Sha256Hash,
+    current_post_hash: Option<Sha256Hash>,
 ) -> bool {
     let Ok(existing) = TemplateConfig::load_for(cfg, image) else {
         tracing::info!("Template config missing — treating template as stale");
         return true;
     };
-    existing.install_script_hash != current_hash
-        || existing.post_install_hash.as_deref() != current_post_hash
+    existing.install_script_hash != current_hash || existing.post_install_hash != current_post_hash
 }
 
 #[expect(clippy::too_many_arguments, reason = "template build orchestration")]
@@ -396,9 +395,9 @@ fn build_template(
     profiles: &[ProfileDef],
     extra_packages: &[String],
     recipe: &str,
-    script_hash: &str,
+    script_hash: Sha256Hash,
     post_install_content: Option<&str>,
-    post_install_hash: Option<&str>,
+    post_install_hash: Option<Sha256Hash>,
     output_path: &Path,
 ) -> Result<()> {
     step("Building template rootfs");
@@ -446,10 +445,10 @@ fn build_template(
     let marker_config = TemplateConfig {
         version: TEMPLATE_VERSION,
         created: utc_timestamp(),
-        install_script_hash: script_hash.to_string(),
+        install_script_hash: script_hash,
         profiles: profile_names(profiles),
         extra_packages: extra_packages.to_vec(),
-        post_install_hash: post_install_hash.map(String::from),
+        post_install_hash,
         marketplaces: Vec::new(),
         plugins: Vec::new(),
     };
@@ -1198,12 +1197,6 @@ fn unmount_chroot(mount_str: &str) {
 }
 
 // ── General helpers ───────────────────────────────────────────
-
-pub fn hash_string(s: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(s.as_bytes());
-    format!("sha256:{}", hex::encode(hasher.finalize()))
-}
 
 pub fn utc_timestamp() -> String {
     Command::new("date")

--- a/src/sha256_hash.rs
+++ b/src/sha256_hash.rs
@@ -1,0 +1,156 @@
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest as _, Sha256};
+
+/// SHA-256 digest stored as the raw 32-byte array.
+///
+/// Round-trips through serde and `Display`/`FromStr` as 64 lowercase
+/// hex characters with no prefix. Equality compares the raw bytes, so
+/// a truncated or padded hex string cannot match a real digest by
+/// accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Sha256Hash([u8; 32]);
+
+impl Sha256Hash {
+    /// Compute the SHA-256 digest of `bytes`.
+    pub fn of(bytes: impl AsRef<[u8]>) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes.as_ref());
+        Self(hasher.finalize().into())
+    }
+}
+
+impl fmt::Display for Sha256Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+impl FromStr for Sha256Hash {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if s.len() != 64 {
+            bail!("expected 64 hex characters, got {}", s.len());
+        }
+        let bytes =
+            hex::decode(s).with_context(|| format!("invalid hex in sha256 digest: {s:?}"))?;
+        let array: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("internal: hex::decode returned wrong length"))?;
+        Ok(Self(array))
+    }
+}
+
+impl Serialize for Sha256Hash {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for Sha256Hash {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
+        s.parse()
+            .map_err(|e: anyhow::Error| serde::de::Error::custom(format!("{e:#}")))
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests use unwrap for brevity")]
+mod tests {
+    use super::*;
+
+    // sha256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+    const HELLO_WORLD_HEX: &str =
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+
+    #[test]
+    fn of_matches_known_vector() {
+        let hash = Sha256Hash::of("hello world");
+        assert_eq!(hash.to_string(), HELLO_WORLD_HEX);
+    }
+
+    #[test]
+    fn display_is_lowercase_64_chars_with_no_prefix() {
+        let rendered = Sha256Hash::of(b"abc").to_string();
+        assert_eq!(rendered.len(), 64);
+        assert!(rendered.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert!(rendered.bytes().all(|b| !b.is_ascii_uppercase()));
+        assert!(!rendered.contains(':'));
+    }
+
+    #[test]
+    fn from_str_round_trips_through_display() {
+        let original = Sha256Hash::of(b"round-trip me");
+        let parsed: Sha256Hash = original.to_string().parse().unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn from_str_accepts_uppercase_hex() {
+        let lower: Sha256Hash = HELLO_WORLD_HEX.parse().unwrap();
+        let upper: Sha256Hash = HELLO_WORLD_HEX.to_ascii_uppercase().parse().unwrap();
+        assert_eq!(lower, upper);
+    }
+
+    #[test]
+    fn from_str_rejects_short_input() {
+        let too_short = &HELLO_WORLD_HEX[..63];
+        assert!(too_short.parse::<Sha256Hash>().is_err());
+    }
+
+    #[test]
+    fn from_str_rejects_long_input() {
+        let too_long = format!("{HELLO_WORLD_HEX}0");
+        assert!(too_long.parse::<Sha256Hash>().is_err());
+    }
+
+    #[test]
+    fn from_str_rejects_non_hex_characters() {
+        let mut bad = String::from(HELLO_WORLD_HEX);
+        bad.replace_range(0..1, "z");
+        assert!(bad.parse::<Sha256Hash>().is_err());
+    }
+
+    #[test]
+    fn from_str_rejects_legacy_sha256_prefix() {
+        let prefixed = format!("sha256:{HELLO_WORLD_HEX}");
+        assert!(prefixed.parse::<Sha256Hash>().is_err());
+    }
+
+    #[test]
+    fn from_str_rejects_empty_string() {
+        assert!("".parse::<Sha256Hash>().is_err());
+    }
+
+    #[test]
+    fn serde_round_trip_through_json() {
+        let original = Sha256Hash::of(b"json-trip");
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, format!("\"{original}\""));
+        let parsed: Sha256Hash = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn serde_rejects_non_string_json() {
+        assert!(serde_json::from_str::<Sha256Hash>("12345").is_err());
+        assert!(serde_json::from_str::<Sha256Hash>("null").is_err());
+    }
+
+    #[test]
+    fn serde_rejects_truncated_hex_in_json() {
+        let truncated = format!("\"{}\"", &HELLO_WORLD_HEX[..63]);
+        assert!(serde_json::from_str::<Sha256Hash>(&truncated).is_err());
+    }
+
+    #[test]
+    fn equality_distinguishes_distinct_inputs() {
+        assert_ne!(Sha256Hash::of(b"a"), Sha256Hash::of(b"b"));
+        assert_eq!(Sha256Hash::of(b"a"), Sha256Hash::of(b"a"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Sha256Hash([u8; 32])` in `src/sha256_hash.rs` with `Sha256Hash::of`, `FromStr`, `Display`, and custom serde impls; round-trips through serde as 64 lowercase hex chars with no prefix, parsed and validated at the deserialize boundary.
- Switches `TemplateConfig::install_script_hash` and `post_install_hash` to `Sha256Hash` / `Option<Sha256Hash>` so a truncated, corrupted, or hand-edited hash fails at JSON parse time instead of diverging silently in a later equality check.
- Removes the redundant `setup::hash_string` helper; `Sha256Hash::of` replaces it in both Firecracker (`setup.rs`) and Lima (`lima.rs`) paths.

## On-disk format change

The serialized form drops the decorative `sha256:` prefix that `hash_string` used. Existing template configs fail to deserialize and trip the "config missing → rebuild" branch in `needs_rebuild`, so the next `coop setup` rebuilds the template once and writes the new format. No code path reads the marker file outside of `TemplateConfig`'s own serde.

## Test plan

- [x] `cargo test sha256_hash` — 13 new tests cover the known-vector digest, hex round-trip, uppercase tolerance, short/long/non-hex/empty rejection, legacy `sha256:` prefix rejection, JSON round-trip, non-string JSON rejection, and equality semantics.
- [x] `cargo test` — full suite, 565 passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `prek run --all-files` — all hooks pass.
- [ ] `./tests/run-integration.sh` (macOS/Lima) — to be run before merge per CLAUDE.md.
- [ ] `./tests/run-integration.sh --remote …` (Linux/Firecracker) — to be run before merge per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)