### PR TITLE
Hint at --workspace/--mount when start name looks like a path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1365,12 +1365,26 @@ fn validate_instance_name(name: &str) -> Result<()> {
         .chars()
         .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_'))
     {
-        bail!(
+        let mut msg = format!(
             "Instance name contains invalid character '{c}' \
              (allowed: a-z, A-Z, 0-9, '-', '_')"
         );
+        if looks_like_path(name) {
+            msg.push_str(
+                ".\nIf you meant to start an instance for that directory, \
+                 use `--workspace <PATH>` or `--mount <PATH>`",
+            );
+        }
+        bail!(msg);
     }
     Ok(())
+}
+
+/// Whether a rejected instance name looks like the user typed a filesystem
+/// path by mistake (e.g. `coop start ~/projects/foo`). Used only to enrich
+/// the validation error with a hint toward `--workspace`/`--mount`.
+fn looks_like_path(name: &str) -> bool {
+    name.contains('/') || name.starts_with('~')
 }
 
 /// Validated instance name. Construction guarantees the name matches
@@ -2702,6 +2716,41 @@ mod tests {
             assert!(
                 err.to_string().contains("invalid character"),
                 "expected rejection for {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_name_path_like_suggests_workspace() {
+        for name in [
+            "/Users/hbrodin/projects/foo",
+            "~/projects/foo",
+            "./relative",
+            "~",
+        ] {
+            let err = validate_instance_name(name).unwrap_err().to_string();
+            assert!(
+                err.contains("invalid character"),
+                "expected base rejection for {name:?}, got: {err}"
+            );
+            assert!(
+                err.contains("--workspace") && err.contains("--mount"),
+                "expected workspace/mount hint for {name:?}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_name_non_path_omits_workspace_hint() {
+        for name in ["has space", "semi;colon", "d.ot"] {
+            let err = validate_instance_name(name).unwrap_err().to_string();
+            assert!(
+                err.contains("invalid character"),
+                "expected rejection for {name:?}, got: {err}"
+            );
+            assert!(
+                !err.contains("--workspace"),
+                "did not expect workspace hint for {name:?}, got: {err}"
             );
         }
     }


### PR DESCRIPTION
## Summary

`coop start <path>` rejected the positional as an instance name with a syntactically accurate but unhelpful message:

```
error: invalid value '/Users/hbrodin/projects/upgrade-do-no-harm' for '[NAME]':
       Instance name contains invalid character '/' (allowed: a-z, A-Z, 0-9, '-', '_')
```

When the rejected name looks like a filesystem path (contains `/` or starts with `~`), the error now appends a hint:

```
error: invalid value '/Users/hbrodin/projects/upgrade-do-no-harm' for '[NAME]': Instance name contains invalid character '/' (allowed: a-z, A-Z, 0-9, '-', '_').
If you meant to start an instance for that directory, use `--workspace <PATH>` or `--mount <PATH>`
```

This is option 1 from the issue: a hint-only change with no behavior change. The positional remains an instance name.

## Implementation

- `validate_instance_name` (`src/config.rs`) appends the hint when `looks_like_path(name)` returns true (contains `/` or starts with `~`). The syntactic checks need no filesystem access.
- The hint lives in the shared validator rather than a `start`-only wrapper. The path-like branch only triggers on user typos, and `start` is the primary command that takes a fresh name; the other subcommands operate on existing instances.

## Tests

- `validate_name_path_like_suggests_workspace` — path-like values get the hint.
- `validate_name_non_path_omits_workspace_hint` — ordinary invalid names (spaces, `;`, `.`) keep the original error without the hint.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)