### PR TITLE
Make the guest user configurable; honor devcontainer remoteUser (closes #217)

### DIFF
--- a/scripts/guest/claude-code.sh
+++ b/scripts/guest/claude-code.sh
@@ -1,11 +1,14 @@
 set -euo pipefail
 
+# GUEST_USER is exported by the orchestrator (setup.rs / lima.rs).
+: "${GUEST_USER:?GUEST_USER must be set by the orchestrator}"
+
 # Skip if a profile already provided a claude binary (e.g. stub-claude
 # for testing). Profile post_install scripts run before this script.
 # Using if/else (not early `exit 0`) because this file is concatenated
 # with codex.sh into a single shell invocation; an unconditional exit
 # would skip the codex installer too.
-if [ -x /home/ubuntu/.local/bin/claude ]; then
+if [ -x "/home/${GUEST_USER}/.local/bin/claude" ]; then
     echo '  [guest] Claude Code CLI already installed, skipping.'
 else
     echo '  [guest] Installing Claude Code CLI...'
@@ -42,5 +45,5 @@ else
         RETRY_DELAY=$((RETRY_DELAY * 2))
     done
 
-    su - ubuntu -c "bash '$INSTALLER'" </dev/null
+    su - "${GUEST_USER}" -c "bash '$INSTALLER'" </dev/null
 fi

--- a/scripts/guest/guest-config.sh
+++ b/scripts/guest/guest-config.sh
@@ -58,43 +58,48 @@ cat > /etc/systemd/system/docker.service.d/no-raw.conf <<'DROPINEOF'
 Environment="DOCKER_INSECURE_NO_IPTABLES_RAW=1"
 DROPINEOF
 
-echo '  [guest] Ensuring ubuntu user exists (uid 1000)...'
-if id ubuntu &>/dev/null; then
-    usermod -aG sudo,docker ubuntu
+# GUEST_USER is exported by the orchestrator before this script runs.
+: "${GUEST_USER:?GUEST_USER must be set by the orchestrator}"
+GUEST_HOME="/home/${GUEST_USER}"
+
+echo "  [guest] Ensuring ${GUEST_USER} user exists (uid 1000)..."
+if id "${GUEST_USER}" &>/dev/null; then
+    usermod -aG sudo,docker "${GUEST_USER}"
 else
-    # Remove any other user occupying uid 1000 (e.g. Lima's host-mirror user)
+    # Remove any other user occupying uid 1000 (e.g. the CI rootfs's ubuntu,
+    # or Lima's host-mirror user) before creating ours with the same uid.
     EXISTING=$(getent passwd 1000 | cut -d: -f1) || true
     if [[ -n "$EXISTING" ]]; then
         userdel "$EXISTING"
     fi
-    useradd -m -s /bin/bash --uid 1000 -G sudo,docker ubuntu
+    useradd -m -s /bin/bash --uid 1000 -G sudo,docker "${GUEST_USER}"
 fi
-echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu
-chmod 440 /etc/sudoers.d/ubuntu
+echo "${GUEST_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${GUEST_USER}"
+chmod 440 "/etc/sudoers.d/${GUEST_USER}"
 
 # Ensure home directory exists with correct ownership
-mkdir -p /home/ubuntu
-chown ubuntu:ubuntu /home/ubuntu
-chmod 755 /home/ubuntu
+mkdir -p "${GUEST_HOME}"
+chown "${GUEST_USER}:${GUEST_USER}" "${GUEST_HOME}"
+chmod 755 "${GUEST_HOME}"
 
 # Create .local tree — the Claude Code installer expects to write here
-install -d -o ubuntu -g ubuntu /home/ubuntu/.local
-install -d -o ubuntu -g ubuntu /home/ubuntu/.local/bin
-install -d -o ubuntu -g ubuntu /home/ubuntu/.local/share
+install -d -o "${GUEST_USER}" -g "${GUEST_USER}" "${GUEST_HOME}/.local"
+install -d -o "${GUEST_USER}" -g "${GUEST_USER}" "${GUEST_HOME}/.local/bin"
+install -d -o "${GUEST_USER}" -g "${GUEST_USER}" "${GUEST_HOME}/.local/share"
 
-# Copy SSH authorized_keys to ubuntu user
-mkdir -p /home/ubuntu/.ssh
-cp /root/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys
-chown -R ubuntu:ubuntu /home/ubuntu/.ssh
-chmod 700 /home/ubuntu/.ssh
-chmod 600 /home/ubuntu/.ssh/authorized_keys
+# Copy SSH authorized_keys to the guest user
+mkdir -p "${GUEST_HOME}/.ssh"
+cp /root/.ssh/authorized_keys "${GUEST_HOME}/.ssh/authorized_keys"
+chown -R "${GUEST_USER}:${GUEST_USER}" "${GUEST_HOME}/.ssh"
+chmod 700 "${GUEST_HOME}/.ssh"
+chmod 600 "${GUEST_HOME}/.ssh/authorized_keys"
 
-echo '  [guest] Configuring ubuntu user PATH...'
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/ubuntu/.profile
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/ubuntu/.bashrc
+echo "  [guest] Configuring ${GUEST_USER} user PATH..."
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${GUEST_HOME}/.profile"
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${GUEST_HOME}/.bashrc"
 
 echo '  [guest] Symlinking claude into system PATH...'
-ln -sf /home/ubuntu/.local/bin/claude /usr/local/bin/claude
+ln -sf "${GUEST_HOME}/.local/bin/claude" /usr/local/bin/claude
 
 echo '  [guest] Installing claude-yolo shortcut...'
 cat > /usr/local/bin/claude-yolo <<'YOLOEOF'
@@ -112,7 +117,7 @@ chmod 755 /usr/local/bin/codex-yolo
 
 echo '  [guest] Preparing workspace directory...'
 mkdir -p /workspace
-chown ubuntu:ubuntu /workspace
+chown "${GUEST_USER}:${GUEST_USER}" /workspace
 
 echo '  [guest] Enabling services...'
 systemctl enable docker ssh systemd-networkd serial-getty@ttyS0

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -914,10 +914,11 @@ impl VmBackend for FirecrackerBackend {
     }
 
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {
+        let guest_user = persisted_guest_user(cfg, &inst.image);
         Ok(SshTarget {
             host: Hostname::new(inst.guest_ip())?,
             port: cfg.ssh_port,
-            user: SshUser::new(crate::guest::GUEST_USER)?,
+            user: SshUser::new(guest_user.as_str())?,
             key_path: cfg.ssh_key_path(),
         })
     }
@@ -1233,9 +1234,10 @@ fn bootstrap_claude(
             || !claude.mcp_servers.is_empty();
 
         if needs_claude_cli
-            && !session
-                .target
-                .exec_ok(&format!("test -x {}", crate::guest::CLAUDE_BIN))
+            && !session.target.exec_ok(&format!(
+                "test -x {}",
+                crate::guest::claude_bin_for(session.target.user.as_ref())
+            ))
         {
             bail!(
                 "Claude Code CLI is not installed in the guest.\n\
@@ -1315,6 +1317,17 @@ fn codex_missing_guest_cli_message() -> &'static str {
      If you want to skip Codex bootstrap for now, retry with \
      `--no-agents` (the `--no-claude` alias is deprecated).\n\
      Otherwise run `coop setup --rebuild` to rebuild the image."
+}
+
+/// Load the persisted guest user for an image, falling back to the
+/// default `ubuntu` when no `template_config.json` exists yet (e.g.
+/// the SSH target is being requested before setup has written the
+/// config). Returning the default keeps pre-existing call sites
+/// working unchanged on legacy images.
+pub fn persisted_guest_user(cfg: &CoopConfig, image: &ImageName) -> crate::guest::GuestUser {
+    crate::setup::TemplateConfig::load_for(cfg, image)
+        .map(|tc| tc.guest_user)
+        .unwrap_or_default()
 }
 
 /// Compute which marketplaces and plugins are missing from the
@@ -1796,7 +1809,7 @@ pub(crate) fn install_marketplaces(session: &SshSession, marketplaces: &[String]
         tracing::info!("Adding marketplace: {guest_source}");
         let cmd = format!(
             "{} plugin marketplace add {} --scope user",
-            crate::guest::CLAUDE_BIN,
+            crate::guest::claude_bin_for(session.target.user.as_ref()),
             shell_escape(&guest_source),
         );
         session
@@ -1811,7 +1824,7 @@ pub(crate) fn install_plugins(session: &SshSession, plugins: &[String]) -> Resul
         tracing::info!("Installing plugin: {plugin}");
         let cmd = format!(
             "{} plugin install {} -s user",
-            crate::guest::CLAUDE_BIN,
+            crate::guest::claude_bin_for(session.target.user.as_ref()),
             shell_escape(plugin),
         );
         session
@@ -1835,7 +1848,7 @@ fn register_mcp_servers(
             .context("Failed to serialize MCP server definition")?;
         let cmd = format!(
             "{} mcp add-json -s user {} {}",
-            crate::guest::CLAUDE_BIN,
+            crate::guest::claude_bin_for(session.target.user.as_ref()),
             shell_escape(name),
             shell_escape(&json),
         );

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1227,18 +1227,14 @@ fn bootstrap_claude(
     mode: BootMode,
 ) -> Result<()> {
     let claude = &cfg.claude;
+    let claude_bin = persisted_guest_user(cfg, &inst.image).claude_bin();
 
     if let BootMode::FirstBoot = mode {
         let needs_claude_cli = !claude.marketplaces.is_empty()
             || !claude.plugins.is_empty()
             || !claude.mcp_servers.is_empty();
 
-        if needs_claude_cli
-            && !session.target.exec_ok(&format!(
-                "test -x {}",
-                crate::guest::claude_bin_for(session.target.user.as_ref())
-            ))
-        {
+        if needs_claude_cli && !session.target.exec_ok(&format!("test -x {claude_bin}")) {
             bail!(
                 "Claude Code CLI is not installed in the guest.\n\
                  The golden image may have been built before the \
@@ -1263,15 +1259,15 @@ fn bootstrap_claude(
         let (missing_marketplaces, missing_plugins) = compute_plugin_delta(cfg, &inst.image);
 
         if !missing_marketplaces.is_empty() {
-            install_marketplaces(session, &missing_marketplaces)?;
+            install_marketplaces(session, &claude_bin, &missing_marketplaces)?;
         }
 
         if !missing_plugins.is_empty() {
-            install_plugins(session, &missing_plugins)?;
+            install_plugins(session, &claude_bin, &missing_plugins)?;
         }
 
         if !claude.mcp_servers.is_empty() {
-            register_mcp_servers(session, &claude.mcp_servers)?;
+            register_mcp_servers(session, &claude_bin, &claude.mcp_servers)?;
         }
     }
 
@@ -1295,7 +1291,7 @@ fn bootstrap_codex(session: &SshSession, cfg: &CoopConfig, mode: BootMode) -> Re
 
     if !session
         .target
-        .exec_ok(&format!("test -x {}", crate::guest::CODEX_BIN))
+        .exec_ok(&format!("test -x {}", crate::guest::codex_bin()))
     {
         bail!("{}", codex_missing_guest_cli_message());
     }
@@ -1771,7 +1767,11 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 
 const GUEST_MARKETPLACE_DIR: &str = "~/.coop/marketplaces";
 
-pub(crate) fn install_marketplaces(session: &SshSession, marketplaces: &[String]) -> Result<()> {
+pub(crate) fn install_marketplaces(
+    session: &SshSession,
+    claude_bin: &GuestPath,
+    marketplaces: &[String],
+) -> Result<()> {
     let mut has_local = false;
 
     for source in marketplaces {
@@ -1808,8 +1808,7 @@ pub(crate) fn install_marketplaces(session: &SshSession, marketplaces: &[String]
 
         tracing::info!("Adding marketplace: {guest_source}");
         let cmd = format!(
-            "{} plugin marketplace add {} --scope user",
-            crate::guest::claude_bin_for(session.target.user.as_ref()),
+            "{claude_bin} plugin marketplace add {} --scope user",
             shell_escape(&guest_source),
         );
         session
@@ -1819,12 +1818,15 @@ pub(crate) fn install_marketplaces(session: &SshSession, marketplaces: &[String]
     Ok(())
 }
 
-pub(crate) fn install_plugins(session: &SshSession, plugins: &[String]) -> Result<()> {
+pub(crate) fn install_plugins(
+    session: &SshSession,
+    claude_bin: &GuestPath,
+    plugins: &[String],
+) -> Result<()> {
     for plugin in plugins {
         tracing::info!("Installing plugin: {plugin}");
         let cmd = format!(
-            "{} plugin install {} -s user",
-            crate::guest::claude_bin_for(session.target.user.as_ref()),
+            "{claude_bin} plugin install {} -s user",
             shell_escape(plugin),
         );
         session
@@ -1836,6 +1838,7 @@ pub(crate) fn install_plugins(session: &SshSession, plugins: &[String]) -> Resul
 
 fn register_mcp_servers(
     session: &SshSession,
+    claude_bin: &GuestPath,
     servers: &std::collections::HashMap<String, McpServerDef>,
 ) -> Result<()> {
     for (name, def) in servers {
@@ -1847,8 +1850,7 @@ fn register_mcp_servers(
         let json = serde_json::to_string(&resolved)
             .context("Failed to serialize MCP server definition")?;
         let cmd = format!(
-            "{} mcp add-json -s user {} {}",
-            crate::guest::claude_bin_for(session.target.user.as_ref()),
+            "{claude_bin} mcp add-json -s user {} {}",
             shell_escape(name),
             shell_escape(&json),
         );

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -19,7 +19,7 @@ use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
 use crate::config::{self, CoopConfig, GiB, MiB, Mount, PortForward};
-use crate::guest::{BuiltinProfile, builtin_for_feature};
+use crate::guest::{BuiltinProfile, GuestUser, builtin_for_feature};
 use crate::guest_env_state::EnvVarName;
 
 /// Default relative path coop looks for inside a workspace or mount root.
@@ -346,7 +346,6 @@ impl Report {
 /// All fields share the `cli_` prefix on purpose: the report needs to
 /// distinguish CLI-sourced values from any other state, and the prefix
 /// reads as a stable boundary in call sites that build this struct.
-#[expect(clippy::struct_field_names, reason = "cli_ prefix is load-bearing")]
 #[derive(Debug, Default)]
 pub struct TranslatorInputs {
     pub cli_vcpus: Option<u8>,
@@ -357,6 +356,17 @@ pub struct TranslatorInputs {
     pub cli_forward_ports: Vec<PortForward>,
     pub cli_mounts: Vec<Mount>,
     pub cli_profiles: Vec<String>,
+    /// CLI-provided guest user, when `--guest-user` was passed to
+    /// `coop setup`. When set, the translator reports the
+    /// devcontainer's `remoteUser` as `Overridden` rather than applying
+    /// it. Only meaningful at `Stage::Setup`.
+    pub cli_guest_user: Option<GuestUser>,
+    /// Persisted guest user from the image's `template_config.json`.
+    /// Only meaningful at `Stage::Start` — the translator compares this
+    /// against the devcontainer's `remoteUser` and skips `containerEnv`
+    /// translation on mismatch (the env vars would target a home dir
+    /// that doesn't exist).
+    pub persisted_guest_user: Option<GuestUser>,
     /// True when the caller passed `--workspace` or `--git-repo`. coop's
     /// `start` path uses `--mount` only when neither of these is set, so
     /// devcontainer `mounts` are dropped with a report row pointing at
@@ -386,6 +396,10 @@ pub struct Translation {
     pub forward_ports: Vec<PortForward>,
     pub mounts: Vec<Mount>,
     pub profiles: Vec<String>,
+    /// Guest user requested by the devcontainer's `remoteUser`, when
+    /// no CLI `--guest-user` overrode it. Only set at `Stage::Setup`;
+    /// callers fold this into `SetupOptions`.
+    pub guest_user: Option<GuestUser>,
     pub report: Report,
 }
 
@@ -453,7 +467,17 @@ pub fn translate(
     }
 
     if let Some(env) = &file.raw.container_env {
-        translate_container_env(env, inputs, stage, &mut t);
+        if stage == Stage::Start && remote_user_mismatch(file, inputs) {
+            t.report.push(
+                "containerEnv",
+                ReportStatus::Unsupported,
+                ReportSource::Devcontainer,
+                format!("{} entries", env.len()),
+                "skipped because devcontainer.json's `remoteUser` does not match the image",
+            );
+        } else {
+            translate_container_env(env, inputs, stage, &mut t);
+        }
     }
 
     if let Some(ports) = &file.raw.forward_ports {
@@ -469,24 +493,7 @@ pub fn translate(
     }
 
     if let Some(user) = &file.raw.remote_user {
-        let key = "remoteUser";
-        if user == "ubuntu" {
-            t.report.push(
-                key,
-                ReportStatus::Applied,
-                ReportSource::Devcontainer,
-                user.clone(),
-                "matches coop's hardcoded guest user",
-            );
-        } else {
-            t.report.push(
-                key,
-                ReportStatus::Unsupported,
-                ReportSource::Devcontainer,
-                user.clone(),
-                "coop hardcodes the guest user to 'ubuntu' in v1",
-            );
-        }
+        translate_remote_user(user, inputs, stage, &mut t);
     }
 
     if file.raw.image.is_some() {
@@ -639,6 +646,120 @@ fn translate_host_requirements(
             "unrecognised hostRequirements key",
         );
     }
+}
+
+/// Translate `remoteUser`. The behaviour differs by stage:
+///
+/// - At `Stage::Setup`, a valid `remoteUser` becomes the requested
+///   guest user unless `--guest-user` already pinned one (then we
+///   report `Overridden`).
+/// - At `Stage::Start`, the persisted user is already baked into the
+///   image. We compare and report `Applied` on match or `Mismatch` on
+///   divergence — `translate_container_env` reads back the mismatch
+///   and refuses to forward env vars whose paths target a missing
+///   home dir.
+fn translate_remote_user(user: &str, inputs: &TranslatorInputs, stage: Stage, t: &mut Translation) {
+    let key = "remoteUser";
+    let parsed = match GuestUser::new(user) {
+        Ok(u) => u,
+        Err(e) => {
+            t.report.push(
+                key,
+                ReportStatus::Invalid,
+                ReportSource::Devcontainer,
+                user.to_string(),
+                e.to_string(),
+            );
+            return;
+        }
+    };
+
+    match stage {
+        Stage::Setup => {
+            if let Some(cli) = &inputs.cli_guest_user {
+                t.report.push(
+                    key,
+                    ReportStatus::Overridden,
+                    ReportSource::Cli,
+                    cli.to_string(),
+                    format!("CLI --guest-user overrides devcontainer.json value {parsed}"),
+                );
+            } else {
+                t.guest_user = Some(parsed.clone());
+                t.report.push(
+                    key,
+                    ReportStatus::Applied,
+                    ReportSource::Devcontainer,
+                    parsed.to_string(),
+                    "baked into the image at setup time",
+                );
+            }
+        }
+        Stage::Start => match &inputs.persisted_guest_user {
+            Some(persisted) if persisted == &parsed => {
+                t.report.push(
+                    key,
+                    ReportStatus::Applied,
+                    ReportSource::Devcontainer,
+                    parsed.to_string(),
+                    "matches the image's persisted guest user",
+                );
+            }
+            Some(persisted) => {
+                t.report.push(
+                    key,
+                    ReportStatus::Unsupported,
+                    ReportSource::Devcontainer,
+                    parsed.to_string(),
+                    format!(
+                        "image was set up with `{persisted}`; \
+                         `coop destroy && coop setup --guest-user {parsed}` to switch \
+                         (containerEnv skipped to avoid pointing at /home/{parsed})"
+                    ),
+                );
+            }
+            None => {
+                // Image lacks a persisted user (legacy template_config.json
+                // or template missing). Default is `ubuntu`.
+                let default = GuestUser::default();
+                if parsed == default {
+                    t.report.push(
+                        key,
+                        ReportStatus::Applied,
+                        ReportSource::Devcontainer,
+                        parsed.to_string(),
+                        "matches the default guest user",
+                    );
+                } else {
+                    t.report.push(
+                        key,
+                        ReportStatus::Unsupported,
+                        ReportSource::Devcontainer,
+                        parsed.to_string(),
+                        format!(
+                            "image was set up with the default `{default}`; \
+                             `coop destroy && coop setup --guest-user {parsed}` to switch"
+                        ),
+                    );
+                }
+            }
+        },
+    }
+}
+
+/// True at `Stage::Start` iff the devcontainer's `remoteUser` does not
+/// match the image's persisted guest user. When this returns `true` the
+/// translator must not forward `containerEnv` — env values often
+/// reference `/home/<remoteUser>/...` paths that don't exist on disk.
+fn remote_user_mismatch(file: &ParsedDevcontainer, inputs: &TranslatorInputs) -> bool {
+    let Some(user) = &file.raw.remote_user else {
+        return false;
+    };
+    let Ok(parsed) = GuestUser::new(user) else {
+        return false;
+    };
+    let persisted = inputs.persisted_guest_user.clone().unwrap_or_default();
+    persisted != parsed
 }
 
 fn translate_container_env(
@@ -1410,7 +1531,7 @@ mod tests {
     }
 
     #[test]
-    fn translate_remote_user_warns_unless_ubuntu() {
+    fn translate_remote_user_rejects_root() {
         let f = parse(r#"{ "remoteUser": "root" }"#);
         let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
         let entry = t
@@ -1419,8 +1540,11 @@ mod tests {
             .iter()
             .find(|e| e.key == "remoteUser")
             .unwrap();
-        assert_eq!(entry.status, ReportStatus::Unsupported);
+        assert_eq!(entry.status, ReportStatus::Invalid);
+    }
 
+    #[test]
+    fn translate_remote_user_matching_default_applies_at_start() {
         let f = parse(r#"{ "remoteUser": "ubuntu" }"#);
         let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
         let entry = t
@@ -1430,6 +1554,92 @@ mod tests {
             .find(|e| e.key == "remoteUser")
             .unwrap();
         assert_eq!(entry.status, ReportStatus::Applied);
+    }
+
+    #[test]
+    fn translate_remote_user_setup_captures_into_translation() {
+        let f = parse(r#"{ "remoteUser": "vscode" }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Setup);
+        assert_eq!(t.guest_user.as_ref().map(GuestUser::as_str), Some("vscode"));
+        let entry = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "remoteUser")
+            .unwrap();
+        assert_eq!(entry.status, ReportStatus::Applied);
+        assert_eq!(entry.source, ReportSource::Devcontainer);
+    }
+
+    #[test]
+    fn translate_remote_user_setup_cli_overrides() {
+        let f = parse(r#"{ "remoteUser": "vscode" }"#);
+        let inputs = TranslatorInputs {
+            cli_guest_user: Some(GuestUser::new("ubuntu").unwrap()),
+            ..TranslatorInputs::default()
+        };
+        let t = translate(&f, &inputs, Stage::Setup);
+        // Translation must not bake `vscode` when CLI pinned `ubuntu`.
+        assert!(t.guest_user.is_none());
+        let entry = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "remoteUser")
+            .unwrap();
+        assert_eq!(entry.status, ReportStatus::Overridden);
+        assert_eq!(entry.source, ReportSource::Cli);
+    }
+
+    #[test]
+    fn translate_remote_user_start_mismatch_reports_unsupported() {
+        let f = parse(r#"{ "remoteUser": "vscode" }"#);
+        let inputs = TranslatorInputs {
+            persisted_guest_user: Some(GuestUser::new("ubuntu").unwrap()),
+            ..TranslatorInputs::default()
+        };
+        let t = translate(&f, &inputs, Stage::Start);
+        let entry = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "remoteUser")
+            .unwrap();
+        assert_eq!(entry.status, ReportStatus::Unsupported);
+        let note = &entry.note;
+        assert!(
+            note.contains("ubuntu") && note.contains("vscode"),
+            "diagnostic should name both users: {note}"
+        );
+    }
+
+    #[test]
+    fn translate_remote_user_start_mismatch_skips_container_env() {
+        // The triggering bug: a mismatched remoteUser must not forward
+        // env vars like GIT_CONFIG_GLOBAL=/home/vscode/.gitconfig.local
+        // into a `ubuntu`-based image.
+        let f = parse(
+            r#"{
+                "remoteUser": "vscode",
+                "containerEnv": { "GIT_CONFIG_GLOBAL": "/home/vscode/.gitconfig.local" }
+            }"#,
+        );
+        let inputs = TranslatorInputs {
+            persisted_guest_user: Some(GuestUser::new("ubuntu").unwrap()),
+            ..TranslatorInputs::default()
+        };
+        let t = translate(&f, &inputs, Stage::Start);
+        assert!(
+            t.guest_env.is_empty(),
+            "containerEnv must not be forwarded on remoteUser mismatch"
+        );
+        let env_entry = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "containerEnv")
+            .unwrap();
+        assert_eq!(env_entry.status, ReportStatus::Unsupported);
     }
 
     #[test]

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -7,6 +7,7 @@ use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{CoopConfig, CustomProfile};
+use crate::paths::GuestPath;
 
 /// Devcontainer feature ids (bare names) that map to builtin profiles.
 /// The id is the same string as the builtin name; this slice acts as the
@@ -95,10 +96,29 @@ impl GuestUser {
         &self.0
     }
 
-    /// Absolute home directory of this user inside the guest.
-    pub fn home(&self) -> String {
-        format!("/home/{}", self.0)
+    /// Absolute home directory of this user inside the guest. Returned
+    /// as a `GuestPath` so call sites can't accidentally confuse it
+    /// with a host `PathBuf` or another string. The result is absolute
+    /// by construction — `/home/<validated user>` — so we don't pay
+    /// for the runtime check on `GuestPath::absolute`.
+    pub fn home(&self) -> GuestPath {
+        GuestPath::new(format!("/home/{}", self.0))
     }
+
+    /// Where the Claude Code installer places the per-user binary.
+    /// The installer writes to `~/.local/bin/claude`; coop calls this
+    /// path directly because non-interactive SSH sessions don't source
+    /// `.bashrc`/`.profile` and so don't have `~/.local/bin` on PATH.
+    pub fn claude_bin(&self) -> GuestPath {
+        GuestPath::new(format!("/home/{}/.local/bin/claude", self.0))
+    }
+}
+
+/// Where the Codex CLI installer places the system-wide binary.
+/// Independent of the guest user — Codex lives in `/usr/local/bin`,
+/// not in any user's home — so callers don't pass a `GuestUser`.
+pub fn codex_bin() -> GuestPath {
+    GuestPath::new("/usr/local/bin/codex")
 }
 
 impl Default for GuestUser {
@@ -136,34 +156,20 @@ impl From<GuestUser> for String {
     }
 }
 
-/// Absolute path to the Claude Code binary in the guest, for the given
-/// user. The installer places the binary under `~/.local/bin/claude`.
-/// Bootstrap commands and verification use this path directly rather
-/// than relying on PATH (non-interactive SSH sessions don't source
-/// `.bashrc`/`.profile`).
-///
-/// Accepts `&str` so call sites can pass either a `GuestUser` (via
-/// `as_str()`) or an `SshUser` (via `as_ref()`) without an extra
-/// conversion. The same validation applies in both directions.
-pub fn claude_bin_for(user: &str) -> String {
-    format!("/home/{user}/.local/bin/claude")
-}
-
-/// Absolute path to the Codex CLI binary in the guest.
-///
-/// The installer places a standalone binary in `/usr/local/bin`, so
-/// both bootstrap and verification can rely on a stable path.
-pub const CODEX_BIN: &str = "/usr/local/bin/codex";
-
 /// Binaries that must exist in the guest image after provisioning.
 /// Absolute paths are checked directly; bare names are looked up via
 /// `command -v` (i.e. must be in the default system PATH).
-pub fn required_guest_binaries(user: &GuestUser) -> [String; 4] {
+///
+/// Returns `GuestPath`s rather than raw strings so call sites that
+/// build shell commands or inspect the chroot get path semantics for
+/// free (and the `/usr/bin/docker`/`/usr/bin/gh` entries can't be
+/// mistaken for host paths).
+pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 4] {
     [
-        "/usr/bin/docker".to_owned(),
-        "/usr/bin/gh".to_owned(),
-        claude_bin_for(user.as_str()),
-        CODEX_BIN.to_owned(),
+        GuestPath::new("/usr/bin/docker"),
+        GuestPath::new("/usr/bin/gh"),
+        user.claude_bin(),
+        codex_bin(),
     ]
 }
 
@@ -479,7 +485,16 @@ mod tests {
     #[test]
     fn guest_user_default_is_ubuntu() {
         assert_eq!(GuestUser::default().as_str(), DEFAULT_GUEST_USER);
-        assert_eq!(GuestUser::default().home(), "/home/ubuntu");
+        assert_eq!(GuestUser::default().home().to_string(), "/home/ubuntu");
+    }
+
+    #[test]
+    fn guest_user_claude_bin_lives_under_home() {
+        let user = GuestUser::new("vscode").unwrap();
+        assert_eq!(
+            user.claude_bin().to_string(),
+            "/home/vscode/.local/bin/claude"
+        );
     }
 
     #[test]
@@ -533,17 +548,11 @@ mod tests {
     }
 
     #[test]
-    fn claude_bin_for_user_uses_home() {
-        assert_eq!(claude_bin_for("ubuntu"), "/home/ubuntu/.local/bin/claude");
-        assert_eq!(claude_bin_for("vscode"), "/home/vscode/.local/bin/claude");
-    }
-
-    #[test]
     fn required_guest_binaries_include_codex() {
         let user = GuestUser::default();
         let bins = required_guest_binaries(&user);
         assert!(
-            bins.iter().any(|b| b == "/usr/local/bin/codex"),
+            bins.iter().any(|b| b.to_string() == "/usr/local/bin/codex"),
             "guest image should include codex in the default PATH",
         );
     }

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -1,8 +1,10 @@
 // Shared guest provisioning constants used by both Lima and Firecracker.
 
 use std::collections::HashMap;
+use std::fmt;
 
 use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
 
 use crate::config::{CoopConfig, CustomProfile};
 
@@ -22,19 +24,130 @@ pub fn builtin_for_feature(id: &str) -> Option<&'static BuiltinProfile> {
     }
 }
 
-/// Username for the non-root guest user. Both backends ensure this user
-/// exists at uid 1000. On Firecracker's rootfs the `ubuntu` user already
-/// exists; on Lima, cloud-init may replace it with a host-mirror user,
-/// so the provisioning script evicts that user and recreates `ubuntu`.
-pub const GUEST_USER: &str = "ubuntu";
+/// Default username when neither the CLI nor a devcontainer pins one.
+/// Matches the user that Firecracker's CI rootfs already ships with and
+/// that Lima's `useradd` block creates at uid 1000.
+pub const DEFAULT_GUEST_USER: &str = "ubuntu";
 
-/// Absolute path to the Claude Code binary in the guest.
+const MAX_GUEST_USER_LEN: usize = 32;
+
+/// Validated guest username, persisted in `TemplateConfig` and threaded
+/// through both backends.
 ///
-/// The installer puts it under the user's home directory. Bootstrap
-/// commands and verification use this path directly rather than
-/// relying on PATH (non-interactive SSH sessions don't source
+/// Enforces the POSIX-portable pattern `[a-z_][a-z0-9_-]{0,31}` and
+/// rejects `root` so the rest of coop can assume an unprivileged uid-1000
+/// account. The same rules as `backend::SshUser` plus the root exclusion,
+/// so callers can losslessly convert to an `SshUser` for SSH plumbing.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct GuestUser(String);
+
+impl GuestUser {
+    /// Construct a validated guest user. Returns an error when the name
+    /// is empty, exceeds 32 characters, contains characters outside the
+    /// portable POSIX set, or is `root`.
+    pub fn new(name: impl Into<String>) -> Result<Self> {
+        let name = name.into();
+        Self::validate(&name)?;
+        Ok(Self(name))
+    }
+
+    /// `clap` value parser. Equivalent to `GuestUser::new` but with the
+    /// `(&str) -> Result<Self>` signature clap's `value_parser` expects.
+    pub fn parse(s: &str) -> Result<Self> {
+        Self::new(s)
+    }
+
+    fn validate(name: &str) -> Result<()> {
+        if name.is_empty() {
+            bail!("guest user must not be empty");
+        }
+        if name.len() > MAX_GUEST_USER_LEN {
+            bail!(
+                "guest user too long ({} chars, max {MAX_GUEST_USER_LEN})",
+                name.len()
+            );
+        }
+        if name == "root" {
+            bail!("guest user must not be 'root'; coop requires an unprivileged uid-1000 account");
+        }
+        for (i, c) in name.chars().enumerate() {
+            let ok = if i == 0 {
+                matches!(c, 'a'..='z' | '_')
+            } else {
+                matches!(c, 'a'..='z' | '0'..='9' | '_' | '-')
+            };
+            if !ok {
+                if i == 0 {
+                    bail!("guest user must start with [a-z_], got {c:?}");
+                }
+                bail!(
+                    "guest user contains invalid character {c:?} \
+                     (allowed: a-z, 0-9, '_', '-')"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Borrow as a string slice for paths, scripts, and shell composition.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Absolute home directory of this user inside the guest.
+    pub fn home(&self) -> String {
+        format!("/home/{}", self.0)
+    }
+}
+
+impl Default for GuestUser {
+    fn default() -> Self {
+        // Safe: DEFAULT_GUEST_USER ("ubuntu") satisfies the validator.
+        Self(DEFAULT_GUEST_USER.to_owned())
+    }
+}
+
+impl fmt::Display for GuestUser {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for GuestUser {
+    #[mutants::skip] // equivalent: trivial forwarder over self.0
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for GuestUser {
+    type Error = anyhow::Error;
+    fn try_from(value: String) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl From<GuestUser> for String {
+    #[mutants::skip] // equivalent: trivial forwarder
+    fn from(value: GuestUser) -> Self {
+        value.0
+    }
+}
+
+/// Absolute path to the Claude Code binary in the guest, for the given
+/// user. The installer places the binary under `~/.local/bin/claude`.
+/// Bootstrap commands and verification use this path directly rather
+/// than relying on PATH (non-interactive SSH sessions don't source
 /// `.bashrc`/`.profile`).
-pub const CLAUDE_BIN: &str = "/home/ubuntu/.local/bin/claude";
+///
+/// Accepts `&str` so call sites can pass either a `GuestUser` (via
+/// `as_str()`) or an `SshUser` (via `as_ref()`) without an extra
+/// conversion. The same validation applies in both directions.
+pub fn claude_bin_for(user: &str) -> String {
+    format!("/home/{user}/.local/bin/claude")
+}
 
 /// Absolute path to the Codex CLI binary in the guest.
 ///
@@ -45,8 +158,14 @@ pub const CODEX_BIN: &str = "/usr/local/bin/codex";
 /// Binaries that must exist in the guest image after provisioning.
 /// Absolute paths are checked directly; bare names are looked up via
 /// `command -v` (i.e. must be in the default system PATH).
-pub const REQUIRED_GUEST_BINARIES: &[&str] =
-    &["/usr/bin/docker", "/usr/bin/gh", CLAUDE_BIN, CODEX_BIN];
+pub fn required_guest_binaries(user: &GuestUser) -> [String; 4] {
+    [
+        "/usr/bin/docker".to_owned(),
+        "/usr/bin/gh".to_owned(),
+        claude_bin_for(user.as_str()),
+        CODEX_BIN.to_owned(),
+    ]
+}
 
 pub const SCRIPT_GH_REPO: &str = include_str!("../scripts/guest/gh-cli-repo.sh");
 pub const SCRIPT_DOCKER_REPO: &str = include_str!("../scripts/guest/docker-repo.sh");
@@ -276,14 +395,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn required_guest_binaries_include_codex() {
-        assert!(
-            REQUIRED_GUEST_BINARIES.contains(&"/usr/local/bin/codex"),
-            "guest image should include codex in the default PATH",
-        );
-    }
-
-    #[test]
     fn codex_script_installs_extracted_binary_not_archive() {
         assert!(
             SCRIPT_CODEX.contains("BIN=\"$TMPDIR/${ASSET%.tar.gz}\""),
@@ -363,5 +474,77 @@ mod tests {
             assert_eq!(bp.name, *id);
         }
         assert!(builtin_for_feature("nonexistent").is_none());
+    }
+
+    #[test]
+    fn guest_user_default_is_ubuntu() {
+        assert_eq!(GuestUser::default().as_str(), DEFAULT_GUEST_USER);
+        assert_eq!(GuestUser::default().home(), "/home/ubuntu");
+    }
+
+    #[test]
+    fn guest_user_accepts_valid_names() {
+        for s in ["ubuntu", "vscode", "_dev", "u", "user_1", "ec2-user"] {
+            let u = GuestUser::new(s).unwrap_or_else(|e| panic!("rejected {s:?}: {e}"));
+            assert_eq!(u.as_str(), s);
+        }
+    }
+
+    #[test]
+    fn guest_user_rejects_root() {
+        let err = GuestUser::new("root").unwrap_err().to_string();
+        assert!(err.contains("must not be 'root'"), "{err}");
+    }
+
+    #[test]
+    fn guest_user_rejects_empty_and_too_long() {
+        assert!(GuestUser::new("").is_err());
+        let long = "a".repeat(MAX_GUEST_USER_LEN + 1);
+        assert!(GuestUser::new(long).is_err());
+    }
+
+    #[test]
+    fn guest_user_rejects_invalid_chars() {
+        for s in [
+            "Ubuntu",
+            "0user",
+            "-user",
+            "user.name",
+            "user!",
+            "user name",
+        ] {
+            assert!(GuestUser::new(s).is_err(), "should reject {s:?}");
+        }
+    }
+
+    #[test]
+    fn guest_user_serde_roundtrip() {
+        let u = GuestUser::new("vscode").unwrap();
+        let json = serde_json::to_string(&u).unwrap();
+        assert_eq!(json, "\"vscode\"");
+        let back: GuestUser = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, u);
+    }
+
+    #[test]
+    fn guest_user_serde_rejects_invalid() {
+        let err = serde_json::from_str::<GuestUser>("\"root\"").unwrap_err();
+        assert!(err.to_string().contains("root"), "{err}");
+    }
+
+    #[test]
+    fn claude_bin_for_user_uses_home() {
+        assert_eq!(claude_bin_for("ubuntu"), "/home/ubuntu/.local/bin/claude");
+        assert_eq!(claude_bin_for("vscode"), "/home/vscode/.local/bin/claude");
+    }
+
+    #[test]
+    fn required_guest_binaries_include_codex() {
+        let user = GuestUser::default();
+        let bins = required_guest_binaries(&user);
+        assert!(
+            bins.iter().any(|b| b == "/usr/local/bin/codex"),
+            "guest image should include codex in the default PATH",
+        );
     }
 }

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -780,13 +780,14 @@ fn install_builder_plugins(
     }
 
     let session = crate::backend::SshSession { target, env };
+    let claude_bin = guest_user.claude_bin();
 
     if !marketplaces.is_empty() {
-        crate::backend::install_marketplaces(&session, &marketplaces)?;
+        crate::backend::install_marketplaces(&session, &claude_bin, &marketplaces)?;
     }
 
     if !plugins.is_empty() {
-        crate::backend::install_plugins(&session, &plugins)?;
+        crate::backend::install_plugins(&session, &claude_bin, &plugins)?;
     }
 
     Ok((marketplaces, plugins))
@@ -965,7 +966,7 @@ fn verify_builder_binaries(guest_user: &GuestUser) -> Result<()> {
             .status();
 
         if !status.is_ok_and(|s| s.success()) {
-            missing.push(path);
+            missing.push(path.to_string());
         }
     }
 

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -9,8 +9,8 @@ use anyhow::{Context, Result, bail};
 use crate::backend::{Hostname, LogMode, SshTarget, SshUser};
 use crate::config::{CoopConfig, GiB, ImageName, Instance, InstanceName};
 use crate::guest::{
-    BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
-    SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
+    BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
+    SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
 };
 use crate::setup::{SetupOptions, TEMPLATE_VERSION, TemplateConfig, utc_timestamp};
 use crate::sha256_hash::Sha256Hash;
@@ -29,7 +29,10 @@ pub fn setup(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
 
     let image = &opts.image;
     let base_img = cfg.lima_base_path(image);
-    if base_img.exists() && !opts.rebuild && !needs_rebuild(cfg, image, &opts.profiles) {
+    if base_img.exists()
+        && !opts.rebuild
+        && !needs_rebuild(cfg, image, &opts.profiles, &opts.guest_user)
+    {
         eprintln!(
             "\n=> Golden image '{image}': up to date ({})",
             base_img.display()
@@ -38,7 +41,7 @@ pub fn setup(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
         if base_img.exists() && !opts.rebuild {
             eprintln!("\n=> Golden image '{image}' is stale — rebuilding");
         }
-        build_golden_image(cfg, image, &opts.profiles)?;
+        build_golden_image(cfg, image, &opts.profiles, &opts.guest_user)?;
     }
 
     generate_start_template(cfg, image)?;
@@ -122,7 +125,14 @@ pub fn create_and_start(
         .spawn()
         .context("Failed to spawn limactl start")?;
 
-    if let Err(e) = wait_for_lima_ssh(&inst.name, &mut child, cfg, Duration::from_secs(60)) {
+    let guest_user = crate::backend::persisted_guest_user(cfg, &inst.image);
+    if let Err(e) = wait_for_lima_ssh(
+        &inst.name,
+        &mut child,
+        cfg,
+        Duration::from_secs(60),
+        &guest_user,
+    ) {
         let _ = child.kill();
         let lima_stderr = match child.wait_with_output() {
             Ok(out) => String::from_utf8_lossy(&out.stderr).to_string(),
@@ -160,7 +170,14 @@ pub fn start_existing(cfg: &CoopConfig, inst: &Instance) -> Result<()> {
         .spawn()
         .context("Failed to spawn limactl start")?;
 
-    if let Err(e) = wait_for_lima_ssh(&inst.name, &mut child, cfg, Duration::from_secs(60)) {
+    let guest_user = crate::backend::persisted_guest_user(cfg, &inst.image);
+    if let Err(e) = wait_for_lima_ssh(
+        &inst.name,
+        &mut child,
+        cfg,
+        Duration::from_secs(60),
+        &guest_user,
+    ) {
         let _ = child.kill();
         let lima_stderr = match child.wait_with_output() {
             Ok(out) => String::from_utf8_lossy(&out.stderr).to_string(),
@@ -407,10 +424,12 @@ pub fn ssh_target(cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {
     let port = u16::try_from(port).context("SSH port out of range")?;
     let port = std::num::NonZeroU16::new(port).context("Lima SSH port is 0")?;
 
+    let guest_user = crate::backend::persisted_guest_user(cfg, &inst.image);
+
     Ok(SshTarget {
         host: Hostname::new("127.0.0.1")?,
         port,
-        user: SshUser::new(crate::guest::GUEST_USER)?,
+        user: SshUser::new(guest_user.as_str())?,
         key_path: cfg.ssh_key_path(),
     })
 }
@@ -464,20 +483,30 @@ fn ensure_ssh_key(cfg: &CoopConfig) -> Result<()> {
     Ok(())
 }
 
-fn provision_script_hash(cfg: &CoopConfig, profiles: &[ProfileDef]) -> Sha256Hash {
+fn provision_script_hash(
+    cfg: &CoopConfig,
+    profiles: &[ProfileDef],
+    guest_user: &GuestUser,
+) -> Sha256Hash {
     let pubkey_path = cfg.ssh_key_path().with_extension("pub");
     let pubkey = fs::read_to_string(&pubkey_path).unwrap_or_default();
-    let script = compose_provision_script(pubkey.trim(), profiles);
+    let script = compose_provision_script(pubkey.trim(), profiles, guest_user);
     Sha256Hash::of(&script)
 }
 
 /// Returns `true` if the golden image needs rebuilding.
 ///
 /// A rebuild is needed when the config file is missing (orphaned
-/// image), the provision-script hash has changed, or the baked
-/// marketplace/plugin lists have changed.
-fn needs_rebuild(cfg: &CoopConfig, image: &ImageName, profiles: &[ProfileDef]) -> bool {
-    let current_hash = provision_script_hash(cfg, profiles);
+/// image), the provision-script hash has changed, the persisted guest
+/// user differs from the requested one, or the baked marketplace/plugin
+/// lists have changed.
+fn needs_rebuild(
+    cfg: &CoopConfig,
+    image: &ImageName,
+    profiles: &[ProfileDef],
+    guest_user: &GuestUser,
+) -> bool {
+    let current_hash = provision_script_hash(cfg, profiles, guest_user);
     let Ok(existing) = TemplateConfig::load_for(cfg, image) else {
         tracing::info!("Template config missing — treating golden image as stale");
         return true;
@@ -487,11 +516,24 @@ fn needs_rebuild(cfg: &CoopConfig, image: &ImageName, profiles: &[ProfileDef]) -
         return true;
     }
 
+    if &existing.guest_user != guest_user {
+        tracing::info!(
+            "Guest user changed ({} -> {guest_user}) — rebuilding",
+            existing.guest_user
+        );
+        return true;
+    }
+
     let (wanted_m, wanted_p) = crate::guest::collect_baked_lists(cfg, profiles);
     existing.marketplaces != wanted_m || existing.plugins != wanted_p
 }
 
-fn build_golden_image(cfg: &CoopConfig, image: &ImageName, profiles: &[ProfileDef]) -> Result<()> {
+fn build_golden_image(
+    cfg: &CoopConfig,
+    image: &ImageName,
+    profiles: &[ProfileDef],
+    guest_user: &GuestUser,
+) -> Result<()> {
     eprintln!(
         "\n=> Building golden VM image \
          (this takes a few minutes on first run)"
@@ -520,7 +562,7 @@ fn build_golden_image(cfg: &CoopConfig, image: &ImageName, profiles: &[ProfileDe
 
     // Generate builder template with full provisioning
     let builder_template = cfg.data_dir.join("lima-builder.yaml");
-    let provision_script = compose_provision_script(pubkey.trim(), profiles);
+    let provision_script = compose_provision_script(pubkey.trim(), profiles, guest_user);
     let yaml = compose_template_yaml(cfg, &provision_script);
     fs::write(&builder_template, &yaml).with_context(|| {
         format!(
@@ -535,7 +577,7 @@ fn build_golden_image(cfg: &CoopConfig, image: &ImageName, profiles: &[ProfileDe
     }
 
     // Build to staging path — old image is never touched
-    let result = run_builder_vm(cfg, profiles, &staging, &builder_template);
+    let result = run_builder_vm(cfg, profiles, &staging, &builder_template, guest_user);
 
     // Always clean up builder resources
     eprintln!("  Cleaning up builder VM...");
@@ -579,12 +621,13 @@ fn build_golden_image(cfg: &CoopConfig, image: &ImageName, profiles: &[ProfileDe
     let template_config = TemplateConfig {
         version: TEMPLATE_VERSION,
         created: utc_timestamp(),
-        install_script_hash: provision_script_hash(cfg, profiles),
+        install_script_hash: provision_script_hash(cfg, profiles, guest_user),
         profiles: profiles.iter().map(|p| p.name.clone()).collect(),
         extra_packages: Vec::new(),
         post_install_hash: None,
         marketplaces,
         plugins,
+        guest_user: guest_user.clone(),
     };
     template_config.save_for(cfg, image)?;
 
@@ -598,6 +641,7 @@ fn run_builder_vm(
     profiles: &[ProfileDef],
     output_path: &std::path::Path,
     builder_template: &std::path::Path,
+    guest_user: &GuestUser,
 ) -> Result<(Vec<String>, Vec<String>)> {
     eprintln!("  Starting builder VM and installing packages...");
     let status = Command::new("limactl")
@@ -621,12 +665,12 @@ fn run_builder_vm(
     // Verify critical binaries are installed before extracting the
     // image. Cloud-init can report "done" even if individual install
     // steps failed silently (e.g. network timeout during download).
-    verify_builder_binaries()?;
+    verify_builder_binaries(guest_user)?;
 
     // Install marketplaces and plugins into the builder VM so they're
     // baked into the golden image. Runs after binary verification
     // (confirms claude CLI is installed) and before cloud-init clean.
-    let (marketplaces, plugins) = install_builder_plugins(cfg, profiles)?;
+    let (marketplaces, plugins) = install_builder_plugins(cfg, profiles, guest_user)?;
 
     // Clean cloud-init state so it re-runs on new instances
     eprintln!("  Preparing image for reuse...");
@@ -697,7 +741,7 @@ fn run_builder_vm(
 }
 
 /// Get an SSH target for the builder VM.
-fn builder_ssh_target(cfg: &CoopConfig) -> Result<SshTarget> {
+fn builder_ssh_target(cfg: &CoopConfig, guest_user: &GuestUser) -> Result<SshTarget> {
     let info = limactl_list_entry(BUILDER_NAME)?;
     let port = info["sshLocalPort"]
         .as_u64()
@@ -707,7 +751,7 @@ fn builder_ssh_target(cfg: &CoopConfig) -> Result<SshTarget> {
     Ok(SshTarget {
         host: Hostname::new("127.0.0.1")?,
         port,
-        user: SshUser::new(crate::guest::GUEST_USER)?,
+        user: SshUser::new(guest_user.as_str())?,
         key_path: cfg.ssh_key_path(),
     })
 }
@@ -718,6 +762,7 @@ fn builder_ssh_target(cfg: &CoopConfig) -> Result<SshTarget> {
 fn install_builder_plugins(
     cfg: &CoopConfig,
     profiles: &[ProfileDef],
+    guest_user: &GuestUser,
 ) -> Result<(Vec<String>, Vec<String>)> {
     let (marketplaces, plugins) = crate::guest::collect_baked_lists(cfg, profiles);
 
@@ -726,7 +771,7 @@ fn install_builder_plugins(
     }
 
     eprintln!("  Installing marketplaces and plugins...");
-    let target = builder_ssh_target(cfg)?;
+    let target = builder_ssh_target(cfg, guest_user)?;
 
     // Minimal env forwarding: GITHUB_TOKEN for private repo access
     let mut env = crate::backend::EnvForward::default();
@@ -905,13 +950,13 @@ fn check_cloud_init_output(exit_code: Option<i32>, stdout: &str) -> Result<()> {
 /// Runs after cloud-init completes but before extracting the disk
 /// image. Catches silent install failures (e.g. network timeouts)
 /// that cloud-init doesn't flag as errors.
-fn verify_builder_binaries() -> Result<()> {
-    use crate::guest::REQUIRED_GUEST_BINARIES;
+fn verify_builder_binaries(guest_user: &GuestUser) -> Result<()> {
+    use crate::guest::required_guest_binaries;
 
     eprintln!("  Verifying installed binaries...");
-    let mut missing = Vec::new();
+    let mut missing: Vec<String> = Vec::new();
 
-    for &path in REQUIRED_GUEST_BINARIES {
+    for path in required_guest_binaries(guest_user) {
         let check_cmd = format!("test -x {path}");
         let status = Command::new("limactl")
             .args(["shell", BUILDER_NAME, "--", "bash", "-c", &check_cmd])
@@ -1078,7 +1123,11 @@ provision:
     )
 }
 
-fn compose_provision_script(ssh_pubkey: &str, profiles: &[ProfileDef]) -> String {
+fn compose_provision_script(
+    ssh_pubkey: &str,
+    profiles: &[ProfileDef],
+    guest_user: &GuestUser,
+) -> String {
     let mut s = String::with_capacity(8192);
 
     // Preamble
@@ -1147,8 +1196,8 @@ fn compose_provision_script(ssh_pubkey: &str, profiles: &[ProfileDef]) -> String
         }
     }
 
-    // Guest configuration configures the ubuntu user — must come before claude-code install
-    s.push_str(&compose_lima_guest_config(ssh_pubkey));
+    // Guest configuration configures the guest user — must come before claude-code install
+    s.push_str(&compose_lima_guest_config(ssh_pubkey, guest_user));
 
     // Claude Code (direct binary download, runs as root, chowns to claude)
     s.push_str(SCRIPT_CLAUDE_CODE);
@@ -1174,42 +1223,51 @@ fn compose_provision_script(ssh_pubkey: &str, profiles: &[ProfileDef]) -> String
     s
 }
 
-fn compose_lima_guest_config(ssh_pubkey: &str) -> String {
+fn compose_lima_guest_config(ssh_pubkey: &str, guest_user: &GuestUser) -> String {
+    // GuestUser::new validated the name against POSIX-portable chars, so
+    // it's safe to interpolate into the shell script body and a single-
+    // quoted export at the top of the recipe.
+    let user = guest_user.as_str();
+    let home = guest_user.home();
     format!(
         r#"
-echo '  [guest] Ensuring ubuntu user exists (uid 1000)...'
-if id ubuntu &>/dev/null; then
-    usermod -aG sudo,docker ubuntu
+export GUEST_USER='{user}'
+
+echo "  [guest] Ensuring {user} user exists (uid 1000)..."
+if id "{user}" &>/dev/null; then
+    usermod -aG sudo,docker "{user}"
 else
-    # Remove any other user occupying uid 1000 (e.g. Lima's host-mirror user)
+    # Remove any other user occupying uid 1000 (e.g. Lima's host-mirror user
+    # or the cloud-init `ubuntu` user) so our configured guest user takes
+    # over uid 1000 cleanly.
     EXISTING=$(getent passwd 1000 | cut -d: -f1) || true
     if [[ -n "$EXISTING" ]]; then
         userdel "$EXISTING"
     fi
-    useradd -m -s /bin/bash --uid 1000 -G sudo,docker ubuntu
+    useradd -m -s /bin/bash --uid 1000 -G sudo,docker "{user}"
 fi
-echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu
-chmod 440 /etc/sudoers.d/ubuntu
+echo "{user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/{user}"
+chmod 440 "/etc/sudoers.d/{user}"
 
-echo '  [guest] Setting up home and SSH for ubuntu user...'
-mkdir -p /home/ubuntu
-chown ubuntu:ubuntu /home/ubuntu
-chmod 755 /home/ubuntu
-install -d -o ubuntu -g ubuntu /home/ubuntu/.local
-install -d -o ubuntu -g ubuntu /home/ubuntu/.local/bin
-install -d -o ubuntu -g ubuntu /home/ubuntu/.local/share
-mkdir -p /home/ubuntu/.ssh
-echo '{ssh_pubkey}' > /home/ubuntu/.ssh/authorized_keys
-chown -R ubuntu:ubuntu /home/ubuntu/.ssh
-chmod 700 /home/ubuntu/.ssh
-chmod 600 /home/ubuntu/.ssh/authorized_keys
+echo "  [guest] Setting up home and SSH for {user} user..."
+mkdir -p "{home}"
+chown "{user}:{user}" "{home}"
+chmod 755 "{home}"
+install -d -o "{user}" -g "{user}" "{home}/.local"
+install -d -o "{user}" -g "{user}" "{home}/.local/bin"
+install -d -o "{user}" -g "{user}" "{home}/.local/share"
+mkdir -p "{home}/.ssh"
+echo '{ssh_pubkey}' > "{home}/.ssh/authorized_keys"
+chown -R "{user}:{user}" "{home}/.ssh"
+chmod 700 "{home}/.ssh"
+chmod 600 "{home}/.ssh/authorized_keys"
 
-echo '  [guest] Configuring ubuntu user PATH...'
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/ubuntu/.profile
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/ubuntu/.bashrc
+echo "  [guest] Configuring {user} user PATH..."
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> "{home}/.profile"
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> "{home}/.bashrc"
 
 echo '  [guest] Symlinking claude into system PATH...'
-ln -sf /home/ubuntu/.local/bin/claude /usr/local/bin/claude
+ln -sf "{home}/.local/bin/claude" /usr/local/bin/claude
 
 echo '  [guest] Installing claude-yolo shortcut...'
 cat > /usr/local/bin/claude-yolo <<'YOLOEOF'
@@ -1227,7 +1285,7 @@ chmod 755 /usr/local/bin/codex-yolo
 
 echo '  [guest] Preparing workspace directory...'
 mkdir -p /workspace
-chown ubuntu:ubuntu /workspace
+chown "{user}:{user}" /workspace
 
 # No iptables-legacy or NO_IPTABLES_RAW needed — Lima uses a full kernel with
 # nftables and iptable_raw support. These workarounds are Firecracker-only
@@ -1262,6 +1320,7 @@ fn wait_for_lima_ssh(
     child: &mut std::process::Child,
     cfg: &CoopConfig,
     timeout: Duration,
+    guest_user: &GuestUser,
 ) -> Result<()> {
     let start = Instant::now();
 
@@ -1291,7 +1350,7 @@ fn wait_for_lima_ssh(
     let target = SshTarget {
         host: Hostname::new("127.0.0.1")?,
         port: std::num::NonZeroU16::new(port).context("Lima assigned SSH port 0")?,
-        user: SshUser::new(crate::guest::GUEST_USER)?,
+        user: SshUser::new(guest_user.as_str())?,
         key_path: cfg.ssh_key_path(),
     };
     let mut delay = Duration::from_millis(500);
@@ -1560,7 +1619,11 @@ mod tests {
     #[test]
     fn provision_script_post_install_without_trailing_newline() {
         let profiles = vec![profile("test", &["curl"], None, Some("echo done"))];
-        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &profiles);
+        let script = compose_provision_script(
+            "ssh-ed25519 AAAA test@test",
+            &profiles,
+            &GuestUser::default(),
+        );
 
         assert!(
             script.contains("echo done\n"),
@@ -1577,7 +1640,11 @@ mod tests {
             Some("curl -fsSL https://example.com | bash"),
             None,
         )];
-        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &profiles);
+        let script = compose_provision_script(
+            "ssh-ed25519 AAAA test@test",
+            &profiles,
+            &GuestUser::default(),
+        );
 
         assert!(
             script.contains("| bash\n"),
@@ -1592,7 +1659,11 @@ mod tests {
             profile("a", &[], None, Some("echo a-done")),
             profile("b", &[], None, Some("echo b-done")),
         ];
-        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &profiles);
+        let script = compose_provision_script(
+            "ssh-ed25519 AAAA test@test",
+            &profiles,
+            &GuestUser::default(),
+        );
 
         assert!(script.contains("echo a-done\n"));
         assert!(script.contains("echo b-done\n"));
@@ -1606,7 +1677,8 @@ mod tests {
 
     #[test]
     fn provision_script_installs_codex() {
-        let script = compose_provision_script("ssh-ed25519 AAAA test@test", &[]);
+        let script =
+            compose_provision_script("ssh-ed25519 AAAA test@test", &[], &GuestUser::default());
 
         assert!(
             script.contains("Installing Codex CLI"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -830,18 +830,21 @@ fn main() -> Result<()> {
                 args.insert(0, "default".to_string());
                 args.insert(0, "--permission-mode".to_string());
             }
-            let claude_bin = crate::guest::claude_bin_for(sess.target.user.as_ref());
-            ssh::run_interactive(&sess, &prepend_binary(&claude_bin, args))
+            let claude_bin = guest::GuestUser::new(sess.target.user.as_ref())?.claude_bin();
+            ssh::run_interactive(&sess, &prepend_binary(&claude_bin.to_string(), args))
         }
         Commands::ClaudeAgents { name, mut args } => {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
             args.insert(0, "agents".to_string());
-            let claude_bin = crate::guest::claude_bin_for(sess.target.user.as_ref());
-            ssh::run_interactive(&sess, &prepend_binary(&claude_bin, args))
+            let claude_bin = guest::GuestUser::new(sess.target.user.as_ref())?.claude_bin();
+            ssh::run_interactive(&sess, &prepend_binary(&claude_bin.to_string(), args))
         }
         Commands::Codex { name, args } => {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
-            ssh::run_interactive(&sess, &prepend_binary(crate::guest::CODEX_BIN, args))
+            ssh::run_interactive(
+                &sess,
+                &prepend_binary(&guest::codex_bin().to_string(), args),
+            )
         }
         Commands::Stop { name } => {
             let inst = cfg.resolve_instance(name.as_ref())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,15 @@ enum Commands {
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         image: config::ImageName,
+        /// Guest username to create in the image (default: "ubuntu").
+        /// Baked into the image at setup time and immutable for its
+        /// lifetime — `start`/`shell`/`exec` read it from the image's
+        /// `template_config.json`. Use this when a workspace's
+        /// `devcontainer.json` declares a `remoteUser` other than
+        /// `ubuntu` (e.g. `vscode` for the Microsoft devcontainer base
+        /// images).
+        #[arg(long, value_name = "NAME", value_parser = guest::GuestUser::parse)]
+        guest_user: Option<guest::GuestUser>,
         /// Workspace directory to scan for `.devcontainer/devcontainer.json`.
         /// When present (and `--no-devcontainer` is not set), coop offers to
         /// apply the file's `features` and `hostRequirements` to this setup.
@@ -619,6 +628,7 @@ fn main() -> Result<()> {
             post_install,
             template_size,
             image,
+            guest_user,
             workspace,
             devcontainer,
             no_devcontainer,
@@ -630,6 +640,7 @@ fn main() -> Result<()> {
                 cli_vcpus: vcpus,
                 cli_mem_mib: mem,
                 cli_profiles: profile.clone(),
+                cli_guest_user: guest_user.clone(),
                 ..devcontainer::TranslatorInputs::default()
             };
             let translation = resolve_devcontainer(
@@ -661,6 +672,11 @@ fn main() -> Result<()> {
             }
             // Resolve profile names once at the CLI boundary.
             let resolved_profiles = guest::resolve_profiles(&profile, &cfg.profiles)?;
+            // CLI wins; otherwise honour the devcontainer's `remoteUser`;
+            // otherwise default to `ubuntu`.
+            let resolved_guest_user = guest_user
+                .or_else(|| translation.as_ref().and_then(|t| t.guest_user.clone()))
+                .unwrap_or_default();
             let _guard = signal::install_handlers();
             be.setup(
                 &cfg,
@@ -672,6 +688,7 @@ fn main() -> Result<()> {
                     extra_packages,
                     post_install: post_install.map(PathBuf::from),
                     image,
+                    guest_user: resolved_guest_user,
                 },
             )
         }
@@ -714,7 +731,9 @@ fn main() -> Result<()> {
                 cli_forward_ports: forward_ports.clone(),
                 cli_mounts: mounts.clone(),
                 cli_profiles: Vec::new(),
+                persisted_guest_user: Some(backend::persisted_guest_user(&cfg, &image)),
                 cli_workspace_or_git_repo: workspace.is_some() || git_repo.is_some(),
+                ..devcontainer::TranslatorInputs::default()
             };
             let ws_path = workspace.as_deref().map(Path::new);
             let translation = resolve_devcontainer(
@@ -811,12 +830,14 @@ fn main() -> Result<()> {
                 args.insert(0, "default".to_string());
                 args.insert(0, "--permission-mode".to_string());
             }
-            ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, args))
+            let claude_bin = crate::guest::claude_bin_for(sess.target.user.as_ref());
+            ssh::run_interactive(&sess, &prepend_binary(&claude_bin, args))
         }
         Commands::ClaudeAgents { name, mut args } => {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
             args.insert(0, "agents".to_string());
-            ssh::run_interactive(&sess, &prepend_binary(crate::guest::CLAUDE_BIN, args))
+            let claude_bin = crate::guest::claude_bin_for(sess.target.user.as_ref());
+            ssh::run_interactive(&sess, &prepend_binary(&claude_bin, args))
         }
         Commands::Codex { name, args } => {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::cmd::Cmd;
 use crate::config::{CoopConfig, ImageName, Instance};
 use crate::guest::{
-    BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, ProfileDef, SCRIPT_CLAUDE_CODE, SCRIPT_CODEX,
-    SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, resolve_profiles,
+    BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
+    SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, resolve_profiles,
 };
 use crate::sha256_hash::Sha256Hash;
 
@@ -32,9 +32,16 @@ pub struct SetupOptions {
     pub extra_packages: Vec<String>,
     pub post_install: Option<PathBuf>,
     pub image: ImageName,
+    pub guest_user: GuestUser,
 }
 
 /// Persisted template configuration (profiles, packages, hashes).
+///
+/// `guest_user` is set at setup time and immutable for the image's
+/// lifetime — `coop start`/`shell`/`exec` read it from here rather
+/// than accepting a flag. Existing `template_config.json` files
+/// without the field deserialize via `GuestUser::default()` to the
+/// historical `ubuntu` user.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TemplateConfig {
     pub version: u32,
@@ -47,6 +54,8 @@ pub struct TemplateConfig {
     pub marketplaces: Vec<String>,
     #[serde(default)]
     pub plugins: Vec<String>,
+    #[serde(default)]
+    pub guest_user: GuestUser,
 }
 
 impl TemplateConfig {
@@ -293,7 +302,7 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
     let (profiles, extra_packages) = resolve_template_config(cfg, opts)?;
 
     // Compose recipe and compute hashes
-    let recipe = compose_recipe(&profiles, &extra_packages);
+    let recipe = compose_recipe(&profiles, &extra_packages, &opts.guest_user);
     let script_hash = Sha256Hash::of(&recipe);
     let post_install_content = load_post_install(opts.post_install.as_ref())?;
     let post_install_hash = post_install_content.as_ref().map(Sha256Hash::of);
@@ -360,6 +369,7 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
         post_install_hash,
         marketplaces: Vec::new(),
         plugins: Vec::new(),
+        guest_user: opts.guest_user.clone(),
     };
     template_config.save_for(cfg, image)?;
 
@@ -451,11 +461,12 @@ fn build_template(
         post_install_hash,
         marketplaces: Vec::new(),
         plugins: Vec::new(),
+        guest_user: opts.guest_user.clone(),
     };
     let marker_json = serde_json::to_string_pretty(&marker_config)
         .context("Failed to serialize version marker")?;
     let full_script = compose_full_script(recipe, &marker_json, post_install_content);
-    install_guest_packages(cfg, output_path, &full_script)?;
+    install_guest_packages(cfg, output_path, &full_script, &opts.guest_user)?;
 
     // Clean up intermediate files
     eprintln!("  Cleaning up...");
@@ -512,7 +523,11 @@ fn load_post_install(path: Option<&PathBuf>) -> Result<Option<String>> {
 ///
 /// This portion is hashed for staleness detection.
 /// Does NOT include version marker, post-install script, or cleanup.
-fn compose_recipe(profiles: &[ProfileDef], extra_packages: &[String]) -> String {
+fn compose_recipe(
+    profiles: &[ProfileDef],
+    extra_packages: &[String],
+    guest_user: &GuestUser,
+) -> String {
     // Collect and deduplicate profile + extra apt packages
     let mut extra_apt: Vec<&str> = profiles
         .iter()
@@ -536,6 +551,14 @@ fn compose_recipe(profiles: &[ProfileDef], extra_packages: &[String]) -> String 
 
     // Preamble (chroot workarounds + initial apt-get update)
     s.push_str(SCRIPT_PREAMBLE);
+
+    // Export GUEST_USER so the chroot scripts (`guest-config.sh`,
+    // `claude-code.sh`) and any user-supplied post-install can pick it
+    // up. `GuestUser::new` validated the name against POSIX-portable
+    // chars, so single-quoting is sufficient against shell injection.
+    s.push_str("\nexport GUEST_USER='");
+    s.push_str(guest_user.as_str());
+    s.push_str("'\n");
 
     // Install base packages first (provides curl/gpg for repo setup)
     s.push_str("echo '  [guest] Installing core tools...'\n");
@@ -602,9 +625,9 @@ fn compose_recipe(profiles: &[ProfileDef], extra_packages: &[String]) -> String 
         s.push_str("exit 1\n");
     }
 
-    // Guest config configures the ubuntu user — must come before claude-code.
+    // Guest config configures the guest user — must come before claude-code.
     s.push_str(SCRIPT_GUEST_CONFIG);
-    // Direct binary download (runs as root in chroot, installs for ubuntu user).
+    // Direct binary download (runs as root in chroot, installs for guest user).
     s.push_str(SCRIPT_CLAUDE_CODE);
     // Codex installs as a standalone binary under /usr/local/bin.
     s.push_str(SCRIPT_CODEX);
@@ -1085,7 +1108,12 @@ fn create_ext4_image(cfg: &CoopConfig, output_path: &Path) -> Result<()> {
 }
 
 /// Mount the template rootfs and run the install script in a chroot.
-fn install_guest_packages(cfg: &CoopConfig, image_path: &Path, script: &str) -> Result<()> {
+fn install_guest_packages(
+    cfg: &CoopConfig,
+    image_path: &Path,
+    script: &str,
+    guest_user: &GuestUser,
+) -> Result<()> {
     eprintln!("  Installing guest packages (Docker, Claude Code, Codex)...");
     eprintln!("  This requires sudo and may take several minutes.");
 
@@ -1101,7 +1129,7 @@ fn install_guest_packages(cfg: &CoopConfig, image_path: &Path, script: &str) -> 
         .run()
         .context("Guest package installation failed")?;
 
-    verify_chroot_binaries(&mount_str)?;
+    verify_chroot_binaries(&mount_str, guest_user)?;
 
     // _guard dropped here → unmount_chroot runs regardless of status
     Ok(())
@@ -1111,17 +1139,17 @@ fn install_guest_packages(cfg: &CoopConfig, image_path: &Path, script: &str) -> 
 ///
 /// Uses `symlink_metadata` (lstat) instead of `exists` (stat) because
 /// the Claude binary is a symlink with an absolute target
-/// (`/home/ubuntu/.local/share/claude/versions/X.Y.Z`). When checked
+/// (`/home/<user>/.local/share/claude/versions/X.Y.Z`). When checked
 /// from outside the chroot, `exists()` follows the symlink to the
 /// host filesystem where the target doesn't exist. A symlink being
 /// present is sufficient — it will resolve correctly inside the guest.
-fn verify_chroot_binaries(mount_str: &str) -> Result<()> {
-    use crate::guest::REQUIRED_GUEST_BINARIES;
+fn verify_chroot_binaries(mount_str: &str, guest_user: &GuestUser) -> Result<()> {
+    use crate::guest::required_guest_binaries;
 
     eprintln!("  Verifying installed binaries...");
     let mut missing = Vec::new();
 
-    for &path in REQUIRED_GUEST_BINARIES {
+    for path in required_guest_binaries(guest_user) {
         let full_path = format!("{mount_str}{path}");
         let exists = std::fs::symlink_metadata(&full_path).is_ok();
         if !exists {
@@ -1385,7 +1413,7 @@ mod tests {
 
     #[test]
     fn compose_recipe_no_profiles_succeeds() {
-        let script = compose_recipe(&[], &[]);
+        let script = compose_recipe(&[], &[], &GuestUser::default());
         assert!(script.contains("apt-get"));
         assert!(
             script.contains("Installing Codex CLI"),
@@ -1395,9 +1423,36 @@ mod tests {
     }
 
     #[test]
+    fn compose_recipe_exports_guest_user() {
+        let user = GuestUser::new("vscode").unwrap();
+        let script = compose_recipe(&[], &[], &user);
+        assert!(
+            script.contains("export GUEST_USER='vscode'"),
+            "recipe must export GUEST_USER for the chroot scripts:\n{script}"
+        );
+    }
+
+    #[test]
+    fn template_config_loads_legacy_json_without_guest_user_field() {
+        // Pre-PR images on disk have no `guest_user` field; the serde
+        // default keeps them deserializable as `ubuntu`. Regression
+        // guard against accidentally dropping the `#[serde(default)]`.
+        let json = r#"{
+            "version": 1,
+            "created": "2026-01-01T00:00:00Z",
+            "install_script_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+            "profiles": [],
+            "extra_packages": [],
+            "post_install_hash": null
+        }"#;
+        let tc: TemplateConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(tc.guest_user, GuestUser::default());
+    }
+
+    #[test]
     fn compose_recipe_post_install_without_trailing_newline() {
         let profiles = vec![profile("test", &["curl"], None, Some("echo done"))];
-        let script = compose_recipe(&profiles, &[]);
+        let script = compose_recipe(&profiles, &[], &GuestUser::default());
 
         // The post_install "echo done" must be on its own line
         assert!(
@@ -1415,7 +1470,7 @@ mod tests {
             Some("curl -fsSL https://example.com | bash"),
             None,
         )];
-        let script = compose_recipe(&profiles, &[]);
+        let script = compose_recipe(&profiles, &[], &GuestUser::default());
 
         assert!(
             script.contains("| bash\n"),
@@ -1427,7 +1482,7 @@ mod tests {
     #[test]
     fn compose_recipe_scripts_with_trailing_newline_no_double() {
         let profiles = vec![profile("test", &[], Some("pre-cmd\n"), Some("post-cmd\n"))];
-        let script = compose_recipe(&profiles, &[]);
+        let script = compose_recipe(&profiles, &[], &GuestUser::default());
 
         // Should not produce triple+ newlines from double-adding
         assert!(
@@ -1443,7 +1498,7 @@ mod tests {
             profile("a", &[], None, Some("echo a-done")),
             profile("b", &[], None, Some("echo b-done")),
         ];
-        let script = compose_recipe(&profiles, &[]);
+        let script = compose_recipe(&profiles, &[], &GuestUser::default());
 
         // Each post_install must be on its own line
         assert!(script.contains("echo a-done\n"));

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1147,13 +1147,13 @@ fn verify_chroot_binaries(mount_str: &str, guest_user: &GuestUser) -> Result<()>
     use crate::guest::required_guest_binaries;
 
     eprintln!("  Verifying installed binaries...");
-    let mut missing = Vec::new();
+    let mut missing: Vec<String> = Vec::new();
 
     for path in required_guest_binaries(guest_user) {
         let full_path = format!("{mount_str}{path}");
         let exists = std::fs::symlink_metadata(&full_path).is_ok();
         if !exists {
-            missing.push(path);
+            missing.push(path.to_string());
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -378,10 +378,11 @@ impl<'a> FirecrackerVm<'a, Running> {
             self.cfg.ssh_port,
         );
 
+        let guest_user = crate::backend::persisted_guest_user(self.cfg, &self.inst.image);
         let target = crate::backend::SshTarget {
             host: crate::backend::Hostname::new(self.inst.guest_ip())?,
             port: self.cfg.ssh_port,
-            user: crate::backend::SshUser::new(crate::guest::GUEST_USER)?,
+            user: crate::backend::SshUser::new(guest_user.as_str())?,
             key_path: self.cfg.ssh_key_path(),
         };
         if let Some(usage) = crate::backend::query_resource_usage(&target) {

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2872,12 +2872,15 @@ test_devcontainer_translator() {
         fail "JSONC (comments + trailing commas) parses" "stderr: $HARNESS_ERR"
     fi
 
-    # remoteUser != ubuntu must surface as unsupported.
-    if grep -q "remoteUser" <<< "$HARNESS_ERR" \
-        && grep -q "unsupported" <<< "$HARNESS_ERR"; then
-        pass "remoteUser != ubuntu is reported unsupported"
+    # `remoteUser: "root"` is rejected by the GuestUser validator
+    # (coop requires an unprivileged uid-1000 account), so the report
+    # row for `remoteUser` must specifically read "invalid" — not
+    # "unsupported" (which other rows like `image` carry, so a fuzzy
+    # whole-buffer grep would pass by coincidence).
+    if grep "remoteUser" <<< "$HARNESS_ERR" | grep -q "invalid"; then
+        pass "remoteUser=root is reported invalid"
     else
-        fail "remoteUser != ubuntu is reported unsupported" "stderr: $HARNESS_ERR"
+        fail "remoteUser=root is reported invalid" "stderr: $HARNESS_ERR"
     fi
 
     # --no-devcontainer silently skips the file: the report header must NOT appear.
@@ -3058,6 +3061,200 @@ test_provision_failure() {
     fi
 }
 
+# ── Guest user CLI validation (pre-VM) ────────────────────────
+
+test_guest_user_validation() {
+    echo ""
+    echo "=== Phase: --guest-user CLI validation ==="
+
+    # `root` is rejected by the GuestUser validator: coop requires an
+    # unprivileged uid-1000 account.
+    if moat_fails setup -y --guest-user root --dry-run; then
+        pass "setup --guest-user root is rejected"
+    else
+        fail "setup --guest-user root is rejected" "should have failed"
+    fi
+
+    # Uppercase and other non-POSIX-portable characters are rejected.
+    if moat_fails setup -y --guest-user Vscode --dry-run; then
+        pass "setup --guest-user with uppercase rejected"
+    else
+        fail "setup --guest-user with uppercase rejected" "should have failed"
+    fi
+
+    # `--guest-user` is only on `setup` — the rest of the lifecycle
+    # reads the persisted value. clap should reject the flag on `start`.
+    if moat_fails start "${INSTANCE}-gu-flag" --guest-user vscode --no-agents; then
+        if grep -qi "unexpected\|unknown\|unrecognized\|--guest-user" <<< "$HARNESS_ERR"; then
+            pass "start --guest-user is rejected as unknown flag"
+        else
+            fail "start --guest-user is rejected as unknown flag" "unexpected error: $HARNESS_ERR"
+        fi
+    else
+        fail "start --guest-user is rejected as unknown flag" "should have failed"
+    fi
+}
+
+# ── Alternate guest user lifecycle (--full only) ──────────────
+
+test_guest_user_alt() {
+    echo ""
+    echo "=== Phase: alternate guest user ==="
+
+    local img_name="test-altuser-$$"
+    local inst_name="${INSTANCE}-altuser"
+    local alt_user="vscode"
+
+    # Setup a separate image whose `template_config.json` should record
+    # guest_user=vscode and whose first boot should create the vscode
+    # account at uid 1000.
+    if coop setup -y --image "$img_name" --guest-user "$alt_user"; then
+        pass "setup --guest-user $alt_user exits 0"
+    else
+        fail "setup --guest-user $alt_user exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        return
+    fi
+
+    # template_config.json must serialize the configured user — this is
+    # what start/shell/exec read on subsequent invocations.
+    local tc_path="$HOME/.coop/images/$img_name/template-config.json"
+    if [[ -f "$tc_path" ]]; then
+        if grep -q "\"guest_user\": *\"$alt_user\"" "$tc_path"; then
+            pass "template_config.json records guest_user=$alt_user"
+        else
+            fail "template_config.json records guest_user=$alt_user" "contents: $(cat "$tc_path")"
+        fi
+    else
+        skip "template_config.json records guest_user=$alt_user" "config at $tc_path not found"
+    fi
+
+    # Start an instance from the alt-user image — no `--guest-user` flag
+    # here on purpose; coop must read the persisted value.
+    if coop start "$inst_name" --no-agents --image "$img_name"; then
+        STARTED_INSTANCES+=("$inst_name")
+        pass "start (alt-user image) exits 0"
+    else
+        fail "start (alt-user image) exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        coop images --delete "$img_name" 2>/dev/null || true
+        return
+    fi
+
+    GUEST_INSTANCE="$inst_name"
+
+    # whoami via SSH — this is the highest-signal assertion. If any
+    # SshTarget construction site still hardcoded `ubuntu`, the session
+    # would either fail to authenticate or land on the wrong account.
+    local whoami_out
+    if whoami_out=$(guest_exec whoami); then
+        if [[ "$whoami_out" == "$alt_user" ]]; then
+            pass "guest user is '$alt_user'"
+        else
+            fail "guest user is '$alt_user'" "got: $whoami_out"
+        fi
+    else
+        fail "guest user is '$alt_user'" "ssh failed; stderr: $(guest_stderr)"
+    fi
+
+    # HOME should resolve to the alt user's directory.
+    local home
+    if home=$(guest_exec printenv HOME); then
+        if [[ "$home" == "/home/$alt_user" ]]; then
+            pass "HOME is /home/$alt_user"
+        else
+            fail "HOME is /home/$alt_user" "got: $home"
+        fi
+    else
+        fail "HOME is /home/$alt_user" "printenv failed"
+    fi
+
+    # /workspace ownership tracks the configured user.
+    local ws_owner
+    if ws_owner=$(guest_exec stat -c '%U' /workspace); then
+        if [[ "$ws_owner" == "$alt_user" ]]; then
+            pass "/workspace owned by $alt_user"
+        else
+            fail "/workspace owned by $alt_user" "owner: $ws_owner"
+        fi
+    else
+        fail "/workspace owned by $alt_user" "stat failed"
+    fi
+
+    # The Claude installer writes to ~/.local/bin under the configured
+    # user's home, not /home/ubuntu. This is exactly the bake-time path
+    # that `GuestUser::claude_bin` resolves at runtime.
+    if guest_exec test -x "/home/$alt_user/.local/bin/claude"; then
+        pass "claude binary at /home/$alt_user/.local/bin/claude"
+    else
+        skip "claude binary at /home/$alt_user/.local/bin/claude" \
+            "not installed in this image (no Claude profile)"
+    fi
+
+    # The alt user must be in sudo + docker groups so the lifecycle
+    # parity with `ubuntu` actually holds.
+    local groups_out
+    if groups_out=$(guest_exec groups); then
+        if echo "$groups_out" | grep -qw docker && echo "$groups_out" | grep -qw sudo; then
+            pass "$alt_user is in sudo and docker groups"
+        else
+            fail "$alt_user is in sudo and docker groups" "groups: $groups_out"
+        fi
+    else
+        fail "$alt_user is in sudo and docker groups" "stderr: $(guest_stderr)"
+    fi
+
+    # Passwordless sudo for the alt user (the sudoers drop-in is keyed
+    # by the configured user name).
+    local sudo_out
+    if sudo_out=$(guest_exec sudo whoami); then
+        if [[ "$sudo_out" == "root" ]]; then
+            pass "$alt_user has passwordless sudo"
+        else
+            fail "$alt_user has passwordless sudo" "got: $sudo_out"
+        fi
+    else
+        fail "$alt_user has passwordless sudo" "stderr: $(guest_stderr)"
+    fi
+
+    unset GUEST_INSTANCE
+
+    # Stop + restart — the restart path reads the persisted user via a
+    # different code path (`start_existing` + `wait_for_lima_ssh`), so
+    # this catches drift between the two SSH-target sites.
+    if coop stop "$inst_name"; then
+        pass "stop alt-user instance exits 0"
+    else
+        fail "stop alt-user instance exits 0" "exit code: $?"
+    fi
+
+    if coop start "$inst_name"; then
+        pass "restart alt-user instance exits 0"
+    else
+        fail "restart alt-user instance exits 0" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    GUEST_INSTANCE="$inst_name"
+    if whoami_out=$(guest_exec whoami); then
+        if [[ "$whoami_out" == "$alt_user" ]]; then
+            pass "whoami after restart still '$alt_user'"
+        else
+            fail "whoami after restart still '$alt_user'" "got: $whoami_out"
+        fi
+    else
+        fail "whoami after restart still '$alt_user'" "stderr: $(guest_stderr)"
+    fi
+    unset GUEST_INSTANCE
+
+    # Cleanup
+    coop destroy "$inst_name" 2>/dev/null || true
+    untrack_instance "$inst_name"
+
+    if coop images --delete "$img_name"; then
+        pass "images --delete $img_name exits 0"
+    else
+        fail "images --delete $img_name exits 0" "exit code: $?"
+    fi
+}
+
 # ── Main ──────────────────────────────────────────────────────
 
 main() {
@@ -3079,6 +3276,7 @@ main() {
     test_profiles_cli
     test_completions
     test_devcontainer_translator
+    test_guest_user_validation
 
     # Setup + primary instance
     test_setup
@@ -3128,6 +3326,7 @@ main() {
         test_git_repo_private_clone
         test_multi_instance
         test_named_images
+        test_guest_user_alt
         test_custom_profiles
         test_builtin_profiles
         test_post_start


### PR DESCRIPTION
## Summary

- Introduce `GuestUser` newtype (`[a-z_][a-z0-9_-]{0,31}`, not `root`) and persist it on `TemplateConfig` with `#[serde(default)]` so legacy images deserialize as `ubuntu`.
- Add `coop setup --guest-user NAME`. `start`/`shell`/`exec` have no flag — they read the persisted value, matching the spec's "immutable for instance lifetime" requirement.
- Template `scripts/guest/{guest-config,claude-code}.sh` and `compose_lima_guest_config` so both backends (Firecracker chroot + Lima cloud-init) create the configured user at uid 1000. The setup-time `--guest-user` flows through `setup::run` and `lima::setup` identically; no backend is punted to a follow-up.
- Devcontainer translator at `Stage::Setup` honours `remoteUser` unless `--guest-user` overrode it (then `Overridden`). At `Stage::Start` it compares against the persisted user — match → `Applied`, mismatch → `Unsupported` with actionable diagnostic, *and* `containerEnv` is skipped entirely. That's the original bug from the issue: `GIT_CONFIG_GLOBAL=/home/vscode/.gitconfig.local` no longer reaches a `ubuntu` guest and `gh auth setup-git` runs cleanly.
- SSH targets in both backends (`backend::FirecrackerBackend::ssh_target`, `lima::ssh_target`, `vm.rs`, builder VM, `wait_for_lima_ssh`) load the user from `TemplateConfig` via a new `backend::persisted_guest_user` helper.

## Test plan

- [x] `cargo test --bins` — 604 tests pass, including new coverage for `GuestUser` validation, serde round-trip / legacy-config defaulting, `compose_recipe_exports_guest_user`, and four translator cases (CLI override, devcontainer→translation capture, start-time match, start-time mismatch skipping `containerEnv`).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `prek run --all-files` — fmt/clippy/test all pass.
- [ ] Manual: `coop setup --guest-user vscode` then `coop start --mount <devcontainer-with-remoteUser-vscode>` end-to-end on Lima.
- [ ] Manual: same Mount against an `ubuntu` image — confirm the report row reads `Unsupported` and `gh auth setup-git` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)