### PR TITLE
Introduce `ToolName` and `AccountName` newtypes (closes #165)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3302,13 +3302,6 @@ skip = ["not-a-slug"]
     }
 
     #[test]
-    fn image_name_rejects_path_separators() {
-        for s in ["foo/bar", "/abs", "a\\b", "../escape", "foo/", "/"] {
-            assert!(ImageName::new(s).is_err(), "{s} should be rejected");
-        }
-    }
-
-    #[test]
     fn image_name_rejects_out_of_charset() {
         // Smoke test that the constructor wires through to
         // `validate_safe_chars`; the exhaustive char-class rejection is
@@ -3333,12 +3326,10 @@ skip = ["not-a-slug"]
 
     #[test]
     fn image_name_rejects_invalid_on_deserialize() {
-        for json in [r#""../evil""#, r#""""#, r#"".""#, r#""..""#, r#""..foo""#] {
-            assert!(
-                serde_json::from_str::<ImageName>(json).is_err(),
-                "{json} should fail to deserialize"
-            );
-        }
+        // Smoke test that the `Deserialize` impl routes through
+        // `ImageName::new`; per-rule rejection is covered by the
+        // dedicated constructor tests.
+        assert!(serde_json::from_str::<ImageName>(r#""../evil""#).is_err());
     }
 
     /// Pins the invariant relied on by `default_image_name`, which
@@ -3525,12 +3516,10 @@ skip = ["not-a-slug"]
 
     #[test]
     fn host_interface_rejects_invalid_interface_name() {
-        for s in [r#""""#, r#""eth/0""#, r#""eth 0""#] {
-            assert!(
-                serde_json::from_str::<HostInterface>(s).is_err(),
-                "{s} should fail to deserialize"
-            );
-        }
+        // Smoke test that `HostInterface`'s `Deserialize` wraps
+        // `InterfaceName::new` for non-`auto` values; the per-rule
+        // rejection is covered by the constructor tests.
+        assert!(serde_json::from_str::<HostInterface>(r#""eth/0""#).is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::cmd::Cmd;
+use crate::naming::validate_safe_chars;
 
 pub const DEFAULT_IMAGE: &str = "default";
 
@@ -732,15 +733,7 @@ fn validate_interface_name(name: &str) -> Result<()> {
             name.len()
         );
     }
-    if let Some(c) = name
-        .chars()
-        .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
-    {
-        bail!(
-            "Interface name '{name}' contains invalid character {c:?} \
-             (allowed: a-z, A-Z, 0-9, '-', '_', '.')"
-        );
-    }
+    validate_safe_chars(name, "Interface name")?;
     Ok(())
 }
 
@@ -1398,15 +1391,7 @@ fn validate_image_name(name: &str) -> Result<()> {
             name.len()
         );
     }
-    if let Some(c) = name
-        .chars()
-        .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
-    {
-        bail!(
-            "Image name contains invalid character '{c}' \
-             (allowed: a-z, A-Z, 0-9, '-', '_', '.')"
-        );
-    }
+    validate_safe_chars(name, "Image name")?;
     Ok(())
 }
 
@@ -3325,9 +3310,10 @@ skip = ["not-a-slug"]
 
     #[test]
     fn image_name_rejects_out_of_charset() {
-        for s in ["with space", "tab\tname", "name\n", "weird!", "café"] {
-            assert!(ImageName::new(s).is_err(), "{s} should be rejected");
-        }
+        // Smoke test that the constructor wires through to
+        // `validate_safe_chars`; the exhaustive char-class rejection is
+        // covered by the `naming` module's tests.
+        assert!(ImageName::new("with space").is_err());
     }
 
     #[test]
@@ -3504,18 +3490,10 @@ skip = ["not-a-slug"]
 
     #[test]
     fn interface_name_rejects_out_of_charset() {
-        for s in [
-            "eth 0",  // space
-            "eth\t0", // tab
-            "eth/0",  // path separator
-            "eth\n0", // newline
-            "weird!", // punctuation
-            "café",   // non-ASCII
-            " eth0",  // leading whitespace
-            "eth0 ",  // trailing whitespace
-        ] {
-            assert!(InterfaceName::new(s).is_err(), "{s} should be rejected");
-        }
+        // Smoke test that the constructor wires through to
+        // `validate_safe_chars`; the exhaustive char-class rejection is
+        // covered by the `naming` module's tests.
+        assert!(InterfaceName::new("eth 0").is_err());
     }
 
     #[test]

--- a/src/github_repo.rs
+++ b/src/github_repo.rs
@@ -12,6 +12,8 @@ use std::str::FromStr;
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
+use crate::naming::is_safe_name_char;
+
 /// A validated `owner/repo` GitHub slug.
 ///
 /// The inner string is module-private — every value must come from
@@ -63,10 +65,9 @@ impl RepoSlug {
 
 /// GitHub usernames and repo names allow ASCII letters, digits, `-`, `_`, `.`.
 /// Leading/trailing `.` or `-` is unusual but accepted by the API; we don't
-/// gate that here.
+/// gate that here. Shares the safe-name character class with [`crate::naming`].
 fn is_valid_segment(s: &str) -> bool {
-    s.chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    s.chars().all(is_safe_name_char)
 }
 
 impl fmt::Display for RepoSlug {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod github_pat;
 mod github_repo;
 mod guest;
 mod guest_env_state;
+mod naming;
 mod pat_prompt;
 mod port_forward;
 mod secret_store;

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1,0 +1,83 @@
+//! Shared character-class validator for newtypes that derive an on-disk
+//! filename or shell-argv element from user input.
+//!
+//! Image names, network-interface names, repo segments, and secret-store
+//! tool names all accept the same character class — `[a-zA-Z0-9_.-]`. The
+//! class lives here so the four newtypes can't drift apart, and so each
+//! constructor's rejection path is exercised once by the helper tests
+//! rather than re-tested at every call site.
+
+use anyhow::{Result, bail};
+
+/// Predicate for the safe-name character class `[a-zA-Z0-9_.-]`.
+pub(crate) fn is_safe_name_char(c: char) -> bool {
+    matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.')
+}
+
+/// Validate that every char of `name` is in [`is_safe_name_char`].
+///
+/// `kind` names what is being validated (e.g. `"Image name"`); it is
+/// quoted into the error message in front of the offending character so
+/// the failure points at both the type and the byte.
+pub(crate) fn validate_safe_chars(name: &str, kind: &str) -> Result<()> {
+    if let Some(c) = name.chars().find(|c| !is_safe_name_char(*c)) {
+        bail!(
+            "{kind} contains invalid character {c:?} \
+             (allowed: a-z, A-Z, 0-9, '-', '_', '.')"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_full_safe_class() {
+        // The whole class on one line so a future drift is caught immediately.
+        validate_safe_chars(
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.",
+            "T",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_out_of_class_chars() {
+        // One example per category of "bad byte" the four newtypes need to
+        // reject — whitespace, shell metacharacters, path separators, control
+        // bytes, and non-ASCII.
+        for s in [
+            "with space",
+            "tab\there",
+            "name\n",
+            "name\0",
+            "weird!",
+            "name;evil",
+            "name$x",
+            "path/separator",
+            "back\\slash",
+            "café",
+        ] {
+            assert!(validate_safe_chars(s, "T").is_err(), "{s:?} should fail");
+        }
+    }
+
+    #[test]
+    fn empty_input_is_accepted() {
+        // The character-class check has nothing to reject in the empty
+        // string; emptiness is a separate invariant each newtype enforces.
+        validate_safe_chars("", "T").unwrap();
+    }
+
+    #[test]
+    fn error_message_quotes_kind_and_char() {
+        let err = validate_safe_chars("a b", "Image name")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Image name"), "missing kind in {err:?}");
+        assert!(err.contains("' '"), "missing offending char in {err:?}");
+    }
+}

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -464,12 +464,12 @@ mod tests {
     }
 
     #[test]
-    fn tool_name_accepts_safe_chars() {
-        for s in ["op", "secret-tool", "tool_1", "a.b", "ABC.def-1_2"] {
-            let t = ToolName::new(s).unwrap();
-            assert_eq!(t.to_string(), s);
-            assert_eq!(<ToolName as AsRef<str>>::as_ref(&t), s);
-        }
+    fn tool_name_forwards_display_and_as_ref() {
+        // Confirms the Display / AsRef impls forward to the inner string.
+        // Char-class acceptance is covered by the `naming` module's tests.
+        let t = ToolName::new("secret-tool").unwrap();
+        assert_eq!(t.to_string(), "secret-tool");
+        assert_eq!(<ToolName as AsRef<str>>::as_ref(&t), "secret-tool");
     }
 
     #[test]

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -10,15 +10,17 @@
 //! is omitted from [`available_backends`]. The file fallback is always
 //! available so the wizard always has at least one storage choice.
 
+use std::fmt;
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::cmd::Cmd;
+use crate::github_repo::RepoSlug;
 
 /// All secret-store backends recognised by the wizard.
 ///
@@ -65,19 +67,19 @@ impl Backend {
             #[cfg(target_os = "macos")]
             Self::MacosKeychain => Path::new("/usr/bin/security").exists(),
             #[cfg(target_os = "linux")]
-            Self::LinuxSecretService => tool_on_path("secret-tool"),
-            Self::OnePassword => tool_on_path("op"),
+            Self::LinuxSecretService => {
+                ToolName::new("secret-tool").is_ok_and(|n| tool_on_path(&n))
+            }
+            Self::OnePassword => ToolName::new("op").is_ok_and(|n| tool_on_path(&n)),
             Self::File => true,
         }
     }
 }
 
-fn tool_on_path(name: &str) -> bool {
-    // `command -v` is a shell builtin — execute it via `sh -c`. Reject
-    // names with whitespace defensively so we don't shell-inject.
-    if name.is_empty() || name.chars().any(|c| !is_safe_tool_name_char(c)) {
-        return false;
-    }
+fn tool_on_path(name: &ToolName) -> bool {
+    // `command -v` is a shell builtin — execute it via `sh -c`. The
+    // `ToolName` constructor already proved `name` matches
+    // `[a-zA-Z0-9_.-]+`, so embedding it in the shell string can't inject.
     Command::new("sh")
         .arg("-c")
         .arg(format!("command -v {name}"))
@@ -85,8 +87,78 @@ fn tool_on_path(name: &str) -> bool {
         .is_ok_and(|s| s.success())
 }
 
-fn is_safe_tool_name_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')
+/// Validated executable name for `tool_on_path` lookups.
+///
+/// The constructor enforces a non-empty `[a-zA-Z0-9_.-]+` string, so
+/// downstream code can embed the name in a `sh -c` command line without
+/// re-checking for shell metacharacters or empty input.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ToolName(String);
+
+impl ToolName {
+    pub fn new(name: &str) -> Result<Self> {
+        if name.is_empty() {
+            bail!("Tool name is empty");
+        }
+        if let Some(c) = name
+            .chars()
+            .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
+        {
+            bail!(
+                "Tool name '{name}' contains invalid character {c:?} \
+                 (allowed: a-z, A-Z, 0-9, '-', '_', '.')"
+            );
+        }
+        Ok(Self(name.to_string()))
+    }
+}
+
+impl fmt::Display for ToolName {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for ToolName {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Account identifier for a secret-store entry.
+///
+/// Built once from a [`RepoSlug`] by replacing the `/` separator with
+/// `-`. Because `RepoSlug` already restricts segments to
+/// `[a-zA-Z0-9_.-]`, the resulting string also matches that class and
+/// is safe to use as a filename component or backend lookup key without
+/// further sanitization.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AccountName(String);
+
+impl AccountName {
+    pub fn from_repo(slug: &RepoSlug) -> Self {
+        Self(slug.as_str().replace('/', "-"))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for AccountName {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for AccountName {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
 }
 
 /// Return the list of usable backends on the current host, in the
@@ -116,7 +188,7 @@ pub fn available_backends() -> Vec<Backend> {
 pub fn store_secret(
     backend: Backend,
     service: &str,
-    account: &str,
+    account: &AccountName,
     token: &str,
     state_dir: &Path,
 ) -> Result<String> {
@@ -136,7 +208,7 @@ pub fn store_secret(
 pub fn delete_secret(
     backend: Backend,
     service: &str,
-    account: &str,
+    account: &AccountName,
     state_dir: &Path,
 ) -> Result<()> {
     match backend {
@@ -147,7 +219,7 @@ pub fn delete_secret(
                 .arg("-s")
                 .arg(service)
                 .arg("-a")
-                .arg(account)
+                .arg(account.as_str())
                 .output();
             Ok(())
         }
@@ -158,7 +230,7 @@ pub fn delete_secret(
                 .arg("service")
                 .arg(service)
                 .arg("account")
-                .arg(account)
+                .arg(account.as_str())
                 .output();
             Ok(())
         }
@@ -223,7 +295,7 @@ pub fn infer_backend(cmd: &str) -> Option<Backend> {
 // ── Backend impls ──────────────────────────────────────────────
 
 #[cfg(target_os = "macos")]
-fn store_keychain(service: &str, account: &str, token: &str) -> Result<String> {
+fn store_keychain(service: &str, account: &AccountName, token: &str) -> Result<String> {
     // macOS `security` lacks a stdin-driven write for generic passwords:
     // `-w <password>` reads the secret from argv. The bytes are briefly
     // visible to local `ps`-equivalent observers — an unavoidable cost
@@ -236,7 +308,7 @@ fn store_keychain(service: &str, account: &str, token: &str) -> Result<String> {
         .arg("-s")
         .arg(service)
         .arg("-a")
-        .arg(account)
+        .arg(account.as_str())
         .arg("-w")
         .redacted_arg(token)
         .run()
@@ -244,12 +316,12 @@ fn store_keychain(service: &str, account: &str, token: &str) -> Result<String> {
     Ok(format!(
         "cmd:security find-generic-password -s {} -a {} -w",
         shell_quote(service),
-        shell_quote(account),
+        shell_quote(account.as_str()),
     ))
 }
 
 #[cfg(target_os = "linux")]
-fn store_secret_service(service: &str, account: &str, token: &str) -> Result<String> {
+fn store_secret_service(service: &str, account: &AccountName, token: &str) -> Result<String> {
     // `secret-tool store` reads the password from stdin.
     Cmd::new("secret-tool")
         .arg("store")
@@ -258,18 +330,18 @@ fn store_secret_service(service: &str, account: &str, token: &str) -> Result<Str
         .arg("service")
         .arg(service)
         .arg("account")
-        .arg(account)
+        .arg(account.as_str())
         .stdin_input(token.as_bytes().to_vec())
         .run()
         .context("Failed to write secret to Linux Secret Service")?;
     Ok(format!(
         "cmd:secret-tool lookup service {} account {}",
         shell_quote(service),
-        shell_quote(account),
+        shell_quote(account.as_str()),
     ))
 }
 
-fn store_onepassword(service: &str, account: &str, token: &str) -> Result<String> {
+fn store_onepassword(service: &str, account: &AccountName, token: &str) -> Result<String> {
     // `op item create` reads field values from argv. The token is briefly
     // visible to local observers via /proc; redacted from coop's own
     // debug log via `redacted_arg`. 1Password rejects duplicate titles, so
@@ -297,7 +369,12 @@ fn store_onepassword(service: &str, account: &str, token: &str) -> Result<String
     ))
 }
 
-fn store_file(service: &str, account: &str, token: &str, state_dir: &Path) -> Result<String> {
+fn store_file(
+    service: &str,
+    account: &AccountName,
+    token: &str,
+    state_dir: &Path,
+) -> Result<String> {
     let dir = state_dir.join("github-pat");
     fs::create_dir_all(&dir).with_context(|| format!("Failed to create {}", dir.display()))?;
     set_dir_mode(&dir, 0o700)?;
@@ -321,22 +398,8 @@ fn store_file(service: &str, account: &str, token: &str, state_dir: &Path) -> Re
     Ok(format!("cmd:cat {}", shell_quote(&path.to_string_lossy())))
 }
 
-fn file_backend_path(state_dir: &Path, account: &str) -> PathBuf {
-    state_dir
-        .join("github-pat")
-        .join(format!("{}.txt", sanitize(account)))
-}
-
-fn sanitize(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect()
+fn file_backend_path(state_dir: &Path, account: &AccountName) -> PathBuf {
+    state_dir.join("github-pat").join(format!("{account}.txt"))
 }
 
 fn set_dir_mode(path: &Path, mode: u32) -> Result<()> {
@@ -357,8 +420,8 @@ fn shell_quote(s: &str) -> String {
 }
 
 /// Build the conventional account name for a repo's PAT entry.
-pub fn account_for_repo(repo: &crate::github_repo::RepoSlug) -> String {
-    repo.as_str().replace('/', "-")
+pub fn account_for_repo(repo: &RepoSlug) -> AccountName {
+    AccountName::from_repo(repo)
 }
 
 /// Conventional service name used across all backends.
@@ -381,10 +444,59 @@ mod tests {
         assert_eq!(*backends.last().unwrap(), Backend::File);
     }
 
+    fn account(s: &str) -> AccountName {
+        AccountName::from_repo(&RepoSlug::new(s).unwrap())
+    }
+
     #[test]
     fn account_replaces_slash() {
-        let slug = crate::github_repo::RepoSlug::new("trailofbits/coop").unwrap();
-        assert_eq!(account_for_repo(&slug), "trailofbits-coop".to_string());
+        let slug = RepoSlug::new("trailofbits/coop").unwrap();
+        assert_eq!(account_for_repo(&slug).as_str(), "trailofbits-coop");
+    }
+
+    #[test]
+    fn account_from_repo_uses_safe_chars_only() {
+        // Constructor is infallible; result must consist only of the
+        // [a-zA-Z0-9_.-] class so downstream filename / lookup-key use
+        // is safe without further sanitization.
+        let slug = RepoSlug::new("trail-of.bits_1/coop").unwrap();
+        let acc = AccountName::from_repo(&slug);
+        assert!(
+            acc.as_str()
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')),
+            "AccountName must only contain [a-zA-Z0-9_.-], got '{acc}'"
+        );
+        assert!(!acc.as_str().contains('/'), "slash must be replaced");
+    }
+
+    #[test]
+    fn tool_name_accepts_safe_chars() {
+        for s in ["op", "secret-tool", "tool_1", "a.b", "ABC.def-1_2"] {
+            let t = ToolName::new(s).unwrap();
+            assert_eq!(t.to_string(), s);
+            assert_eq!(<ToolName as AsRef<str>>::as_ref(&t), s);
+        }
+    }
+
+    #[test]
+    fn tool_name_rejects_empty() {
+        assert!(ToolName::new("").is_err());
+    }
+
+    #[test]
+    fn tool_name_rejects_unsafe_chars() {
+        for s in [
+            "secret tool", // space
+            "rm -rf /",    // space + /
+            "tool;evil",   // shell metachar
+            "tool$x",      // shell metachar
+            "tool\nx",     // newline
+            "tool/x",      // path separator
+            "tóol",        // non-ASCII
+        ] {
+            assert!(ToolName::new(s).is_err(), "should reject {s:?}");
+        }
     }
 
     #[test]
@@ -400,18 +512,13 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_replaces_unsafe_chars() {
-        assert_eq!(sanitize("owner/repo"), "owner-repo");
-        assert_eq!(sanitize("safe-name_v2"), "safe-name_v2");
-    }
-
-    #[test]
     fn file_backend_round_trip() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let cmd = store_file(SERVICE, "trailofbits-coop", "github_pat_xyz", tmp.path()).unwrap();
+        let acc = account("trailofbits/coop");
+        let cmd = store_file(SERVICE, &acc, "github_pat_xyz", tmp.path()).unwrap();
         assert!(cmd.starts_with("cmd:cat "));
         // Verify the file exists with the right contents and mode.
-        let path = file_backend_path(tmp.path(), "trailofbits-coop");
+        let path = file_backend_path(tmp.path(), &acc);
         let content = std::fs::read_to_string(&path).unwrap();
         assert_eq!(content.trim(), "github_pat_xyz");
         let meta = std::fs::metadata(&path).unwrap();
@@ -421,9 +528,10 @@ mod tests {
     #[test]
     fn file_backend_delete_removes_file() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let _ = store_file(SERVICE, "x-y", "token", tmp.path()).unwrap();
-        delete_secret(Backend::File, SERVICE, "x-y", tmp.path()).unwrap();
-        let path = file_backend_path(tmp.path(), "x-y");
+        let acc = account("x/y");
+        let _ = store_file(SERVICE, &acc, "token", tmp.path()).unwrap();
+        delete_secret(Backend::File, SERVICE, &acc, tmp.path()).unwrap();
+        let path = file_backend_path(tmp.path(), &acc);
         assert!(!path.exists());
     }
 

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -21,6 +21,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::cmd::Cmd;
 use crate::github_repo::RepoSlug;
+use crate::naming::validate_safe_chars;
 
 /// All secret-store backends recognised by the wizard.
 ///
@@ -100,15 +101,7 @@ impl ToolName {
         if name.is_empty() {
             bail!("Tool name is empty");
         }
-        if let Some(c) = name
-            .chars()
-            .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
-        {
-            bail!(
-                "Tool name '{name}' contains invalid character {c:?} \
-                 (allowed: a-z, A-Z, 0-9, '-', '_', '.')"
-            );
-        }
+        validate_safe_chars(name, "Tool name")?;
         Ok(Self(name.to_string()))
     }
 }
@@ -485,18 +478,11 @@ mod tests {
     }
 
     #[test]
-    fn tool_name_rejects_unsafe_chars() {
-        for s in [
-            "secret tool", // space
-            "rm -rf /",    // space + /
-            "tool;evil",   // shell metachar
-            "tool$x",      // shell metachar
-            "tool\nx",     // newline
-            "tool/x",      // path separator
-            "tóol",        // non-ASCII
-        ] {
-            assert!(ToolName::new(s).is_err(), "should reject {s:?}");
-        }
+    fn tool_name_rejects_unsafe_char() {
+        // Smoke test that the constructor wires through to
+        // `validate_safe_chars`; the exhaustive char-class rejection is
+        // covered by the `naming` module's tests.
+        assert!(ToolName::new("rm -rf /").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `ToolName::new` (validates `[a-zA-Z0-9_.-]+`) and `AccountName::from_repo` (replaces `/` with `-` from a `RepoSlug`). `tool_on_path` now takes `&ToolName` and embeds it in a `sh -c` line without rechecking. `store_secret`, `delete_secret`, and the file/keychain helpers take `&AccountName`, dropping the inline `sanitize` call in `file_backend_path`.
- Follow-up commit pulls the `[a-zA-Z0-9_.-]` class out of four duplicate sites (`ToolName`, `ImageName`, `InterfaceName`, `RepoSlug` segments) into a new `naming` module — `is_safe_name_char` + `validate_safe_chars(name, kind)` — so the class lives in one place. The exhaustive rejection test moves to `naming`; each per-type `*_rejects_out_of_charset` test trims to a single smoke example.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (572 passed) including new `naming::` and `tool_name_*` / `account_*` tests
- [x] `prek run --all-files`
- [ ] Integration tests on macOS/Lima and Linux/Firecracker — refactor is pure type-system; produced `cmd:` strings and on-disk paths are byte-identical to before for any input the previous code accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)