### PR TITLE
Thread `InstanceName` through CLI commands and handlers (closes #192)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1342,6 +1342,11 @@ impl InstanceName {
         Ok(Self(name.to_string()))
     }
 
+    /// Clap `value_parser` entry point for instance-name arguments.
+    pub fn parse(s: &str) -> Result<Self> {
+        Self::new(s)
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -1767,12 +1772,12 @@ impl CoopConfig {
     }
 
     /// Resolve an instance by name, or auto-select if only one exists.
-    pub fn resolve_instance(&self, name: Option<&str>) -> Result<Instance> {
+    pub fn resolve_instance(&self, name: Option<&InstanceName>) -> Result<Instance> {
         let instances = self.list_instances()?;
         if let Some(name) = name {
             instances
                 .into_iter()
-                .find(|i| i.name == *name)
+                .find(|i| &i.name == name)
                 .with_context(|| {
                     let available = self.format_instance_list_or_none();
                     format!(
@@ -1817,7 +1822,7 @@ impl CoopConfig {
     /// concurrent allocations.
     pub fn allocate_instance(
         &self,
-        name: Option<&str>,
+        name: Option<&InstanceName>,
         image: &ImageName,
         workspace_path: Option<&Path>,
     ) -> Result<Instance> {
@@ -1844,7 +1849,7 @@ impl CoopConfig {
         };
 
         let name = if let Some(n) = name {
-            InstanceName::new(n)?
+            n.clone()
         } else if let Some(ws) = workspace_path {
             let basename = ws
                 .file_name()
@@ -2206,10 +2211,18 @@ mod tests {
         ImageName::new(DEFAULT_IMAGE).unwrap()
     }
 
-    fn make_instance(dir: &Path, name: &str, index: u16) -> Instance {
+    fn idx(n: u16) -> InstanceIndex {
+        InstanceIndex::new(n).unwrap()
+    }
+
+    fn iname(s: &str) -> InstanceName {
+        InstanceName::new(s).unwrap()
+    }
+
+    fn make_instance(dir: &Path, name: &str, index: InstanceIndex) -> Instance {
         let inst = Instance {
             name: InstanceName::new(name).unwrap(),
-            index: InstanceIndex::new(index).unwrap(),
+            index,
             dir: dir.join("instances").join(name),
             image: ImageName::new(DEFAULT_IMAGE).unwrap(),
         };
@@ -2217,10 +2230,10 @@ mod tests {
         inst
     }
 
-    fn test_inst(name: &str, index: u16, dir: PathBuf) -> Instance {
+    fn test_inst(name: &str, index: InstanceIndex, dir: PathBuf) -> Instance {
         Instance {
             name: InstanceName::new(name).unwrap(),
-            index: InstanceIndex::new(index).unwrap(),
+            index,
             dir,
             image: ImageName::new(DEFAULT_IMAGE).unwrap(),
         }
@@ -2286,13 +2299,13 @@ mod tests {
     /// off-by-one bugs would land.
     #[test]
     fn instance_network_derivations_at_boundaries() {
-        let lo = test_inst("test", 0, PathBuf::from("/tmp/fake"));
+        let lo = test_inst("test", idx(0), PathBuf::from("/tmp/fake"));
         assert_eq!(lo.guest_ip(), "172.16.0.2");
         assert_eq!(lo.guest_mac(), "06:00:AC:10:00:02");
         assert_eq!(lo.tap_device(), "tap0");
         assert_eq!(lo.vsock_cid(), 3);
 
-        let hi = test_inst("test", InstanceIndex::MAX, PathBuf::from("/tmp/fake"));
+        let hi = test_inst("test", idx(InstanceIndex::MAX), PathBuf::from("/tmp/fake"));
         assert_eq!(hi.guest_ip(), "172.16.0.254");
         assert_eq!(hi.guest_mac(), "06:00:AC:10:00:fe");
         assert_eq!(hi.tap_device(), "tap252");
@@ -2303,7 +2316,7 @@ mod tests {
 
     #[test]
     fn instance_paths_under_dir() {
-        let inst = test_inst("foo", 0, PathBuf::from("/data/instances/foo"));
+        let inst = test_inst("foo", idx(0), PathBuf::from("/data/instances/foo"));
         assert_eq!(
             inst.rootfs_path(),
             PathBuf::from("/data/instances/foo/rootfs.ext4")
@@ -2340,7 +2353,7 @@ mod tests {
     fn instance_save_load_roundtrip() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path().join("myinst");
-        let inst = test_inst("myinst", 42, dir.clone());
+        let inst = test_inst("myinst", idx(42), dir.clone());
         inst.save().unwrap();
 
         let loaded = Instance::load(&dir).unwrap();
@@ -2388,7 +2401,7 @@ mod tests {
     #[test]
     fn is_running_false_when_pid_file_missing() {
         let tmp = TempDir::new().unwrap();
-        let inst = test_inst("test", 0, tmp.path().to_path_buf());
+        let inst = test_inst("test", idx(0), tmp.path().to_path_buf());
         assert!(!inst.pid_file_path().exists());
         assert!(!inst.is_running());
     }
@@ -2397,7 +2410,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn is_running_false_for_dead_pid_and_removes_pid_file() {
         let tmp = TempDir::new().unwrap();
-        let inst = test_inst("test", 0, tmp.path().to_path_buf());
+        let inst = test_inst("test", idx(0), tmp.path().to_path_buf());
         fs::write(inst.pid_file_path(), DEAD_PID.to_string()).unwrap();
 
         assert!(!inst.is_running());
@@ -2411,7 +2424,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn is_running_false_for_live_non_firecracker_pid_and_removes_pid_file() {
         let tmp = TempDir::new().unwrap();
-        let inst = test_inst("test", 0, tmp.path().to_path_buf());
+        let inst = test_inst("test", idx(0), tmp.path().to_path_buf());
         let mut child = spawn_sleep();
         fs::write(inst.pid_file_path(), child.id().to_string()).unwrap();
 
@@ -2430,7 +2443,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn is_running_true_for_live_firecracker_like_pid() {
         let tmp = TempDir::new().unwrap();
-        let inst = test_inst("test", 0, tmp.path().to_path_buf());
+        let inst = test_inst("test", idx(0), tmp.path().to_path_buf());
         let mut child = spawn_firecracker_like();
         fs::write(inst.pid_file_path(), child.id().to_string()).unwrap();
 
@@ -2510,7 +2523,7 @@ mod tests {
         let cfg = test_config(&tmp);
 
         let inst = cfg
-            .allocate_instance(Some("my-project"), &default_img(), None)
+            .allocate_instance(Some(&iname("my-project")), &default_img(), None)
             .unwrap();
         assert_eq!(inst.name, *"my-project");
         assert_eq!(inst.index.as_u16(), 0);
@@ -2521,10 +2534,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        cfg.allocate_instance(Some("dupe"), &default_img(), None)
+        cfg.allocate_instance(Some(&iname("dupe")), &default_img(), None)
             .unwrap();
         let err = cfg
-            .allocate_instance(Some("dupe"), &default_img(), None)
+            .allocate_instance(Some(&iname("dupe")), &default_img(), None)
             .unwrap_err();
         assert!(err.to_string().contains("already exists"));
     }
@@ -2536,11 +2549,11 @@ mod tests {
 
         // Create instance at index 0, then remove it, then create at 1
         let inst0 = cfg
-            .allocate_instance(Some("a"), &default_img(), None)
+            .allocate_instance(Some(&iname("a")), &default_img(), None)
             .unwrap();
         assert_eq!(inst0.index.as_u16(), 0);
         let inst1 = cfg
-            .allocate_instance(Some("b"), &default_img(), None)
+            .allocate_instance(Some(&iname("b")), &default_img(), None)
             .unwrap();
         assert_eq!(inst1.index.as_u16(), 1);
 
@@ -2549,7 +2562,7 @@ mod tests {
 
         // Next allocation should be index 2 (highest + 1), not 0 (gap)
         let inst2 = cfg
-            .allocate_instance(Some("c"), &default_img(), None)
+            .allocate_instance(Some(&iname("c")), &default_img(), None)
             .unwrap();
         assert_eq!(inst2.index.as_u16(), 2);
     }
@@ -2560,17 +2573,17 @@ mod tests {
         let cfg = test_config(&tmp);
 
         // Create instance at index 252 (max)
-        make_instance(tmp.path(), "max", 252);
+        make_instance(tmp.path(), "max", idx(252));
 
         // Create another at index 0 (gap at low end)
-        make_instance(tmp.path(), "zero", 0);
+        make_instance(tmp.path(), "zero", idx(0));
 
         // Remove index 0
         fs::remove_dir_all(tmp.path().join("instances/zero")).unwrap();
 
         // Next should fill gap at 0 since highest (252) is at ceiling
         let inst = cfg
-            .allocate_instance(Some("fill"), &default_img(), None)
+            .allocate_instance(Some(&iname("fill")), &default_img(), None)
             .unwrap();
         assert_eq!(inst.index.as_u16(), 0);
     }
@@ -2620,16 +2633,6 @@ mod tests {
         validate_instance_name(&max).unwrap();
     }
 
-    #[test]
-    fn allocate_rejects_invalid_name() {
-        let tmp = TempDir::new().unwrap();
-        let cfg = test_config(&tmp);
-        let err = cfg
-            .allocate_instance(Some("../evil"), &default_img(), None)
-            .unwrap_err();
-        assert!(err.to_string().contains("invalid character"));
-    }
-
     // ── List instances ───────────────────────────────────────
 
     #[test]
@@ -2645,9 +2648,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        make_instance(tmp.path(), "high", 10);
-        make_instance(tmp.path(), "low", 2);
-        make_instance(tmp.path(), "mid", 5);
+        make_instance(tmp.path(), "high", idx(10));
+        make_instance(tmp.path(), "low", idx(2));
+        make_instance(tmp.path(), "mid", idx(5));
 
         let instances = cfg.list_instances().unwrap();
         let indices: Vec<u16> = instances.iter().map(|i| i.index.as_u16()).collect();
@@ -2661,7 +2664,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        make_instance(tmp.path(), "only", 0);
+        make_instance(tmp.path(), "only", idx(0));
 
         let inst = cfg.resolve_instance(None).unwrap();
         assert_eq!(inst.name, *"only");
@@ -2681,8 +2684,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        make_instance(tmp.path(), "a", 0);
-        make_instance(tmp.path(), "b", 1);
+        make_instance(tmp.path(), "a", idx(0));
+        make_instance(tmp.path(), "b", idx(1));
 
         let err = cfg.resolve_instance(None).unwrap_err();
         assert!(err.to_string().contains("Multiple instances"));
@@ -2693,10 +2696,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        make_instance(tmp.path(), "alpha", 0);
-        make_instance(tmp.path(), "beta", 1);
+        make_instance(tmp.path(), "alpha", idx(0));
+        make_instance(tmp.path(), "beta", idx(1));
 
-        let inst = cfg.resolve_instance(Some("beta")).unwrap();
+        let inst = cfg.resolve_instance(Some(&iname("beta"))).unwrap();
         assert_eq!(inst.name, *"beta");
         assert_eq!(inst.index.as_u16(), 1);
     }
@@ -2706,9 +2709,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        make_instance(tmp.path(), "real", 0);
+        make_instance(tmp.path(), "real", idx(0));
 
-        let err = cfg.resolve_instance(Some("fake")).unwrap_err();
+        let err = cfg.resolve_instance(Some(&iname("fake"))).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("No instance named 'fake'"));
         assert!(msg.contains("Available: real"), "missing hint in: {msg}");
@@ -2719,7 +2722,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        let err = cfg.resolve_instance(Some("ghost")).unwrap_err();
+        let err = cfg.resolve_instance(Some(&iname("ghost"))).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("No instance named 'ghost'"));
         assert!(
@@ -2739,8 +2742,8 @@ mod tests {
     fn format_instance_list_or_none_lists_names() {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
-        make_instance(tmp.path(), "alpha", 0);
-        make_instance(tmp.path(), "beta", 1);
+        make_instance(tmp.path(), "alpha", idx(0));
+        make_instance(tmp.path(), "beta", idx(1));
         assert_eq!(cfg.format_instance_list_or_none(), "Available: alpha, beta");
     }
 
@@ -4156,7 +4159,7 @@ skip = ["not-a-slug"]
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        make_instance(tmp.path(), "good", 0);
+        make_instance(tmp.path(), "good", idx(0));
 
         // Create a dir with no instance.json (crashed mid-create)
         let orphan = tmp.path().join("instances").join("orphan");
@@ -4172,7 +4175,7 @@ skip = ["not-a-slug"]
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        make_instance(tmp.path(), "good", 0);
+        make_instance(tmp.path(), "good", idx(0));
 
         // Create a dir with garbage JSON (truncated write)
         let broken = tmp.path().join("instances").join("broken");
@@ -4189,7 +4192,7 @@ skip = ["not-a-slug"]
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp);
 
-        make_instance(tmp.path(), "good", 0);
+        make_instance(tmp.path(), "good", idx(0));
 
         // Create a dir with empty file (truncated before any content)
         let empty = tmp.path().join("instances").join("empty");
@@ -4581,7 +4584,7 @@ skip = ["not-a-slug"]
     #[test]
     fn unique_name_with_collision() {
         let tmp = TempDir::new().unwrap();
-        let inst = make_instance(tmp.path(), "foo", 0);
+        let inst = make_instance(tmp.path(), "foo", idx(0));
         let name = unique_instance_name("foo", &[inst]).unwrap();
         assert_eq!(name, *"foo-2");
     }
@@ -4589,8 +4592,8 @@ skip = ["not-a-slug"]
     #[test]
     fn unique_name_multiple_collisions() {
         let tmp = TempDir::new().unwrap();
-        let i1 = make_instance(tmp.path(), "foo", 0);
-        let i2 = make_instance(tmp.path(), "foo-2", 1);
+        let i1 = make_instance(tmp.path(), "foo", idx(0));
+        let i2 = make_instance(tmp.path(), "foo-2", idx(1));
         let name = unique_instance_name("foo", &[i1, i2]).unwrap();
         assert_eq!(name, *"foo-3");
     }
@@ -4639,7 +4642,7 @@ skip = ["not-a-slug"]
         fs::create_dir(&ws).unwrap();
 
         let inst = cfg
-            .allocate_instance(Some("custom"), &default_img(), Some(&ws))
+            .allocate_instance(Some(&iname("custom")), &default_img(), Some(&ws))
             .unwrap();
         assert_eq!(inst.name, *"custom");
     }

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 
 use crate::backend::{Hostname, LogMode, SshTarget, SshUser};
-use crate::config::{CoopConfig, GiB, ImageName, Instance};
+use crate::config::{CoopConfig, GiB, ImageName, Instance, InstanceName};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
     SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
@@ -86,7 +86,7 @@ pub fn create_and_start(
     };
 
     // Clean up leftover Lima instance from a previous failed start
-    if let Some(status) = lima_status(&name) {
+    if let Some(status) = lima_status(&inst.name) {
         tracing::warn!(
             "Lima instance '{name}' already exists (status: {status}) — \
              cleaning up before re-creating"
@@ -122,7 +122,7 @@ pub fn create_and_start(
         .spawn()
         .context("Failed to spawn limactl start")?;
 
-    if let Err(e) = wait_for_lima_ssh(&name, &mut child, cfg, Duration::from_secs(60)) {
+    if let Err(e) = wait_for_lima_ssh(&inst.name, &mut child, cfg, Duration::from_secs(60)) {
         let _ = child.kill();
         let lima_stderr = match child.wait_with_output() {
             Ok(out) => String::from_utf8_lossy(&out.stderr).to_string(),
@@ -160,7 +160,7 @@ pub fn start_existing(cfg: &CoopConfig, inst: &Instance) -> Result<()> {
         .spawn()
         .context("Failed to spawn limactl start")?;
 
-    if let Err(e) = wait_for_lima_ssh(&name, &mut child, cfg, Duration::from_secs(60)) {
+    if let Err(e) = wait_for_lima_ssh(&inst.name, &mut child, cfg, Duration::from_secs(60)) {
         let _ = child.kill();
         let lima_stderr = match child.wait_with_output() {
             Ok(out) => String::from_utf8_lossy(&out.stderr).to_string(),
@@ -209,7 +209,7 @@ pub fn destroy(inst: &Instance) -> Result<()> {
     tracing::info!("Deleting Lima instance '{name}'");
 
     // If the instance doesn't exist in Lima, nothing to do
-    if lima_status(&name).is_none() {
+    if lima_status(&inst.name).is_none() {
         tracing::debug!("Lima instance '{name}' not found — already deleted");
         return Ok(());
     }
@@ -306,8 +306,7 @@ pub fn disk_path(inst: &Instance) -> Result<PathBuf> {
 
 /// Check if a Lima instance is running.
 pub fn is_running(inst: &Instance) -> bool {
-    let name = lima_name(inst);
-    match lima_status(&name) {
+    match lima_status(&inst.name) {
         Some(s) => s == "Running",
         None => false,
     }
@@ -315,8 +314,7 @@ pub fn is_running(inst: &Instance) -> bool {
 
 /// Get a human-readable status string.
 pub fn status(cfg: &CoopConfig, inst: &Instance) -> Result<String> {
-    let name = lima_name(inst);
-    let info = limactl_info(&name)?;
+    let info = limactl_info(&inst.name)?;
 
     let status_str = info["status"].as_str().unwrap_or("Unknown");
     let arch = info["arch"].as_str().unwrap_or("unknown");
@@ -401,8 +399,7 @@ pub fn stream_logs(inst: &Instance, mode: LogMode) -> Result<()> {
 
 /// Get SSH connection details for a Lima instance.
 pub fn ssh_target(cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {
-    let name = lima_name(inst);
-    let info = limactl_info(&name)?;
+    let info = limactl_info(&inst.name)?;
 
     let port = info["sshLocalPort"]
         .as_u64()
@@ -701,7 +698,7 @@ fn run_builder_vm(
 
 /// Get an SSH target for the builder VM.
 fn builder_ssh_target(cfg: &CoopConfig) -> Result<SshTarget> {
-    let info = limactl_info(BUILDER_NAME)?;
+    let info = limactl_list_entry(BUILDER_NAME)?;
     let port = info["sshLocalPort"]
         .as_u64()
         .context("Builder VM has no sshLocalPort")?;
@@ -1261,7 +1258,7 @@ echo 'AcceptEnv *' >> /etc/ssh/sshd_config
 /// hostagent is already running as a daemon; the CLI process is
 /// just waiting to print "READY".
 fn wait_for_lima_ssh(
-    name: &str,
+    name: &InstanceName,
     child: &mut std::process::Child,
     cfg: &CoopConfig,
     timeout: Duration,
@@ -1319,7 +1316,8 @@ fn wait_for_lima_ssh(
 }
 
 /// Get the SSH local port for a Lima instance from `limactl list`.
-fn get_lima_ssh_port(name: &str) -> Option<u16> {
+fn get_lima_ssh_port(name: &InstanceName) -> Option<u16> {
+    let lima_name = lima_name_for(name);
     let output = Command::new("limactl")
         .args(["list", "--json"])
         .stdout(Stdio::piped())
@@ -1338,7 +1336,7 @@ fn get_lima_ssh_port(name: &str) -> Option<u16> {
             continue;
         }
         if let Ok(val) = serde_json::from_str::<serde_json::Value>(line)
-            && val["name"].as_str() == Some(name)
+            && val["name"].as_str() == Some(&lima_name)
             && let Some(port) = val["sshLocalPort"].as_u64()
             && let Ok(port) = u16::try_from(port)
             && port > 0
@@ -1417,7 +1415,11 @@ fn extract_logfmt_msg(line: &str) -> Option<String> {
 }
 
 fn lima_name(inst: &Instance) -> String {
-    format!("{LIMA_PREFIX}{}", inst.name)
+    lima_name_for(&inst.name)
+}
+
+fn lima_name_for(name: &InstanceName) -> String {
+    format!("{LIMA_PREFIX}{name}")
 }
 
 fn lima_home() -> Result<PathBuf> {
@@ -1430,13 +1432,19 @@ fn lima_home() -> Result<PathBuf> {
 }
 
 /// Get the status string for a Lima instance ("Running", "Stopped", etc.).
-fn lima_status(name: &str) -> Option<String> {
+fn lima_status(name: &InstanceName) -> Option<String> {
     let info = limactl_info(name).ok()?;
     info["status"].as_str().map(String::from)
 }
 
-/// Get full instance info from limactl.
-fn limactl_info(name: &str) -> Result<serde_json::Value> {
+/// Get full instance info from limactl for a coop instance.
+fn limactl_info(name: &InstanceName) -> Result<serde_json::Value> {
+    limactl_list_entry(&lima_name_for(name))
+}
+
+/// Find a `limactl list --json` entry by its Lima VM name (the
+/// `coop-<instance>` form, or the special `coop-builder`).
+fn limactl_list_entry(lima_name: &str) -> Result<serde_json::Value> {
     let output = Command::new("limactl")
         .args(["list", "--json"])
         .output()
@@ -1459,12 +1467,12 @@ fn limactl_info(name: &str) -> Result<serde_json::Value> {
                      {line}"
             )
         })?;
-        if val["name"].as_str() == Some(name) {
+        if val["name"].as_str() == Some(lima_name) {
             return Ok(val);
         }
     }
 
-    bail!("Lima instance '{name}' not found in limactl list")
+    bail!("Lima instance '{lima_name}' not found in limactl list")
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,8 @@ enum Commands {
     /// Launch a new Firecracker VM instance
     Start {
         /// Instance name (auto-generated if omitted)
-        name: Option<String>,
+        #[arg(value_parser = config::InstanceName::parse)]
+        name: Option<config::InstanceName>,
         /// Workspace directory to sync into the VM
         #[arg(long, conflicts_with = "git_repo")]
         workspace: Option<String>,
@@ -205,8 +206,11 @@ enum Commands {
     #[command(alias = "ssh")]
     Shell {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Command to run (non-interactive, no PTY)
         #[arg(allow_hyphen_values = true, last = true)]
         command: Vec<String>,
@@ -214,8 +218,11 @@ enum Commands {
     /// Launch Claude Code inside the VM (skips permissions by default)
     Claude {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Prompt for permissions instead of skipping them
         #[arg(long)]
         ask: bool,
@@ -227,8 +234,11 @@ enum Commands {
     #[command(alias = "ca")]
     ClaudeAgents {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Extra arguments passed to `claude agents`
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -236,8 +246,11 @@ enum Commands {
     /// Launch Codex inside the VM
     Codex {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Extra arguments passed to `codex`
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -245,14 +258,20 @@ enum Commands {
     /// Gracefully stop the VM
     Stop {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
     },
     /// Stop and clean up instance resources (keeps template)
     Destroy {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Also remove template, kernel, and Firecracker binary
         #[arg(long)]
         all: bool,
@@ -263,14 +282,20 @@ enum Commands {
     /// Show VM status
     Status {
         /// Instance name (shows all if omitted)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
     },
     /// Stream VM serial console logs
     Logs {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Follow log output
         #[arg(short, long)]
         follow: bool,
@@ -278,8 +303,11 @@ enum Commands {
     /// Push local workspace into the running VM
     Push {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Local directory to push (defaults to `workspace.json` `host_path`)
         #[arg(long)]
         dir: Option<String>,
@@ -293,8 +321,11 @@ enum Commands {
     /// Pull guest workspace to local directory
     Pull {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Local directory to pull into (defaults to `workspace.json` `host_path`)
         #[arg(long)]
         dir: Option<String>,
@@ -312,8 +343,11 @@ enum Commands {
     /// `coop exec my-vm -- ls -la` or `coop exec -- ls -la`.
     Exec {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Command and arguments to run (after `--`)
         #[arg(required = true, last = true, allow_hyphen_values = true)]
         command: Vec<String>,
@@ -321,8 +355,11 @@ enum Commands {
     /// Open VS Code connected to the guest VM
     Vscode {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// Remote path to open in VS Code
         #[arg(long, default_value = "/workspace")]
         project: String,
@@ -346,8 +383,11 @@ enum Commands {
     /// Resize a stopped instance's disk
     Resize {
         /// Instance name (required if multiple instances exist)
-        #[arg(add = ArgValueCandidates::new(completions::instance_candidates))]
-        name: Option<String>,
+        #[arg(
+            value_parser = config::InstanceName::parse,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
         /// New size: absolute GiB (e.g. 150, 150G) or relative (e.g. +20, +20G)
         #[arg(long, required = true)]
         size: String,
@@ -749,7 +789,7 @@ fn main() -> Result<()> {
                 &be,
                 &mut cfg,
                 &StartOpts {
-                    name: name.as_deref(),
+                    name: name.as_ref(),
                     image: &image,
                     workspace_dir: workspace.as_deref(),
                     git_repo: git_repo.as_deref(),
@@ -765,13 +805,13 @@ fn main() -> Result<()> {
                 },
             )
         }
-        Commands::Shell { name, command } => cmd_shell(&be, &cfg, name.as_deref(), &command),
+        Commands::Shell { name, command } => cmd_shell(&be, &cfg, name.as_ref(), &command),
         Commands::Claude {
             name,
             ask,
             mut args,
         } => {
-            let sess = open_ssh_session(&be, &cfg, name.as_deref())?;
+            let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
             // Guest user settings set `defaultMode: bypassPermissions`. Opting in
             // to prompts means overriding that default explicitly.
             if ask {
@@ -781,26 +821,26 @@ fn main() -> Result<()> {
             ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, args))
         }
         Commands::ClaudeAgents { name, mut args } => {
-            let sess = open_ssh_session(&be, &cfg, name.as_deref())?;
+            let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
             args.insert(0, "agents".to_string());
             ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, args))
         }
         Commands::Codex { name, args } => {
-            let sess = open_ssh_session(&be, &cfg, name.as_deref())?;
+            let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
             ssh::run_interactive(&sess, &prepend_binary(crate::guest::CODEX_BIN, args))
         }
         Commands::Stop { name } => {
-            let inst = cfg.resolve_instance(name.as_deref())?;
+            let inst = cfg.resolve_instance(name.as_ref())?;
             cmd_stop(&be, &cfg, &inst)
         }
         Commands::Destroy { name, all } => {
             let _guard = signal::install_handlers();
-            cmd_destroy(&be, &cfg, name.as_deref(), all)
+            cmd_destroy(&be, &cfg, name.as_ref(), all)
         }
         Commands::List => cmd_list(&be, &cfg),
-        Commands::Status { name } => cmd_status(&be, &cfg, name.as_deref()),
+        Commands::Status { name } => cmd_status(&be, &cfg, name.as_ref()),
         Commands::Logs { name, follow } => {
-            let running = resolve_running(&be, &cfg, name.as_deref())?;
+            let running = resolve_running(&be, &cfg, name.as_ref())?;
             let mode = if follow {
                 backend::LogMode::Follow
             } else {
@@ -814,7 +854,7 @@ fn main() -> Result<()> {
             force,
             exclude_git,
         } => {
-            let running = resolve_running(&be, &cfg, name.as_deref())?;
+            let running = resolve_running(&be, &cfg, name.as_ref())?;
             workspace::push(&running, dir.as_deref(), force, exclude_git)
         }
         Commands::Pull {
@@ -823,10 +863,10 @@ fn main() -> Result<()> {
             force,
             exclude_git,
         } => {
-            let running = resolve_running(&be, &cfg, name.as_deref())?;
+            let running = resolve_running(&be, &cfg, name.as_ref())?;
             workspace::pull(&running, dir.as_deref(), force, exclude_git)
         }
-        Commands::Exec { name, command } => cmd_exec(&be, &cfg, name.as_deref(), &command),
+        Commands::Exec { name, command } => cmd_exec(&be, &cfg, name.as_ref(), &command),
         Commands::Vscode {
             name,
             project,
@@ -834,16 +874,16 @@ fn main() -> Result<()> {
             clean,
         } => {
             if clean {
-                let inst = cfg.resolve_instance(name.as_deref())?;
+                let inst = cfg.resolve_instance(name.as_ref())?;
                 workspace::remove_ssh_config(&inst)?;
                 tracing::info!("Removed SSH config for '{}'", inst.name);
                 return Ok(());
             }
-            let running = resolve_running(&be, &cfg, name.as_deref())?;
+            let running = resolve_running(&be, &cfg, name.as_ref())?;
             workspace::vscode(&running, Some(&project), editor.as_deref())
         }
         Commands::Images { delete } => cmd_images(&be, &cfg, delete.as_ref()),
-        Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_deref(), &size),
+        Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_ref(), &size),
         Commands::Profiles { action } => {
             cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
         }
@@ -1095,7 +1135,7 @@ fn cmd_build(cfg: &config::CoopConfig) -> Result<()> {
 }
 
 struct StartOpts<'a> {
-    name: Option<&'a str>,
+    name: Option<&'a config::InstanceName>,
     image: &'a config::ImageName,
     workspace_dir: Option<&'a str>,
     git_repo: Option<&'a str>,
@@ -1190,13 +1230,13 @@ fn cmd_start(
 fn find_stopped_instance(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&str>,
+    name: Option<&config::InstanceName>,
     workspace_dir: Option<&Path>,
 ) -> Result<Option<config::Instance>> {
     let mut instances = cfg.list_instances()?;
 
     if let Some(name) = name {
-        let Some(inst) = instances.into_iter().find(|i| i.name.as_str() == name) else {
+        let Some(inst) = instances.into_iter().find(|i| &i.name == name) else {
             return Ok(None);
         };
         if be.is_running(&inst) {
@@ -1545,14 +1585,14 @@ fn warn_on_live_git_mounts(mounts: &[config::Mount]) {
 fn resolve_running(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&str>,
+    name: Option<&config::InstanceName>,
 ) -> Result<backend::RunningInstance> {
     let instances = cfg.list_instances()?;
 
     if let Some(name) = name {
         let inst = instances
             .into_iter()
-            .find(|i| i.name.as_str() == name)
+            .find(|i| &i.name == name)
             .with_context(|| {
                 format!(
                     "No instance named '{name}'.\n\
@@ -1614,7 +1654,7 @@ fn resolve_running(
 fn cmd_shell(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&str>,
+    name: Option<&config::InstanceName>,
     command: &[String],
 ) -> Result<()> {
     let session = open_ssh_session(be, cfg, name)?;
@@ -1636,7 +1676,7 @@ fn prepend_binary(binary: &str, args: Vec<String>) -> Vec<String> {
 fn cmd_exec(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&str>,
+    name: Option<&config::InstanceName>,
     command: &[String],
 ) -> Result<()> {
     let session = open_ssh_session(be, cfg, name)?;
@@ -1651,7 +1691,7 @@ fn cmd_exec(
 fn open_ssh_session(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&str>,
+    name: Option<&config::InstanceName>,
 ) -> Result<backend::SshSession> {
     let running = resolve_running(be, cfg, name)?;
     let repo = backend::detect_instance_repo(running.instance());
@@ -1723,7 +1763,7 @@ fn cmd_stop(
 fn cmd_destroy(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&str>,
+    name: Option<&config::InstanceName>,
     all: bool,
 ) -> Result<()> {
     if all {
@@ -1986,7 +2026,7 @@ fn remove_self_binary(binary_path: &Path) -> Result<()> {
 fn cmd_status(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&str>,
+    name: Option<&config::InstanceName>,
 ) -> Result<()> {
     if let Some(name) = name {
         let inst = cfg.resolve_instance(Some(name))?;
@@ -2029,7 +2069,7 @@ fn cmd_status(
 fn cmd_resize(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&str>,
+    name: Option<&config::InstanceName>,
     size: &str,
 ) -> Result<()> {
     let inst = cfg.resolve_instance(name)?;
@@ -2302,7 +2342,10 @@ mod tests {
         let super::Commands::Claude { name, args, .. } = cli.command else {
             panic!("expected Claude variant");
         };
-        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
         assert_eq!(args, vec!["--model", "opus"]);
     }
 
@@ -2324,7 +2367,10 @@ mod tests {
         let super::Commands::ClaudeAgents { name, args, .. } = cli.command else {
             panic!("expected ClaudeAgents variant");
         };
-        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
         assert_eq!(args, vec!["--cwd", "/workspace"]);
     }
 
@@ -2334,7 +2380,10 @@ mod tests {
         let super::Commands::Codex { name, args, .. } = cli.command else {
             panic!("expected Codex variant");
         };
-        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
         assert_eq!(args, vec!["--model", "gpt-5"]);
     }
 
@@ -2523,7 +2572,10 @@ mod tests {
         else {
             panic!("expected Push variant");
         };
-        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
         assert_eq!(dir.as_deref(), Some("./src"));
         assert!(force);
     }
@@ -2537,7 +2589,10 @@ mod tests {
         else {
             panic!("expected Push variant");
         };
-        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
         assert!(dir.is_none());
         assert!(!force);
     }
@@ -2565,7 +2620,10 @@ mod tests {
         else {
             panic!("expected Pull variant");
         };
-        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
         assert_eq!(dir.as_deref(), Some("./out"));
         assert!(force);
     }
@@ -2576,7 +2634,10 @@ mod tests {
         let super::Commands::Exec { name, command } = cli.command else {
             panic!("expected Exec variant");
         };
-        assert_eq!(name.as_deref(), Some("myvm"));
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
         assert_eq!(command, vec!["ls", "-la"]);
     }
 


### PR DESCRIPTION
## Summary
- Add `InstanceName::parse` and switch every instance-name CLI option from `Option<String>` to `Option<InstanceName>` so validation happens once at the clap boundary.
- Propagate `&InstanceName` through `CoopConfig::{resolve_instance, allocate_instance}`, `main.rs` handlers (`cmd_shell`, `cmd_exec`, `cmd_destroy`, `cmd_status`, `cmd_resize`, `resolve_running`, `find_stopped_instance`, `open_ssh_session`, `StartOpts`), and `lima.rs` helpers (`wait_for_lima_ssh`, `get_lima_ssh_port`, `lima_status`, `limactl_info`).
- Builder-VM lookups keep their raw lima-name path via a new internal `limactl_list_entry(&str)`.
- Test helpers `make_instance` / `test_inst` accept `InstanceIndex` directly; deleted `allocate_rejects_invalid_name` (the signature change makes it structurally unrepresentable; `validate_name_rejects_path_traversal` already pins the regression).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (583 passing)
- [x] `prek run --all-files`
- [ ] `./tests/run-integration.sh` on macOS/Lima
- [ ] `./tests/run-integration.sh --remote` on Linux/Firecracker