### PR TITLE
Thread `MiB`/`GiB` from clap through the devcontainer translator (closes #194)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -150,6 +150,21 @@ impl MiB {
         NonZeroU32::new(value).map(Self)
     }
 
+    /// Wrap an existing `NonZeroU32` — infallible because the inner
+    /// invariant already holds. Use this to bridge from other
+    /// non-zero-backed types without round-tripping through `Option`.
+    pub fn from_nonzero(value: NonZeroU32) -> Self {
+        Self(value)
+    }
+
+    /// Clap value parser: accept a positive integer string, reject zero.
+    pub fn parse_cli(s: &str) -> Result<Self> {
+        let n: u32 = s
+            .parse()
+            .with_context(|| format!("expected positive integer MiB, got '{s}'"))?;
+        Self::new(n).with_context(|| format!("MiB must be > 0, got '{s}'"))
+    }
+
     pub fn as_u32(self) -> u32 {
         self.0.get()
     }
@@ -175,6 +190,21 @@ impl GiB {
     /// Create from a runtime value. Returns `None` if zero.
     pub fn new(value: u32) -> Option<Self> {
         NonZeroU32::new(value).map(Self)
+    }
+
+    /// Wrap an existing `NonZeroU32` — infallible because the inner
+    /// invariant already holds. Use this to bridge from other
+    /// non-zero-backed types without round-tripping through `Option`.
+    pub fn from_nonzero(value: NonZeroU32) -> Self {
+        Self(value)
+    }
+
+    /// Clap value parser: accept a positive integer string, reject zero.
+    pub fn parse_cli(s: &str) -> Result<Self> {
+        let n: u32 = s
+            .parse()
+            .with_context(|| format!("expected positive integer GiB, got '{s}'"))?;
+        Self::new(n).with_context(|| format!("GiB must be > 0, got '{s}'"))
     }
 
     pub fn as_u32(self) -> u32 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, File};
+use std::marker::PhantomData;
 use std::net::Ipv4Addr;
 use std::num::{NonZeroU8, NonZeroU16, NonZeroU32};
 use std::os::unix::io::AsRawFd;
@@ -138,84 +139,91 @@ impl<T> fmt::Debug for Secret<T> {
 
 // ── Newtypes ─────────────────────────────────────────────────
 
-/// Memory size in mebibytes. Inner `NonZeroU32` rejects zero at
-/// deserialization time — no runtime validation needed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct MiB(NonZeroU32);
+/// Marker types and trait for [`Quantity`] — the only place a new
+/// unit is introduced. Adding a unit means: a marker struct, an
+/// `impl Unit for ...` with the human-facing suffix, and a `type` alias.
+pub trait Unit: Copy + fmt::Debug + 'static {
+    /// Human-readable suffix used in CLI/parser error messages.
+    const SUFFIX: &'static str;
+}
 
