### PR TITLE
Type `env_forward` as `Vec<EnvVarName>` (closes #196)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1147,16 +1147,9 @@ pub fn prepare_env_forwarding(
     }
 
     // User-specified env_forward vars from process environment
-    for name in &claude.env_forward {
-        if !env.contains(name)
-            && let Ok(val) = std::env::var(name)
-        {
-            env.set(name.as_str(), val);
-        }
-    }
-    for name in &codex.env_forward {
-        if !env.contains(name)
-            && let Ok(val) = std::env::var(name)
+    for name in claude.env_forward.iter().chain(codex.env_forward.iter()) {
+        if !env.contains(name.as_str())
+            && let Ok(val) = std::env::var(name.as_str())
         {
             env.set(name.as_str(), val);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::cmd::Cmd;
+use crate::guest_env_state::EnvVarName;
 use crate::naming::validate_safe_chars;
 use crate::paths::GuestPath;
 
@@ -1246,7 +1247,7 @@ pub struct ClaudeConfig {
 
     /// Additional env var names to forward from host to guest via SSH
     #[serde(default)]
-    pub env_forward: Vec<String>,
+    pub env_forward: Vec<EnvVarName>,
 
     /// Plugin marketplace sources (URL, path, or GitHub repo)
     #[serde(default)]
@@ -1295,7 +1296,7 @@ pub struct CodexConfig {
 
     /// Additional env var names to forward from host to guest via SSH
     #[serde(default)]
-    pub env_forward: Vec<String>,
+    pub env_forward: Vec<EnvVarName>,
 
     /// MCP servers to register in `~/.codex/config.toml`
     #[serde(default)]
@@ -2768,7 +2769,7 @@ mod tests {
             cfg.api_key.as_ref().map(|s| s.expose().as_str()),
             Some("sk-ant-test")
         );
-        assert_eq!(cfg.env_forward, vec!["MYORG_KEY"]);
+        assert_eq!(cfg.env_forward, vec![EnvVarName::new("MYORG_KEY").unwrap()]);
         assert_eq!(cfg.marketplaces.len(), 1);
         assert_eq!(cfg.plugins, vec!["context7"]);
         assert_eq!(cfg.mcp_servers.len(), 1);
@@ -2803,7 +2804,7 @@ mod tests {
             cfg.api_key.as_ref().map(|s| s.expose().as_str()),
             Some("sk-openai-test")
         );
-        assert_eq!(cfg.env_forward, vec!["MYORG_KEY"]);
+        assert_eq!(cfg.env_forward, vec![EnvVarName::new("MYORG_KEY").unwrap()]);
         assert_eq!(cfg.mcp_servers.len(), 1);
         assert!(cfg.mcp_servers.contains_key("sentry"));
     }

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -353,7 +353,7 @@ pub struct TranslatorInputs {
     pub cli_mem_mib: Option<u32>,
     pub cli_disk_gib: Option<u32>,
     pub cli_post_start: Option<String>,
-    pub cli_guest_env_keys: Vec<String>,
+    pub cli_guest_env_keys: Vec<EnvVarName>,
     pub cli_forward_ports: Vec<PortForward>,
     pub cli_mounts: Vec<Mount>,
     pub cli_profiles: Vec<String>,
@@ -664,7 +664,7 @@ fn translate_container_env(
     let cli_keys: std::collections::HashSet<&str> = inputs
         .cli_guest_env_keys
         .iter()
-        .map(String::as_str)
+        .map(EnvVarName::as_str)
         .collect();
     let mut overridden = Vec::new();
     let mut applied = Vec::new();
@@ -1638,7 +1638,7 @@ mod tests {
     fn translate_container_env_overridden_by_cli() {
         let f = parse(r#"{ "containerEnv": { "FOO": "x", "BAR": "y" } }"#);
         let inputs = TranslatorInputs {
-            cli_guest_env_keys: vec!["FOO".to_string()],
+            cli_guest_env_keys: vec![EnvVarName::new("FOO").unwrap()],
             ..TranslatorInputs::default()
         };
         let t = translate(&f, &inputs, Stage::Start);

--- a/src/guest_env_state.rs
+++ b/src/guest_env_state.rs
@@ -330,19 +330,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_cli_env_arg_rejects_invalid_key() {
-        // Empty key, leading digit, embedded space, embedded '=' in key
-        // all funnel through `EnvVarName::new`, so one test covers them.
-        for bad in ["=value", "1FOO=v", "FOO BAR=v"] {
-            let err = parse_cli_env_arg(bad).unwrap_err();
-            assert!(
-                format!("{err:#}").contains("--env KEY is invalid"),
-                "expected validation error for '{bad}', got: {err:#}",
-            );
-        }
-    }
-
-    #[test]
     fn parse_cli_env_arg_value_may_contain_equals() {
         let (k, v) = parse_cli_env_arg("URL=https://x?a=b&c=d").unwrap();
         assert_eq!(k, env("URL"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -706,10 +706,7 @@ fn main() -> Result<()> {
                     "--no-claude is deprecated and will be removed in a future release; use --no-agents"
                 );
             }
-            let cli_env_keys = guest_env
-                .iter()
-                .map(|(k, _)| k.as_str().to_string())
-                .collect();
+            let cli_env_keys = guest_env.iter().map(|(k, _)| k.clone()).collect();
             let inputs = devcontainer::TranslatorInputs {
                 cli_vcpus: vcpus,
                 cli_mem_mib: mem,


### PR DESCRIPTION
## Summary
- Change `ClaudeConfig::env_forward` and `CodexConfig::env_forward` from `Vec<String>` to `Vec<EnvVarName>` so invalid POSIX names fail at config load via the existing `EnvVarName: Deserialize` impl.
- Move `TranslatorInputs::cli_guest_env_keys` to `Vec<EnvVarName>`; drop the `String` round-trip at the single call site in `main.rs`.
- Simplify `prepare_env_forwarding` to consume the strong type — fold the two identical loops over `claude.env_forward` / `codex.env_forward` into one chained iterator.
- Delete `parse_cli_env_arg_rejects_invalid_key` (duplicates `env_var_name_rejects_invalid_forms`).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --bins` (582 passed)
- [x] `prek run --all-files`
- [ ] Integration tests on both platforms (per CLAUDE.md "Before committing")

🤖 Generated with [Claude Code](https://claude.com/claude-code)