### PR TITLE
Add `coop quickstart` for one-shot setup + start + claude (closes #74)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -748,6 +748,13 @@ pub trait VmBackend: std::fmt::Display {
     /// Whether mounts use live filesystem sharing (Lima/virtiofs)
     /// vs one-time sync (Firecracker/rsync).
     fn mounts_are_live(&self) -> bool;
+    /// Whether `image` has its backend-specific build artifacts on disk.
+    ///
+    /// On Firecracker this means the template rootfs (`rootfs-template.ext4`).
+    /// On Lima it means both the base disk (`lima-base.img`) and the start
+    /// template (`lima-template.yaml`). Used by `coop quickstart` to skip
+    /// `setup` when nothing needs building.
+    fn image_is_built(&self, cfg: &CoopConfig, image: &ImageName) -> bool;
 }
 
 // ── Firecracker backend ───────────────────────────────────────
@@ -930,6 +937,10 @@ impl VmBackend for FirecrackerBackend {
     fn mounts_are_live(&self) -> bool {
         false
     }
+
+    fn image_is_built(&self, cfg: &CoopConfig, image: &ImageName) -> bool {
+        cfg.template_path_for(image).exists()
+    }
 }
 
 // ── Lima backend ──────────────────────────────────────────────
@@ -1064,6 +1075,10 @@ impl VmBackend for LimaBackend {
 
     fn mounts_are_live(&self) -> bool {
         true
+    }
+
+    fn image_is_built(&self, cfg: &CoopConfig, image: &ImageName) -> bool {
+        cfg.lima_base_path(image).exists() && cfg.lima_template_path(image).exists()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2064,7 +2064,7 @@ struct InstanceMeta {
 /// Returns the [`ImageName`] for [`DEFAULT_IMAGE`]. Direct field
 /// construction (skipping `ImageName::new`) is safe here because the
 /// const is pinned by the `default_image_is_valid` test below.
-fn default_image_name() -> ImageName {
+pub(crate) fn default_image_name() -> ImageName {
     ImageName(DEFAULT_IMAGE.to_string())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,20 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// One-shot: ensure default image, start an instance for cwd, launch Claude.
+    ///
+    /// Re-runnable: if an instance already exists for the current workspace it
+    /// is reconnected (running) or restarted (stopped) instead of being
+    /// recreated. For per-instance tuning (profiles, mounts, image, ...) use
+    /// `coop setup` / `coop start` directly.
+    Quickstart {
+        /// Skip mounting the current directory as the workspace.
+        #[arg(long)]
+        no_workspace: bool,
+        /// Ignore any discovered `devcontainer.json` (escape hatch for CI).
+        #[arg(long)]
+        no_devcontainer: bool,
+    },
     /// Check prerequisites, install Firecracker, fetch kernel and build template rootfs
     Setup {
         /// Skip confirmation prompts (accept all)
@@ -618,6 +632,18 @@ fn main() -> Result<()> {
     tracing::debug!("Using backend: {be}");
 
     match cli.command {
+        Commands::Quickstart {
+            no_workspace,
+            no_devcontainer,
+        } => cmd_quickstart(
+            &be,
+            &mut cfg,
+            &cli.config,
+            &QuickstartOpts {
+                no_workspace,
+                no_devcontainer,
+            },
+        ),
         Commands::Setup {
             yes,
             vcpus,
@@ -1044,6 +1070,275 @@ fn probe_pat_token(token: &str) -> Result<String> {
         .and_then(|s| s.split('"').nth(1))
         .unwrap_or("?");
     Ok(login.to_string())
+}
+
+struct QuickstartOpts {
+    no_workspace: bool,
+    no_devcontainer: bool,
+}
+
+/// One-shot `setup → start → claude`. See `Commands::Quickstart`.
+///
+/// The flow short-circuits any step that's already done:
+/// * skips `setup` when the default template rootfs already exists;
+/// * reconnects to a running instance for the current workspace, or restarts
+///   a stopped one, instead of allocating fresh.
+///
+/// `--no-workspace` skips workspace affinity entirely and falls back to the
+/// same "single running / single stopped" rules used by `coop start` and
+/// `coop claude` when called without a name.
+fn cmd_quickstart(
+    be: &backend::PlatformBackend,
+    cfg: &mut config::CoopConfig,
+    config_path: &Path,
+    opts: &QuickstartOpts,
+) -> Result<()> {
+    let validated = cfg.validate_and_warn()?;
+    let image = config::default_image_name();
+
+    if cfg.template_path_for(&image).exists() {
+        tracing::debug!("Image '{image}' already built — skipping setup");
+    } else {
+        tracing::info!("No '{image}' image found — running setup");
+        let _guard = signal::install_handlers();
+        be.setup(
+            cfg,
+            &validated,
+            &setup::SetupOptions {
+                skip_confirm: true,
+                rebuild: false,
+                profiles: Vec::new(),
+                extra_packages: Vec::new(),
+                post_install: None,
+                image: image.clone(),
+            },
+        )?;
+    }
+
+    let workspace_dir = resolve_quickstart_workspace(opts.no_workspace)?;
+
+    let existing = match &workspace_dir {
+        Some(ws) => find_workspace_instance(cfg, ws)?,
+        None => None,
+    };
+
+    let inst_name: Option<config::InstanceName> = match existing {
+        Some(inst) if be.is_running(&inst) => {
+            tracing::info!("Reusing running instance '{}'", inst.name);
+            Some(inst.name)
+        }
+        Some(inst) => {
+            tracing::info!("Restarting stopped instance '{}'", inst.name);
+            cmd_start(
+                be,
+                cfg,
+                &validated,
+                &StartOpts {
+                    name: Some(&inst.name),
+                    image: &image,
+                    workspace_dir: None,
+                    git_repo: None,
+                    no_agents: false,
+                    no_prompt: false,
+                    disk: None,
+                    mounts: Vec::new(),
+                    exclude_git: false,
+                    forward_ports: Vec::new(),
+                    config_path,
+                    post_start_override: None,
+                    persisted_guest_env: std::collections::BTreeMap::new(),
+                },
+            )?;
+            Some(inst.name)
+        }
+        None => {
+            quickstart_fresh_start(
+                be,
+                cfg,
+                config_path,
+                &validated,
+                &image,
+                workspace_dir.as_deref(),
+                opts.no_devcontainer,
+            )?;
+            // Re-derive the started instance from the workspace state we
+            // just persisted. For `--no-workspace`, fall through to
+            // `resolve_running`'s "single running" rule by passing None.
+            workspace_dir
+                .as_deref()
+                .map(|ws| find_workspace_instance(cfg, ws))
+                .transpose()?
+                .flatten()
+                .map(|i| i.name)
+        }
+    };
+
+    let sess = open_ssh_session(be, cfg, inst_name.as_ref())?;
+    ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, Vec::new()))
+}
+
+/// Drives `cmd_start` with `--workspace <ws>` defaults (no mounts, no
+/// `--env`, no forwards, no `--post-start`), folding any discovered
+/// `devcontainer.json` into the start.
+fn quickstart_fresh_start(
+    be: &backend::PlatformBackend,
+    cfg: &mut config::CoopConfig,
+    config_path: &Path,
+    validated: &config::Validated,
+    image: &config::ImageName,
+    workspace_dir: Option<&Path>,
+    no_devcontainer: bool,
+) -> Result<()> {
+    let inputs = devcontainer::TranslatorInputs {
+        cli_workspace_or_git_repo: workspace_dir.is_some(),
+        ..devcontainer::TranslatorInputs::default()
+    };
+    let translation = resolve_devcontainer(
+        &DevcontainerOpts {
+            explicit_path: None,
+            no_devcontainer,
+            dry_run: false,
+            workspace: workspace_dir,
+            mounts: &[],
+        },
+        &inputs,
+        devcontainer::Stage::Start,
+    )?;
+
+    if let Some(t) = &translation {
+        devcontainer::apply_to_config(cfg, t)?;
+    }
+
+    let forward_ports = translation
+        .as_ref()
+        .map(|t| devcontainer::merge_into_forward_ports(&t.forward_ports, &[]))
+        .unwrap_or_default();
+
+    let dc_guest_env = translation
+        .as_ref()
+        .map(|t| t.guest_env.clone())
+        .unwrap_or_default();
+    let persisted_guest_env =
+        guest_env_state::merge_persisted_entries(&dc_guest_env, &std::collections::BTreeMap::new());
+
+    let default_translation = devcontainer::Translation::default();
+    let effective_disk =
+        devcontainer::effective_disk(None, translation.as_ref().unwrap_or(&default_translation));
+    let post_start_override = translation.as_ref().and_then(|t| t.post_start.clone());
+
+    let final_mounts = translation
+        .as_ref()
+        .map(|t| t.mounts.clone())
+        .unwrap_or_default();
+
+    let workspace_str = workspace_dir
+        .map(|p| {
+            p.to_str()
+                .with_context(|| format!("Workspace path is not valid UTF-8: {}", p.display()))
+        })
+        .transpose()?;
+
+    cmd_start(
+        be,
+        cfg,
+        validated,
+        &StartOpts {
+            name: None,
+            image,
+            workspace_dir: workspace_str,
+            git_repo: None,
+            no_agents: false,
+            no_prompt: false,
+            disk: effective_disk,
+            mounts: final_mounts,
+            exclude_git: false,
+            forward_ports,
+            config_path,
+            post_start_override: post_start_override.as_deref(),
+            persisted_guest_env,
+        },
+    )
+}
+
+/// Resolve the workspace directory for `coop quickstart`.
+///
+/// Returns `None` when `--no-workspace` is set or when the user declines a
+/// `$HOME` / `/` prompt; `Some(cwd)` otherwise. Non-TTY callers in a
+/// sensitive directory get an explicit bail rather than a silent mount.
+fn resolve_quickstart_workspace(no_workspace: bool) -> Result<Option<PathBuf>> {
+    if no_workspace {
+        return Ok(None);
+    }
+
+    let cwd = std::env::current_dir().context("Failed to read current directory")?;
+
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    if is_sensitive_workspace(&cwd, home.as_deref()) {
+        use std::io::IsTerminal as _;
+        if !std::io::stdin().is_terminal() {
+            bail!(
+                "Current directory {} looks like your home or root — refusing to mount silently.\n\
+                 Pass --no-workspace to skip the mount, or run from a project directory.",
+                cwd.display(),
+            );
+        }
+        let prompt = format!("Mount {} into the guest? This may be large.", cwd.display());
+        if !prompt::confirm(&prompt)? {
+            tracing::info!("Skipping workspace mount (declined at prompt)");
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(cwd))
+}
+
+/// True when `p` is the user's `$HOME` (per the `home` argument) or the root
+/// directory `/`.
+///
+/// `home` is passed in rather than read from the process env so the function
+/// is pure and testable without env mutation.
+fn is_sensitive_workspace(p: &Path, home: Option<&Path>) -> bool {
+    if p == Path::new("/") {
+        return true;
+    }
+    home.is_some_and(|h| p == h)
+}
+
+/// Find the (single) instance whose persisted workspace state's `host_path`
+/// matches `workspace` (after canonicalisation). Returns `None` when no
+/// instance has been started for this directory; bails when multiple do
+/// (the caller has to pick one explicitly).
+fn find_workspace_instance(
+    cfg: &config::CoopConfig,
+    workspace: &Path,
+) -> Result<Option<config::Instance>> {
+    let canonical = workspace
+        .canonicalize()
+        .with_context(|| format!("Failed to resolve workspace path {}", workspace.display()))?;
+    let instances = cfg.list_instances()?;
+    let mut matching: Vec<config::Instance> = instances
+        .into_iter()
+        .filter(|inst| {
+            workspace::WorkspaceState::try_load(inst)
+                .ok()
+                .flatten()
+                .and_then(|s| s.source.host_path().map(Path::to_path_buf))
+                .is_some_and(|hp| hp == canonical)
+        })
+        .collect();
+    match matching.len() {
+        0 => Ok(None),
+        1 => Ok(Some(matching.swap_remove(0))),
+        _ => {
+            let names: Vec<_> = matching.iter().map(|i| i.name.as_str()).collect();
+            bail!(
+                "Multiple instances share workspace {}:\n  {}\n\
+                 Pick one explicitly: coop claude <name>",
+                canonical.display(),
+                names.join(", "),
+            )
+        }
+    }
 }
 
 fn apply_vm_overrides(
@@ -3128,6 +3423,179 @@ mod tests {
         let cfg_path = tmp.path().join("config.toml");
         let opts = start_opts(Vec::new(), &cfg_path);
         assert!(!super::creation_intent_without_target(&opts));
+    }
+
+    #[test]
+    fn quickstart_subcommand_parses_with_defaults() {
+        let cli = parse(&["quickstart"]);
+        let super::Commands::Quickstart {
+            no_workspace,
+            no_devcontainer,
+        } = cli.command
+        else {
+            panic!("expected Quickstart variant");
+        };
+        assert!(!no_workspace);
+        assert!(!no_devcontainer);
+    }
+
+    #[test]
+    fn quickstart_no_workspace_flag_parses() {
+        let cli = parse(&["quickstart", "--no-workspace"]);
+        let super::Commands::Quickstart { no_workspace, .. } = cli.command else {
+            panic!("expected Quickstart variant");
+        };
+        assert!(no_workspace);
+    }
+
+    #[test]
+    fn quickstart_no_devcontainer_flag_parses() {
+        let cli = parse(&["quickstart", "--no-devcontainer"]);
+        let super::Commands::Quickstart {
+            no_devcontainer, ..
+        } = cli.command
+        else {
+            panic!("expected Quickstart variant");
+        };
+        assert!(no_devcontainer);
+    }
+
+    #[test]
+    fn quickstart_rejects_unknown_flag() {
+        let err = parse_err(&["quickstart", "--name", "foo"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn is_sensitive_workspace_detects_root() {
+        let home = std::path::Path::new("/home/alice");
+        assert!(super::is_sensitive_workspace(
+            std::path::Path::new("/"),
+            Some(home),
+        ));
+    }
+
+    #[test]
+    fn is_sensitive_workspace_detects_home() {
+        let home = std::path::Path::new("/home/alice");
+        assert!(super::is_sensitive_workspace(home, Some(home)));
+    }
+
+    #[test]
+    fn is_sensitive_workspace_passes_through_project_dir() {
+        let home = std::path::Path::new("/home/alice");
+        let project = std::path::Path::new("/home/alice/projects/coop");
+        assert!(!super::is_sensitive_workspace(project, Some(home)));
+    }
+
+    #[test]
+    fn is_sensitive_workspace_handles_missing_home() {
+        // When HOME is unset, only `/` should be flagged.
+        let project = std::path::Path::new("/tmp/work");
+        assert!(!super::is_sensitive_workspace(project, None));
+        assert!(super::is_sensitive_workspace(
+            std::path::Path::new("/"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn resolve_quickstart_workspace_returns_none_when_opted_out() {
+        // --no-workspace takes precedence over everything; doesn't even
+        // touch the filesystem.
+        let result = super::resolve_quickstart_workspace(true).expect("ok");
+        assert_eq!(result, None);
+    }
+
+    fn write_workspace_state(inst: &super::config::Instance, host_path: &std::path::Path) {
+        let state = super::workspace::WorkspaceState {
+            guest_path: super::workspace::default_workspace_path(),
+            source: super::workspace::WorkspaceSource::Workspace {
+                host_path: host_path.to_path_buf(),
+            },
+        };
+        state.save(inst).expect("save workspace state");
+    }
+
+    #[test]
+    fn find_workspace_instance_returns_none_when_no_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let ws = tmp.path().join("project");
+        std::fs::create_dir(&ws).expect("create_dir");
+        let result = super::find_workspace_instance(&cfg, &ws).expect("ok");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_workspace_instance_finds_single_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let ws = tmp.path().join("project");
+        std::fs::create_dir(&ws).expect("create_dir");
+        let canonical = ws.canonicalize().expect("canonicalize");
+        let inst = cfg
+            .allocate_instance(None, &img, Some(&canonical))
+            .expect("allocate");
+        write_workspace_state(&inst, &canonical);
+
+        let found = super::find_workspace_instance(&cfg, &ws)
+            .expect("ok")
+            .expect("expected one match");
+        assert_eq!(found.name.as_str(), inst.name.as_str());
+    }
+
+    #[test]
+    fn find_workspace_instance_bails_on_multiple_matches() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let ws = tmp.path().join("project");
+        std::fs::create_dir(&ws).expect("create_dir");
+        let canonical = ws.canonicalize().expect("canonicalize");
+
+        let inst_a = cfg
+            .allocate_instance(
+                Some(&super::config::InstanceName::new("alpha").unwrap()),
+                &img,
+                Some(&canonical),
+            )
+            .expect("allocate alpha");
+        let inst_b = cfg
+            .allocate_instance(
+                Some(&super::config::InstanceName::new("beta").unwrap()),
+                &img,
+                Some(&canonical),
+            )
+            .expect("allocate beta");
+        write_workspace_state(&inst_a, &canonical);
+        write_workspace_state(&inst_b, &canonical);
+
+        let err = super::find_workspace_instance(&cfg, &ws).expect_err("expected bail");
+        let msg = format!("{err}");
+        assert!(msg.contains("alpha"), "{msg}");
+        assert!(msg.contains("beta"), "{msg}");
+    }
+
+    #[test]
+    fn find_workspace_instance_ignores_unrelated_workspaces() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let ws_a = tmp.path().join("a");
+        let ws_b = tmp.path().join("b");
+        std::fs::create_dir(&ws_a).expect("create_dir a");
+        std::fs::create_dir(&ws_b).expect("create_dir b");
+        let a = ws_a.canonicalize().expect("canon a");
+
+        let inst_a = cfg
+            .allocate_instance(None, &img, Some(&a))
+            .expect("allocate");
+        write_workspace_state(&inst_a, &a);
+
+        let found = super::find_workspace_instance(&cfg, &ws_b).expect("ok");
+        assert!(found.is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -842,6 +842,7 @@ fn main() -> Result<()> {
                     persisted_guest_env,
                 },
             )
+            .map(|_| ())
         }
         Commands::Shell { name, command } => cmd_shell(&be, &cfg, name.as_ref(), &command),
         Commands::Claude {
@@ -1096,7 +1097,7 @@ fn cmd_quickstart(
     let validated = cfg.validate_and_warn()?;
     let image = config::default_image_name();
 
-    if cfg.template_path_for(&image).exists() {
+    if be.image_is_built(cfg, &image) {
         tracing::debug!("Image '{image}' already built — skipping setup");
     } else {
         tracing::info!("No '{image}' image found — running setup");
@@ -1122,20 +1123,26 @@ fn cmd_quickstart(
         None => None,
     };
 
-    let inst_name: Option<config::InstanceName> = match existing {
+    let inst = match existing {
         Some(inst) if be.is_running(&inst) => {
             tracing::info!("Reusing running instance '{}'", inst.name);
-            Some(inst.name)
+            inst
         }
         Some(inst) => {
             tracing::info!("Restarting stopped instance '{}'", inst.name);
+            // Use the existing instance's image, not the default — the two
+            // can diverge if the instance was created via `coop start
+            // --image <other>`. On restart this is currently ignored, but
+            // passing `&image` would silently allocate fresh with the
+            // wrong image if `find_stopped_instance` lost the race to a
+            // concurrent destroy.
             cmd_start(
                 be,
                 cfg,
                 &validated,
                 &StartOpts {
                     name: Some(&inst.name),
-                    image: &image,
+                    image: &inst.image,
                     workspace_dir: None,
                     git_repo: None,
                     no_agents: false,
@@ -1148,38 +1155,31 @@ fn cmd_quickstart(
                     post_start_override: None,
                     persisted_guest_env: std::collections::BTreeMap::new(),
                 },
-            )?;
-            Some(inst.name)
+            )?
         }
-        None => {
-            quickstart_fresh_start(
-                be,
-                cfg,
-                config_path,
-                &validated,
-                &image,
-                workspace_dir.as_deref(),
-                opts.no_devcontainer,
-            )?;
-            // Re-derive the started instance from the workspace state we
-            // just persisted. For `--no-workspace`, fall through to
-            // `resolve_running`'s "single running" rule by passing None.
-            workspace_dir
-                .as_deref()
-                .map(|ws| find_workspace_instance(cfg, ws))
-                .transpose()?
-                .flatten()
-                .map(|i| i.name)
-        }
+        None => quickstart_fresh_start(
+            be,
+            cfg,
+            config_path,
+            &validated,
+            &image,
+            workspace_dir.as_deref(),
+            opts.no_devcontainer,
+        )?,
     };
 
-    let sess = open_ssh_session(be, cfg, inst_name.as_ref())?;
+    let sess = open_ssh_session(be, cfg, Some(&inst.name))?;
     ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, Vec::new()))
 }
 
-/// Drives `cmd_start` with `--workspace <ws>` defaults (no mounts, no
+/// Drives a fresh start with `--workspace <ws>` defaults (no mounts, no
 /// `--env`, no forwards, no `--post-start`), folding any discovered
-/// `devcontainer.json` into the start.
+/// `devcontainer.json` into the start. Returns the started instance.
+///
+/// With `workspace_dir = None` (i.e. `--no-workspace`) this calls
+/// `allocate_and_start` directly rather than `cmd_start`, deliberately
+/// bypassing `find_stopped_instance`'s "single stopped instance" fallback
+/// — that fallback would silently restart an unrelated stopped instance.
 fn quickstart_fresh_start(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
@@ -1188,7 +1188,7 @@ fn quickstart_fresh_start(
     image: &config::ImageName,
     workspace_dir: Option<&Path>,
     no_devcontainer: bool,
-) -> Result<()> {
+) -> Result<config::Instance> {
     let inputs = devcontainer::TranslatorInputs {
         cli_workspace_or_git_repo: workspace_dir.is_some(),
         ..devcontainer::TranslatorInputs::default()
@@ -1209,6 +1209,8 @@ fn quickstart_fresh_start(
         devcontainer::apply_to_config(cfg, t)?;
     }
 
+    // `cfg.forward_ports` is folded in by `start_instance` itself, so it
+    // doesn't need to be merged in here.
     let forward_ports = translation
         .as_ref()
         .map(|t| devcontainer::merge_into_forward_ports(&t.forward_ports, &[]))
@@ -1238,26 +1240,30 @@ fn quickstart_fresh_start(
         })
         .transpose()?;
 
-    cmd_start(
-        be,
-        cfg,
-        validated,
-        &StartOpts {
-            name: None,
-            image,
-            workspace_dir: workspace_str,
-            git_repo: None,
-            no_agents: false,
-            no_prompt: false,
-            disk: effective_disk,
-            mounts: final_mounts,
-            exclude_git: false,
-            forward_ports,
-            config_path,
-            post_start_override: post_start_override.as_deref(),
-            persisted_guest_env,
-        },
-    )
+    let start_opts = StartOpts {
+        name: None,
+        image,
+        workspace_dir: workspace_str,
+        git_repo: None,
+        no_agents: false,
+        no_prompt: false,
+        disk: effective_disk,
+        mounts: final_mounts,
+        exclude_git: false,
+        forward_ports,
+        config_path,
+        post_start_override: post_start_override.as_deref(),
+        persisted_guest_env,
+    };
+
+    if workspace_dir.is_some() {
+        cmd_start(be, cfg, validated, &start_opts)
+    } else {
+        // `--no-workspace`: skip the "single stopped instance" fallback in
+        // `find_stopped_instance` so we never hijack an unrelated VM. Each
+        // quickstart with `--no-workspace` allocates a fresh instance.
+        allocate_and_start(be, cfg, None, image, None, &start_opts)
+    }
 }
 
 /// Resolve the workspace directory for `coop quickstart`.
@@ -1296,7 +1302,13 @@ fn resolve_quickstart_workspace(no_workspace: bool) -> Result<Option<PathBuf>> {
 /// directory `/`.
 ///
 /// `home` is passed in rather than read from the process env so the function
-/// is pure and testable without env mutation.
+/// is pure and testable without env mutation. The comparison is byte-equality
+/// — symlinks (e.g. macOS `/var` → `/private/var`) and trailing slashes are
+/// intentionally *not* normalised, so this is a best-effort guardrail rather
+/// than a hard safety check. The fallback behaviour (proceed with the cwd
+/// mount) is benign for any user who deliberately runs in a normalised
+/// project directory; users who land here from an unusual cwd can still
+/// opt out with `--no-workspace`.
 fn is_sensitive_workspace(p: &Path, home: Option<&Path>) -> bool {
     if p == Path::new("/") {
         return true;
@@ -1333,7 +1345,8 @@ fn find_workspace_instance(
             let names: Vec<_> = matching.iter().map(|i| i.name.as_str()).collect();
             bail!(
                 "Multiple instances share workspace {}:\n  {}\n\
-                 Pick one explicitly: coop claude <name>",
+                 Pick one explicitly with `coop start <name>` (for a stopped\n\
+                 instance) or `coop claude <name>` (for a running one).",
                 canonical.display(),
                 names.join(", "),
             )
@@ -1496,7 +1509,7 @@ fn cmd_start(
     cfg: &mut config::CoopConfig,
     _: &config::Validated,
     opts: &StartOpts<'_>,
-) -> Result<()> {
+) -> Result<config::Instance> {
     let ws_path = opts.workspace_dir.map(Path::new);
 
     // Creation-only flags (`--mount`, `--git-repo`, `--disk`, `--exclude-git`)
@@ -1530,10 +1543,27 @@ fn cmd_start(
             );
         }
 
-        return restart_instance(be, cfg, &inst, opts);
+        restart_instance(be, cfg, &inst, opts)?;
+        return Ok(inst);
     }
 
-    let inst = cfg.allocate_instance(opts.name, opts.image, ws_path)?;
+    allocate_and_start(be, cfg, opts.name, opts.image, ws_path, opts)
+}
+
+/// Allocate a fresh instance and run the first-boot start, cleaning up any
+/// partial state on error. Used by `cmd_start`'s "no stopped instance to
+/// restart" path and by `cmd_quickstart`'s `--no-workspace` fresh path
+/// (which skips the `find_stopped_instance` "single stopped" rule to avoid
+/// hijacking an unrelated instance).
+fn allocate_and_start(
+    be: &backend::PlatformBackend,
+    cfg: &mut config::CoopConfig,
+    name: Option<&config::InstanceName>,
+    image: &config::ImageName,
+    workspace_path: Option<&Path>,
+    opts: &StartOpts<'_>,
+) -> Result<config::Instance> {
+    let inst = cfg.allocate_instance(name, image, workspace_path)?;
     tracing::info!("Starting instance '{}' (index {})", inst.name, inst.index);
 
     let _guard = signal::install_handlers();
@@ -1552,7 +1582,7 @@ fn cmd_start(
         }
     }
 
-    result
+    result.map(|()| inst)
 }
 
 /// Find a stopped instance to restart, if applicable.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1112,6 +1112,7 @@ fn cmd_quickstart(
                 extra_packages: Vec::new(),
                 post_install: None,
                 image: image.clone(),
+                guest_user: guest::GuestUser::default(),
             },
         )?;
     }
@@ -1169,7 +1170,8 @@ fn cmd_quickstart(
     };
 
     let sess = open_ssh_session(be, cfg, Some(&inst.name))?;
-    ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, Vec::new()))
+    let claude_bin = guest::GuestUser::new(sess.target.user.as_ref())?.claude_bin();
+    ssh::run_interactive(&sess, &prepend_binary(&claude_bin.to_string(), Vec::new()))
 }
 
 /// Drives a fresh start with `--workspace <ws>` defaults (no mounts, no

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1643,6 +1643,109 @@ test_idempotency() {
     untrack_instance "$inst_name"
 }
 
+# ── Quickstart (--full only) ──────────────────────────────────
+
+# `coop quickstart` chains ensure-image, ensure-instance, launch-claude. The
+# first two steps share code with `coop setup` / `coop start` (covered above);
+# this phase exercises the reconnect/restart logic specific to quickstart and
+# the workspace-affinity lookup that drives it.
+#
+# Claude is interactive — with stdin redirected from /dev/null `ssh` doesn't
+# allocate a PTY and the claude binary fails fast. `run_interactive` only
+# logs (does not error) on non-zero remote status, so quickstart still
+# returns 0 to the host. Each invocation is bounded with `timeout` defensively
+# so a future claude that hangs on EOF can't wedge the suite.
+test_quickstart() {
+    echo ""
+    echo "=== Phase: quickstart ==="
+
+    if ! "$BINARY" exec --help >/dev/null 2>&1; then
+        skip "quickstart" "binary missing exec subcommand"
+        return
+    fi
+
+    local qs_ws qs_inst_name
+    qs_ws=$(mktemp -d "$tmpdir/qs-ws-XXXXXX")
+    # The instance name is the sanitised basename of the workspace path.
+    qs_inst_name=$(basename "$qs_ws" | tr -c 'a-zA-Z0-9_-' '-')
+
+    # First invocation: image is already built (from test_setup) and no
+    # instance for this workspace exists, so quickstart must allocate fresh.
+    local rc=0
+    ( cd "$qs_ws" && timeout 180 "$BINARY" quickstart --no-devcontainer \
+        </dev/null >"$tmpdir/qs1_out" 2>"$tmpdir/qs1_err" ) || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        pass "first quickstart exits 0"
+    else
+        fail "first quickstart exits 0" "exit: $rc; stderr: $(cat "$tmpdir/qs1_err")"
+        rm -rf "$qs_ws"
+        return
+    fi
+
+    # Track for cleanup even if status assertions below fail.
+    STARTED_INSTANCES+=("$qs_inst_name")
+
+    if "$BINARY" status "$qs_inst_name" >/dev/null 2>&1; then
+        pass "quickstart created and started instance '$qs_inst_name'"
+    else
+        fail "quickstart created and started instance" "no instance '$qs_inst_name'"
+        rm -rf "$qs_ws"
+        return
+    fi
+
+    # Second invocation in the same cwd: must reconnect — same name, no new
+    # instance allocated.
+    local pre_list post_list
+    pre_list=$("$BINARY" list 2>/dev/null | sort)
+
+    rc=0
+    ( cd "$qs_ws" && timeout 180 "$BINARY" quickstart --no-devcontainer \
+        </dev/null >"$tmpdir/qs2_out" 2>"$tmpdir/qs2_err" ) || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        pass "second quickstart exits 0 (reconnect path)"
+    else
+        fail "second quickstart exits 0" "exit: $rc; stderr: $(cat "$tmpdir/qs2_err")"
+    fi
+
+    post_list=$("$BINARY" list 2>/dev/null | sort)
+    if [[ "$pre_list" == "$post_list" ]]; then
+        pass "second quickstart reuses existing instance for cwd"
+    else
+        fail "second quickstart reuses existing instance for cwd" \
+            "list changed (diff): $(diff <(echo "$pre_list") <(echo "$post_list"))"
+    fi
+
+    # Stop and re-invoke: must restart the same stopped instance.
+    if ! coop stop "$qs_inst_name"; then
+        fail "stop quickstart instance before restart test" "exit code: $?"
+        return
+    fi
+
+    rc=0
+    ( cd "$qs_ws" && timeout 180 "$BINARY" quickstart --no-devcontainer \
+        </dev/null >"$tmpdir/qs3_out" 2>"$tmpdir/qs3_err" ) || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        pass "third quickstart exits 0 (restart path)"
+    else
+        fail "third quickstart exits 0" "exit: $rc; stderr: $(cat "$tmpdir/qs3_err")"
+    fi
+
+    if "$BINARY" status "$qs_inst_name" 2>/dev/null | grep -q -i running; then
+        pass "quickstart restarted stopped instance '$qs_inst_name'"
+    else
+        fail "quickstart restarted stopped instance" \
+            "status: $("$BINARY" status "$qs_inst_name" 2>&1)"
+    fi
+
+    # Cleanup
+    coop destroy "$qs_inst_name" 2>/dev/null || true
+    untrack_instance "$qs_inst_name"
+    rm -rf "$qs_ws"
+}
+
 # ── Workspace sync tests (--full only) ────────────────────────
 
 test_workspace_sync() {
@@ -3385,6 +3488,7 @@ main() {
 
     # Extended tests (each manages its own instance lifecycle)
     if [[ "$FULL" == "1" ]]; then
+        test_quickstart
         test_mount_conflicts
         test_host_mount
         test_host_mount_custom_guest_path

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1686,6 +1686,17 @@ test_quickstart() {
     # Track for cleanup even if status assertions below fail.
     STARTED_INSTANCES+=("$qs_inst_name")
 
+    # `ssh::run_interactive` swallows non-zero remote exit, so checking only
+    # `rc=0` would let a quickstart that bailed before the ssh leg slip
+    # through. Grep the tracing output for the connect line to confirm the
+    # claude exec was actually reached.
+    if grep -q "Connecting via SSH" "$tmpdir/qs1_err"; then
+        pass "first quickstart reached SSH/claude exec"
+    else
+        fail "first quickstart reached SSH/claude exec" \
+            "stderr: $(cat "$tmpdir/qs1_err")"
+    fi
+
     if "$BINARY" status "$qs_inst_name" >/dev/null 2>&1; then
         pass "quickstart created and started instance '$qs_inst_name'"
     else
@@ -1707,6 +1718,13 @@ test_quickstart() {
         pass "second quickstart exits 0 (reconnect path)"
     else
         fail "second quickstart exits 0" "exit: $rc; stderr: $(cat "$tmpdir/qs2_err")"
+    fi
+
+    if grep -q "Connecting via SSH" "$tmpdir/qs2_err"; then
+        pass "second quickstart reached SSH/claude exec"
+    else
+        fail "second quickstart reached SSH/claude exec" \
+            "stderr: $(cat "$tmpdir/qs2_err")"
     fi
 
     post_list=$("$BINARY" list 2>/dev/null | sort)
@@ -1731,6 +1749,13 @@ test_quickstart() {
         pass "third quickstart exits 0 (restart path)"
     else
         fail "third quickstart exits 0" "exit: $rc; stderr: $(cat "$tmpdir/qs3_err")"
+    fi
+
+    if grep -q "Connecting via SSH" "$tmpdir/qs3_err"; then
+        pass "third quickstart reached SSH/claude exec"
+    else
+        fail "third quickstart reached SSH/claude exec" \
+            "stderr: $(cat "$tmpdir/qs3_err")"
     fi
 
     if "$BINARY" status "$qs_inst_name" 2>/dev/null | grep -q -i running; then

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -138,6 +138,34 @@ guest_stderr() {
     cat "$tmpdir/guest_stderr" 2>/dev/null
 }
 
+# Cross-platform timeout wrapper. Prefer GNU timeout (Linux, or macOS with
+# coreutils installed as `gtimeout`); fall back to a perl-based implementation
+# since perl ships in the macOS base system.
+if command -v timeout >/dev/null 2>&1; then
+    _timeout() { timeout "$@"; }
+elif command -v gtimeout >/dev/null 2>&1; then
+    _timeout() { gtimeout "$@"; }
+else
+    _timeout() {
+        perl -e '
+            my $d = shift;
+            my $pid = fork() // die "fork: $!";
+            if ($pid == 0) { exec @ARGV; die "exec: $!"; }
+            local $SIG{ALRM} = sub {
+                kill TERM => $pid;
+                sleep 1;
+                kill KILL => $pid;
+                waitpid $pid, 0;
+                exit 124;
+            };
+            alarm $d;
+            waitpid $pid, 0;
+            alarm 0;
+            exit($? & 127 ? 128 + ($? & 127) : $? >> 8);
+        ' "$@"
+    }
+fi
+
 # Remove an instance from the tracked list.
 untrack_instance() {
     local target="$1"
@@ -1653,7 +1681,7 @@ test_idempotency() {
 # Claude is interactive — with stdin redirected from /dev/null `ssh` doesn't
 # allocate a PTY and the claude binary fails fast. `run_interactive` only
 # logs (does not error) on non-zero remote status, so quickstart still
-# returns 0 to the host. Each invocation is bounded with `timeout` defensively
+# returns 0 to the host. Each invocation is bounded with `_timeout` defensively
 # so a future claude that hangs on EOF can't wedge the suite.
 test_quickstart() {
     echo ""
@@ -1667,12 +1695,15 @@ test_quickstart() {
     local qs_ws qs_inst_name
     qs_ws=$(mktemp -d "$tmpdir/qs-ws-XXXXXX")
     # The instance name is the sanitised basename of the workspace path.
-    qs_inst_name=$(basename "$qs_ws" | tr -c 'a-zA-Z0-9_-' '-')
+    # `basename | tr` would rewrite the trailing newline to a dash; use bash
+    # pattern expansion to mirror `sanitize_basename` in src/config.rs.
+    qs_inst_name=${qs_ws##*/}
+    qs_inst_name=${qs_inst_name//[!a-zA-Z0-9_-]/-}
 
     # First invocation: image is already built (from test_setup) and no
     # instance for this workspace exists, so quickstart must allocate fresh.
     local rc=0
-    ( cd "$qs_ws" && timeout 180 "$BINARY" quickstart --no-devcontainer \
+    ( cd "$qs_ws" && _timeout 180 "$BINARY" quickstart --no-devcontainer \
         </dev/null >"$tmpdir/qs1_out" 2>"$tmpdir/qs1_err" ) || rc=$?
 
     if [[ $rc -eq 0 ]]; then
@@ -1711,7 +1742,7 @@ test_quickstart() {
     pre_list=$("$BINARY" list 2>/dev/null | sort)
 
     rc=0
-    ( cd "$qs_ws" && timeout 180 "$BINARY" quickstart --no-devcontainer \
+    ( cd "$qs_ws" && _timeout 180 "$BINARY" quickstart --no-devcontainer \
         </dev/null >"$tmpdir/qs2_out" 2>"$tmpdir/qs2_err" ) || rc=$?
 
     if [[ $rc -eq 0 ]]; then
@@ -1742,7 +1773,7 @@ test_quickstart() {
     fi
 
     rc=0
-    ( cd "$qs_ws" && timeout 180 "$BINARY" quickstart --no-devcontainer \
+    ( cd "$qs_ws" && _timeout 180 "$BINARY" quickstart --no-devcontainer \
         </dev/null >"$tmpdir/qs3_out" 2>"$tmpdir/qs3_err" ) || rc=$?
 
     if [[ $rc -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- New `coop quickstart` verb that chains ensure-image → ensure-instance → launch-claude, short-circuiting each step that's already done. Re-runnable: subsequent invocations from the same cwd reconnect to a running instance (or restart a stopped one) instead of allocating fresh, via the workspace-affinity lookup already used by `coop start`.
- `--no-workspace` opts out of the cwd mount; sensitive directories (`\$HOME`, `/`) prompt default-no on a TTY and bail non-interactively. `--no-devcontainer` keeps the same opt-out semantics as `coop start`.
- For per-instance tuning (profiles, mounts, image, …) the issue intentionally keeps users on `coop setup` / `coop start`; `quickstart` always uses the default image with no extras.

Implements the design from #74:
1. `setup::run` with `skip_confirm: true` when no template rootfs exists for the default image.
2. Workspace-affinity lookup (matching `find_stopped_instance`'s logic) → reconnect / restart / fresh.
3. Defaults `--workspace .` with `\$HOME`/`/` guardrails.
4. Same `prepend_binary` path as `coop claude` for the final exec.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` clean (602 unit tests, including 13 new ones covering CLI parsing, `is_sensitive_workspace`, `resolve_quickstart_workspace`, and `find_workspace_instance` with 0/1/multi matches).
- [x] `prek run --all-files` clean.
- [x] `coop quickstart --help` renders correctly.
- [ ] Integration test (`test_quickstart` in `tests/integration.sh`, gated on `--full`) — exercises three lifecycle paths: fresh allocate, reconnect, restart-stopped. Will need to be run on Linux/Firecracker and macOS/Lima before landing.

## Notes

- `is_sensitive_workspace` takes `home: Option<&Path>` rather than reading the env directly so the unit tests can pin it without mutating process state.
- `default_image_name()` in `config.rs` was bumped from private to `pub(crate)` for reuse — the construction is still pinned by the existing `default_image_is_valid` test.
- `cmd_start`'s "ignored flags on restart" check (workspace/mounts/disk passed but the instance already exists) is bypassed for the quickstart restart path by calling with name-only and no workspace, so the second `quickstart` from the same cwd doesn't trip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)