### PR TITLE
Surface workspace.json parse errors at all three call sites

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1099,14 +1099,29 @@ pub type PlatformBackend = FirecrackerBackend;
 /// `mount` source has a host path we can scan for a `.git/config`
 /// `origin`. Returns `None` when no slug can be derived — pat-mode
 /// then falls back to a clear error.
+///
+/// An unreadable or stale-format `workspace.json` (e.g. a pre-#147 file
+/// that no longer deserializes) is logged at `WARN` with the loader's
+/// migration hint before returning `None`, so the lost repo context is
+/// diagnosable rather than silently degrading to "no token forwarded".
 pub fn detect_instance_repo(
     inst: &crate::config::Instance,
 ) -> Option<crate::github_repo::RepoSlug> {
     use crate::workspace::WorkspaceSource;
 
-    let state = crate::workspace::WorkspaceState::try_load(inst)
-        .ok()
-        .flatten()?;
+    let state = match crate::workspace::WorkspaceState::try_load(inst) {
+        Ok(Some(state)) => state,
+        Ok(None) => return None,
+        Err(e) => {
+            tracing::warn!(
+                "Could not read workspace state for '{}'; GitHub repo \
+                 detection is disabled (pat-mode tokens will not be \
+                 forwarded). {e:#}",
+                inst.name,
+            );
+            return None;
+        }
+    };
     match &state.source {
         WorkspaceSource::GitRepo { url } => crate::github_repo::parse_repo_slug_from_url(url),
         WorkspaceSource::Workspace { host_path } | WorkspaceSource::Mount { host_path } => {
@@ -2108,6 +2123,37 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
     #[test]
     fn hostname_rejects_non_ascii() {
         assert!(Hostname::new("hôst").is_err());
+    }
+
+    fn temp_instance(dir: &std::path::Path) -> crate::config::Instance {
+        crate::config::Instance {
+            name: crate::config::InstanceName::new("test").unwrap(),
+            index: crate::config::InstanceIndex::new(0).unwrap(),
+            dir: dir.to_path_buf(),
+            image: crate::config::ImageName::new("default").unwrap(),
+        }
+    }
+
+    #[test]
+    fn detect_instance_repo_none_when_state_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let inst = temp_instance(dir.path());
+        assert!(detect_instance_repo(&inst).is_none());
+    }
+
+    #[test]
+    fn detect_instance_repo_none_on_stale_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let inst = temp_instance(dir.path());
+        // Pre-#147 flat shape: `host_path` at the top level and a bare
+        // `source` string. The current loader rejects this; detection must
+        // degrade to `None` rather than panic.
+        std::fs::write(
+            inst.workspace_state_path(),
+            r#"{"host_path":"/x","guest_path":"/workspace","source":"mount"}"#,
+        )
+        .unwrap();
+        assert!(detect_instance_repo(&inst).is_none());
     }
 
     #[test]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1109,19 +1109,10 @@ pub fn detect_instance_repo(
 ) -> Option<crate::github_repo::RepoSlug> {
     use crate::workspace::WorkspaceSource;
 
-    let state = match crate::workspace::WorkspaceState::try_load(inst) {
-        Ok(Some(state)) => state,
-        Ok(None) => return None,
-        Err(e) => {
-            tracing::warn!(
-                "Could not read workspace state for '{}'; GitHub repo \
-                 detection is disabled (pat-mode tokens will not be \
-                 forwarded). {e:#}",
-                inst.name,
-            );
-            return None;
-        }
-    };
+    let state = crate::workspace::try_load_or_warn(
+        inst,
+        "GitHub repo detection is disabled (pat-mode tokens will not be forwarded)",
+    )?;
     match &state.source {
         WorkspaceSource::GitRepo { url } => crate::github_repo::parse_repo_slug_from_url(url),
         WorkspaceSource::Workspace { host_path } | WorkspaceSource::Mount { host_path } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1334,9 +1334,7 @@ fn find_workspace_instance(
     let mut matching: Vec<config::Instance> = instances
         .into_iter()
         .filter(|inst| {
-            workspace::WorkspaceState::try_load(inst)
-                .ok()
-                .flatten()
+            workspace::try_load_or_warn(inst, "workspace-affinity matching will skip this instance")
                 .and_then(|s| s.source.host_path().map(Path::to_path_buf))
                 .is_some_and(|hp| hp == canonical)
         })
@@ -1633,11 +1631,12 @@ fn find_stopped_instance(
             .iter()
             .enumerate()
             .filter(|(_, inst)| {
-                workspace::WorkspaceState::try_load(inst)
-                    .ok()
-                    .flatten()
-                    .and_then(|s| s.source.host_path().map(Path::to_path_buf))
-                    .is_some_and(|hp| hp == canonical)
+                workspace::try_load_or_warn(
+                    inst,
+                    "workspace-affinity matching will skip this instance",
+                )
+                .and_then(|s| s.source.host_path().map(Path::to_path_buf))
+                .is_some_and(|hp| hp == canonical)
             })
             .map(|(i, _)| i)
             .collect();

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -101,6 +101,29 @@ impl WorkspaceState {
     }
 }
 
+/// Load `workspace.json`, logging a `WARN` on parse errors.
+///
+/// Returns `None` when no state file exists (the instance simply hasn't
+/// been started, or was started by a coop too old to write one) and also
+/// when the file exists but cannot be deserialized — typically a pre-#147
+/// shape that the current loader rejects. The parse-error case logs a
+/// warning that includes the loader's migration hint and the supplied
+/// `consequence` so the user can see which feature degraded (pat-mode
+/// token forwarding, workspace-affinity matching, etc.) rather than the
+/// failure being silently swallowed.
+pub fn try_load_or_warn(inst: &Instance, consequence: &str) -> Option<WorkspaceState> {
+    match WorkspaceState::try_load(inst) {
+        Ok(state) => state,
+        Err(e) => {
+            tracing::warn!(
+                "Could not read workspace state for '{}'; {consequence}. {e:#}",
+                inst.name,
+            );
+            None
+        }
+    }
+}
+
 /// Transfer a local directory to the guest via tar-pipe over SSH.
 ///
 /// Streams `tar cf -` straight into a guest-side `tar xf - -C /workspace`.
@@ -1109,6 +1132,39 @@ mod tests {
         fs::write(inst.workspace_state_path(), "not json").expect("write");
         let result = WorkspaceState::try_load(&inst);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_load_or_warn_returns_none_when_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inst = temp_instance(dir.path());
+        assert!(try_load_or_warn(&inst, "test").is_none());
+    }
+
+    #[test]
+    fn try_load_or_warn_returns_none_on_parse_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inst = temp_instance(dir.path());
+        fs::write(inst.workspace_state_path(), "not json").expect("write");
+        assert!(try_load_or_warn(&inst, "test").is_none());
+    }
+
+    #[test]
+    fn try_load_or_warn_returns_state_when_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inst = temp_instance(dir.path());
+        let state = WorkspaceState {
+            guest_path: GuestPath::absolute(GUEST_WORKSPACE).unwrap(),
+            source: WorkspaceSource::GitRepo {
+                url: "https://github.com/x/y.git".to_string(),
+            },
+        };
+        state.save(&inst).expect("save");
+        let loaded = try_load_or_warn(&inst, "test").expect("state should load");
+        assert!(matches!(
+            loaded.source,
+            WorkspaceSource::GitRepo { ref url } if url == "https://github.com/x/y.git"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- A stale or unreadable `workspace.json` (e.g. a pre-#147 flat-format file) made `WorkspaceState::try_load` return `Err`, which three callers discarded via `.ok().flatten()`. The migration hint that `try_load` carefully attaches with `with_context` was thrown away, so users got either a vague "no token forwarded" path or a silently-allocated fresh instance.
- `detect_instance_repo` now matches on the load result and logs a `WARN` (with the full context chain) before falling back to `None`, so pat-mode users see why the slug went missing.
- The same `try_load(inst).ok().flatten()` shape also lived in `find_workspace_instance` and `find_stopped_instance`. A parse error there silently excluded the instance from workspace-affinity matching, so `coop start` would allocate a new instance instead of reusing the matching one. A small `workspace::try_load_or_warn(inst, consequence)` helper now routes all three call sites through the same WARN-then-skip path; the `consequence` string lets each caller name what degraded.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --bins` — 652 passed
- [x] New unit tests cover `detect_instance_repo` (missing state + stale pre-#147 shape) and `try_load_or_warn` (missing, parse error, present)
- [ ] Integration tests on Lima and Firecracker (`./tests/run-integration.sh` / `--remote …`) — change is confined to a load-error log path and doesn't touch VM lifecycle, but reviewers should run both before merge per `CLAUDE.md`