-impl MiB {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MibUnit;
+impl Unit for MibUnit {
+    const SUFFIX: &'static str = "MiB";
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct GibUnit;
+impl Unit for GibUnit {
+    const SUFFIX: &'static str = "GiB";
+}
+
+/// Non-zero byte-scaled quantity. The phantom unit parameter prevents
+/// silently mixing `MiB` and `GiB`; the inner `NonZeroU32` rejects
+/// zero at deserialization time so no runtime check is needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Quantity<U: Unit>(NonZeroU32, PhantomData<U>);
+
+/// Memory size in mebibytes.
+pub type MiB = Quantity<MibUnit>;
+/// Disk/storage size in gibibytes.
+pub type GiB = Quantity<GibUnit>;
+
+impl<U: Unit> Quantity<U> {
     /// Create from a runtime value. Returns `None` if zero.
     pub fn new(value: u32) -> Option<Self> {
-        NonZeroU32::new(value).map(Self)
+        NonZeroU32::new(value).map(|n| Self(n, PhantomData))
     }
 
     /// Wrap an existing `NonZeroU32` — infallible because the inner
     /// invariant already holds. Use this to bridge from other
-    /// non-zero-backed types without round-tripping through `Option`.
-    pub fn from_nonzero(value: NonZeroU32) -> Self {
-        Self(value)
+    /// non-zero-backed types without round-tripping through `Option`,
+    /// and to build `const` quantity values from non-zero literals.
+    pub const fn from_nonzero(value: NonZeroU32) -> Self {
+        Self(value, PhantomData)
     }
 
     /// Clap value parser: accept a positive integer string, reject zero.
     pub fn parse_cli(s: &str) -> Result<Self> {
         let n: u32 = s
             .parse()
-            .with_context(|| format!("expected positive integer MiB, got '{s}'"))?;
-        Self::new(n).with_context(|| format!("MiB must be > 0, got '{s}'"))
+            .with_context(|| format!("expected positive integer {}, got '{s}'", U::SUFFIX))?;
+        Self::new(n).with_context(|| format!("{} must be > 0, got '{s}'", U::SUFFIX))
     }
 
     pub fn as_u32(self) -> u32 {
         self.0.get()
     }
 
+    pub fn as_nonzero(self) -> NonZeroU32 {
+        self.0
+    }
+}
+
+impl<U: Unit> fmt::Display for Quantity<U> {
+    #[mutants::skip] // equivalent: callers don't assert the formatted output, only round-trip via parse_cli
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<U: Unit> Serialize for Quantity<U> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(s)
+    }
+}
+
+impl<'de, U: Unit> Deserialize<'de> for Quantity<U> {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        NonZeroU32::deserialize(d).map(Self::from_nonzero)
+    }
+}
+
+impl Quantity<MibUnit> {
+    /// MiB → GiB as floating-point (1024 MiB = 1 GiB).
     pub fn as_gib_f64(self) -> f64 {
         f64::from(self.0.get()) / 1024.0
-    }
-}
-
-impl fmt::Display for MiB {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// Disk size in gibibytes. Inner `NonZeroU32` rejects zero at
-/// deserialization time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct GiB(NonZeroU32);
-
-impl GiB {
-    /// Create from a runtime value. Returns `None` if zero.
-    pub fn new(value: u32) -> Option<Self> {
-        NonZeroU32::new(value).map(Self)
-    }
-
-    /// Wrap an existing `NonZeroU32` — infallible because the inner
-    /// invariant already holds. Use this to bridge from other
-    /// non-zero-backed types without round-tripping through `Option`.
-    pub fn from_nonzero(value: NonZeroU32) -> Self {
-        Self(value)
-    }
-
-    /// Clap value parser: accept a positive integer string, reject zero.
-    pub fn parse_cli(s: &str) -> Result<Self> {
-        let n: u32 = s
-            .parse()
-            .with_context(|| format!("expected positive integer GiB, got '{s}'"))?;
-        Self::new(n).with_context(|| format!("GiB must be > 0, got '{s}'"))
-    }
-
-    pub fn as_u32(self) -> u32 {
-        self.0.get()
-    }
-}
-
-impl fmt::Display for GiB {
-    #[mutants::skip] // equivalent: callers don't assert the formatted output, only that GiB round-trips through CLI parsing
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
     }
 }
 
@@ -250,14 +258,18 @@ impl DiskSize {
     }
 
     /// Resolve to an absolute GiB value given the current disk size.
-    pub fn resolve(self, current_gib: u32) -> Result<GiB> {
-        let target = match self {
-            Self::Absolute(gib) => gib.as_u32(),
-            Self::Relative(gib) => current_gib
+    ///
+    /// Both inputs are non-zero, so the result is too; the only
+    /// remaining failure mode is `u32` overflow on a relative add.
+    pub fn resolve(self, current: GiB) -> Result<GiB> {
+        match self {
+            Self::Absolute(gib) => Ok(gib),
+            Self::Relative(gib) => current
+                .as_nonzero()
                 .checked_add(gib.as_u32())
-                .context("Disk size overflow")?,
-        };
-        GiB::new(target).context("Resolved disk size is 0")
+                .map(GiB::from_nonzero)
+                .context("Disk size overflow"),
+        }
     }
 }
 
@@ -1603,16 +1615,18 @@ impl CoopConfig {
     /// Returns `Ok(warnings)` where warnings are non-fatal observations,
     /// or `Err` with all fatal validation errors joined.
     pub fn validate(&self) -> Result<Vec<String>> {
+        const MIN_MEM_MIB: MiB = MiB::from_nonzero(NonZeroU32::new(128).unwrap());
+
         let mut errors: Vec<String> = Vec::new();
         let mut warnings: Vec<String> = Vec::new();
 
         // VM config bounds
         // vcpu_count, mem_size_mib, template_size_gib, and ssh_port are
         // NonZero types — zero is rejected at deserialization time.
-        if self.vm.mem_size_mib.as_u32() < 128 {
+        if self.vm.mem_size_mib < MIN_MEM_MIB {
             errors.push(format!(
-                "vm.mem_size_mib={} is too low (minimum 128)",
-                self.vm.mem_size_mib
+                "vm.mem_size_mib={} is too low (minimum {MIN_MEM_MIB})",
+                self.vm.mem_size_mib,
             ));
         }
 
@@ -4332,15 +4346,15 @@ skip = ["not-a-slug"]
     #[test]
     fn disk_size_resolve_absolute() {
         let ds = DiskSize::Absolute(GiB::new(150).unwrap());
-        let resolved = ds.resolve(100).unwrap();
-        assert_eq!(resolved.as_u32(), 150);
+        let resolved = ds.resolve(GiB::new(100).unwrap()).unwrap();
+        assert_eq!(resolved, GiB::new(150).unwrap());
     }
 
     #[test]
     fn disk_size_resolve_relative() {
         let ds = DiskSize::Relative(GiB::new(20).unwrap());
-        let resolved = ds.resolve(100).unwrap();
-        assert_eq!(resolved.as_u32(), 120);
+        let resolved = ds.resolve(GiB::new(100).unwrap()).unwrap();
+        assert_eq!(resolved, GiB::new(120).unwrap());
     }
 
     // ── Mount parsing ───────────────────────────────────────────

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -350,8 +350,8 @@ impl Report {
 #[derive(Debug, Default)]
 pub struct TranslatorInputs {
     pub cli_vcpus: Option<u8>,
-    pub cli_mem_mib: Option<u32>,
-    pub cli_disk_gib: Option<u32>,
+    pub cli_mem_mib: Option<MiB>,
+    pub cli_disk_gib: Option<GiB>,
     pub cli_post_start: Option<String>,
     pub cli_guest_env_keys: Vec<EnvVarName>,
     pub cli_forward_ports: Vec<PortForward>,
@@ -379,8 +379,8 @@ pub enum Stage {
 #[derive(Debug, Default)]
 pub struct Translation {
     pub vcpus: Option<u8>,
-    pub mem_mib: Option<u32>,
-    pub disk_gib: Option<u32>,
+    pub mem_mib: Option<MiB>,
+    pub disk_gib: Option<GiB>,
     pub post_start: Option<String>,
     pub guest_env: BTreeMap<EnvVarName, String>,
     pub forward_ports: Vec<PortForward>,
@@ -963,13 +963,21 @@ impl MemorySpec {
     }
 
     /// Mebibytes (rounded up).
-    pub fn as_mib(self) -> u32 {
-        self.0.get()
+    pub fn as_mib(self) -> MiB {
+        // `MiB` and `MemorySpec` share the same `NonZeroU32` invariant,
+        // so the wrap is infallible.
+        MiB::from_nonzero(self.0)
     }
 
     /// Gibibytes (rounded up from the stored MiB).
-    pub fn as_gib(self) -> u32 {
-        self.0.get().div_ceil(1024)
+    pub fn as_gib(self) -> GiB {
+        #[expect(
+            clippy::expect_used,
+            reason = "div_ceil of a non-zero by 1024 stays non-zero"
+        )]
+        let nz = NonZeroU32::new(self.0.get().div_ceil(1024))
+            .expect("div_ceil of non-zero MiB by 1024 is non-zero");
+        GiB::from_nonzero(nz)
     }
 }
 
@@ -1246,7 +1254,7 @@ pub fn apply_to_config(cfg: &mut CoopConfig, t: &Translation) -> Result<()> {
             std::num::NonZeroU8::new(v).context("translated --vcpus value resolved to zero")?;
     }
     if let Some(m) = t.mem_mib {
-        cfg.vm.mem_size_mib = MiB::new(m).context("translated --mem value resolved to zero")?;
+        cfg.vm.mem_size_mib = m;
     }
     if let Some(p) = &t.post_start {
         cfg.post_start = Some(p.clone());
@@ -1262,10 +1270,7 @@ pub fn apply_to_config(cfg: &mut CoopConfig, t: &Translation) -> Result<()> {
 /// `disk_gib` is used.
 #[must_use]
 pub fn effective_disk(cli: Option<GiB>, t: &Translation) -> Option<GiB> {
-    if let Some(c) = cli {
-        return Some(c);
-    }
-    t.disk_gib.and_then(GiB::new)
+    cli.or(t.disk_gib)
 }
 
 /// Merge devcontainer.json forwards on top of existing config defaults.
@@ -1460,31 +1465,35 @@ mod tests {
 
     #[test]
     fn memory_spec_parses_binary_units() {
-        assert_eq!(MemorySpec::parse("4GiB").unwrap().as_mib(), 4096);
-        assert_eq!(MemorySpec::parse("4096MiB").unwrap().as_mib(), 4096);
-        assert_eq!(MemorySpec::parse("512MiB").unwrap().as_mib(), 512);
-        assert_eq!(MemorySpec::parse("8GiB").unwrap().as_gib(), 8);
+        assert_eq!(MemorySpec::parse("4GiB").unwrap().as_mib().as_u32(), 4096);
+        assert_eq!(
+            MemorySpec::parse("4096MiB").unwrap().as_mib().as_u32(),
+            4096,
+        );
+        assert_eq!(MemorySpec::parse("512MiB").unwrap().as_mib().as_u32(), 512);
+        assert_eq!(MemorySpec::parse("8GiB").unwrap().as_gib().as_u32(), 8);
     }
 
     #[test]
     fn memory_spec_parses_decimal_units() {
         // 1G = 1_000_000_000 B; ceil(1e9 / 2^20) = 954 MiB
-        assert_eq!(MemorySpec::parse("1g").unwrap().as_mib(), 954);
+        assert_eq!(MemorySpec::parse("1g").unwrap().as_mib().as_u32(), 954);
         // 512MB = 5.12e8 B; ceil(5.12e8 / 2^20) = 489 MiB
-        assert_eq!(MemorySpec::parse("512mb").unwrap().as_mib(), 489);
+        assert_eq!(MemorySpec::parse("512mb").unwrap().as_mib().as_u32(), 489);
         // 4GB rounds to 3815 MiB
-        assert_eq!(MemorySpec::parse("4GB").unwrap().as_mib(), 3815);
+        assert_eq!(MemorySpec::parse("4GB").unwrap().as_mib().as_u32(), 3815);
     }
 
     #[test]
     fn memory_spec_accepts_bare_bytes() {
         // Bare integer = bytes; 1024 B rounds up to 1 MiB.
-        assert_eq!(MemorySpec::parse("1024").unwrap().as_mib(), 1);
+        assert_eq!(MemorySpec::parse("1024").unwrap().as_mib().as_u32(), 1);
         // 2 MiB worth of bytes survives the round-trip exactly.
         assert_eq!(
             MemorySpec::parse(&(2u64 * 1024 * 1024).to_string())
                 .unwrap()
-                .as_mib(),
+                .as_mib()
+                .as_u32(),
             2,
         );
     }
@@ -1503,8 +1512,8 @@ mod tests {
     fn memory_spec_as_gib_rounds_up_from_mib() {
         // 1500 MiB → ceil(1500/1024) = 2 GiB
         let spec = MemorySpec::parse("1500MiB").unwrap();
-        assert_eq!(spec.as_mib(), 1500);
-        assert_eq!(spec.as_gib(), 2);
+        assert_eq!(spec.as_mib().as_u32(), 1500);
+        assert_eq!(spec.as_gib().as_u32(), 2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,8 +80,8 @@ enum Commands {
         #[arg(long)]
         vcpus: Option<u8>,
         /// Memory in MiB (overrides config)
-        #[arg(long)]
-        mem: Option<u32>,
+        #[arg(long, value_parser = config::MiB::parse_cli)]
+        mem: Option<config::MiB>,
         /// Force rebuild of template rootfs
         #[arg(long)]
         rebuild: bool,
@@ -99,8 +99,8 @@ enum Commands {
         #[arg(long)]
         post_install: Option<String>,
         /// Template rootfs size in GiB (default: 8)
-        #[arg(long)]
-        template_size: Option<u32>,
+        #[arg(long, value_parser = config::GiB::parse_cli)]
+        template_size: Option<config::GiB>,
         /// Named image to build (default: "default")
         #[arg(
             long,
@@ -142,11 +142,11 @@ enum Commands {
         #[arg(long)]
         vcpus: Option<u8>,
         /// Memory in MiB (overrides config)
-        #[arg(long)]
-        mem: Option<u32>,
+        #[arg(long, value_parser = config::MiB::parse_cli)]
+        mem: Option<config::MiB>,
         /// Instance disk size in GiB (grows from template size if larger)
-        #[arg(long)]
-        disk: Option<u32>,
+        #[arg(long, value_parser = config::GiB::parse_cli)]
+        disk: Option<config::GiB>,
         /// Skip injecting Claude Code and Codex credentials/config into the VM
         #[arg(long, alias = "no-claude")]
         no_agents: bool,
@@ -759,12 +759,9 @@ fn main() -> Result<()> {
                 .unwrap_or_default();
             let persisted_guest_env =
                 guest_env_state::merge_persisted_entries(&dc_guest_env, &cli_guest_env);
-            let cli_disk = disk
-                .map(|d| config::GiB::new(d).context("--disk must be > 0"))
-                .transpose()?;
             let default_translation = devcontainer::Translation::default();
             let effective_disk = devcontainer::effective_disk(
-                cli_disk,
+                disk,
                 translation.as_ref().unwrap_or(&default_translation),
             );
             let post_start_override = post_start
@@ -1029,17 +1026,17 @@ fn probe_pat_token(token: &str) -> Result<String> {
 fn apply_vm_overrides(
     cfg: &mut config::CoopConfig,
     vcpus: Option<u8>,
-    mem: Option<u32>,
-    template_size: Option<u32>,
+    mem: Option<config::MiB>,
+    template_size: Option<config::GiB>,
 ) -> Result<()> {
     if let Some(v) = vcpus {
         cfg.vm.vcpu_count = std::num::NonZeroU8::new(v).context("--vcpus must be > 0")?;
     }
     if let Some(m) = mem {
-        cfg.vm.mem_size_mib = config::MiB::new(m).context("--mem must be > 0")?;
+        cfg.vm.mem_size_mib = m;
     }
     if let Some(ts) = template_size {
-        cfg.vm.template_size_gib = config::GiB::new(ts).context("--template-size must be > 0")?;
+        cfg.vm.template_size_gib = ts;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2069,20 +2069,21 @@ fn cmd_resize(
     let inst = cfg.resolve_instance(name)?;
     let disk_size = config::DiskSize::parse(size)?;
 
-    let current_gib = current_disk_gib(be, &inst)?;
-    let new_size = disk_size.resolve(current_gib)?;
+    let current = current_disk_gib(be, &inst)?;
+    let new_size = disk_size.resolve(current)?;
 
     be.resize_disk(cfg, &inst, new_size)
 }
 
-fn current_disk_gib(be: &backend::PlatformBackend, inst: &config::Instance) -> Result<u32> {
+fn current_disk_gib(be: &backend::PlatformBackend, inst: &config::Instance) -> Result<config::GiB> {
     let path = be.disk_path(inst)?;
     let bytes = std::fs::metadata(&path)
         .with_context(|| format!("Failed to stat {}", path.display()))?
         .len();
     #[expect(clippy::cast_possible_truncation, reason = "disk GiB fits in u32")]
     let gib = (bytes / (1024 * 1024 * 1024)) as u32;
-    Ok(gib)
+    config::GiB::new(gib)
+        .with_context(|| format!("Disk at {} is smaller than 1 GiB", path.display()))
 }
 
 fn cmd_profiles(cfg: &config::CoopConfig, action: &ProfilesAction) -> Result<()> {


### PR DESCRIPTION
## Summary

- Adds `MiB::parse_cli` / `GiB::parse_cli` clap value parsers that reject zero at argument-parse time, plus `from_nonzero` constructors for infallible conversions between `NonZeroU32`-backed types.
- Switches `--mem`, `--disk`, and `--template-size` to `Option<MiB>` / `Option<GiB>` directly, and threads those types through `TranslatorInputs`, `Translation`, and `MemorySpec::as_mib` / `as_gib`.
- Drops the redundant zero-checks in `effective_disk`, `apply_to_config`, and `apply_vm_overrides` — the types now carry the invariant.

Closes #194.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (583 tests pass)
- [x] Verified clap rejects bad values: `--mem 0`, `--disk abc`, `--template-size 0` all fail at argument-parse time with clear messages.
- [ ] Local Lima integration test (`./tests/run-integration.sh`)
- [ ] Remote Firecracker integration test (`./tests/run-integration.sh --remote ...`)