### PR TITLE
Direct-probe `resolve_instance` fast path for the by-name case (closes #203)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1818,9 +1818,20 @@ impl CoopConfig {
 
     /// Resolve an instance by name, or auto-select if only one exists.
     pub fn resolve_instance(&self, name: Option<&InstanceName>) -> Result<Instance> {
-        let instances = self.list_instances()?;
         if let Some(name) = name {
-            instances
+            // Fast path: `allocate_instance` writes each instance to
+            // `instances_dir/<name>/`, so the metadata is one file read
+            // away. Skipping the full directory walk avoids parsing every
+            // other `instance.json` on `coop stop`/`shell`/`destroy`.
+            if let Ok(inst) = Instance::load(&self.instances_dir().join(name.as_str()))
+                && &inst.name == name
+            {
+                return Ok(inst);
+            }
+            // Miss or stale metadata: fall back to the full listing so
+            // the error message still names the available instances.
+            let instances = self.list_instances()?;
+            return instances
                 .into_iter()
                 .find(|i| &i.name == name)
                 .with_context(|| {
@@ -1829,8 +1840,10 @@ impl CoopConfig {
                         "No instance named '{name}'. {available}\n\
                          Create one with: coop start --name {name}"
                     )
-                })
-        } else if instances.len() == 1 {
+                });
+        }
+        let instances = self.list_instances()?;
+        if instances.len() == 1 {
             // Safe: we just checked len == 1
             instances
                 .into_iter()


### PR DESCRIPTION
## Summary

- `CoopConfig::resolve_instance(Some(name))` no longer parses every `instance.json` on the happy path. Because `allocate_instance` writes each instance to `instances_dir/<name>/`, the metadata is one `Instance::load` away — try that path directly and return on success.
- On miss (no such dir, parse failure, or stale metadata whose stored name doesn't match the dir), fall back to `list_instances` so the error still reads "No instance named X. Available: a, b, c".
- `resolve_instance(None)` (auto-select) is unchanged — it still needs the full listing.

## Test plan

- [x] `cargo test --bins` — 589 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Existing tests cover both paths: `resolve_by_name` exercises the fast path, `resolve_unknown_name_errors` / `resolve_unknown_name_with_no_instances_lists_none` exercise the fallback's error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)