### PR TITLE
Allocate a fresh instance for bare `coop start --mount` (closes #214)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1181,6 +1181,21 @@ struct StartOpts<'a> {
     persisted_guest_env: std::collections::BTreeMap<guest_env_state::EnvVarName, String>,
 }
 
+/// Did the user pass creation-only flags (`--mount`, `--git-repo`, `--disk`,
+/// `--exclude-git`) without an identifier (`--name` or `--workspace`) that
+/// could pick out an existing instance?
+///
+/// When true, `cmd_start` must allocate a fresh instance rather than fall
+/// back to the "single stopped instance" shortcut in `find_stopped_instance`.
+fn creation_intent_without_target(opts: &StartOpts<'_>) -> bool {
+    let identifies_existing = opts.name.is_some() || opts.workspace_dir.is_some();
+    let has_creation_only_flags = !opts.mounts.is_empty()
+        || opts.git_repo.is_some()
+        || opts.disk.is_some()
+        || opts.exclude_git;
+    has_creation_only_flags && !identifies_existing
+}
+
 fn cmd_start(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
@@ -1188,7 +1203,20 @@ fn cmd_start(
     opts: &StartOpts<'_>,
 ) -> Result<()> {
     let ws_path = opts.workspace_dir.map(Path::new);
-    if let Some(inst) = find_stopped_instance(be, cfg, opts.name, ws_path)? {
+
+    // Creation-only flags (`--mount`, `--git-repo`, `--disk`, `--exclude-git`)
+    // unambiguously signal "I want a new VM with these settings". When the user
+    // didn't also identify an existing instance (via `--name` or `--workspace`),
+    // skip the single-stopped-instance shortcut in `find_stopped_instance` —
+    // otherwise we'd tell the user to destroy an unrelated stopped instance
+    // when their real intent was to allocate a fresh one (issue #214).
+    let restart_candidate = if creation_intent_without_target(opts) {
+        None
+    } else {
+        find_stopped_instance(be, cfg, opts.name, ws_path)?
+    };
+
+    if let Some(inst) = restart_candidate {
         let has_ignored_flags = !opts.mounts.is_empty()
             || opts.workspace_dir.is_some()
             || opts.git_repo.is_some()
@@ -3018,6 +3046,88 @@ mod tests {
         let opts = start_opts(Vec::new(), &cfg_path);
         let slug = super::resolve_start_repo(&opts).expect("ok");
         assert!(slug.is_none());
+    }
+
+    /// Issue #214 regression: bare `coop start --mount <dir>` must signal
+    /// "allocate a new VM" even when an unrelated stopped instance exists.
+    #[test]
+    fn creation_intent_without_target_detects_bare_mount() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mount = super::config::Mount {
+            host_path: tmp.path().to_path_buf(),
+            guest_path: super::workspace::default_workspace_path(),
+        };
+        let cfg_path = tmp.path().join("config.toml");
+        let opts = start_opts(vec![mount], &cfg_path);
+        assert!(super::creation_intent_without_target(&opts));
+    }
+
+    #[test]
+    fn creation_intent_without_target_detects_git_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("config.toml");
+        let mut opts = start_opts(Vec::new(), &cfg_path);
+        opts.git_repo = Some("trailofbits/coop");
+        assert!(super::creation_intent_without_target(&opts));
+    }
+
+    #[test]
+    fn creation_intent_without_target_detects_disk() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("config.toml");
+        let mut opts = start_opts(Vec::new(), &cfg_path);
+        opts.disk = super::config::GiB::new(20);
+        assert!(super::creation_intent_without_target(&opts));
+    }
+
+    #[test]
+    fn creation_intent_without_target_detects_exclude_git() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("config.toml");
+        let mut opts = start_opts(Vec::new(), &cfg_path);
+        opts.exclude_git = true;
+        assert!(super::creation_intent_without_target(&opts));
+    }
+
+    /// A `--name` defers to the find/restart path even with creation-only
+    /// flags; the bail message there still tells the user how to proceed.
+    #[test]
+    fn creation_intent_without_target_false_when_name_given() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mount = super::config::Mount {
+            host_path: tmp.path().to_path_buf(),
+            guest_path: super::workspace::default_workspace_path(),
+        };
+        let cfg_path = tmp.path().join("config.toml");
+        let name = super::config::InstanceName::new("explicit").expect("valid name");
+        let mut opts = start_opts(vec![mount], &cfg_path);
+        opts.name = Some(&name);
+        assert!(!super::creation_intent_without_target(&opts));
+    }
+
+    /// A `--workspace` is the affinity key for restart; the find path keeps
+    /// owning that decision so workspace-matched instances can be restarted.
+    #[test]
+    fn creation_intent_without_target_false_when_workspace_given() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mount = super::config::Mount {
+            host_path: tmp.path().to_path_buf(),
+            guest_path: super::workspace::default_workspace_path(),
+        };
+        let cfg_path = tmp.path().join("config.toml");
+        let mut opts = start_opts(vec![mount], &cfg_path);
+        opts.workspace_dir = Some("/some/workspace");
+        assert!(!super::creation_intent_without_target(&opts));
+    }
+
+    /// `coop start` with no flags must keep going through the
+    /// single-stopped-instance lookup — that's the normal restart UX.
+    #[test]
+    fn creation_intent_without_target_false_for_bare_start() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("config.toml");
+        let opts = start_opts(Vec::new(), &cfg_path);
+        assert!(!super::creation_intent_without_target(&opts));
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1470,6 +1470,67 @@ test_restart_rejects_ignored_flags() {
     rm -rf "$mount_dir"
 }
 
