### PR TITLE
Type-system survey: four small newtype / struct refactors

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,7 +14,7 @@ use crate::config::{ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, McpS
 use crate::setup::SetupOptions;
 use crate::shell::shell_escape;
 
-// ── Guest path newtype ────────────────────────────────────────
+// ── Path newtypes ─────────────────────────────────────────────
 
 /// Path inside the guest VM. Prevents confusion between host
 /// `PathBuf` and guest path strings (which use Linux conventions
@@ -35,6 +35,41 @@ impl GuestPath {
 impl std::fmt::Display for GuestPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+/// Path on the host. Pairs with [`GuestPath`] so scp call sites
+/// distinguish source and destination by type rather than by
+/// argument order. Carries no invariant beyond direction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostPath(PathBuf);
+
+impl HostPath {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self(path.into())
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl From<PathBuf> for HostPath {
+    fn from(p: PathBuf) -> Self {
+        Self(p)
+    }
+}
+
+impl From<&Path> for HostPath {
+    fn from(p: &Path) -> Self {
+        Self(p.to_path_buf())
+    }
+}
+
+impl AsRef<Path> for HostPath {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn as_ref(&self) -> &Path {
+        &self.0
     }
 }
 
@@ -475,32 +510,32 @@ impl SshTarget {
     }
 
     /// SCP a local file to the guest.
-    pub fn scp_to(&self, local_path: &Path, remote: &GuestPath) -> Result<()> {
+    pub fn scp_to(&self, local: &HostPath, remote: &GuestPath) -> Result<()> {
         let status = Command::new("scp")
             .args(self.scp_opts())
-            .arg(local_path)
+            .arg(local.as_path())
             .arg(format!("{}:{remote}", self.addr()))
             .status()
             .context("Failed to run scp")?;
 
         if !status.success() {
-            bail!("scp failed: {} -> {remote}", local_path.display());
+            bail!("scp failed: {} -> {remote}", local.as_path().display());
         }
         Ok(())
     }
 
     /// Copy a local directory to the guest recursively via scp.
-    pub fn scp_to_recursive(&self, local_path: &Path, remote: &GuestPath) -> Result<()> {
+    pub fn scp_to_recursive(&self, local: &HostPath, remote: &GuestPath) -> Result<()> {
         let status = Command::new("scp")
             .args(self.scp_opts())
             .arg("-r")
-            .arg(local_path)
+            .arg(local.as_path())
             .arg(format!("{}:{remote}", self.addr()))
             .status()
             .context("Failed to run scp")?;
 
         if !status.success() {
-            bail!("scp -r failed: {} -> {remote}", local_path.display());
+            bail!("scp -r failed: {} -> {remote}", local.as_path().display());
         }
         Ok(())
     }
@@ -1484,13 +1519,14 @@ fn copy_claude_config(target: &SshTarget, config_dir: &ConfigDir) -> Result<()> 
     for entry in std::fs::read_dir(staging_path).context("Failed to read staging directory")? {
         let entry = entry.context("Failed to read staging entry")?;
         let path = entry.path();
+        let local = HostPath::new(&path);
         if path.is_dir() {
             target
-                .scp_to_recursive(&path, &guest_claude)
+                .scp_to_recursive(&local, &guest_claude)
                 .with_context(|| format!("Failed to copy {} to guest", path.display()))?;
         } else {
             target
-                .scp_to(&path, &guest_claude)
+                .scp_to(&local, &guest_claude)
                 .with_context(|| format!("Failed to copy {} to guest", path.display()))?;
         }
     }
@@ -1567,13 +1603,14 @@ fn copy_codex_config(
     for entry in std::fs::read_dir(staging_path).context("Failed to read staging directory")? {
         let entry = entry.context("Failed to read staging entry")?;
         let path = entry.path();
+        let local = HostPath::new(&path);
         if path.is_dir() {
             target
-                .scp_to_recursive(&path, &guest_codex)
+                .scp_to_recursive(&local, &guest_codex)
                 .with_context(|| format!("Failed to copy {} to guest", path.display()))?;
         } else {
             target
-                .scp_to(&path, &guest_codex)
+                .scp_to(&local, &guest_codex)
                 .with_context(|| format!("Failed to copy {} to guest", path.display()))?;
         }
     }
@@ -1807,7 +1844,7 @@ pub(crate) fn install_marketplaces(session: &SshSession, marketplaces: &[String]
             );
             session
                 .target
-                .scp_to_recursive(local_path, &remote)
+                .scp_to_recursive(&HostPath::from(local_path), &remote)
                 .with_context(|| {
                     format!(
                         "Failed to copy marketplace '{}' to guest",

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -11,67 +11,9 @@ use toml::Value as TomlValue;
 
 use crate::cmd::Cmd;
 use crate::config::{ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, McpServerDef};
+use crate::paths::{GuestPath, HostPath};
 use crate::setup::SetupOptions;
 use crate::shell::shell_escape;
-
-// ── Path newtypes ─────────────────────────────────────────────
-
-/// Path inside the guest VM. Prevents confusion between host
-/// `PathBuf` and guest path strings (which use Linux conventions
-/// regardless of the host OS).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GuestPath(String);
-
-impl GuestPath {
-    pub fn new(path: impl Into<String>) -> Self {
-        Self(path.into())
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for GuestPath {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-/// Path on the host. Pairs with [`GuestPath`] so scp call sites
-/// distinguish source and destination by type rather than by
-/// argument order. Carries no invariant beyond direction.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HostPath(PathBuf);
-
-impl HostPath {
-    pub fn new(path: impl Into<PathBuf>) -> Self {
-        Self(path.into())
-    }
-
-    pub fn as_path(&self) -> &Path {
-        &self.0
-    }
-}
-
-impl From<PathBuf> for HostPath {
-    fn from(p: PathBuf) -> Self {
-        Self(p)
-    }
-}
-
-impl From<&Path> for HostPath {
-    fn from(p: &Path) -> Self {
-        Self(p.to_path_buf())
-    }
-}
-
-impl AsRef<Path> for HostPath {
-    #[mutants::skip] // equivalent: trivial forwarder over self.0
-    fn as_ref(&self) -> &Path {
-        &self.0
-    }
-}
 
 // ── Operation modes ───────────────────────────────────────────
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cmd::Cmd;
 use crate::naming::validate_safe_chars;
+use crate::paths::GuestPath;
 
 pub const DEFAULT_IMAGE: &str = "default";
 
@@ -296,7 +297,7 @@ impl TryFrom<u16> for InstanceIndex {
 #[derive(Debug, Clone)]
 pub struct Mount {
     pub host_path: PathBuf,
-    pub guest_path: String,
+    pub guest_path: GuestPath,
 }
 
 impl Mount {
@@ -305,20 +306,22 @@ impl Mount {
     /// If `GUEST_PATH` is omitted, defaults to `/workspace`.
     pub fn parse(spec: &str) -> Result<Self> {
         let (host, guest_path) = if let Some((h, g)) = spec.split_once(':') {
-            (h, g.to_string())
+            (h, GuestPath::absolute(g)?)
         } else {
-            (spec, "/workspace".to_string())
+            (spec, GuestPath::absolute("/workspace")?)
         };
         Self::from_parts(host, guest_path)
     }
 
     /// Build a `Mount` from already-split host and guest components.
     ///
-    /// Single source of truth for the canonicalize / is-dir / absolute-guest
-    /// invariants; callers that build the spec from typed fields (devcontainer
-    /// JSON, Docker `type=bind` form) skip the string round-trip by calling
-    /// this directly.
-    pub fn from_parts(host: &str, guest_path: String) -> Result<Self> {
+    /// Single source of truth for the canonicalize / is-dir
+    /// invariants; the absolute-guest invariant is carried by
+    /// `GuestPath::absolute` at the type boundary. Callers that build
+    /// the spec from typed fields (devcontainer JSON, Docker
+    /// `type=bind` form) skip the string round-trip by calling this
+    /// directly.
+    pub fn from_parts(host: &str, guest_path: GuestPath) -> Result<Self> {
         let host_path = Path::new(host)
             .canonicalize()
             .with_context(|| format!("Mount host path does not exist: {host}"))?;
@@ -327,11 +330,6 @@ impl Mount {
             host_path.is_dir(),
             "Mount host path is not a directory: {}",
             host_path.display()
-        );
-
-        anyhow::ensure!(
-            guest_path.starts_with('/'),
-            "Mount guest path must be absolute: {guest_path}"
         );
 
         Ok(Self {
@@ -4318,7 +4316,7 @@ skip = ["not-a-slug"]
         let tmp = TempDir::new().unwrap();
         let m = Mount::parse(tmp.path().to_str().unwrap()).unwrap();
         assert_eq!(m.host_path, tmp.path().canonicalize().unwrap());
-        assert_eq!(m.guest_path, "/workspace");
+        assert_eq!(m.guest_path.as_str(), "/workspace");
     }
 
     #[test]
@@ -4327,7 +4325,7 @@ skip = ["not-a-slug"]
         let spec = format!("{}:/data/project", tmp.path().display());
         let m = Mount::parse(&spec).unwrap();
         assert_eq!(m.host_path, tmp.path().canonicalize().unwrap());
-        assert_eq!(m.guest_path, "/data/project");
+        assert_eq!(m.guest_path.as_str(), "/data/project");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,15 +302,23 @@ pub struct Mount {
 impl Mount {
     /// Parse a mount spec in the form `HOST_PATH[:GUEST_PATH]`.
     ///
-    /// If `GUEST_PATH` is omitted, defaults to `/mnt/<dirname>` where
-    /// `<dirname>` is the last component of the host path.
+    /// If `GUEST_PATH` is omitted, defaults to `/workspace`.
     pub fn parse(spec: &str) -> Result<Self> {
         let (host, guest_path) = if let Some((h, g)) = spec.split_once(':') {
             (h, g.to_string())
         } else {
             (spec, "/workspace".to_string())
         };
+        Self::from_parts(host, guest_path)
+    }
 
+    /// Build a `Mount` from already-split host and guest components.
+    ///
+    /// Single source of truth for the canonicalize / is-dir / absolute-guest
+    /// invariants; callers that build the spec from typed fields (devcontainer
+    /// JSON, Docker `type=bind` form) skip the string round-trip by calling
+    /// this directly.
+    pub fn from_parts(host: &str, guest_path: String) -> Result<Self> {
         let host_path = Path::new(host)
             .canonicalize()
             .with_context(|| format!("Mount host path does not exist: {host}"))?;

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -1087,7 +1087,7 @@ fn parse_mount_entry(v: &serde_json::Value) -> Result<Mount> {
                 .get("target")
                 .and_then(|v| v.as_str())
                 .context("mount object requires 'target'")?;
-            Mount::from_parts(source, target.to_string())
+            Mount::from_parts(source, crate::paths::GuestPath::absolute(target)?)
         }
         _ => bail!("expected mount string or object"),
     }
@@ -1135,7 +1135,7 @@ fn parse_mount_string(s: &str) -> Result<Mount> {
     }
     let source = source.context("mount string missing source=...")?;
     let target = target.context("mount string missing target=...")?;
-    Mount::from_parts(source, target.to_string())
+    Mount::from_parts(source, crate::paths::GuestPath::absolute(target)?)
 }
 
 /// Map a devcontainer feature id (raw key) to a built-in coop profile,
@@ -1531,11 +1531,11 @@ mod tests {
 
         let docker = format!("type=bind,source={host},target=/b");
         let m = parse_mount_string(&docker).unwrap();
-        assert_eq!(m.guest_path, "/b");
+        assert_eq!(m.guest_path.as_str(), "/b");
 
         let no_type = format!("source={host},target=/b,readonly");
         let m = parse_mount_string(&no_type).unwrap();
-        assert_eq!(m.guest_path, "/b");
+        assert_eq!(m.guest_path.as_str(), "/b");
 
         assert!(parse_mount_string("type=volume,source=v,target=/b").is_err());
     }
@@ -1548,7 +1548,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let spec = format!("{}:/g", tmp.path().display());
         let m = parse_mount_string(&spec).unwrap();
-        assert_eq!(m.guest_path, "/g");
+        assert_eq!(m.guest_path.as_str(), "/g");
     }
 
     #[test]
@@ -1557,7 +1557,7 @@ mod tests {
         let host = tmp.path().to_str().unwrap();
         let obj = serde_json::json!({"type": "bind", "source": host, "target": "/b"});
         let m = parse_mount_entry(&obj).unwrap();
-        assert_eq!(m.guest_path, "/b");
+        assert_eq!(m.guest_path.as_str(), "/b");
     }
 
     #[test]

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -1069,8 +1069,8 @@ fn parse_forward_port_entry(v: &serde_json::Value) -> Result<PortForward> {
 }
 
 fn parse_mount_entry(v: &serde_json::Value) -> Result<Mount> {
-    let spec = match v {
-        serde_json::Value::String(s) => normalize_mount_string(s)?,
+    match v {
+        serde_json::Value::String(s) => parse_mount_string(s),
         serde_json::Value::Object(map) => {
             let typ = map
                 .get("type")
@@ -1087,19 +1087,23 @@ fn parse_mount_entry(v: &serde_json::Value) -> Result<Mount> {
                 .get("target")
                 .and_then(|v| v.as_str())
                 .context("mount object requires 'target'")?;
-            format!("{source}:{target}")
+            Mount::from_parts(source, target.to_string())
         }
         _ => bail!("expected mount string or object"),
-    };
-    Mount::parse(&spec)
+    }
 }
 
-/// Convert a docker-style mount string (`type=bind,source=...,target=...`)
-/// into coop's `HOST_PATH[:GUEST_PATH]` form.
-fn normalize_mount_string(s: &str) -> Result<String> {
+/// Parse a devcontainer mount string into a [`Mount`].
+///
+/// Accepts both coop's native `HOST_PATH[:GUEST_PATH]` form (deferred to
+/// [`Mount::parse`]) and Docker's `type=bind,source=...,target=...` form
+/// (parsed here and constructed via [`Mount::from_parts`]). Either way
+/// the validated `Mount` value is the single output — no intermediate
+/// string round-trip.
+fn parse_mount_string(s: &str) -> Result<Mount> {
     if !s.contains('=') {
-        // Already in HOST:GUEST or HOST form — pass through.
-        return Ok(s.to_string());
+        // Native HOST:GUEST or HOST form — let `Mount::parse` handle it.
+        return Mount::parse(s);
     }
     let mut typ: Option<&str> = None;
     let mut source: Option<&str> = None;
@@ -1131,7 +1135,7 @@ fn normalize_mount_string(s: &str) -> Result<String> {
     }
     let source = source.context("mount string missing source=...")?;
     let target = target.context("mount string missing target=...")?;
-    Ok(format!("{source}:{target}"))
+    Mount::from_parts(source, target.to_string())
 }
 
 /// Map a devcontainer feature id (raw key) to a built-in coop profile,
@@ -1521,16 +1525,30 @@ mod tests {
     }
 
     #[test]
-    fn normalize_mount_string_handles_docker_form() {
-        assert_eq!(
-            normalize_mount_string("type=bind,source=/a,target=/b").unwrap(),
-            "/a:/b"
-        );
-        assert_eq!(
-            normalize_mount_string("source=/a,target=/b,readonly").unwrap(),
-            "/a:/b"
-        );
-        assert!(normalize_mount_string("type=volume,source=v,target=/b").is_err());
+    fn parse_mount_string_handles_docker_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let host = tmp.path().to_str().unwrap();
+
+        let docker = format!("type=bind,source={host},target=/b");
+        let m = parse_mount_string(&docker).unwrap();
+        assert_eq!(m.guest_path, "/b");
+
+        let no_type = format!("source={host},target=/b,readonly");
+        let m = parse_mount_string(&no_type).unwrap();
+        assert_eq!(m.guest_path, "/b");
+
+        assert!(parse_mount_string("type=volume,source=v,target=/b").is_err());
+    }
+
+    #[test]
+    fn parse_mount_string_native_form_defers_to_mount_parse() {
+        // Native `HOST[:GUEST]` form goes through `Mount::parse`, which
+        // canonicalises the host path. Use a real directory so the call
+        // succeeds, and check the guest path was preserved.
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = format!("{}:/g", tmp.path().display());
+        let m = parse_mount_string(&spec).unwrap();
+        assert_eq!(m.guest_path, "/g");
     }
 
     #[test]

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -143,17 +143,16 @@ pub fn run_status(cfg: &CoopConfig, probe: bool) {
 
 /// `coop github forget-pat --repo owner/name` — remove the secret and
 /// the config entry. Does **not** add a skip marker.
-pub fn run_forget_pat(cfg: &CoopConfig, repo: &str, config_path: &Path) -> Result<()> {
-    let repo = RepoSlug::new(repo)?;
+pub fn run_forget_pat(cfg: &CoopConfig, repo: &RepoSlug, config_path: &Path) -> Result<()> {
     let entry = cfg
         .github
         .as_ref()
-        .and_then(|g| g.pat_entry(&repo))
+        .and_then(|g| g.pat_entry(repo))
         .with_context(|| {
             format!("No PAT entry for '{repo}' — nothing to forget. Run `coop github status`.")
         })?;
     let backend = infer_backend(entry.token.expose());
-    let account = account_for_repo(&repo);
+    let account = account_for_repo(repo);
     let state_dir = cfg.data_dir.join("state");
     if let Some(b) = backend {
         if let Err(e) = delete_secret(b, SERVICE, &account, &state_dir) {
@@ -165,7 +164,7 @@ pub fn run_forget_pat(cfg: &CoopConfig, repo: &str, config_path: &Path) -> Resul
              clean up the underlying secret manually if needed."
         );
     }
-    remove_pat_entry(config_path, &repo)?;
+    remove_pat_entry(config_path, repo)?;
     eprintln!("Removed PAT entry for {repo}.");
     eprintln!(
         "note: the token itself may still be live on GitHub — \

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1606,7 +1606,7 @@ mod tests {
         let yaml = "mountType: \"virtiofs\"\nmounts: []\n";
         let mounts = vec![crate::config::Mount {
             host_path: "/home/user/project".into(),
-            guest_path: "/workspace".into(),
+            guest_path: crate::paths::GuestPath::absolute("/workspace").unwrap(),
         }];
         let result = super::inject_mounts(yaml, &mounts);
         assert!(
@@ -1633,11 +1633,11 @@ mod tests {
         let mounts = vec![
             crate::config::Mount {
                 host_path: "/a".into(),
-                guest_path: "/workspace".into(),
+                guest_path: crate::paths::GuestPath::absolute("/workspace").unwrap(),
             },
             crate::config::Mount {
                 host_path: "/b".into(),
-                guest_path: "/data".into(),
+                guest_path: crate::paths::GuestPath::absolute("/data").unwrap(),
             },
         ];
         let result = super::inject_mounts(yaml, &mounts);
@@ -1654,7 +1654,7 @@ mod tests {
         let yaml = "vmType: \"vz\"\nmounts: []\ncontainerd:\n  system: false\n";
         let mounts = vec![crate::config::Mount {
             host_path: "/x".into(),
-            guest_path: "/y".into(),
+            guest_path: crate::paths::GuestPath::absolute("/y").unwrap(),
         }];
         let result = super::inject_mounts(yaml, &mounts);
         assert!(result.contains("vmType: \"vz\""), "lost vmType: {result}");

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1606,7 +1606,7 @@ mod tests {
         let yaml = "mountType: \"virtiofs\"\nmounts: []\n";
         let mounts = vec![crate::config::Mount {
             host_path: "/home/user/project".into(),
-            guest_path: crate::paths::GuestPath::absolute("/workspace").unwrap(),
+            guest_path: crate::workspace::default_workspace_path(),
         }];
         let result = super::inject_mounts(yaml, &mounts);
         assert!(
@@ -1633,7 +1633,7 @@ mod tests {
         let mounts = vec![
             crate::config::Mount {
                 host_path: "/a".into(),
-                guest_path: crate::paths::GuestPath::absolute("/workspace").unwrap(),
+                guest_path: crate::workspace::default_workspace_path(),
             },
             crate::config::Mount {
                 host_path: "/b".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1474,7 +1474,7 @@ fn start_instance(
         workspace::tar_pipe_transfer(&target, &abs_path, opts.exclude_git)?;
 
         let state = workspace::WorkspaceState {
-            guest_path: paths::GuestPath::absolute("/workspace")?,
+            guest_path: workspace::default_workspace_path(),
             source: workspace::WorkspaceSource::Workspace {
                 host_path: abs_path,
             },
@@ -1484,7 +1484,7 @@ fn start_instance(
         backend::clone_git_repo(&target, cfg.github.as_ref(), repo_url)?;
 
         let state = workspace::WorkspaceState {
-            guest_path: paths::GuestPath::absolute("/workspace")?,
+            guest_path: workspace::default_workspace_path(),
             source: workspace::WorkspaceSource::GitRepo {
                 url: repo_url.to_string(),
             },
@@ -2902,7 +2902,7 @@ mod tests {
         );
         let mount = super::config::Mount {
             host_path: tmp.path().to_path_buf(),
-            guest_path: super::paths::GuestPath::absolute("/workspace").expect("absolute"),
+            guest_path: super::workspace::default_workspace_path(),
         };
         let cfg_path = tmp.path().join("config.toml");
         let opts = start_opts(vec![mount], &cfg_path);
@@ -2923,7 +2923,7 @@ mod tests {
         );
         let mount = super::config::Mount {
             host_path: tmp.path().to_path_buf(),
-            guest_path: super::paths::GuestPath::absolute("/workspace").expect("absolute"),
+            guest_path: super::workspace::default_workspace_path(),
         };
         let cfg_path = tmp.path().join("config.toml");
         let opts = start_opts(vec![mount], &cfg_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1471,7 +1471,7 @@ fn start_instance(
         workspace::tar_pipe_transfer(&target, &abs_path, opts.exclude_git)?;
 
         let state = workspace::WorkspaceState {
-            guest_path: "/workspace".to_string(),
+            guest_path: paths::GuestPath::absolute("/workspace")?,
             source: workspace::WorkspaceSource::Workspace {
                 host_path: abs_path,
             },
@@ -1481,7 +1481,7 @@ fn start_instance(
         backend::clone_git_repo(&target, cfg.github.as_ref(), repo_url)?;
 
         let state = workspace::WorkspaceState {
-            guest_path: "/workspace".to_string(),
+            guest_path: paths::GuestPath::absolute("/workspace")?,
             source: workspace::WorkspaceSource::GitRepo {
                 url: repo_url.to_string(),
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod guest;
 mod guest_env_state;
 mod naming;
 mod pat_prompt;
+mod paths;
 mod port_forward;
 mod secret_store;
 mod sha256_hash;
@@ -2898,7 +2899,7 @@ mod tests {
         );
         let mount = super::config::Mount {
             host_path: tmp.path().to_path_buf(),
-            guest_path: "/workspace".to_string(),
+            guest_path: super::paths::GuestPath::absolute("/workspace").expect("absolute"),
         };
         let cfg_path = tmp.path().join("config.toml");
         let opts = start_opts(vec![mount], &cfg_path);
@@ -2919,7 +2920,7 @@ mod tests {
         );
         let mount = super::config::Mount {
             host_path: tmp.path().to_path_buf(),
-            guest_path: "/workspace".to_string(),
+            guest_path: super::paths::GuestPath::absolute("/workspace").expect("absolute"),
         };
         let cfg_path = tmp.path().join("config.toml");
         let opts = start_opts(vec![mount], &cfg_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -878,7 +878,10 @@ fn cmd_github(cfg: &config::CoopConfig, config_path: &Path, action: &GithubActio
             github_pat::run_status(cfg, *probe);
             Ok(())
         }
-        GithubAction::ForgetPat { repo } => github_pat::run_forget_pat(cfg, repo, config_path),
+        GithubAction::ForgetPat { repo } => {
+            let slug = github_repo::RepoSlug::new(repo)?;
+            github_pat::run_forget_pat(cfg, &slug, config_path)
+        }
     }
 }
 

--- a/src/pat_prompt.rs
+++ b/src/pat_prompt.rs
@@ -27,26 +27,31 @@ pub enum Decision {
     Prompt,
 }
 
+/// Runtime context that influences whether the PAT wizard prompt is
+/// offered. Grouped into a struct so call sites name each flag at the
+/// keyword position rather than relying on positional booleans.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PromptContext {
+    /// Whether stdin is attached to an interactive terminal.
+    pub is_tty: bool,
+    /// Whether the `CI` env var is set (non-interactive batch run).
+    pub is_ci: bool,
+    /// Whether the caller passed `--no-prompt`.
+    pub no_prompt_flag: bool,
+}
+
 impl Decision {
     /// Pure decision step — no I/O. Easy to unit-test.
     ///
     /// `repo` is the resolved `owner/repo` slug, if any.
-    /// `tty` reflects whether stdin is interactive.
-    /// `ci` reflects whether the `CI` env var is set.
-    /// `no_prompt_flag` reflects whether `--no-prompt` was passed.
-    pub fn resolve(
-        cfg: &CoopConfig,
-        repo: Option<&RepoSlug>,
-        tty: bool,
-        ci: bool,
-        no_prompt_flag: bool,
-    ) -> Self {
+    /// `ctx` carries the TTY / CI / `--no-prompt` flags.
+    pub fn resolve(cfg: &CoopConfig, repo: Option<&RepoSlug>, ctx: PromptContext) -> Self {
         // No repo → nothing to scope to.
         let Some(repo) = repo else {
             return Self::Skip;
         };
         // Hard suppressors first.
-        if no_prompt_flag || ci || !tty || !cfg.setup.prompt_for_pat {
+        if ctx.no_prompt_flag || ctx.is_ci || !ctx.is_tty || !cfg.setup.prompt_for_pat {
             return Self::Skip;
         }
         match cfg.github.as_ref() {
@@ -83,15 +88,18 @@ pub fn maybe_prompt(
     repo: Option<&RepoSlug>,
     no_prompt_flag: bool,
 ) -> Result<()> {
-    let tty = std::io::stdin().is_terminal();
-    let ci = std::env::var("CI").is_ok();
-    let decision = Decision::resolve(cfg, repo, tty, ci, no_prompt_flag);
+    let ctx = PromptContext {
+        is_tty: std::io::stdin().is_terminal(),
+        is_ci: std::env::var("CI").is_ok(),
+        no_prompt_flag,
+    };
+    let decision = Decision::resolve(cfg, repo, ctx);
     match decision {
         Decision::Skip => {
             // Even when we skip the prompt, surface a hint to non-interactive
             // contexts so users discover the wizard exists.
             if let Some(slug) = repo
-                && (!tty || ci)
+                && (!ctx.is_tty || ctx.is_ci)
                 && matches!(cfg.github.as_ref(), None | Some(GitHubAuth::Off))
             {
                 tracing::info!(
@@ -186,20 +194,30 @@ mod tests {
         RepoSlug::new(s).unwrap()
     }
 
+    /// Default interactive context: TTY on, not in CI, no `--no-prompt`.
+    fn interactive() -> PromptContext {
+        PromptContext {
+            is_tty: true,
+            is_ci: false,
+            no_prompt_flag: false,
+        }
+    }
+
     #[test]
     fn skips_when_no_repo() {
         let cfg = cfg_with(None);
-        assert_eq!(
-            Decision::resolve(&cfg, None, true, false, false),
-            Decision::Skip
-        );
+        assert_eq!(Decision::resolve(&cfg, None, interactive()), Decision::Skip);
     }
 
     #[test]
     fn skips_when_no_tty() {
         let cfg = cfg_with(None);
+        let ctx = PromptContext {
+            is_tty: false,
+            ..interactive()
+        };
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), false, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), ctx),
             Decision::Skip
         );
     }
@@ -207,8 +225,12 @@ mod tests {
     #[test]
     fn skips_when_ci() {
         let cfg = cfg_with(None);
+        let ctx = PromptContext {
+            is_ci: true,
+            ..interactive()
+        };
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, true, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), ctx),
             Decision::Skip
         );
     }
@@ -216,8 +238,12 @@ mod tests {
     #[test]
     fn skips_when_no_prompt_flag() {
         let cfg = cfg_with(None);
+        let ctx = PromptContext {
+            no_prompt_flag: true,
+            ..interactive()
+        };
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, true),
+            Decision::resolve(&cfg, Some(&slug("a/b")), ctx),
             Decision::Skip
         );
     }
@@ -226,7 +252,7 @@ mod tests {
     fn prompts_when_mode_off_and_interactive() {
         let cfg = cfg_with(Some(GitHubAuth::Off));
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), interactive()),
             Decision::Prompt
         );
     }
@@ -235,7 +261,7 @@ mod tests {
     fn prompts_when_pat_mode_but_no_entry() {
         let cfg = cfg_with(Some(GitHubAuth::Pat(PatConfig::default())));
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), interactive()),
             Decision::Prompt
         );
     }
@@ -251,7 +277,7 @@ mod tests {
         );
         let cfg = cfg_with(Some(GitHubAuth::Pat(pc)));
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), interactive()),
             Decision::Skip
         );
     }
@@ -262,7 +288,7 @@ mod tests {
         pc.skip.push(slug("a/b"));
         let cfg = cfg_with(Some(GitHubAuth::Pat(pc)));
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), interactive()),
             Decision::Skip
         );
     }
@@ -271,7 +297,7 @@ mod tests {
     fn skips_when_mode_auto() {
         let cfg = cfg_with(Some(GitHubAuth::Auto));
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), interactive()),
             Decision::Skip
         );
     }
@@ -280,7 +306,7 @@ mod tests {
     fn skips_when_mode_env() {
         let cfg = cfg_with(Some(GitHubAuth::Env));
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), interactive()),
             Decision::Skip
         );
     }
@@ -290,7 +316,7 @@ mod tests {
         let mut cfg = cfg_with(Some(GitHubAuth::Off));
         cfg.setup.prompt_for_pat = false;
         assert_eq!(
-            Decision::resolve(&cfg, Some(&slug("a/b")), true, false, false),
+            Decision::resolve(&cfg, Some(&slug("a/b")), interactive()),
             Decision::Skip
         );
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,133 @@
+//! Direction-typed path newtypes that flow between host and guest.
+//!
+//! `GuestPath` and `HostPath` are paired so that scp/rsync call sites
+//! distinguish source from destination by type rather than by argument
+//! order. `GuestPath` additionally carries the SFTP-friendly `./...`
+//! vs. absolute `/...` distinction that prevents the OpenSSH 9+
+//! tilde-expansion gotcha (see CLAUDE.md).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
+
+// ── Guest path ────────────────────────────────────────────────
+
+/// Path inside the guest VM. Prevents confusion between host
+/// `PathBuf` and guest path strings (which use Linux conventions
+/// regardless of the host OS).
+///
+/// The permissive [`Self::new`] constructor accepts any string;
+/// callers that require an absolute guest path (e.g. mount targets,
+/// workspace roots) construct via [`Self::absolute`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GuestPath(String);
+
+impl GuestPath {
+    /// Permissive constructor. Accepts any guest path, including
+    /// relative SFTP-style `./foo` used by scp targets in the home
+    /// directory.
+    pub fn new(path: impl Into<String>) -> Self {
+        Self(path.into())
+    }
+
+    /// Construct a `GuestPath` that is required to be absolute
+    /// (starts with `/`). Used for fields that downstream code reads
+    /// as already-absolute (mount targets, workspace roots) so the
+    /// invariant lives at construction rather than at every use.
+    pub fn absolute(path: impl Into<String>) -> Result<Self> {
+        let path = path.into();
+        if !path.starts_with('/') {
+            bail!("Guest path must be absolute: '{path}'");
+        }
+        Ok(Self(path))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for GuestPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+// ── Host path ─────────────────────────────────────────────────
+
+/// Path on the host. Pairs with [`GuestPath`] so scp call sites
+/// distinguish source and destination by type rather than by
+/// argument order. Carries no invariant beyond direction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostPath(PathBuf);
+
+impl HostPath {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self(path.into())
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl From<PathBuf> for HostPath {
+    fn from(p: PathBuf) -> Self {
+        Self(p)
+    }
+}
+
+impl From<&Path> for HostPath {
+    fn from(p: &Path) -> Self {
+        Self(p.to_path_buf())
+    }
+}
+
+impl AsRef<Path> for HostPath {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absolute_accepts_leading_slash() {
+        let p = GuestPath::absolute("/workspace").unwrap();
+        assert_eq!(p.as_str(), "/workspace");
+    }
+
+    #[test]
+    fn absolute_rejects_relative() {
+        let err = GuestPath::absolute("./foo").unwrap_err().to_string();
+        assert!(err.contains("must be absolute"), "{err}");
+    }
+
+    #[test]
+    fn absolute_rejects_empty() {
+        assert!(GuestPath::absolute("").is_err());
+    }
+
+    #[test]
+    fn new_accepts_relative_dot_slash() {
+        // Permissive constructor: `./...` is intentional (SFTP tilde
+        // expansion gotcha, see CLAUDE.md).
+        let p = GuestPath::new("./.claude");
+        assert_eq!(p.as_str(), "./.claude");
+    }
+
+    #[test]
+    fn serde_round_trip_is_transparent() {
+        let p = GuestPath::new("/x/y");
+        let json = serde_json::to_string(&p).unwrap();
+        assert_eq!(json, "\"/x/y\"");
+        let back: GuestPath = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, p);
+    }
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -896,7 +896,7 @@ fn fetch_kernel(cfg: &CoopConfig, skip_confirm: bool) -> Result<()> {
     let arch = Architecture::current()?;
 
     let latest = discover_latest_fc_version()?;
-    let ci_version = derive_ci_version(&latest);
+    let ci_version = FcVersion::parse(&latest)?.ci_dirname();
 
     eprintln!("  Looking for kernels in CI bucket (version {ci_version})...");
     let prefix = format!("firecracker-ci/{ci_version}/{arch}/vmlinux-");
@@ -955,7 +955,7 @@ fn fetch_kernel(cfg: &CoopConfig, skip_confirm: bool) -> Result<()> {
 fn discover_ci_rootfs(cfg: &CoopConfig) -> Result<String> {
     let arch = Architecture::current()?;
     let latest = discover_latest_fc_version()?;
-    let ci_version = derive_ci_version(&latest);
+    let ci_version = FcVersion::parse(&latest)?.ci_dirname();
 
     eprintln!("  Looking for rootfs in CI bucket (version {ci_version})...");
     let prefix = format!("firecracker-ci/{ci_version}/{arch}/ubuntu-");
@@ -1236,14 +1236,49 @@ fn discover_latest_fc_version() -> Result<String> {
     Ok(version)
 }
 
-/// Derive the CI bucket version from a release version.
-/// e.g., "v1.15.0" -> "v1.15", "v1.14.2" -> "v1.14"
-fn derive_ci_version(release_version: &str) -> String {
-    let parts: Vec<&str> = release_version.split('.').collect();
-    if parts.len() >= 2 {
-        format!("{}.{}", parts[0], parts[1])
-    } else {
-        release_version.to_string()
+/// Parsed Firecracker release version (e.g. `v1.15`).
+///
+/// Carries the major and minor components so the CI bucket directory
+/// name is derived from a parsed value rather than re-slicing a string
+/// each time it's needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FcVersion {
+    pub major: u16,
+    pub minor: u16,
+}
+
+impl FcVersion {
+    /// Parse a Firecracker release tag like `v1.15.0`.
+    ///
+    /// Accepts the GitHub release tag format: a leading `v` followed by
+    /// at least `MAJOR.MINOR` numeric components. Any trailing `.PATCH`
+    /// (or further) segments are tolerated but discarded — the CI bucket
+    /// is keyed by `vMAJOR.MINOR` only.
+    pub fn parse(release: &str) -> Result<Self> {
+        let rest = release
+            .strip_prefix('v')
+            .with_context(|| format!("Firecracker version must start with 'v': '{release}'"))?;
+        let mut parts = rest.split('.');
+        let major_str = parts
+            .next()
+            .filter(|s| !s.is_empty())
+            .with_context(|| format!("Firecracker version is missing MAJOR: '{release}'"))?;
+        let minor_str = parts
+            .next()
+            .filter(|s| !s.is_empty())
+            .with_context(|| format!("Firecracker version is missing MINOR: '{release}'"))?;
+        let major = major_str.parse::<u16>().with_context(|| {
+            format!("Firecracker MAJOR is not a u16 in '{release}' (got '{major_str}')")
+        })?;
+        let minor = minor_str.parse::<u16>().with_context(|| {
+            format!("Firecracker MINOR is not a u16 in '{release}' (got '{minor_str}')")
+        })?;
+        Ok(Self { major, minor })
+    }
+
+    /// CI bucket directory name, e.g. `v1.15`.
+    pub fn ci_dirname(self) -> String {
+        format!("v{}.{}", self.major, self.minor)
     }
 }
 
@@ -1323,6 +1358,7 @@ fn confirm(action: &str, skip: bool) -> Result<bool> {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
 
@@ -1473,5 +1509,65 @@ mod tests {
             Architecture::current(),
             Ok(Architecture::X86_64 | Architecture::Aarch64)
         ));
+    }
+
+    #[test]
+    fn fc_version_parses_release_tag() {
+        let v = FcVersion::parse("v1.15.0").unwrap();
+        assert_eq!(
+            v,
+            FcVersion {
+                major: 1,
+                minor: 15
+            }
+        );
+    }
+
+    #[test]
+    fn fc_version_parses_double_digit_minor() {
+        let v = FcVersion::parse("v2.103.7").unwrap();
+        assert_eq!(
+            v,
+            FcVersion {
+                major: 2,
+                minor: 103,
+            }
+        );
+    }
+
+    #[test]
+    fn fc_version_ci_dirname_keeps_v_prefix() {
+        assert_eq!(
+            FcVersion {
+                major: 1,
+                minor: 15
+            }
+            .ci_dirname(),
+            "v1.15"
+        );
+    }
+
+    #[test]
+    fn fc_version_rejects_missing_v_prefix() {
+        let err = FcVersion::parse("1.15.0").unwrap_err().to_string();
+        assert!(err.contains("must start with 'v'"), "{err}");
+    }
+
+    #[test]
+    fn fc_version_rejects_missing_minor() {
+        let err = FcVersion::parse("v1").unwrap_err().to_string();
+        assert!(err.contains("missing MINOR"), "{err}");
+    }
+
+    #[test]
+    fn fc_version_rejects_non_numeric_major() {
+        let err = FcVersion::parse("vfoo.bar").unwrap_err().to_string();
+        assert!(err.contains("MAJOR is not a u16"), "{err}");
+    }
+
+    #[test]
+    fn fc_version_rejects_empty_segments() {
+        let err = FcVersion::parse("v.15").unwrap_err().to_string();
+        assert!(err.contains("missing MAJOR"), "{err}");
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -310,11 +310,16 @@ fn format_pull_failure(ssh_stderr: &[u8], tar_stderr: &[u8]) -> String {
     }
 }
 
+/// The coop convention for where a workspace lands inside the guest.
+///
+/// Use this in preference to constructing `GuestPath::absolute("/workspace")`
+/// at call sites: it's the single source of truth for the default mount
+/// target and never fails (the underlying constant is a static absolute path).
 #[expect(
     clippy::expect_used,
     reason = "GUEST_WORKSPACE is a const literal starting with '/'; invariant holds at compile time"
 )]
-fn default_workspace_path() -> GuestPath {
+pub(crate) fn default_workspace_path() -> GuestPath {
     GuestPath::absolute(GUEST_WORKSPACE).expect("GUEST_WORKSPACE constant is absolute")
 }
 
@@ -1149,7 +1154,7 @@ mod tests {
         let mounts = vec![
             crate::config::Mount {
                 host_path: primary.path().to_path_buf(),
-                guest_path: crate::paths::GuestPath::absolute("/workspace").unwrap(),
+                guest_path: default_workspace_path(),
             },
             crate::config::Mount {
                 host_path: secondary.path().to_path_buf(),

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::backend::{RunningInstance, SshTarget};
 use crate::config::Instance;
+use crate::paths::GuestPath;
 
 const GUEST_WORKSPACE: &str = "/workspace";
 
@@ -28,8 +29,8 @@ const GIT_EXCLUDE: &str = ".git/";
 /// Persisted workspace metadata written during `start`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WorkspaceState {
-    /// Path inside the guest VM.
-    pub guest_path: String,
+    /// Path inside the guest VM. Always absolute by construction.
+    pub guest_path: GuestPath,
     /// How the workspace was created. Variant-specific fields (host
     /// path, original repo URL) live inside the source so invalid
     /// combinations can't be expressed.
@@ -309,13 +310,21 @@ fn format_pull_failure(ssh_stderr: &[u8], tar_stderr: &[u8]) -> String {
     }
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "GUEST_WORKSPACE is a const literal starting with '/'; invariant holds at compile time"
+)]
+fn default_workspace_path() -> GuestPath {
+    GuestPath::absolute(GUEST_WORKSPACE).expect("GUEST_WORKSPACE constant is absolute")
+}
+
 fn load_or_default(inst: &Instance, dir: Option<&str>, cmd: &str) -> Result<WorkspaceState> {
     if let Some(state) = WorkspaceState::try_load(inst)? {
         return Ok(state);
     }
     if let Some(d) = dir {
         return Ok(WorkspaceState {
-            guest_path: GUEST_WORKSPACE.to_string(),
+            guest_path: default_workspace_path(),
             source: WorkspaceSource::Workspace {
                 host_path: PathBuf::from(d),
             },
@@ -426,7 +435,7 @@ pub fn sync_mounts(
         tracing::info!("Syncing {} -> guest:{guest}", m.host_path.display(),);
 
         if target.exec_ok("which rsync") {
-            rsync_push(target, &m.host_path, guest.as_str(), exclude_git)?;
+            rsync_push(target, &m.host_path, guest, exclude_git)?;
         } else {
             tracing::info!("rsync not available on guest, using tar-pipe");
             tar_pipe_transfer(target, &m.host_path, exclude_git)?;
@@ -445,7 +454,7 @@ pub fn sync_mounts(
 pub fn record_mount_state(inst: &Instance, mounts: &[crate::config::Mount]) -> Result<()> {
     if let Some(m) = mounts.first() {
         let state = WorkspaceState {
-            guest_path: m.guest_path.as_str().to_string(),
+            guest_path: m.guest_path.clone(),
             source: WorkspaceSource::Mount {
                 host_path: m.host_path.clone(),
             },
@@ -466,10 +475,14 @@ pub fn vscode(
 ) -> Result<()> {
     let inst = running.instance();
     let target = running.target();
-    let remote_path = project.unwrap_or(GUEST_WORKSPACE);
+    let remote_path = match project {
+        Some(p) => GuestPath::absolute(p)
+            .with_context(|| format!("--project must be an absolute guest path: {p:?}"))?,
+        None => default_workspace_path(),
+    };
 
     update_ssh_config(target, inst)?;
-    launch_editor(inst, remote_path, editor)?;
+    launch_editor(inst, &remote_path, editor)?;
 
     let block = ssh_config_block(target, inst);
     writeln!(
@@ -542,7 +555,7 @@ fn rsync_base_args(target: &SshTarget, exclude_git: bool) -> Vec<String> {
 pub fn rsync_push(
     target: &SshTarget,
     source: &Path,
-    guest_path: &str,
+    guest_path: &GuestPath,
     exclude_git: bool,
 ) -> Result<()> {
     let mut args = rsync_base_args(target, exclude_git);
@@ -561,7 +574,12 @@ pub fn rsync_push(
     Ok(())
 }
 
-fn rsync_pull(target: &SshTarget, guest_path: &str, dest: &Path, exclude_git: bool) -> Result<()> {
+fn rsync_pull(
+    target: &SshTarget,
+    guest_path: &GuestPath,
+    dest: &Path,
+    exclude_git: bool,
+) -> Result<()> {
     let mut args = rsync_base_args(target, exclude_git);
     args.push(format!("{}:{guest_path}/", target.addr()));
     args.push(format!("{}/", dest.display()));
@@ -581,7 +599,7 @@ fn rsync_pull(target: &SshTarget, guest_path: &str, dest: &Path, exclude_git: bo
 
 fn tar_pipe_pull(
     target: &SshTarget,
-    guest_path: &str,
+    guest_path: &GuestPath,
     dest: &Path,
     exclude_git: bool,
 ) -> Result<()> {
@@ -709,7 +727,7 @@ fn resolve_host_dir(explicit: Option<&str>, state: &WorkspaceState, cmd: &str) -
         })
 }
 
-fn check_guest_dirty(target: &SshTarget, guest_path: &str) -> Result<()> {
+fn check_guest_dirty(target: &SshTarget, guest_path: &GuestPath) -> Result<()> {
     // Untracked files are excluded — they're almost always host-side noise
     // (build artifacts, editor state) that was copied in at start time, not
     // edits made inside the guest. Modified tracked files and unpushed
@@ -907,11 +925,12 @@ struct LaunchStrategy {
     args: Vec<String>,
 }
 
-fn vscode_strategies(remote_arg: &str, remote_path: &str) -> Vec<LaunchStrategy> {
+fn vscode_strategies(remote_arg: &str, remote_path: &GuestPath) -> Vec<LaunchStrategy> {
+    let path_arg = remote_path.as_str().to_string();
     let mut strategies = vec![LaunchStrategy {
         name: "code CLI",
         cmd: "code".into(),
-        args: vec!["--remote".into(), remote_arg.into(), remote_path.into()],
+        args: vec!["--remote".into(), remote_arg.into(), path_arg.clone()],
     }];
     if cfg!(target_os = "macos") {
         strategies.push(LaunchStrategy {
@@ -923,14 +942,14 @@ fn vscode_strategies(remote_arg: &str, remote_path: &str) -> Vec<LaunchStrategy>
                 "--args".into(),
                 "--remote".into(),
                 remote_arg.into(),
-                remote_path.into(),
+                path_arg,
             ],
         });
     }
     strategies
 }
 
-fn launch_editor(inst: &Instance, remote_path: &str, editor: Option<&str>) -> Result<()> {
+fn launch_editor(inst: &Instance, remote_path: &GuestPath, editor: Option<&str>) -> Result<()> {
     let host = ssh_config_host(inst);
     let remote_arg = format!("ssh-remote+{host}");
 
@@ -1092,14 +1111,14 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let inst = temp_instance(dir.path());
         let state = WorkspaceState {
-            guest_path: "/custom".to_string(),
+            guest_path: GuestPath::absolute("/custom").unwrap(),
             source: WorkspaceSource::GitRepo {
                 url: "https://github.com/x/y.git".to_string(),
             },
         };
         state.save(&inst).expect("save");
         let loaded = load_or_default(&inst, None, "push").expect("load");
-        assert_eq!(loaded.guest_path, "/custom");
+        assert_eq!(loaded.guest_path.as_str(), "/custom");
         assert!(matches!(
             loaded.source,
             WorkspaceSource::GitRepo { ref url } if url == "https://github.com/x/y.git"
@@ -1114,7 +1133,7 @@ mod tests {
         // explicit --dir as its host_path so consumers can read it
         // uniformly.
         let loaded = load_or_default(&inst, Some("./project"), "push").expect("load");
-        assert_eq!(loaded.guest_path, GUEST_WORKSPACE);
+        assert_eq!(loaded.guest_path.as_str(), GUEST_WORKSPACE);
         assert!(matches!(
             loaded.source,
             WorkspaceSource::Workspace { ref host_path } if host_path == Path::new("./project")
@@ -1145,7 +1164,7 @@ mod tests {
             loaded.source,
             WorkspaceSource::Mount { ref host_path } if host_path == primary.path()
         ));
-        assert_eq!(loaded.guest_path, "/workspace");
+        assert_eq!(loaded.guest_path.as_str(), "/workspace");
     }
 
     #[test]
@@ -1312,14 +1331,14 @@ Host coop-0\n\
         // `record_mount_state_persists_first_mount` (Mount) and
         // `load_or_default_uses_saved_state` (GitRepo).
         let state = WorkspaceState {
-            guest_path: "/workspace".to_string(),
+            guest_path: GuestPath::absolute("/workspace").unwrap(),
             source: WorkspaceSource::Workspace {
                 host_path: PathBuf::from("/host/dir"),
             },
         };
         let json = serde_json::to_string(&state).expect("serialize");
         let back: WorkspaceState = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back.guest_path, "/workspace");
+        assert_eq!(back.guest_path.as_str(), "/workspace");
         assert!(matches!(
             back.source,
             WorkspaceSource::Workspace { ref host_path } if host_path == Path::new("/host/dir")

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -426,7 +426,7 @@ pub fn sync_mounts(
         tracing::info!("Syncing {} -> guest:{guest}", m.host_path.display(),);
 
         if target.exec_ok("which rsync") {
-            rsync_push(target, &m.host_path, guest, exclude_git)?;
+            rsync_push(target, &m.host_path, guest.as_str(), exclude_git)?;
         } else {
             tracing::info!("rsync not available on guest, using tar-pipe");
             tar_pipe_transfer(target, &m.host_path, exclude_git)?;
@@ -445,7 +445,7 @@ pub fn sync_mounts(
 pub fn record_mount_state(inst: &Instance, mounts: &[crate::config::Mount]) -> Result<()> {
     if let Some(m) = mounts.first() {
         let state = WorkspaceState {
-            guest_path: m.guest_path.clone(),
+            guest_path: m.guest_path.as_str().to_string(),
             source: WorkspaceSource::Mount {
                 host_path: m.host_path.clone(),
             },
@@ -1130,11 +1130,11 @@ mod tests {
         let mounts = vec![
             crate::config::Mount {
                 host_path: primary.path().to_path_buf(),
-                guest_path: "/workspace".to_string(),
+                guest_path: crate::paths::GuestPath::absolute("/workspace").unwrap(),
             },
             crate::config::Mount {
                 host_path: secondary.path().to_path_buf(),
-                guest_path: "/data".to_string(),
+                guest_path: crate::paths::GuestPath::absolute("/data").unwrap(),
             },
         ];
         record_mount_state(&inst, &mounts).expect("save");


### PR DESCRIPTION
## Summary

Bundles four issues from the type-system survey plus three follow-up
cleanups uncovered while reviewing the first round.

### Closes:

- **`HostPath` newtype** paired with `GuestPath` so `scp_to` / `scp_to_recursive` distinguish source and destination by type (closes #155).
- **`FcVersion` newtype** with `parse` + `ci_dirname`, replacing `derive_ci_version`'s string slicing so parse is separated from format (closes #168).
- **`PromptContext` struct** groups the three booleans `Decision::resolve` used to take positionally (closes #167).
- **`Mount::from_parts`** lifts the canonicalize / is-dir / absolute-guest checks into one helper; devcontainer parsers construct `Mount` directly instead of round-tripping through a string (closes #164).

### Follow-up commits (no issue, in-survey):

- **Move path newtypes to `src/paths.rs`.** `GuestPath` / `HostPath` lived in `backend.rs` only because the type-system PR put them there. They needed to be importable from `config.rs` (which `backend.rs` already imports from). Adds a `GuestPath::absolute` smart constructor and changes `Mount.guest_path: String → GuestPath`, removing the residual `String` slot in `Mount::from_parts`.
- **Apply `GuestPath` across `workspace.rs`.** `WorkspaceState.guest_path` becomes `GuestPath` (serde-transparent, on-disk format unchanged), and `rsync_push` / `rsync_pull` / `tar_pipe_pull` / `check_guest_dirty` / `launch_editor` / `vscode_strategies` take `&GuestPath` instead of `&str`.
- **`run_forget_pat` takes `&RepoSlug` instead of `&str`.** Drops the on-entry re-validation in favour of pushing the parse to the call site.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 584 passed, 0 failed (5 new tests for `FcVersion`, `parse_mount_string`, `GuestPath::absolute`, `GuestPath` serde round-trip)
- [ ] Integration tests on macOS/Lima (`./tests/run-integration.sh`) — not run; please run before merging
- [ ] Integration tests on Linux/Firecracker — not run; please run before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)