### PR TITLE
Defer `CoopConfig::validate` to commands that touch probed paths (closes #202)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -10,7 +10,9 @@ use indexmap::IndexMap;
 use toml::Value as TomlValue;
 
 use crate::cmd::Cmd;
-use crate::config::{ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, McpServerDef};
+use crate::config::{
+    ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, McpServerDef, Validated,
+};
 use crate::paths::{GuestPath, HostPath};
 use crate::setup::SetupOptions;
 use crate::shell::shell_escape;
@@ -699,7 +701,7 @@ fn parse_meminfo_kib(value: &str) -> Option<u64> {
 /// The `PlatformBackend` type alias selects the correct one at compile
 /// time via `#[cfg]`.
 pub trait VmBackend: std::fmt::Display {
-    fn setup(&self, cfg: &CoopConfig, opts: &SetupOptions) -> Result<()>;
+    fn setup(&self, cfg: &CoopConfig, validated: &Validated, opts: &SetupOptions) -> Result<()>;
     fn create_and_start(
         &self,
         cfg: &CoopConfig,
@@ -769,7 +771,7 @@ impl std::fmt::Display for FirecrackerBackend {
 
 #[cfg(not(target_os = "macos"))]
 impl VmBackend for FirecrackerBackend {
-    fn setup(&self, cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
+    fn setup(&self, cfg: &CoopConfig, _: &Validated, opts: &SetupOptions) -> Result<()> {
         crate::setup::run(cfg, opts)
     }
 
@@ -950,7 +952,7 @@ impl std::fmt::Display for LimaBackend {
 
 #[cfg(target_os = "macos")]
 impl VmBackend for LimaBackend {
-    fn setup(&self, cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
+    fn setup(&self, cfg: &CoopConfig, _: &Validated, opts: &SetupOptions) -> Result<()> {
         crate::lima::setup(cfg, opts)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1564,6 +1564,16 @@ fn unique_instance_name(base: &str, instances: &[Instance]) -> Result<InstanceNa
     bail!("Could not find unique instance name for '{base}'")
 }
 
+/// Witness that [`CoopConfig::validate_and_warn`] has been run.
+///
+/// Only obtainable via [`CoopConfig::validate_and_warn`] (the unit field
+/// is private). Functions that depend on the paths probed by
+/// [`CoopConfig::validate`] take `&Validated` so the compiler refuses
+/// calls that skipped validation. Sibling to `RunningInstance` in
+/// `backend.rs`.
+#[must_use]
+pub struct Validated(());
+
 impl CoopConfig {
     /// Default config path: `~/.coop/config.toml`.
     pub fn default_path() -> PathBuf {
@@ -1607,6 +1617,24 @@ impl CoopConfig {
             })
             .collect();
         Ok(cfg)
+    }
+
+    /// Run `validate` and surface warnings via `tracing::warn`, returning
+    /// a [`Validated`] witness.
+    ///
+    /// Commands that consume the paths probed by [`Self::validate`]
+    /// (`setup`, `build`, `start`) take `&Validated` so the compiler
+    /// enforces the precondition. Query commands (`list`/`status`/`logs`)
+    /// skip the call and don't need the witness, so an unrelated config
+    /// error (e.g. a stale `claude.config_dir`) can't block them.
+    ///
+    /// `coop validate` keeps using [`Self::validate`] directly because
+    /// it prints warnings to stdout instead of routing them to tracing.
+    pub fn validate_and_warn(&self) -> Result<Validated> {
+        for w in self.validate()? {
+            tracing::warn!("{w}");
+        }
+        Ok(Validated(()))
     }
 
     /// Validate config values, returning all problems found.

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,12 +522,18 @@ fn init_tracing(verbosity: u8) {
         .init();
 }
 
-fn load_and_validate_config(path: &Path) -> Result<config::CoopConfig> {
-    let cfg = config::CoopConfig::load(path)?;
+/// Run `CoopConfig::validate` and surface warnings via `tracing::warn`.
+///
+/// Called by commands that consume the paths probed in `validate`
+/// (`setup`, `build`, `start`). Query commands like `list`/`status`/`logs`
+/// skip this so an unrelated config error (e.g. a stale
+/// `claude.config_dir`) can't block them. `coop validate` runs the same
+/// check explicitly and prints the warnings to stdout instead.
+fn warn_on_validate(cfg: &config::CoopConfig) -> Result<()> {
     for w in cfg.validate()? {
         tracing::warn!("{w}");
     }
-    Ok(cfg)
+    Ok(())
 }
 
 /// Returns true if the raw argv contains the deprecated `--no-claude`
@@ -610,7 +616,7 @@ fn main() -> Result<()> {
         );
     }
 
-    let mut cfg = load_and_validate_config(&cli.config)?;
+    let mut cfg = config::CoopConfig::load(&cli.config)?;
     update::maybe_print_notify(&cfg.updates);
     update::maybe_run_background_check(&cfg.updates);
     let be: backend::PlatformBackend = backend::PlatformBackend::new();
@@ -632,6 +638,7 @@ fn main() -> Result<()> {
             no_devcontainer,
             dry_run,
         } => {
+            warn_on_validate(&cfg)?;
             let ws_path = workspace.as_deref().map(Path::new);
             let inputs = devcontainer::TranslatorInputs {
                 cli_vcpus: vcpus,
@@ -681,7 +688,10 @@ fn main() -> Result<()> {
                 },
             )
         }
-        Commands::Build => cmd_build(&cfg),
+        Commands::Build => {
+            warn_on_validate(&cfg)?;
+            cmd_build(&cfg)
+        }
         Commands::Start {
             name,
             workspace,
@@ -701,6 +711,7 @@ fn main() -> Result<()> {
             no_devcontainer,
             dry_run,
         } => {
+            warn_on_validate(&cfg)?;
             if raw_args_use_deprecated_no_claude(std::env::args()) {
                 tracing::warn!(
                     "--no-claude is deprecated and will be removed in a future release; use --no-agents"

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,20 +522,6 @@ fn init_tracing(verbosity: u8) {
         .init();
 }
 
-/// Run `CoopConfig::validate` and surface warnings via `tracing::warn`.
-///
-/// Called by commands that consume the paths probed in `validate`
-/// (`setup`, `build`, `start`). Query commands like `list`/`status`/`logs`
-/// skip this so an unrelated config error (e.g. a stale
-/// `claude.config_dir`) can't block them. `coop validate` runs the same
-/// check explicitly and prints the warnings to stdout instead.
-fn warn_on_validate(cfg: &config::CoopConfig) -> Result<()> {
-    for w in cfg.validate()? {
-        tracing::warn!("{w}");
-    }
-    Ok(())
-}
-
 /// Returns true if the raw argv contains the deprecated `--no-claude`
 /// alias. Clap rewrites the alias to `--no-agents` before the `Start`
 /// variant is matched, so we inspect the raw args to emit a one-time
@@ -638,7 +624,7 @@ fn main() -> Result<()> {
             no_devcontainer,
             dry_run,
         } => {
-            warn_on_validate(&cfg)?;
+            let validated = cfg.validate_and_warn()?;
             let ws_path = workspace.as_deref().map(Path::new);
             let inputs = devcontainer::TranslatorInputs {
                 cli_vcpus: vcpus,
@@ -678,6 +664,7 @@ fn main() -> Result<()> {
             let _guard = signal::install_handlers();
             be.setup(
                 &cfg,
+                &validated,
                 &setup::SetupOptions {
                     skip_confirm: yes,
                     rebuild,
@@ -689,8 +676,8 @@ fn main() -> Result<()> {
             )
         }
         Commands::Build => {
-            warn_on_validate(&cfg)?;
-            cmd_build(&cfg)
+            let validated = cfg.validate_and_warn()?;
+            cmd_build(&cfg, &validated)
         }
         Commands::Start {
             name,
@@ -711,7 +698,7 @@ fn main() -> Result<()> {
             no_devcontainer,
             dry_run,
         } => {
-            warn_on_validate(&cfg)?;
+            let validated = cfg.validate_and_warn()?;
             if raw_args_use_deprecated_no_claude(std::env::args()) {
                 tracing::warn!(
                     "--no-claude is deprecated and will be removed in a future release; use --no-agents"
@@ -793,6 +780,7 @@ fn main() -> Result<()> {
             cmd_start(
                 &be,
                 &mut cfg,
+                &validated,
                 &StartOpts {
                     name: name.as_ref(),
                     image: &image,
@@ -1132,7 +1120,7 @@ fn resolve_devcontainer(
     Ok(Some(translation))
 }
 
-fn cmd_build(cfg: &config::CoopConfig) -> Result<()> {
+fn cmd_build(cfg: &config::CoopConfig, _: &config::Validated) -> Result<()> {
     tracing::info!("Building rootfs and fetching kernel");
     rootfs::build(cfg)?;
     tracing::info!("Build complete");
@@ -1172,6 +1160,7 @@ struct StartOpts<'a> {
 fn cmd_start(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
+    _: &config::Validated,
     opts: &StartOpts<'_>,
 ) -> Result<()> {
     let ws_path = opts.workspace_dir.map(Path::new);


### PR DESCRIPTION
## Summary

- `CoopConfig::validate` ran on every CLI invocation and stat'd `kernel_path`, `firecracker_bin`, `claude.config_dir`, `codex.config_dir`, and each `claude.marketplaces` entry. A broken entry (e.g. a stale `claude.config_dir`) would abort unrelated commands like `coop list` / `status` / `logs` that never read those paths.
- Move the call into the three command paths that actually consume the probed state: `setup`, `build`, `start`. `coop validate` keeps running `validate` directly (it prints warnings to stdout, not via tracing) and is unchanged.
- The new `CoopConfig::validate_and_warn` returns a `Validated` witness (private unit field; mirrors the existing `RunningInstance` pattern). `cmd_build`, `cmd_start`, and `VmBackend::setup` take `&Validated` so the compiler refuses any future command path that forgets to validate.
- Query commands (`list`, `status`, `logs`, `stop`, `destroy`, `shell`, `exec`, `push`, `pull`, `vscode`, `claude`, `codex`, `claude-agents`, `profiles`, `github`, `resize`, `images`) no longer touch those paths.

Closes #202.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (589 tests pass)
- [ ] `./tests/run-integration.sh` (local, macOS/Lima)
- [ ] `./tests/run-integration.sh --remote …` (Linux/Firecracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)