### PR TITLE
Discover submodule repos in setup-pat wizard (closes #219)

### DIFF
--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -350,12 +350,58 @@ fn curl_with_accept(token: &str, url: &str, accept: &str) -> Result<(u16, String
         .arg(url)
         .capture()
         .with_context(|| format!("curl GET {url} failed"))?;
+    parse_curl_status_body(&out)
+}
+
+/// Anonymous (no Authorization header) GET — used to detect public
+/// GitHub repos without consuming the user's token's API budget.
+///
+/// Returns `Err` only on a curl failure; HTTP errors are returned via
+/// the status code so the caller can map them. Unauthenticated GitHub
+/// API requests share a 60/hour rate limit per IP, so we keep the use
+/// narrow (one probe per cross-owner / same-owner submodule slug).
+fn curl_anonymous(url: &str) -> Result<(u16, String)> {
+    let out = Cmd::new("curl")
+        .arg("-sSL")
+        .arg("-H")
+        .arg("Accept: application/vnd.github+json")
+        .arg("-w")
+        .arg("\n%{http_code}")
+        .arg(url)
+        .capture()
+        .with_context(|| format!("curl GET {url} failed"))?;
+    parse_curl_status_body(&out)
+}
+
+fn parse_curl_status_body(out: &str) -> Result<(u16, String)> {
     let (body, status_str) = out.rsplit_once('\n').unwrap_or(("", out.trim()));
     let status: u16 = status_str
         .trim()
         .parse()
         .with_context(|| format!("Failed to parse HTTP status from curl output: '{status_str}'"))?;
     Ok((status, body.to_string()))
+}
+
+/// Does an anonymous `GET /repos/{slug}` return 200?
+///
+/// `true` only when an unauthenticated request can read the repo —
+/// i.e. it is genuinely public. Anything else (404 for private/missing,
+/// 403 for rate-limited, network failure) is treated as "not public"
+/// so the wizard errs on the side of recommending a PAT rather than
+/// silently skipping a repo the user actually needs to authorize.
+fn is_public_repo_anonymous(slug: &RepoSlug) -> bool {
+    let url = format!("https://api.github.com/repos/{slug}");
+    match curl_anonymous(&url) {
+        Ok((200, _)) => true,
+        Ok((status, _)) => {
+            tracing::debug!("anonymous probe of {slug} returned HTTP {status}");
+            false
+        }
+        Err(e) => {
+            tracing::debug!("anonymous probe of {slug} failed: {e:#}");
+            false
+        }
+    }
 }
 
 /// Fetch `.gitmodules` from the parent's default branch and classify the URLs.
@@ -408,10 +454,21 @@ fn probe_same_owner_coverage(token: &str, expected: &[RepoSlug]) -> Result<Vec<R
 /// passed `probe_user` + `probe_repo` for `parent`, so the broader
 /// scope replaces the originally pasted token.
 fn handle_submodules(token: String, parent: &RepoSlug) -> Result<String> {
-    let discovery = discover_submodule_repos(&token, parent)?;
+    let mut discovery = discover_submodule_repos(&token, parent)?;
 
     if discovery.is_empty() {
         return Ok(token);
+    }
+
+    let public_skipped = discovery.drop_public(is_public_repo_anonymous);
+    if !public_skipped.is_empty() {
+        eprintln!(
+            "\nSkipping {} public submodule repo(s) — they clone without a token:",
+            public_skipped.len(),
+        );
+        for slug in &public_skipped {
+            eprintln!("  - {slug}");
+        }
     }
 
     if !discovery.non_github_urls.is_empty() {

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -24,6 +24,7 @@ use anyhow::{Context, Result, bail};
 use crate::cmd::Cmd;
 use crate::config::{CoopConfig, GitHubAuth, resolve_cmd_value};
 use crate::github_repo::{RepoSlug, detect_workspace_repo, parse_repo_slug_from_url};
+use crate::github_submodules::{SubmoduleDiscovery, classify_urls, extract_urls};
 use crate::secret_store::{
     SERVICE, account_for_repo, available_backends, delete_secret, infer_backend, store_secret,
 };
@@ -55,6 +56,7 @@ pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
     eprintln!("\nValidating token against api.github.com…");
     probe_user(&token)?;
     probe_repo(&token, &repo)?;
+    let token = handle_submodules(token, &repo)?;
 
     let backend = pick_backend()?;
     let account = account_for_repo(&repo);
@@ -332,10 +334,14 @@ fn probe_repo(token: &str, repo: &RepoSlug) -> Result<()> {
 /// to see the response body even on 4xx for diagnostics, and the status
 /// alone is enough to drive the wizard branches.
 fn curl_with_token(token: &str, url: &str) -> Result<(u16, String)> {
+    curl_with_accept(token, url, "application/vnd.github+json")
+}
+
+fn curl_with_accept(token: &str, url: &str, accept: &str) -> Result<(u16, String)> {
     let out = Cmd::new("curl")
         .arg("-sSL")
         .arg("-H")
-        .arg("Accept: application/vnd.github+json")
+        .arg(format!("Accept: {accept}"))
         .arg("-H")
         .arg("@-")
         .stdin_input(format!("Authorization: token {token}\n"))
@@ -350,6 +356,129 @@ fn curl_with_token(token: &str, url: &str) -> Result<(u16, String)> {
         .parse()
         .with_context(|| format!("Failed to parse HTTP status from curl output: '{status_str}'"))?;
     Ok((status, body.to_string()))
+}
+
+/// Fetch `.gitmodules` from the parent's default branch and classify the URLs.
+///
+/// Returns an empty discovery for `404` (the common "no submodules" case)
+/// and for any other non-`200` status, logging a warning. We deliberately
+/// don't fail the wizard on transient or permission errors here: the user
+/// already authenticated to the parent repo, and a problem with the
+/// contents endpoint shouldn't block writing a valid PAT entry. Worst
+/// case, submodule clones will still surface a clear failure at clone
+/// time — the wizard's job is purely advisory.
+fn discover_submodule_repos(token: &str, parent: &RepoSlug) -> Result<SubmoduleDiscovery> {
+    let url = format!("https://api.github.com/repos/{parent}/contents/.gitmodules");
+    let (status, body) = curl_with_accept(token, &url, "application/vnd.github.raw+json")?;
+    match status {
+        200 => Ok(classify_urls(parent, &extract_urls(&body))),
+        404 => Ok(SubmoduleDiscovery::default()),
+        other => {
+            eprintln!(
+                "warning: GET /repos/{parent}/contents/.gitmodules returned HTTP {other} — \
+                 skipping submodule check."
+            );
+            Ok(SubmoduleDiscovery::default())
+        }
+    }
+}
+
+/// Probe each `expected` slug with `token`. Returns those that the token
+/// could not access (HTTP 403/404). Transient errors (non-2xx, non-4xx)
+/// bubble up so the wizard can report them.
+fn probe_same_owner_coverage(token: &str, expected: &[RepoSlug]) -> Result<Vec<RepoSlug>> {
+    let mut failed = Vec::new();
+    for slug in expected {
+        let url = format!("https://api.github.com/repos/{slug}");
+        let (status, _body) = curl_with_token(token, &url)?;
+        match status {
+            200 => {}
+            403 | 404 => failed.push(slug.clone()),
+            other => bail!("GET /repos/{slug} returned HTTP {other}"),
+        }
+    }
+    Ok(failed)
+}
+
+/// Surface the discovery to the user and, when same-owner submodules
+/// exist, loop until the pasted token covers them all.
+///
+/// Returns the (possibly re-pasted) token. The caller stores whatever
+/// token this returns — by construction it is the latest one that
+/// passed `probe_user` + `probe_repo` for `parent`, so the broader
+/// scope replaces the originally pasted token.
+fn handle_submodules(token: String, parent: &RepoSlug) -> Result<String> {
+    let discovery = discover_submodule_repos(&token, parent)?;
+
+    if discovery.is_empty() {
+        return Ok(token);
+    }
+
+    if !discovery.non_github_urls.is_empty() {
+        eprintln!("\nIgnoring non-GitHub submodule URLs (this token can't cover them):");
+        for url in &discovery.non_github_urls {
+            eprintln!("  - {url}");
+        }
+    }
+
+    let mut token = token;
+    if !discovery.same_owner.is_empty() {
+        loop {
+            let failed = probe_same_owner_coverage(&token, &discovery.same_owner)?;
+            if failed.is_empty() {
+                eprintln!("  ✓ all same-owner submodule repos covered");
+                break;
+            }
+            print_widen_instructions(parent, &discovery.same_owner, &failed);
+            token = read_token_no_echo()?;
+            warn_token_format(&token);
+            eprintln!("\nValidating widened token against api.github.com…");
+            probe_user(&token)?;
+            probe_repo(&token, parent)?;
+        }
+    }
+
+    if !discovery.cross_owner.is_empty() {
+        eprintln!(
+            "\nNote: submodules under other resource owners need their own \
+             FGPAT (one form per owner). Run:"
+        );
+        for (owner, repos) in &discovery.cross_owner {
+            eprintln!("\n  Resource owner: {owner}");
+            for slug in repos {
+                eprintln!("    coop github setup-pat --repo {slug}");
+            }
+        }
+    }
+
+    eprintln!(
+        "\nNote: only depth-1 submodules were checked. Nested submodules \
+         (submodules of submodules) need their own `setup-pat` runs."
+    );
+
+    Ok(token)
+}
+
+fn print_widen_instructions(parent: &RepoSlug, expected: &[RepoSlug], failed: &[RepoSlug]) {
+    eprintln!(
+        "\n{} submodule repo(s) under '{}' are not covered by this token:",
+        failed.len(),
+        parent.owner(),
+    );
+    for slug in failed {
+        eprintln!("  - {slug}");
+    }
+    eprintln!(
+        "\nRe-open {PAT_NEW_URL} (or edit the existing token), keep \
+         Resource owner '{}', and under 'Only select repositories' \
+         include all of:",
+        parent.owner(),
+    );
+    eprintln!("  - {parent}");
+    for slug in expected {
+        eprintln!("  - {slug}");
+    }
+    eprintln!("Generate a fresh token, then paste it below. (Empty input aborts.)");
 }
 
 fn pick_backend() -> Result<crate::secret_store::Backend> {

--- a/src/github_submodules.rs
+++ b/src/github_submodules.rs
@@ -1,0 +1,348 @@
+//! Depth-1 GitHub submodule discovery for the FGPAT wizard.
+//!
+//! When the parent repo's `.gitmodules` lists submodules on
+//! `github.com`, a token scoped to a single repo cannot follow them.
+//! The wizard fetches `.gitmodules` via the GitHub Contents API and
+//! classifies submodule URLs into three buckets:
+//!
+//! - **Same resource owner.** A single FGPAT can cover the parent plus
+//!   sibling repos under the same owner — the wizard re-prompts the
+//!   user to include them in the form's repository selection.
+//! - **Other resource owners.** One FGPAT per owner; the wizard prints
+//!   a `coop github setup-pat --repo <slug>` line for each.
+//! - **Non-GitHub URLs.** Warned about once and otherwise ignored.
+//!
+//! The HTTP call lives in [`crate::github_pat`]; the parsing and
+//! classification live here so they can be exercised by unit tests
+//! without a network round-trip.
+//!
+//! Only depth 1 is inspected. Submodules of submodules need a
+//! follow-up `coop github setup-pat` invocation.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::github_repo::{RepoSlug, parse_repo_slug_from_url};
+
+/// Classified, dedup'd submodule repositories discovered at depth 1.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct SubmoduleDiscovery {
+    /// Slugs under the same resource owner as the parent (parent excluded).
+    pub(crate) same_owner: Vec<RepoSlug>,
+    /// Slugs under other resource owners, grouped by owner.
+    pub(crate) cross_owner: BTreeMap<String, Vec<RepoSlug>>,
+    /// Submodule URLs that resolve to something other than github.com.
+    pub(crate) non_github_urls: Vec<String>,
+}
+
+impl SubmoduleDiscovery {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.same_owner.is_empty() && self.cross_owner.is_empty() && self.non_github_urls.is_empty()
+    }
+}
+
+/// Extract `url = …` values from a `.gitmodules` body.
+///
+/// Ignores blank lines, `#`/`;` comment lines, and `[submodule "…"]`
+/// section headers. The gitconfig grammar allows optional double-quotes
+/// around the value — those are stripped. A submodule entry without a
+/// `url` is invalid per git itself, so we don't surface partial entries.
+pub(crate) fn extract_urls(gitmodules: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in gitmodules.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if !key.trim().eq_ignore_ascii_case("url") {
+            continue;
+        }
+        let value = value.trim().trim_matches('"');
+        if !value.is_empty() {
+            out.push(value.to_string());
+        }
+    }
+    out
+}
+
+/// Resolve a submodule URL relative to its parent repository.
+///
+/// Absolute URLs are returned unchanged. A `../` prefix walks up the
+/// parent's HTTPS path (`/owner/repo`). The join is bounded: a walk
+/// that overshoots the owner level, or whose remaining tail still
+/// contains `../` after a sanity limit, is dropped with a debug note
+/// rather than synthesised into a bogus slug.
+fn resolve_url(parent: &RepoSlug, raw: &str) -> Option<String> {
+    if raw.is_empty() {
+        return None;
+    }
+    if let Some(rest) = raw.strip_prefix("./") {
+        return Some(format!("https://github.com/{parent}/{rest}"));
+    }
+    if !raw.starts_with("../") {
+        return Some(raw.to_string());
+    }
+    let mut up: usize = 0;
+    let mut rest = raw;
+    while let Some(after) = rest.strip_prefix("../") {
+        up = up.checked_add(1)?;
+        rest = after;
+        if up > 8 {
+            return None;
+        }
+    }
+    let segments: [&str; 2] = [parent.owner(), parent.repo()];
+    if up > segments.len() {
+        return None;
+    }
+    let mut kept: Vec<&str> = segments[..segments.len() - up].to_vec();
+    if !rest.is_empty() {
+        kept.push(rest);
+    }
+    if kept.is_empty() {
+        return None;
+    }
+    Some(format!("https://github.com/{}", kept.join("/")))
+}
+
+/// Classify resolved submodule URLs against `parent`.
+///
+/// The parent slug itself is dropped (a submodule pointing at the
+/// parent is meaningless for token coverage). Joined relative URLs
+/// that don't end up matching `github.com/{owner}/{repo}` are dropped
+/// with a debug note rather than minted into a bogus slug or routed
+/// into the non-GitHub bucket. Same-owner and cross-owner buckets
+/// are deterministically ordered via `BTreeSet` so the wizard's
+/// output is stable across invocations.
+pub(crate) fn classify_urls(parent: &RepoSlug, urls: &[String]) -> SubmoduleDiscovery {
+    let mut same_owner: BTreeSet<RepoSlug> = BTreeSet::new();
+    let mut cross_owner: BTreeMap<String, BTreeSet<RepoSlug>> = BTreeMap::new();
+    let mut non_github: BTreeSet<String> = BTreeSet::new();
+
+    for raw in urls {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let was_relative = is_relative(trimmed);
+        let Some(resolved) = resolve_url(parent, trimmed) else {
+            tracing::debug!("submodule url not resolvable, dropping: {raw}");
+            continue;
+        };
+        match (parse_repo_slug_from_url(&resolved), was_relative) {
+            (Some(slug), _) if &slug == parent => {}
+            (Some(slug), _) if slug.owner() == parent.owner() => {
+                same_owner.insert(slug);
+            }
+            (Some(slug), _) => {
+                cross_owner
+                    .entry(slug.owner().to_string())
+                    .or_default()
+                    .insert(slug);
+            }
+            (None, true) => {
+                tracing::debug!(
+                    "joined relative submodule url doesn't match github.com/{{owner}}/{{repo}}, \
+                     dropping: {resolved} (from {raw})",
+                );
+            }
+            (None, false) => {
+                non_github.insert(resolved);
+            }
+        }
+    }
+
+    SubmoduleDiscovery {
+        same_owner: same_owner.into_iter().collect(),
+        cross_owner: cross_owner
+            .into_iter()
+            .map(|(k, v)| (k, v.into_iter().collect()))
+            .collect(),
+        non_github_urls: non_github.into_iter().collect(),
+    }
+}
+
+fn is_relative(url: &str) -> bool {
+    url.starts_with("./") || url.starts_with("../")
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    fn slug(s: &str) -> RepoSlug {
+        RepoSlug::new(s).unwrap()
+    }
+
+    #[test]
+    fn extract_urls_picks_url_lines() {
+        let body = "\
+[submodule \"a\"]
+    path = vendor/a
+    url = https://github.com/owner/a
+[submodule \"b\"]
+    path = vendor/b
+    url = ../b
+";
+        assert_eq!(
+            extract_urls(body),
+            vec!["https://github.com/owner/a", "../b"]
+        );
+    }
+
+    #[test]
+    fn extract_urls_skips_comments_and_blank_lines() {
+        let body = "\
+# top-level comment
+; another comment
+
+[submodule \"a\"]
+    url = https://github.com/o/a
+";
+        assert_eq!(extract_urls(body), vec!["https://github.com/o/a"]);
+    }
+
+    #[test]
+    fn extract_urls_strips_surrounding_quotes() {
+        let body = "    url = \"https://github.com/o/a\"\n";
+        assert_eq!(extract_urls(body), vec!["https://github.com/o/a"]);
+    }
+
+    #[test]
+    fn extract_urls_is_case_insensitive_on_key() {
+        // gitconfig keys are case-insensitive; `URL = …` is legal.
+        let body = "    URL = https://github.com/o/a\n";
+        assert_eq!(extract_urls(body), vec!["https://github.com/o/a"]);
+    }
+
+    #[test]
+    fn extract_urls_drops_empty_value() {
+        let body = "    url =\n    url = \n";
+        assert!(extract_urls(body).is_empty());
+    }
+
+    #[test]
+    fn classify_groups_same_and_cross_owner() {
+        let parent = slug("acme/parent");
+        let urls = vec![
+            "https://github.com/acme/lib-a".to_string(),
+            "https://github.com/acme/lib-b".to_string(),
+            "git@github.com:third-party/foo.git".to_string(),
+            "https://github.com/other/bar".to_string(),
+        ];
+        let d = classify_urls(&parent, &urls);
+        assert_eq!(d.same_owner, vec![slug("acme/lib-a"), slug("acme/lib-b")]);
+        assert_eq!(
+            d.cross_owner.get("other").map(Vec::as_slice),
+            Some(&[slug("other/bar")][..]),
+        );
+        assert_eq!(
+            d.cross_owner.get("third-party").map(Vec::as_slice),
+            Some(&[slug("third-party/foo")][..]),
+        );
+        assert!(d.non_github_urls.is_empty());
+    }
+
+    #[test]
+    fn classify_dedupes_repeated_urls() {
+        let parent = slug("acme/parent");
+        let urls = vec![
+            "https://github.com/acme/lib-a".to_string(),
+            "https://github.com/acme/lib-a.git".to_string(),
+            "git@github.com:acme/lib-a.git".to_string(),
+        ];
+        let d = classify_urls(&parent, &urls);
+        assert_eq!(d.same_owner, vec![slug("acme/lib-a")]);
+    }
+
+    #[test]
+    fn classify_drops_self_reference() {
+        let parent = slug("acme/parent");
+        let urls = vec![
+            "https://github.com/acme/parent.git".to_string(),
+            "https://github.com/acme/sibling".to_string(),
+        ];
+        let d = classify_urls(&parent, &urls);
+        assert_eq!(d.same_owner, vec![slug("acme/sibling")]);
+    }
+
+    #[test]
+    fn classify_collects_non_github_urls() {
+        let parent = slug("acme/parent");
+        let urls = vec![
+            "https://gitlab.com/acme/lib-a".to_string(),
+            "https://internal.example.com/x/y".to_string(),
+        ];
+        let d = classify_urls(&parent, &urls);
+        assert!(d.same_owner.is_empty());
+        assert!(d.cross_owner.is_empty());
+        assert_eq!(
+            d.non_github_urls,
+            vec![
+                "https://gitlab.com/acme/lib-a",
+                "https://internal.example.com/x/y",
+            ]
+        );
+    }
+
+    #[test]
+    fn classify_resolves_relative_url_to_sibling_under_same_owner() {
+        let parent = slug("acme/parent");
+        let urls = vec!["../sibling".to_string()];
+        let d = classify_urls(&parent, &urls);
+        assert_eq!(d.same_owner, vec![slug("acme/sibling")]);
+    }
+
+    #[test]
+    fn classify_resolves_relative_url_to_other_owner() {
+        let parent = slug("acme/parent");
+        let urls = vec!["../../other/repo".to_string()];
+        let d = classify_urls(&parent, &urls);
+        assert!(d.same_owner.is_empty());
+        assert_eq!(
+            d.cross_owner.get("other").map(Vec::as_slice),
+            Some(&[slug("other/repo")][..]),
+        );
+    }
+
+    #[test]
+    fn classify_drops_overshoot_relative_url() {
+        // `../../../too-far` walks past the owner level — the join is
+        // bounded to keep us from minting a bogus slug.
+        let parent = slug("acme/parent");
+        let urls = vec!["../../../too-far".to_string()];
+        let d = classify_urls(&parent, &urls);
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn classify_drops_joined_url_that_isnt_owner_repo_shape() {
+        // `./extra/foo` joins to `github.com/acme/parent/extra/foo` which
+        // has too many path segments to be a repo slug. Per the bounded-
+        // join rule, drop it silently rather than routing it to
+        // `non_github_urls` (the host is still github.com).
+        let parent = slug("acme/parent");
+        let urls = vec!["./extra/foo".to_string()];
+        let d = classify_urls(&parent, &urls);
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn classify_drops_empty_url() {
+        let parent = slug("acme/parent");
+        let urls = vec![String::new()];
+        let d = classify_urls(&parent, &urls);
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn is_empty_reflects_all_three_buckets() {
+        assert!(SubmoduleDiscovery::default().is_empty());
+        let mut d = SubmoduleDiscovery::default();
+        d.same_owner.push(slug("a/b"));
+        assert!(!d.is_empty());
+    }
+}

--- a/src/github_submodules.rs
+++ b/src/github_submodules.rs
@@ -38,6 +38,44 @@ impl SubmoduleDiscovery {
     pub(crate) fn is_empty(&self) -> bool {
         self.same_owner.is_empty() && self.cross_owner.is_empty() && self.non_github_urls.is_empty()
     }
+
+    /// Drop slugs that `is_public` accepts from both actionable buckets.
+    ///
+    /// Public GitHub repos clone without authentication, so suggesting
+    /// a PAT for them is noise. Returns the dropped slugs (sorted) so
+    /// the wizard can announce them. Empty cross-owner groups left
+    /// behind by the filter are pruned to keep the output tight.
+    ///
+    /// The predicate is passed in (rather than calling out to curl
+    /// here) so the function is exercised by unit tests without a
+    /// network round-trip.
+    pub(crate) fn drop_public(
+        &mut self,
+        mut is_public: impl FnMut(&RepoSlug) -> bool,
+    ) -> Vec<RepoSlug> {
+        let mut dropped = Vec::new();
+        self.same_owner.retain(|slug| {
+            if is_public(slug) {
+                dropped.push(slug.clone());
+                false
+            } else {
+                true
+            }
+        });
+        for slugs in self.cross_owner.values_mut() {
+            slugs.retain(|slug| {
+                if is_public(slug) {
+                    dropped.push(slug.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        self.cross_owner.retain(|_, v| !v.is_empty());
+        dropped.sort();
+        dropped
+    }
 }
 
 /// Extract `url = …` values from a `.gitmodules` body.
@@ -336,6 +374,60 @@ mod tests {
         let urls = vec![String::new()];
         let d = classify_urls(&parent, &urls);
         assert!(d.is_empty());
+    }
+
+    #[test]
+    fn drop_public_filters_both_buckets_and_returns_sorted_list() {
+        let parent = slug("acme/parent");
+        let urls = vec![
+            "https://github.com/acme/private-lib".to_string(),
+            "https://github.com/acme/public-lib".to_string(),
+            "https://github.com/other/public-thing".to_string(),
+            "https://github.com/other/private-thing".to_string(),
+        ];
+        let mut d = classify_urls(&parent, &urls);
+        let publics = [slug("acme/public-lib"), slug("other/public-thing")]
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let dropped = d.drop_public(|s| publics.contains(s));
+
+        assert_eq!(
+            dropped,
+            vec![slug("acme/public-lib"), slug("other/public-thing")]
+        );
+        assert_eq!(d.same_owner, vec![slug("acme/private-lib")]);
+        assert_eq!(d.cross_owner.len(), 1);
+        assert_eq!(
+            d.cross_owner.get("other").map(Vec::as_slice),
+            Some(&[slug("other/private-thing")][..])
+        );
+    }
+
+    #[test]
+    fn drop_public_prunes_empty_cross_owner_groups() {
+        let parent = slug("acme/parent");
+        let urls = vec![
+            "https://github.com/other/only-public".to_string(),
+            "https://github.com/another/keep-private".to_string(),
+        ];
+        let mut d = classify_urls(&parent, &urls);
+        let dropped = d.drop_public(|s| s.owner() == "other");
+
+        assert_eq!(dropped, vec![slug("other/only-public")]);
+        assert!(!d.cross_owner.contains_key("other"));
+        assert!(d.cross_owner.contains_key("another"));
+    }
+
+    #[test]
+    fn drop_public_no_matches_is_noop() {
+        let parent = slug("acme/parent");
+        let urls = vec!["https://github.com/acme/lib-a".to_string()];
+        let mut d = classify_urls(&parent, &urls);
+        let dropped = d.drop_public(|_| false);
+
+        assert!(dropped.is_empty());
+        assert_eq!(d.same_owner, vec![slug("acme/lib-a")]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod devcontainer;
 mod fs_util;
 mod github_pat;
 mod github_repo;
+mod github_submodules;
 mod guest;
 mod guest_env_state;
 mod naming;


### PR DESCRIPTION
## Summary

- After `probe_repo` succeeds in `coop github setup-pat`, fetch `.gitmodules` from the parent's default branch via the GitHub Contents API and classify submodule URLs into same-owner / cross-owner / non-GitHub buckets.
- Same-owner submodules: probe each with the pasted token; on miss, print widen instructions and re-prompt for a fresh token until all are covered.
- Cross-owner submodules: print one `coop github setup-pat --repo <slug>` line per group (a single FGPAT can't cover multiple resource owners).
- Non-GitHub submodule URLs are warned about once; nested submodules are mentioned in the output (depth-1 only).
- Relative URLs (`../sibling`) are resolved against the parent's HTTPS URL with a bounded `..` walk — joins that overshoot or no longer match `github.com/{owner}/{repo}` are dropped with a debug note rather than minted into a bogus slug.
- Non-200/404 responses on the contents endpoint downgrade to a warning so the wizard still writes the parent entry.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --bins` (639 passed; 15 new tests cover gitmodules parsing, relative URL resolution, dedup, and classification)
- [ ] Manual: run `coop github setup-pat --repo <repo-with-same-owner-submodule>` against a PAT scoped to the parent only; expect widen prompt
- [ ] Manual: run `coop github setup-pat --repo <repo-with-cross-owner-submodule>`; expect the per-group `setup-pat` advice
- [ ] Manual: run against a repo without `.gitmodules`; expect no extra output (404 → empty discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)