+# Issue #214 regression: with $INSTANCE stopped and unrelated to the user's
+# intent, `coop start --mount <dir>` (no --name, no --workspace) must allocate
+# a fresh VM rather than reusing the stopped one or bailing with a destroy
+# advisory. The unit tests cover the predicate; this phase exercises the full
+# cmd_start path that uses it.
+test_bare_start_allocates_fresh() {
+    echo ""
+    echo "=== Phase: bare start --mount allocates fresh instance ==="
+
+    local mount_dir
+    mount_dir=$(mktemp -d)
+
+    # Snapshot instance names before allocating. The only entry should be the
+    # stopped $INSTANCE left by the previous phase.
+    local before_names
+    before_names=$(RUST_LOG=off "$BINARY" status 2>/dev/null \
+        | awk '/running|stopped/ {print $1}' | sort -u)
+
+    if ! coop start --no-agents --mount "$mount_dir"; then
+        fail "bare start --mount exits 0" "exit=$?; stderr: $HARNESS_ERR"
+        rm -rf "$mount_dir"
+        return
+    fi
+    pass "bare start --mount exits 0"
+
+    local after_names
+    after_names=$(RUST_LOG=off "$BINARY" status 2>/dev/null \
+        | awk '/running|stopped/ {print $1}' | sort -u)
+
+    local new_name
+    new_name=$(comm -13 <(echo "$before_names") <(echo "$after_names") | head -n1)
+
+    if [[ -z "$new_name" ]]; then
+        fail "fresh instance allocated" "no new name in status; after: $after_names"
+        rm -rf "$mount_dir"
+        return
+    fi
+    STARTED_INSTANCES+=("$new_name")
+    pass "fresh instance allocated ($new_name)"
+
+    if [[ "$new_name" == "$INSTANCE" ]]; then
+        fail "fresh instance is distinct from stopped \$INSTANCE" "got: $new_name"
+    else
+        pass "fresh instance is distinct from stopped \$INSTANCE"
+    fi
+
+    # The pre-existing $INSTANCE must remain stopped and untouched.
+    if RUST_LOG=off "$BINARY" status 2>/dev/null | grep -qE "^${INSTANCE} +stopped\\b"; then
+        pass "pre-existing stopped instance untouched"
+    else
+        fail "pre-existing stopped instance untouched" \
+            "status: $(RUST_LOG=off "$BINARY" status 2>/dev/null)"
+    fi
+
+    # Tear down the freshly allocated instance so subsequent phases see the
+    # same world they expect: $INSTANCE stopped, no other coop VMs.
+    coop destroy "$new_name" 2>/dev/null || true
+    untrack_instance "$new_name"
+    rm -rf "$mount_dir"
+}
+
 test_destroy() {
     echo ""
     echo "=== Phase: destroy ==="
@@ -3308,6 +3369,7 @@ main() {
     test_resize_status
     test_restart_stopped
     test_restart_rejects_ignored_flags
+    test_bare_start_allocates_fresh
     test_destroy
     test_auto_resolve_no_instances
     test_list_empty


### PR DESCRIPTION
## Summary

- Bare `coop start --mount <dir>` (no `--name`, no `--workspace`) now allocates a new VM instead of picking up an unrelated stopped instance and bailing with destroy advice.
- Adds a small helper, `creation_intent_without_target`, that gates the "single stopped instance" shortcut in `find_stopped_instance`. The bail message still fires when the user explicitly named or workspace-keyed an existing instance and passed creation-only flags alongside it.

## Test plan

- [x] `cargo test` — 7 new unit tests covering each creation-only flag (`--mount`, `--git-repo`, `--disk`, `--exclude-git`) and the three negative cases (`--name`, `--workspace`, bare `start`).
- [x] `prek run --all-files` — fmt / clippy / cargo test all pass.
- [ ] Manual: with a stopped instance `0`, run `coop start --mount /tmp/foo` and confirm it allocates `1` instead of erroring out.