### PR TITLE
Skip redundant is_running() in stop/stream_logs (closes #195)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -801,7 +801,7 @@ impl VmBackend for FirecrackerBackend {
 
     fn stop(&self, cfg: &CoopConfig, running: RunningInstance) -> Result<()> {
         let (inst, _target) = running.into_parts();
-        let vm = crate::vm::FirecrackerVm::from_running(cfg, &inst)?;
+        let vm = crate::vm::FirecrackerVm::from_running_unchecked(cfg, &inst);
         vm.stop()
     }
 
@@ -907,7 +907,7 @@ impl VmBackend for FirecrackerBackend {
         running: &RunningInstance,
         mode: LogMode,
     ) -> Result<()> {
-        let vm = crate::vm::FirecrackerVm::from_running(cfg, running.instance())?;
+        let vm = crate::vm::FirecrackerVm::from_running_unchecked(cfg, running.instance());
         vm.stream_logs(mode)
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -221,7 +221,10 @@ impl<'a> FirecrackerVm<'a, Running> {
     /// PID file.
     ///
     /// Validates that the PID is alive and belongs to a Firecracker
-    /// process, cleaning up stale PID files if not.
+    /// process, cleaning up stale PID files if not. Callers that
+    /// already hold a `RunningInstance` proof should use
+    /// [`Self::from_running_unchecked`] instead to avoid the
+    /// redundant live-state probe.
     pub fn from_running(cfg: &'a CoopConfig, inst: &'a Instance) -> Result<Self> {
         if !inst.is_running() {
             let pid_path = inst.pid_file_path();
@@ -233,12 +236,20 @@ impl<'a> FirecrackerVm<'a, Running> {
             );
         }
 
-        Ok(Self {
+        Ok(Self::from_running_unchecked(cfg, inst))
+    }
+
+    /// Attach to a Firecracker VM whose running state has already
+    /// been established by the caller (e.g. via a
+    /// [`crate::backend::RunningInstance`] proof). Skips the
+    /// `is_running()` probe that [`Self::from_running`] performs.
+    pub fn from_running_unchecked(cfg: &'a CoopConfig, inst: &'a Instance) -> Self {
+        Self {
             cfg,
             inst,
             fc_config: build_config(cfg, inst),
             _state: PhantomData,
-        })
+        }
     }
 
     /// Wait for the guest to become reachable via SSH.


### PR DESCRIPTION
## Summary

- `RunningInstance` (#180) already proves a VM was alive at the call boundary, but `FirecrackerBackend::stop` and `::stream_logs` then constructed the VM via `FirecrackerVm::from_running`, which re-ran `Instance::is_running()` — an unreachable check from these call sites.
- Add `FirecrackerVm::from_running_unchecked` for callers that hold the proof, and switch `stop` and `stream_logs` to it. `from_running` now delegates to the unchecked variant once the guard passes.
- `from_running` is kept for `destroy_instance` and `status`, which take a bare `&Instance` and have no proof to lean on.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --bins` (583 passed)
- [ ] `./tests/run-integration.sh` (macOS/Lima)
- [ ] `./tests/run-integration.sh --remote …` (Linux/Firecracker)