### PR TITLE
Drop GuestPath::as_str().to_string() round-trips (closes #193)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1793,7 +1793,7 @@ pub(crate) fn install_marketplaces(session: &SshSession, marketplaces: &[String]
                         local_path.display()
                     )
                 })?;
-            remote.as_str().to_string()
+            remote.to_string()
         } else {
             source.clone()
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -4319,7 +4319,7 @@ skip = ["not-a-slug"]
         let tmp = TempDir::new().unwrap();
         let m = Mount::parse(tmp.path().to_str().unwrap()).unwrap();
         assert_eq!(m.host_path, tmp.path().canonicalize().unwrap());
-        assert_eq!(m.guest_path.as_str(), "/workspace");
+        assert_eq!(m.guest_path.to_string(), "/workspace");
     }
 
     #[test]
@@ -4328,7 +4328,7 @@ skip = ["not-a-slug"]
         let spec = format!("{}:/data/project", tmp.path().display());
         let m = Mount::parse(&spec).unwrap();
         assert_eq!(m.host_path, tmp.path().canonicalize().unwrap());
-        assert_eq!(m.guest_path.as_str(), "/data/project");
+        assert_eq!(m.guest_path.to_string(), "/data/project");
     }
 
     #[test]

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -1531,11 +1531,11 @@ mod tests {
 
         let docker = format!("type=bind,source={host},target=/b");
         let m = parse_mount_string(&docker).unwrap();
-        assert_eq!(m.guest_path.as_str(), "/b");
+        assert_eq!(m.guest_path.to_string(), "/b");
 
         let no_type = format!("source={host},target=/b,readonly");
         let m = parse_mount_string(&no_type).unwrap();
-        assert_eq!(m.guest_path.as_str(), "/b");
+        assert_eq!(m.guest_path.to_string(), "/b");
 
         assert!(parse_mount_string("type=volume,source=v,target=/b").is_err());
     }
@@ -1548,7 +1548,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let spec = format!("{}:/g", tmp.path().display());
         let m = parse_mount_string(&spec).unwrap();
-        assert_eq!(m.guest_path.as_str(), "/g");
+        assert_eq!(m.guest_path.to_string(), "/g");
     }
 
     #[test]
@@ -1557,7 +1557,7 @@ mod tests {
         let host = tmp.path().to_str().unwrap();
         let obj = serde_json::json!({"type": "bind", "source": host, "target": "/b"});
         let m = parse_mount_entry(&obj).unwrap();
-        assert_eq!(m.guest_path.as_str(), "/b");
+        assert_eq!(m.guest_path.to_string(), "/b");
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -43,10 +43,6 @@ impl GuestPath {
         }
         Ok(Self(path))
     }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
 }
 
 impl std::fmt::Display for GuestPath {
@@ -100,7 +96,7 @@ mod tests {
     #[test]
     fn absolute_accepts_leading_slash() {
         let p = GuestPath::absolute("/workspace").unwrap();
-        assert_eq!(p.as_str(), "/workspace");
+        assert_eq!(p.to_string(), "/workspace");
     }
 
     #[test]
@@ -119,7 +115,7 @@ mod tests {
         // Permissive constructor: `./...` is intentional (SFTP tilde
         // expansion gotcha, see CLAUDE.md).
         let p = GuestPath::new("./.claude");
-        assert_eq!(p.as_str(), "./.claude");
+        assert_eq!(p.to_string(), "./.claude");
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -931,7 +931,7 @@ struct LaunchStrategy {
 }
 
 fn vscode_strategies(remote_arg: &str, remote_path: &GuestPath) -> Vec<LaunchStrategy> {
-    let path_arg = remote_path.as_str().to_string();
+    let path_arg = remote_path.to_string();
     let mut strategies = vec![LaunchStrategy {
         name: "code CLI",
         cmd: "code".into(),
@@ -1123,7 +1123,7 @@ mod tests {
         };
         state.save(&inst).expect("save");
         let loaded = load_or_default(&inst, None, "push").expect("load");
-        assert_eq!(loaded.guest_path.as_str(), "/custom");
+        assert_eq!(loaded.guest_path.to_string(), "/custom");
         assert!(matches!(
             loaded.source,
             WorkspaceSource::GitRepo { ref url } if url == "https://github.com/x/y.git"
@@ -1138,7 +1138,7 @@ mod tests {
         // explicit --dir as its host_path so consumers can read it
         // uniformly.
         let loaded = load_or_default(&inst, Some("./project"), "push").expect("load");
-        assert_eq!(loaded.guest_path.as_str(), GUEST_WORKSPACE);
+        assert_eq!(loaded.guest_path.to_string(), GUEST_WORKSPACE);
         assert!(matches!(
             loaded.source,
             WorkspaceSource::Workspace { ref host_path } if host_path == Path::new("./project")
@@ -1169,7 +1169,7 @@ mod tests {
             loaded.source,
             WorkspaceSource::Mount { ref host_path } if host_path == primary.path()
         ));
-        assert_eq!(loaded.guest_path.as_str(), "/workspace");
+        assert_eq!(loaded.guest_path.to_string(), "/workspace");
     }
 
     #[test]
@@ -1343,7 +1343,7 @@ Host coop-0\n\
         };
         let json = serde_json::to_string(&state).expect("serialize");
         let back: WorkspaceState = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back.guest_path.as_str(), "/workspace");
+        assert_eq!(back.guest_path.to_string(), "/workspace");
         assert!(matches!(
             back.source,
             WorkspaceSource::Workspace { ref host_path } if host_path == Path::new("/host/dir")


### PR DESCRIPTION
## Summary

The structural items in #193 — `&GuestPath` parameters on `rsync_push` / `rsync_pull` / `tar_pipe_pull` / `check_guest_dirty`, and `GuestPath` typing for `Mount::guest_path` and `WorkspaceState::guest_path` — all landed with #191. What was left from the issue's scope was the `.as_str().to_string()` round-trip explicitly called out at `src/backend.rs:1711` (now line 1796 in `install_marketplaces`), plus the same anti-pattern that #191 itself introduced inside `vscode_strategies` at `src/workspace.rs:934`. Both now go through `Display` via `to_string()`.

Once production callers were gone, `GuestPath::as_str` was used only by tests, which clippy's `dead_code` lint flagged under `-D warnings`. Rather than `#[allow(dead_code)]`, the accessor is removed and the affected test assertions switch to `to_string()` (the same pattern other newtype tests already use).

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 583 passed, 0 failed
- [x] `prek run --all-files` (fmt, clippy, test, EOL, whitespace, large-file, merge-conflict, yaml) all pass
- [ ] Integration tests on macOS/Lima — not run; please run before merging
- [ ] Integration tests on Linux/Firecracker — not run; please run before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)