### PR TITLE
Add project-oriented coop up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,19 @@ Set up the VM template, start an instance, and launch an agent CLI:
 export ANTHROPIC_API_KEY=sk-ant-...
 export OPENAI_API_KEY=sk-proj-...
 coop setup
-coop start my-project --workspace ~/code/my-project
+cd ~/code/my-project
+coop up
 coop claude
 # or
 coop codex
 ```
 
-That gives you a Claude Code or Codex session running inside an isolated VM with your project synced in. During `coop start`, coop writes `~/.claude/settings.json` in the guest with `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts — the VM itself is the isolation boundary. Pass `--ask` to `coop claude` to restore prompts for that session (`--permission-mode default`).
+That gives you a Claude Code or Codex session running inside an isolated VM with your project synced in. `coop up` is re-runnable: it creates an environment for the current project the first time, reuses it if it is already running, and restarts it after `coop stop`. During startup, coop writes `~/.claude/settings.json` in the guest with `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts — the VM itself is the isolation boundary. Pass `--ask` to `coop claude` to restore prompts for that session (`--permission-mode default`).
 
 ## Features
 
 - **Two backends**: Firecracker microVMs (Linux/KVM) and Lima VMs (macOS/Virtualization.framework), auto-detected by platform
-- **Workspace sync**: push a local directory into the VM, or clone a git repo directly with `--git-repo` (private GitHub repos use `gh auth token` or `GITHUB_TOKEN` on the host)
+- **Workspace sync**: copy or mount a local project directory into the VM with `coop up`
 - **Profiles**: customizable guest environments with apt packages and install scripts; built-in profiles for Python, Node, C, Rust, Go, and fuzzing
 - **Named images**: build multiple template images with different profiles (`coop setup --image ml-dev --profile python`)
 - **Claude Code integration**: API key forwarding, CLAUDE.md injection, plugin/marketplace support, MCP server configuration
@@ -56,9 +57,10 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 
 | Command | Description |
 |---------|-------------|
+| `up` | Ensure a project environment exists and is running |
 | `setup` | Install backend runtime, fetch kernel, build template rootfs |
 | `build` | Rebuild rootfs image and fetch kernel |
-| `start` | Launch a new VM instance |
+| `start` | Start an existing stopped VM instance |
 | `stop` | Stop a running VM (preserves disk) |
 | `destroy` | Stop and remove a VM instance |
 | `shell` | Interactive shell session in a running VM |

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -38,7 +38,7 @@ Each instance is a Lima VM created with `limactl start` using the fast-start tem
 The Lima template configures:
 - `vmType: "vz"` (Virtualization.framework, not QEMU)
 - Rosetta enabled for x86_64 binary translation on Apple Silicon
-- `mountType: "virtiofs"` with no host mounts (empty `mounts: []`). When `coop start --mount` is used, Lima adds virtiofs mount entries for the specified host directories, providing live mounts where changes are visible immediately on both sides.
+- `mountType: "virtiofs"` with no host mounts (empty `mounts: []`). When `coop up --mount` is used, Lima adds virtiofs mount entries for the specified host directories, providing live mounts where changes are visible immediately on both sides.
 - Lima's built-in containerd disabled (Docker is installed in the guest instead)
 
 ### Disk resize
@@ -72,7 +72,7 @@ All three steps are idempotent. If the artifact already exists and is up to date
 
 ### How instances work
 
-Creating an instance (`coop start`) follows this sequence:
+Creating an instance (`coop up`) follows this sequence:
 
 1. Copies the template rootfs to the instance directory using `cp --reflink=auto` for copy-on-write on supported filesystems.
 2. Mounts the copy and patches the guest network config with the instance's unique IP address and hostname.
@@ -141,7 +141,8 @@ Both backends support the same CLI commands and guest capabilities:
 | Capability | Lima (macOS) | Firecracker (Linux) |
 |---|---|---|
 | `coop setup` | Builds golden image via builder VM | Installs binary + kernel, builds rootfs via chroot |
-| `coop start` | `limactl start` with fast-start template | Copies rootfs, configures TAP, starts Firecracker |
+| `coop up` | Creates or reconnects/restarts a project VM | Copies rootfs, configures TAP, starts Firecracker |
+| `coop start` | Starts an existing stopped Lima VM | Starts an existing stopped Firecracker VM |
 | `coop stop` | `limactl stop` | API socket shutdown, SIGTERM, SIGKILL |
 | `coop destroy` | `limactl delete --force` | Kill process, remove TAP, delete instance dir |
 | `coop status` | Queries `limactl list --json` | Reads PID file, queries guest via SSH |

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -1,6 +1,6 @@
 # Claude Code Integration
 
-coop sets up Claude Code inside guest VMs and gives you a single command to launch it. This guide covers the `coop claude` command, the configuration that controls what gets injected into the guest, and the bootstrap sequence that runs at `coop start`.
+coop sets up Claude Code inside guest VMs and gives you a single command to launch it. This guide covers the `coop claude` command, the configuration that controls what gets injected into the guest, and the bootstrap sequence that runs when a VM starts.
 
 ## Launching Claude Code
 
@@ -8,7 +8,7 @@ coop sets up Claude Code inside guest VMs and gives you a single command to laun
 coop claude [instance-name] [-- extra-args...]
 ```
 
-This SSHes into the guest and runs the `claude` CLI. The guest's managed `~/.claude/settings.json` (written during `coop start`) sets `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude operates without confirmation prompts. The VM is the isolation boundary; permission prompts inside it are redundant.
+This SSHes into the guest and runs the `claude` CLI. The guest's managed `~/.claude/settings.json` (written during VM startup) sets `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude operates without confirmation prompts. The VM is the isolation boundary; permission prompts inside it are redundant.
 
 To restore permission prompts for a single session, pass `--ask`. coop then launches `claude` with `--permission-mode default`, overriding the guest default:
 
@@ -176,11 +176,11 @@ Server definitions can include an `env` map for environment variable name mappin
 
 ## Bootstrap sequence
 
-When `coop start` runs (without `--no-agents`), it executes the following steps after the VM boots and SSH becomes available:
+When `coop up` creates/restarts a project VM or `coop start` restarts a stopped VM (without `--no-agents`), coop executes the following steps after the VM boots and SSH becomes available:
 
 1. **GitHub auth**: If a `GITHUB_TOKEN` is available, run `gh auth setup-git` in the guest.
 2. **User content**: Copy the allowlisted entries (`CLAUDE.md`, `rules/`, `commands/`) from `config_dir` to `~/.claude/` in the guest.
-3. **Managed permissions**: Write a coop-managed `~/.claude/settings.json` in the guest containing `permissions.defaultMode: bypassPermissions` and `permissions.skipDangerousModePermissionPrompt: true`. The setting must live in user scope — Claude Code ignores `skipDangerousModePermissionPrompt` from project settings. This file is overwritten on every `coop start`; per-VM customization belongs in coop's config, not in the guest file.
+3. **Managed permissions**: Write a coop-managed `~/.claude/settings.json` in the guest containing `permissions.defaultMode: bypassPermissions` and `permissions.skipDangerousModePermissionPrompt: true`. The setting must live in user scope — Claude Code ignores `skipDangerousModePermissionPrompt` from project settings. This file is overwritten on every VM startup; per-VM customization belongs in coop's config, not in the guest file.
 4. **Marketplaces**: Register each marketplace source (local directories are copied to the guest first). On first boot, coop compares the configured marketplaces against those already baked into the golden image (from `coop setup --profile`) and only installs the ones that are missing.
 5. **Plugins**: Install each plugin from the registered marketplaces. Like marketplaces, coop computes the delta against plugins already present in the golden image and skips those that are already installed.
 6. **MCP servers**: Register each MCP server definition.
@@ -189,9 +189,10 @@ On restart (`coop start` of a stopped instance), only ephemeral state is refresh
 
 ### Skipping bootstrap
 
-To start a VM without any Claude Code configuration:
+To create or restart a VM without any Claude Code configuration:
 
 ```bash
+coop up . --no-agents
 coop start --no-agents
 ```
 

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -1,6 +1,6 @@
 # Codex Integration
 
-coop installs Codex into every guest image and gives you a dedicated `coop codex` launcher. This guide covers the `coop codex` command, the configuration that controls what gets injected into the guest, and the bootstrap sequence that runs at `coop start`.
+coop installs Codex into every guest image and gives you a dedicated `coop codex` launcher. This guide covers the `coop codex` command, the configuration that controls what gets injected into the guest, and the bootstrap sequence that runs when a VM starts.
 
 ## Launching Codex
 
@@ -97,7 +97,7 @@ If `config_dir` also provides a `config.toml`, coop preserves its other settings
 
 ## Bootstrap sequence
 
-When `coop start` runs (without `--no-agents`), it executes the following steps after the VM boots and SSH becomes available:
+When `coop up` creates/restarts a project VM or `coop start` restarts a stopped VM (without `--no-agents`), coop executes the following steps after the VM boots and SSH becomes available:
 
 1. **GitHub auth**: If a `GITHUB_TOKEN` is available, run `gh auth setup-git` in the guest.
 2. **User content**: Copy the allowlisted Codex entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from `config_dir` to `~/.codex/` in the guest.
@@ -107,9 +107,10 @@ On restart (`coop start` of a stopped instance), the same Codex config files are
 
 ### Skipping bootstrap
 
-To start a VM without any Claude Code or Codex configuration:
+To create or restart a VM without any Claude Code or Codex configuration:
 
 ```bash
+coop up . --no-agents
 coop start --no-agents
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,11 +14,67 @@ coop creates isolated VM environments for running Claude Code and Codex. It runs
 
 Most commands accept an optional instance name. coop resolves the target instance with three rules:
 
-- **Zero instances exist.** The command fails and tells you to run `coop start`.
+- **Zero instances exist.** The command fails and tells you to run `coop up`.
 - **One instance exists.** The name is optional. coop selects it automatically.
 - **Multiple instances exist.** The name is required. coop lists available instances on error.
 
 ## Commands
+
+### `up`
+
+Ensure an environment exists and is running for a project directory.
+
+```
+coop up [DIR] [FLAGS]
+```
+
+`DIR` defaults to the current directory. coop canonicalizes it and uses it as
+the project identity for instance naming, devcontainer discovery, GitHub PAT
+lookup, and future `coop up DIR` affinity. If a matching instance is already
+running, `up` reports success without creating another VM. If a matching
+instance is stopped, `up` restarts it. If no matching instance exists, `up`
+creates one.
+
+By default, `up` copies/syncs the project into `/workspace`. Pass `--mount` to use the mount transport for the
+project at `/workspace` instead. On macOS/Lima this is a live virtiofs mount;
+on Linux/Firecracker it is a one-time sync.
+`--copy` is accepted as an explicit spelling of the default.
+
+| Flag | Description |
+|------|-------------|
+| `DIR` | Project directory (default: current directory) |
+| `--name <name>` | Instance name to use when creating the project environment |
+| `--copy` | Copy/sync `DIR` into `/workspace` (default) |
+| `--mount` | Mount `DIR` at `/workspace` instead of using `--copy` |
+| `--extra-mount <spec>` | Additional host directory to mount into the guest (`HOST_PATH[:GUEST_PATH]`, repeatable; specify a guest path other than `/workspace` when using `--copy`) |
+| `--vcpus <N>` | Number of vCPUs when creating a new instance |
+| `--mem <MiB>` | Memory in MiB when creating a new instance |
+| `--disk <GiB>` | Instance disk size when creating a new instance |
+| `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
+| `--image <name>` | Named image to use when creating a new instance (default: `default`) |
+| `--exclude-git` | Skip the `.git/` directory when copying/syncing |
+| `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo |
+| `--forward-port <spec>` | Forward a guest port to the host (`GUEST[:HOST]`, repeatable) |
+| `--post-start <cmd>` | Shell command to run inside the guest after boot |
+| `--env KEY=VALUE` | Literal env var to set in the guest (repeatable) |
+| `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt) |
+| `--no-devcontainer` | Ignore any discovered `devcontainer.json` |
+| `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work |
+
+```
+coop up .
+coop up ~/code/my-project --mount
+coop up . --copy --forward-port 3000
+coop up . --extra-mount ~/data:/data
+```
+
+Creation options such as `--vcpus`, `--mem`, `--disk`, `--image`,
+`--extra-mount`, `--exclude-git`, and `--devcontainer` are applied only when
+`up` creates a new instance. If a matching project instance already exists,
+destroy it first to recreate it with different creation options. Runtime
+startup options such as `--forward-port`, `--post-start`, and `--env` can be
+used when `up` creates or restarts an instance; if the matching instance is
+already running, stop it first so those options can take effect.
 
 ### `init`
 
@@ -41,8 +97,8 @@ coop setup [FLAGS]
 | Flag | Description |
 |------|-------------|
 | `-y`, `--yes` | Skip confirmation prompts (accept all) |
-| `--vcpus <N>` | Number of vCPUs (overrides config) |
-| `--mem <MiB>` | Memory in MiB (overrides config) |
+| `--vcpus <N>` | Number of vCPUs for generated devcontainer/setup settings (overrides config) |
+| `--mem <MiB>` | Memory in MiB for generated devcontainer/setup settings (overrides config) |
 | `--rebuild` | Force rebuild of template rootfs |
 | `--profile <list>` | Comma-separated install profiles: `python`, `node`, `c`, `fuzz`, `rust`, `go` |
 | `--extra-packages <list>` | Comma-separated extra apt packages to install |
@@ -74,25 +130,30 @@ No additional flags.
 
 ### `start`
 
-Launch a new VM instance.
+Start an existing stopped VM instance.
 
 ```
 coop start [NAME] [FLAGS]
 ```
 
+`start` is restart-only: it never creates a new instance. Use `coop up [DIR]`
+to create or reconnect to a project environment. Without `NAME`, `start`
+restarts the only stopped instance if exactly one exists; with multiple stopped
+instances, pass the instance name.
+
 | Flag | Description |
 |------|-------------|
-| `NAME` | Instance name (auto-generated if omitted) |
-| `--workspace <dir>` | Local directory to sync into the VM (conflicts with `--git-repo`) |
-| `--git-repo <url>` | Git repository URL to clone inside the VM (conflicts with `--workspace`) |
-| `--vcpus <N>` | Number of vCPUs (overrides config) |
-| `--mem <MiB>` | Memory in MiB (overrides config) |
-| `--disk <GiB>` | Instance disk size in GiB (grows from template size if larger) |
+| `NAME` | Stopped instance name (optional only when exactly one stopped instance exists) |
+| `--workspace <dir>` | Restart the stopped instance associated with this project path (conflicts with `--git-repo`) |
+| `--git-repo <url>` | Creation-time option retained only for compatibility; use `coop up` for new project environments |
+| `--vcpus <N>` | Creation-time option retained only for compatibility; rejected on restart |
+| `--mem <MiB>` | Creation-time option retained only for compatibility; rejected on restart |
+| `--disk <GiB>` | Creation-time option retained only for compatibility; rejected on restart |
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
-| `--image <name>` | Named image to use (default: `default`) |
-| `--mount <spec>` | Mount host directory into guest (`HOST_PATH[:GUEST_PATH]`, repeatable). Conflicts with `--workspace` and `--git-repo`. |
+| `--image <name>` | Creation-time option retained only for compatibility; rejected on restart |
+| `--mount <spec>` | Creation-time option retained only for compatibility; rejected on restart |
 | `--forward-port <spec>` | Forward a guest port to the host (`GUEST[:HOST]`, repeatable). Lives for the lifetime of the VM; torn down on `coop stop`. |
-| `--exclude-git` | Skip the `.git/` directory when syncing the workspace (conflicts with `--git-repo`). |
+| `--exclude-git` | Creation-time option retained only for compatibility; rejected on restart |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
 | `--env KEY=VALUE` | Literal env var to set in the guest (repeatable). Overrides `guest_env` config entries and any forwarded values with the same name. |
@@ -100,17 +161,12 @@ coop start [NAME] [FLAGS]
 | `--no-devcontainer` | Ignore any discovered `devcontainer.json` (escape hatch for CI). |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work. |
 
-When `--workspace <dir>` contains a `.devcontainer/devcontainer.json` (or one of `--mount`'s host roots does), coop reads a subset of it and prompts before applying. See [docs/devcontainer.md](devcontainer.md) for the supported keys and discovery rules.
-
-`--workspace` and `--git-repo` are mutually exclusive. Use `--workspace` to tar-pipe a local directory into the guest. Use `--git-repo` to clone a repository inside the VM at boot.
-
-For private GitHub repos, `--git-repo` resolves a host-side token (`gh auth token` first, then `GITHUB_TOKEN`) and hands it to git in the guest via a one-shot credential helper. Without a token, the clone runs unauthenticated and will fail for private repos.
+When `--workspace <dir>` contains a `.devcontainer/devcontainer.json`, coop reads a subset of it and prompts before applying restart-time settings. See [docs/devcontainer.md](devcontainer.md) for the supported keys and discovery rules.
 
 ```
-coop start my-project --workspace ./src --vcpus 4 --mem 8192
-coop start --git-repo https://github.com/org/repo.git --disk 50
-coop start --image ml-dev --no-agents
-coop start --mount ~/data:/mnt/data
+coop start
+coop start my-project
+coop start my-project --no-agents
 coop start --env RUST_LOG=info --env MY_FLAG=1
 coop start --forward-port 3000 --forward-port 8080:18080
 ```
@@ -140,7 +196,7 @@ coop shell my-project -- cat /etc/os-release
 
 ### `claude`
 
-Launch Claude Code inside the VM. The guest's `~/.claude/settings.json` (written during `coop start`) sets `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts — the VM itself is the isolation boundary. Use `--ask` to override the guest default for that session (coop passes `--permission-mode default`).
+Launch Claude Code inside the VM. The guest's `~/.claude/settings.json` (written during VM startup) sets `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts — the VM itself is the isolation boundary. Use `--ask` to override the guest default for that session (coop passes `--permission-mode default`).
 
 ```
 coop claude [NAME] [FLAGS] [ARGS...]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ Run `coop validate` to surface errors and warnings before anything touches a VM.
 | `ssh_port` | integer | `22` | SSH port on the guest VM. Must be > 0. |
 | `firecracker_bin` | string (path) | `~/.coop/firecracker` | Path to the Firecracker binary. Linux only; ignored on macOS (Lima backend). |
 | `github` | string or table | unset (treated as `"off"`) | GitHub authentication strategy. See [GitHub auth](#github-auth). |
-| `post_start` | string | unset | Shell command run in the guest after every successful boot, before any interactive `shell` / agent launch. Failure is logged at `WARN` and does not fail the start. Override per invocation with `coop start --post-start <cmd>`. |
+| `post_start` | string | unset | Shell command run in the guest after every successful boot, before any interactive `shell` / agent launch. Failure is logged at `WARN` and does not fail startup. Override per invocation with `coop up --post-start <cmd>` or `coop start --post-start <cmd>`. |
 
 ## GitHub auth
 
@@ -31,7 +31,7 @@ When a token is present, coop runs `gh auth setup-git` inside the guest to wire 
 
 ### Fine-grained PAT (`github = "pat"`)
 
-In pat mode coop forwards a *per-repo* fine-grained personal access token: the resolved `owner/repo` at `coop start` time selects the matching entry in `[github.pat]`. Compared with `"auto"` / `"env"`, the effective reach of a leaked token is bounded by the repos and permissions GitHub recorded when it was created — GitHub rejects out-of-scope operations (REST and GraphQL) server-side, not in coop.
+In pat mode coop forwards a *per-repo* fine-grained personal access token: the resolved `owner/repo` at VM startup selects the matching entry in `[github.pat]`. Compared with `"auto"` / `"env"`, the effective reach of a leaked token is bounded by the repos and permissions GitHub recorded when it was created — GitHub rejects out-of-scope operations (REST and GraphQL) server-side, not in coop.
 
 Configure via the wizard:
 
@@ -78,9 +78,9 @@ Other subcommands:
 | `coop github forget-pat --repo X/Y` | Remove the stored secret and the `[github.pat."X/Y"]` entry. Does **not** add a skip marker; the token may still be live on GitHub. |
 | `coop validate --probe` | Resolves each entry and probes `GET /user` against api.github.com. May trigger Keychain authorization or a 1Password Touch-ID prompt the first time per session. |
 
-#### Auto-prompt at `coop start`
+#### Auto-prompt at VM startup
 
-When `coop start` runs with a resolvable repo (from `--git-repo` or the synced workspace's `origin`) and `github` is `"off"` (or `"pat"` with no matching entry), coop offers to run the wizard inline: `[y/N/never]`. Three answers:
+When `coop up` or `coop start` runs with a resolvable repo (usually the synced workspace's `origin`) and `github` is `"off"` (or `"pat"` with no matching entry), coop offers to run the wizard inline: `[y/N/never]`. Three answers:
 
 - `y` — run the wizard, then continue the start.
 - `N` (default) — start unauthenticated, ask again next time.
@@ -134,7 +134,7 @@ Keys are env var names; values are the literals to inject. Entries here **overri
 
 **Secrets:** values land in the guest's process environment in plain text and may be visible via `ps`/`/proc` to guest users. For credentials, prefer `env_forward` (host process env stays the source of truth) or one of the `cmd:` integrations on the structured fields (`claude.api_key`, etc.).
 
-Override or extend per-invocation with `coop start --env KEY=VALUE` (repeatable).
+Override or extend per-invocation with `coop up --env KEY=VALUE` or `coop start --env KEY=VALUE` (repeatable).
 
 ## `claude` section
 
@@ -222,7 +222,7 @@ Custom profiles compose with built-in ones (`python`, `node`, `c`, `fuzz`, `rust
 
 ## `forward_ports` field
 
-Default host-to-guest TCP port forwards applied to every `coop start`. Forwards are established as SSH `-L` tunnels after the VM is ready and torn down on `coop stop`.
+Default host-to-guest TCP port forwards applied to every VM startup. Forwards are established as SSH `-L` tunnels after the VM is ready and torn down on `coop stop`.
 
 Each entry accepts a bare port (host and guest match), a `"GUEST:HOST"` string, or a table.
 
@@ -240,7 +240,7 @@ host = 15432
 label = "postgres"
 ```
 
-`--forward-port` on `coop start` appends to (or overrides on guest-port collision) the entries from config; later entries win. Each instance remembers its forward set across `coop stop` / `coop start`, so a restart without `--forward-port` re-establishes the same tunnels.
+`--forward-port` on `coop up` or `coop start` appends to (or overrides on guest-port collision) the entries from config; later entries win. Each instance remembers its forward set across `coop stop` / `coop start`, so a restart without `--forward-port` re-establishes the same tunnels.
 
 Collision with an in-use host port fails fast before the VM is created. The error names the offending port and suggests a `GUEST:HOST` override.
 

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -4,7 +4,7 @@ coop reads a **subset** of [devcontainer.json](https://containers.dev/) and maps
 
 ## How discovery and apply work
 
-When you run `coop start --workspace <dir>` or `coop setup --workspace <dir>`, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each `--mount` host root, with workspace winning ties).
+When you run `coop up <dir>` or `coop setup --workspace <dir>`, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each mount host root, with the project directory winning ties). On restart, `coop start --workspace <dir>` can also read the project's devcontainer file for restart-time settings.
 
 If a file is found, coop prompts:
 
@@ -53,4 +53,4 @@ CLI flags > `devcontainer.json` > defaults. The reporting table marks overrides 
 - OCI feature registry pulls (`ghcr.io/devcontainers/features/*` features other than the built-in name match)
 - `--git-repo` auto-detection — the file lives inside the repo before coop has cloned it
 - Sticky `--no-devcontainer` (persistent per-workspace state)
-- Live re-application on an existing VM (destroy + start to pick up changes)
+- Live re-application on an existing VM (destroy + `coop up` to pick up changes)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ The `github` field controls how coop resolves a GitHub token for the guest:
 - `"env"`: requires `GITHUB_TOKEN` in your environment
 - `"pat"`: forwards a per-repo fine-grained PAT recorded under `[github.pat."owner/repo"]`. GitHub enforces the token's scope server-side — see [GitHub auth](configuration.md#fine-grained-pat-github--pat) for the full reference.
 
-GitHub auth is off by default. Set `github = "auto"` (or run `coop github setup-pat --repo owner/name` for a scoped PAT) to enable it. `coop start` itself offers to run the PAT wizard inline the first time you start an instance against a GitHub repo without auth configured.
+GitHub auth is off by default. Set `github = "auto"` (or run `coop github setup-pat --repo owner/name` for a scoped PAT) to enable it. `coop up` offers to run the PAT wizard inline the first time you bring up a project backed by a GitHub repo without auth configured.
 
 coop picks up `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from your environment automatically. Setting them explicitly under `claude.api_key` or `codex.api_key` also works, but environment variables are preferred.
 
@@ -102,51 +102,68 @@ coop setup -y --profile python
 
 Setup is idempotent. Rerunning with the same profiles skips completed work. Pass `--rebuild` to force a fresh template build.
 
-### 2. Start an instance
+### 2. Bring up a project environment
+
+For normal project work, use `coop up` from your project directory:
+
+```
+cd ~/code/my-project
+coop up
+```
+
+`coop up` is project-oriented and re-runnable. It creates an instance the
+first time, reuses it if it is already running, and restarts it after
+`coop stop`. By default it copies/syncs the project into `/workspace`.
+
+Choose mount transport explicitly:
+
+```
+coop up . --mount
+```
+
+On macOS/Lima this is live filesystem sharing. On Linux/Firecracker it is a
+one-time sync.
+
+Mount additional data directories when creating the project instance:
+
+```
+coop up . --extra-mount ~/data:/data
+```
+
+After the environment is running, connect to it:
+
+```
+coop shell
+coop claude
+coop codex
+```
+
+### 3. Restart a stopped instance
 
 ```
 coop start
 ```
 
-This creates a VM instance from the template, boots it, waits for SSH, and injects Claude Code and Codex credentials/config. The instance gets an auto-generated name.
+`coop start` only starts existing stopped instances. Use it after `coop stop`
+when you want to boot the same VM disk again. If exactly one stopped instance
+exists, the name is optional.
 
-Name it explicitly:
+Restart a specific stopped instance:
 
 ```
 coop start my-project
 ```
 
-Sync a local directory into the VM as `/workspace`:
+Restart by project path when the instance was created for that project:
 
 ```
-coop start my-project --workspace ~/code/my-project
+coop start --workspace ~/code/my-project
 ```
 
-Clone a git repository inside the VM instead:
+Creation options belong to `coop up`, not `coop start`:
 
 ```
-coop start my-project --git-repo https://github.com/user/repo
-```
-
-Set a custom disk size for the instance (must be >= template size):
-
-```
-coop start my-project --disk 40
-```
-
-Mount host directories into the VM:
-
-```
-coop start my-project --mount ~/data
-coop start my-project --mount ~/data:/guest/data --mount ~/models:/guest/models
-```
-
-`--mount HOST_PATH[:GUEST_PATH]` is repeatable. On macOS/Lima, mounts are live virtiofs mounts. On Linux/Firecracker, mounts are a one-time rsync sync. Conflicts with `--workspace` and `--git-repo`.
-
-Start from a specific named image:
-
-```
-coop start my-project --image python-dev
+coop up ~/code/my-project --disk 40 --mount
 ```
 
 Skip Claude Code and Codex credential/config injection:
@@ -155,7 +172,7 @@ Skip Claude Code and Codex credential/config injection:
 coop start my-project --no-agents
 ```
 
-### 3. Connect
+### 4. Connect
 
 **Launch Claude Code inside the VM:**
 
@@ -163,7 +180,7 @@ coop start my-project --no-agents
 coop claude
 ```
 
-During `coop start`, coop writes `~/.claude/settings.json` in the guest with `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts by default. The VM itself is the isolation boundary. For permission prompts (coop launches `claude` with `--permission-mode default`):
+During VM startup, coop writes `~/.claude/settings.json` in the guest with `defaultMode: bypassPermissions` and `skipDangerousModePermissionPrompt: true`, so Claude Code runs without permission prompts by default. The VM itself is the isolation boundary. For permission prompts (coop launches `claude` with `--permission-mode default`):
 
 ```
 coop claude --ask
@@ -200,7 +217,7 @@ coop shell -- ls /workspace
 coop exec -- docker ps
 ```
 
-### 4. Check status
+### 5. Check status
 
 ```
 coop status
@@ -214,7 +231,7 @@ coop status my-project
 
 Running instances report resource usage: load average, memory, and disk.
 
-### 5. Sync files
+### 6. Sync files
 
 Push local changes into a running VM:
 
@@ -228,7 +245,7 @@ Pull guest changes back to the host:
 coop pull
 ```
 
-Both commands default to the workspace path from `coop start --workspace`. Override with `--dir`:
+Both commands default to the workspace path recorded by `coop up`. Override with `--dir`:
 
 ```
 coop push --dir ~/other-dir
@@ -264,10 +281,10 @@ coop setup --image python-dev --profile python
 coop setup --image polyglot --profile python,node,rust
 ```
 
-Start an instance from a specific image:
+Create a project environment from a specific image:
 
 ```
-coop start --image python-dev
+coop up . --image python-dev
 ```
 
 List images:

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -1,6 +1,6 @@
 # Images and Profiles
 
-coop builds **golden images** (templates) once and copies them to create VM instances. `coop setup` builds the template. `coop start` copies it. Profiles control which development tools go into the template.
+coop builds **golden images** (templates) once and copies them to create VM instances. `coop setup` builds the template. `coop up` copies it when creating a project instance. Profiles control which development tools go into the template.
 
 ## How templates work
 
@@ -12,7 +12,7 @@ A template is a fully provisioned ext4 root filesystem. The build process:
 4. Applies requested profiles and extra packages
 5. Runs post-install scripts if provided
 
-coop stores the result under `~/.coop/images/<name>/`. On `coop start`, it copies the template to create an instance-specific rootfs. The copy uses `cp --reflink=auto` on Linux. On filesystems that support reflinks (btrfs, XFS), this shares storage blocks until written, making the copy fast and space-efficient.
+coop stores the result under `~/.coop/images/<name>/`. When creating an instance, coop copies the template to create an instance-specific rootfs. The copy uses `cp --reflink=auto` on Linux. On filesystems that support reflinks (btrfs, XFS), this shares storage blocks until written, making the copy fast and space-efficient.
 
 ## What every template includes
 
@@ -106,8 +106,8 @@ By default, coop builds an image called `default`. Build multiple images with di
 coop setup --profile python --image py-dev
 coop setup --profile python,node,rust --image polyglot
 
-coop start --image py-dev
-coop start --image polyglot
+coop up . --image py-dev
+coop up . --image polyglot
 ```
 
 Each named image lives in its own directory under `~/.coop/images/<name>/` with independent versioning and staleness tracking.
@@ -138,7 +138,7 @@ coop records what went into each template in a `template-config.json` file along
 - **Install script hash**: SHA-256 of the composed install recipe (base + profile + extra packages). Changing profiles or extra packages changes this hash.
 - **Post-install script hash**: SHA-256 of the post-install script content, if one was provided.
 - **Profile list and extra packages**: the exact inputs used to build the template.
-- **Marketplaces and plugins**: the marketplace sources and plugins that were baked into the template. On `coop start`, coop compares this list against the current config and only installs the delta (marketplaces or plugins added since the template was built).
+- **Marketplaces and plugins**: the marketplace sources and plugins that were baked into the template. On VM startup, coop compares this list against the current config and only installs the delta (marketplaces or plugins added since the template was built).
 - **Creation timestamp**: when the template was built.
 
 On every `coop setup`, coop computes the current recipe hash and compares it to the stored config. If the hashes differ, the template is stale and coop rebuilds it. A missing config file (orphaned image) also triggers a rebuild.
@@ -158,7 +158,7 @@ The build is crash-safe. coop writes the new template to a staging path (`rootfs
 
 ## Instance creation from templates
 
-`coop start` creates an instance from a template:
+`coop up` creates an instance from a template when no project instance exists:
 
 1. Copies the template rootfs to an instance-specific path
 2. Resizes the disk if `--disk` exceeds the template size
@@ -166,9 +166,9 @@ The build is crash-safe. coop writes the new template to a staging path (`rootfs
 4. Boots the VM
 
 ```bash
-coop start
-coop start --disk 50
-coop start --image py-dev --disk 100
+coop up .
+coop up . --disk 50
+coop up . --image py-dev --disk 100
 ```
 
 If `--disk` is smaller than the template size, coop logs a warning and uses the template size (shrinking is not supported). If larger, coop extends the image with `truncate` and grows the filesystem with `resize2fs`.

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -4,14 +4,14 @@ coop runs multiple VM instances simultaneously. Each instance gets its own name,
 
 ## Named vs. auto-named instances
 
-Every instance has a name. You provide one explicitly or let coop generate one from the allocated index.
+Every instance has a name. By default, `coop up` derives it from the project directory. You can provide one explicitly with `--name`.
 
 ```
-# Named instance
-coop start my-project
+# Project-derived instance
+coop up ./my-project
 
-# Auto-named instance (uses the allocated index, e.g. "0", "1")
-coop start
+# Explicit instance name
+coop up ./my-project --name my-project
 ```
 
 Named instances pay off when you have several running at once. The name appears in `coop list` / `coop status` output and targets commands at a specific instance.
@@ -29,7 +29,7 @@ Names that violate these rules are rejected at creation time.
 
 Most commands accept an optional instance name. Resolution follows three cases:
 
-- **Zero instances exist.** The command fails with a message to run `coop start`.
+- **Zero instances exist.** The command fails with a message to run `coop up`.
 - **Exactly one instance exists.** The name is optional. coop auto-selects it.
 - **Multiple instances exist.** The name is required. coop lists the available names in the error if you omit it.
 
@@ -82,14 +82,14 @@ The output format depends on the backend. It includes the full resource breakdow
 
 ## Per-instance image selection
 
-Each instance can use a different golden image. Build images with `coop setup --image <name>`, then select one at start time:
+Each instance can use a different golden image. Build images with `coop setup --image <name>`, then select one when creating the project instance:
 
 ```
 coop setup --image python --profile python
 coop setup --image node --profile node
 
-coop start py-work --image python
-coop start js-work --image node
+coop up ./py-work --image python
+coop up ./js-work --image node
 ```
 
 Omitting `--image` selects the image named `default`.
@@ -101,7 +101,7 @@ Omitting `--image` selects the image named `default`.
 `--disk` sets the instance disk size in GiB:
 
 ```
-coop start big-project --disk 100
+coop up ./big-project --disk 100
 ```
 
 The instance disk grows from the template size when the requested size is larger.
@@ -126,8 +126,8 @@ The instance must be stopped first. coop rejects the resize and tells you to sto
 Each instance is fully independent. Start, stop, and destroy instances without affecting others:
 
 ```
-coop start frontend
-coop start backend
+coop up ./frontend --name frontend
+coop up ./backend --name backend
 coop stop frontend        # backend keeps running
 coop destroy frontend     # backend unaffected
 ```
@@ -157,7 +157,7 @@ On Lima, the directory structure differs because Lima manages its own VM state. 
 
 ## Concurrent access and file locking
 
-When allocating a new instance, coop acquires an exclusive file lock (`flock`) on the instances directory. This prevents two concurrent `coop start` invocations from claiming the same index or name. The lock is held only during index allocation and released automatically when the operation completes.
+When allocating a new instance, coop acquires an exclusive file lock (`flock`) on the instances directory. This prevents two concurrent `coop up` invocations from claiming the same index or name. The lock is held only during index allocation and released automatically when the operation completes.
 
 ## Index allocation
 

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -55,7 +55,7 @@ Restart the shell (or `source` your rc) after the first install.
 
 ## Dynamic completion
 
-Dynamic completion lets `coop` itself compute candidates on TAB — so `coop shell <TAB>` lists your running instances, `coop start --image <TAB>` lists existing images, and `coop setup --profile <TAB>` lists builtin and custom profiles.
+Dynamic completion lets `coop` itself compute candidates on TAB — so `coop shell <TAB>` lists your running instances, `coop up --image <TAB>` lists existing images, and `coop setup --profile <TAB>` lists builtin and custom profiles.
 
 Add one line to your shell rc:
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,42 +1,41 @@
 # Workspace Sync
 
-coop moves code between the host and guest VM. There are three ways to get code in, and two commands, `push` and `pull`, for ongoing sync.
+coop moves code between the host and guest VM. The normal way to get code in is `coop up`, with `push` and `pull` for ongoing sync.
 
 ## Getting Code into the VM
 
-### Local directory (`--workspace`)
+### Project environment (`coop up`)
 
 ```bash
-coop start --workspace ./my-project
+coop up ./my-project
+coop up ./my-project --mount
 ```
 
-This tar-pipes the contents of `./my-project` into `/workspace` inside the guest over SSH. Both sides independently SHA-256-hash the tar stream. If the checksums diverge, the transfer aborts.
+`coop up` treats the directory as the project identity. Re-running the same
+command finds the existing instance for that directory instead of allocating
+another VM. The default transport is copy/sync into `/workspace`; `--mount`
+uses mount transport for the project directory. On macOS/Lima this is live
+filesystem sharing; on Linux/Firecracker it is a one-time sync. Use
+`--extra-mount HOST:GUEST` for additional mounted data directories when
+creating the project instance. If the instance already exists, destroy it
+first to change creation-time choices such as transport, image, disk size, or
+extra mounts.
 
-coop persists the host-to-guest path mapping in `workspace.json` so that later `push` and `pull` calls resolve paths automatically.
+`coop up` in copy mode tar-pipes the project into `/workspace` inside the
+guest over SSH. Both sides independently SHA-256-hash the tar stream. If the
+checksums diverge, the transfer aborts. coop persists the host-to-guest path
+mapping in `workspace.json` so that later `push` and `pull` calls resolve paths
+automatically.
 
-### Git clone (`--git-repo`)
-
-```bash
-coop start --git-repo https://github.com/org/repo.git
-```
-
-Clones the repository inside the guest at `/workspace/repo`. Nothing transfers from the host. The resulting `workspace.json` has a null `host_path`, so `push` and `pull` require an explicit directory argument.
-
-For private GitHub repositories, coop resolves a host-side token (`gh auth token` first, then `GITHUB_TOKEN`) and forwards it to git in the guest via a one-shot credential helper for this clone only. The token never appears on argv and never persists in the guest. Without a token, the clone runs unauthenticated and will fail for private repos.
-
-### Host mount (`--mount`)
-
-```bash
-coop start --mount ~/data
-coop start --mount ~/data:/mnt/data
-```
-
-Mounts a host directory into the guest. Behavior differs by backend:
+`coop up --mount` mounts the project directory into the guest. Behavior differs
+by backend:
 
 - **Lima (macOS)**: Live virtiofs mount. Changes on host are visible in guest immediately and vice versa.
 - **Firecracker (Linux)**: One-time rsync sync at boot. Not a live mount. Use `coop push` / `coop pull` to sync changes afterward.
 
-If GUEST_PATH is omitted, defaults to `/workspace`. Conflicts with `--workspace` and `--git-repo`.
+Additional host data can be mounted at creation time with
+`coop up --extra-mount HOST_PATH:GUEST_PATH`. In copy mode, extra mounts must
+not target `/workspace`, because the copied project owns that path.
 
 #### Mounting a git repository (live-mount caveat)
 
@@ -49,7 +48,10 @@ Because the mount is live, those entries appear on the host as well. After the V
 
 coop prints a warning at start time when a live-mount source is a git repo. To avoid the issue, do not run commands inside the guest that record absolute paths in `.git/config` — in particular, `git worktree add` and `prek install` (or any other tool that calls `git config core.hooksPath`).
 
-Switching from `--mount` to `--workspace` does not on its own fix this: `--workspace` copies the repo into the guest, but `.git/` is included by default and is brought back by `coop pull`, so corrupted config entries written inside the guest still reach the host. Either avoid the offending commands or pass `--exclude-git` on `coop pull`.
+Switching from mount mode to copy mode does not on its own fix this: copy mode
+includes `.git/` by default and `coop pull` can bring corrupted config entries
+written inside the guest back to the host. Either avoid the offending commands
+or pass `--exclude-git` on `coop pull`.
 
 ### Manual via SSH
 
@@ -62,13 +64,13 @@ No workspace state is recorded. `push` and `pull` will not work without a `works
 
 ## State file: `workspace.json`
 
-Starting a VM with `--workspace`, `--git-repo`, or `--mount` writes a `workspace.json` in the instance directory:
+Creating a project VM with `coop up` writes a `workspace.json` in the instance directory:
 
 | Field        | Description                                                    |
 |-------------|----------------------------------------------------------------|
-| `host_path`  | Absolute path on the host (null for `--git-repo` workspaces)  |
+| `host_path`  | Absolute path on the host                                     |
 | `guest_path` | Path inside the guest VM (always `/workspace`)                 |
-| `source`     | How the workspace was created: `workspace`, `git_repo`, or `mount` |
+| `source`     | How the workspace was created: `workspace` or `mount`          |
 
 `push` and `pull` read this file to resolve default paths.
 
@@ -118,7 +120,7 @@ All transfers (rsync and tar-pipe) exclude these reproducible build and cache di
 - `.venv/`
 - `.coop/`
 
-`.git/` is **included** by default so agents in the guest get full history, branches, and the ability to make commits that survive a `coop pull`. Pass `--exclude-git` to `coop start`, `coop push`, or `coop pull` to skip it on a per-transfer basis (useful for very large repos where transfer time dominates).
+`.git/` is **included** by default so agents in the guest get full history, branches, and the ability to make commits that survive a `coop pull`. Pass `--exclude-git` to `coop up`, `coop push`, or `coop pull` to skip it on a per-transfer basis (useful for very large repos where transfer time dominates).
 
 ## .gitignore integration
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1529,7 +1529,7 @@ fn managed_claude_settings_json() -> String {
 
 /// Write coop's managed `~/.claude/settings.json` to the guest.
 ///
-/// Runs every `coop start`, overwriting any in-guest edits. The file
+/// Runs every VM startup, overwriting any in-guest edits. The file
 /// is small and owned by coop; users wanting per-VM customization should
 /// extend coop's config rather than editing the guest file in place.
 fn write_managed_claude_settings(target: &SshTarget) -> Result<()> {
@@ -1929,7 +1929,7 @@ pub fn clone_git_repo(
                 "Failed to clone {repo_url} in guest. \
                  If this is a private repo, configure a PAT with \
                  `coop github setup-pat --repo <owner/repo>`, run `gh auth login`, \
-                 or set `GITHUB_TOKEN` on the host before `coop start --git-repo`."
+                 or set `GITHUB_TOKEN` on the host before starting the VM."
             )
         } else {
             format!("Failed to clone {repo_url} in guest")

--- a/src/config.rs
+++ b/src/config.rs
@@ -618,7 +618,7 @@ pub struct CoopConfig {
     #[serde(default)]
     pub post_start: Option<String>,
 
-    /// Default host:guest port forwards applied to every `coop start`.
+    /// Default host:guest port forwards applied to every VM startup.
     ///
     /// CLI `--forward-port` values are appended; later entries override
     /// earlier ones with the same guest port.
@@ -926,7 +926,7 @@ pub struct PatConfig {
     /// [`RepoSlug`](crate::github_repo::RepoSlug).
     #[serde(default, rename = "pat")]
     pub entries: std::collections::BTreeMap<crate::github_repo::RepoSlug, PatEntry>,
-    /// Repos for which the auto-prompt at `coop start` is suppressed.
+    /// Repos for which the VM startup auto-prompt is suppressed.
     #[serde(default)]
     pub skip: Vec<crate::github_repo::RepoSlug>,
 }
@@ -1308,10 +1308,10 @@ pub struct ClaudeConfig {
     pub config_dir: ConfigDir,
 }
 
-/// `[setup]` section: controls one-time UX behaviour at `coop start`.
+/// `[setup]` section: controls one-time UX behaviour at VM startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetupConfig {
-    /// Whether `coop start` prompts the user to set up a fine-grained PAT
+    /// Whether VM startup prompts the user to set up a fine-grained PAT
     /// when the resolved repo has no entry. Set to `false` to suppress
     /// globally. The per-repo `skip` list under `[github]` suppresses
     /// individual repos.
@@ -1371,8 +1371,8 @@ fn validate_instance_name(name: &str) -> Result<()> {
         );
         if looks_like_path(name) {
             msg.push_str(
-                ".\nIf you meant to start an instance for that directory, \
-                 use `--workspace <PATH>` or `--mount <PATH>`",
+                ".\nIf you meant to create or reconnect to a project environment, \
+                 use `coop up <PATH>`",
             );
         }
         bail!(msg);
@@ -1382,7 +1382,7 @@ fn validate_instance_name(name: &str) -> Result<()> {
 
 /// Whether a rejected instance name looks like the user typed a filesystem
 /// path by mistake (e.g. `coop start ~/projects/foo`). Used only to enrich
-/// the validation error with a hint toward `--workspace`/`--mount`.
+/// the validation error with a hint toward `coop up <PATH>`.
 fn looks_like_path(name: &str) -> bool {
     name.contains('/') || name.starts_with('~')
 }
@@ -1880,7 +1880,7 @@ impl CoopConfig {
                     let available = self.format_instance_list_or_none();
                     format!(
                         "No instance named '{name}'. {available}\n\
-                         Create one with: coop start --name {name}"
+                         Create one with: coop up . --name {name}"
                     )
                 });
         }
@@ -1894,7 +1894,7 @@ impl CoopConfig {
         } else if instances.is_empty() {
             bail!(
                 "No instances found.\n\
-                 Create one with: coop start\n\
+                 Create one with: coop up\n\
                  (Run `coop setup` first if you haven't built an image yet.)"
             )
         } else {
@@ -2735,8 +2735,8 @@ mod tests {
                 "expected base rejection for {name:?}, got: {err}"
             );
             assert!(
-                err.contains("--workspace") && err.contains("--mount"),
-                "expected workspace/mount hint for {name:?}, got: {err}"
+                err.contains("coop up <PATH>"),
+                "expected coop up hint for {name:?}, got: {err}"
             );
         }
     }

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -75,7 +75,7 @@ pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
         opts.config_path.display(),
         cmd_str,
     );
-    eprintln!("\nDone. `coop start --git-repo https://github.com/{repo}` will use this token.");
+    eprintln!("\nDone. VM startups for https://github.com/{repo} will use this token.");
     Ok(())
 }
 
@@ -734,7 +734,7 @@ fn pick_backend() -> Result<crate::secret_store::Backend> {
 ///
 /// Holds an exclusive `flock` on a sibling `.lock` file across the
 /// read-modify-write window so concurrent wizard invocations (e.g. two
-/// `coop start` auto-prompts firing at once) don't lose each other's
+/// VM startup auto-prompts firing at once) don't lose each other's
 /// writes.
 fn upsert_pat_entry(path: &Path, repo: &RepoSlug, token_cmd: &str) -> Result<()> {
     let _lock = crate::fs_util::lock_sibling(path)?;
@@ -892,7 +892,7 @@ fn doc_contains_literal_token(doc: &toml::Value) -> bool {
     })
 }
 
-/// Hint helper used by `coop start` and other code paths to format the
+/// Hint helper used by VM startup code paths to format the
 /// "no entry for this repo" error consistently.
 pub fn missing_entry_error(repo: &RepoSlug) -> String {
     format!(

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -47,7 +47,7 @@ pub fn setup(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
     generate_start_template(cfg, image)?;
 
     eprintln!("\nSetup complete.");
-    eprintln!("Run `coop start` to launch a VM.");
+    eprintln!("Run `coop up` in a project directory to launch a VM.");
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,12 +72,86 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Ensure an environment for a project directory exists and is running.
+    ///
+    /// Re-runnable: if an instance already exists for DIR it is reused
+    /// (running) or restarted (stopped) instead of being recreated.
+    Up {
+        /// Project directory (default: current directory)
+        dir: Option<String>,
+        /// Instance name to use when creating the project environment
+        #[arg(long, value_parser = config::InstanceName::parse)]
+        name: Option<config::InstanceName>,
+        /// Copy/sync DIR into the guest as /workspace (default)
+        #[arg(long, conflicts_with = "mount")]
+        copy: bool,
+        /// Mount DIR at /workspace instead of using --copy
+        #[arg(long)]
+        mount: bool,
+        /// Additional host directory to mount into the guest (`HOST_PATH[:GUEST_PATH]`, repeatable)
+        #[arg(long, value_parser = config::Mount::parse)]
+        extra_mount: Vec<config::Mount>,
+        /// Number of vCPUs (overrides config when creating a new instance)
+        #[arg(long)]
+        vcpus: Option<u8>,
+        /// Memory in MiB (overrides config when creating a new instance)
+        #[arg(long, value_parser = config::MiB::parse_cli)]
+        mem: Option<config::MiB>,
+        /// Instance disk size in GiB (only used when creating a new instance)
+        #[arg(long, value_parser = config::GiB::parse_cli)]
+        disk: Option<config::GiB>,
+        /// Skip injecting Claude Code and Codex credentials/config into the VM
+        #[arg(long, alias = "no-claude")]
+        no_agents: bool,
+        /// Named image to use when creating a new instance (default: "default")
+        #[arg(
+            long,
+            default_value = config::DEFAULT_IMAGE,
+            value_parser = config::ImageName::parse,
+            add = ArgValueCandidates::new(completions::image_candidates),
+        )]
+        image: config::ImageName,
+        /// Skip the `.git` directory when copying/syncing the project
+        #[arg(long)]
+        exclude_git: bool,
+        /// Suppress the interactive prompt to set up a scoped GitHub PAT
+        /// when one is missing for the resolved repo.
+        #[arg(long)]
+        no_prompt: bool,
+        /// Forward a guest port to the host (`GUEST[:HOST]`, repeatable).
+        #[arg(long, value_parser = config::PortForward::parse)]
+        forward_port: Vec<config::PortForward>,
+        /// Shell command to run inside the guest after boot (overrides
+        /// `post_start` from `config.toml`). Failure is logged but does
+        /// not fail the start.
+        #[arg(long, value_name = "CMD")]
+        post_start: Option<String>,
+        /// Literal env var to set in the guest (`KEY=VALUE`, repeatable).
+        /// Overrides `guest_env` entries from config and any forwarded
+        /// values with the same name.
+        #[arg(
+            long = "env",
+            value_name = "KEY=VALUE",
+            value_parser = guest_env_state::parse_cli_env_arg,
+        )]
+        guest_env: Vec<(guest_env_state::EnvVarName, String)>,
+        /// Explicit path to a `devcontainer.json` to use (skips discovery).
+        #[arg(long, value_name = "PATH", conflicts_with = "no_devcontainer")]
+        devcontainer: Option<String>,
+        /// Ignore any discovered `devcontainer.json` (escape hatch for CI).
+        #[arg(long)]
+        no_devcontainer: bool,
+        /// Translate `devcontainer.json` and print the report, then exit
+        /// before any VM work.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// One-shot: ensure default image, start an instance for cwd, launch Claude.
     ///
     /// Re-runnable: if an instance already exists for the current workspace it
     /// is reconnected (running) or restarted (stopped) instead of being
     /// recreated. For per-instance tuning (profiles, mounts, image, ...) use
-    /// `coop setup` / `coop start` directly.
+    /// `coop setup` / `coop up` directly.
     Quickstart {
         /// Skip mounting the current directory as the workspace.
         #[arg(long)]
@@ -151,30 +225,30 @@ enum Commands {
     },
     /// Build rootfs image and fetch kernel (use `setup` for first-time install)
     Build,
-    /// Launch a new Firecracker VM instance
+    /// Start an existing stopped VM instance
     Start {
-        /// Instance name (auto-generated if omitted)
+        /// Stopped instance name (optional only when exactly one stopped instance exists)
         #[arg(value_parser = config::InstanceName::parse)]
         name: Option<config::InstanceName>,
-        /// Workspace directory to sync into the VM
+        /// Project directory used to select an associated stopped instance
         #[arg(long, conflicts_with = "git_repo")]
         workspace: Option<String>,
-        /// Git repository URL to clone inside the VM
+        /// Deprecated creation option; rejected by `coop start`
         #[arg(long, conflicts_with = "workspace")]
         git_repo: Option<String>,
-        /// Number of vCPUs (overrides config)
+        /// Creation-time option; rejected by `coop start`
         #[arg(long)]
         vcpus: Option<u8>,
-        /// Memory in MiB (overrides config)
+        /// Creation-time option; rejected by `coop start`
         #[arg(long, value_parser = config::MiB::parse_cli)]
         mem: Option<config::MiB>,
-        /// Instance disk size in GiB (grows from template size if larger)
+        /// Creation-time option; rejected by `coop start`
         #[arg(long, value_parser = config::GiB::parse_cli)]
         disk: Option<config::GiB>,
         /// Skip injecting Claude Code and Codex credentials/config into the VM
         #[arg(long, alias = "no-claude")]
         no_agents: bool,
-        /// Mount host directory into guest (`HOST_PATH[:GUEST_PATH]`, repeatable)
+        /// Creation-time option; rejected by `coop start`
         #[arg(
             long,
             conflicts_with_all = ["workspace", "git_repo"],
@@ -186,7 +260,7 @@ enum Commands {
         /// `--forward-port 3000:3001` forwards guest 3000 to host 3001.
         #[arg(long, value_parser = config::PortForward::parse)]
         forward_port: Vec<config::PortForward>,
-        /// Named image to use (default: "default")
+        /// Creation-time option; rejected by `coop start`
         #[arg(
             long,
             default_value = config::DEFAULT_IMAGE,
@@ -194,7 +268,7 @@ enum Commands {
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         image: config::ImageName,
-        /// Skip the `.git` directory when syncing the workspace
+        /// Creation-time option; rejected by `coop start`
         #[arg(long, conflicts_with = "git_repo")]
         exclude_git: bool,
         /// Suppress the interactive prompt to set up a scoped GitHub PAT
@@ -562,6 +636,15 @@ where
         .any(|a| a.as_ref() == "--no-claude" || a.as_ref().starts_with("--no-claude="))
 }
 
+fn raw_args_use_long_flag<I, S>(args: I, flag: &str) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter()
+        .any(|a| a.as_ref() == flag || a.as_ref().starts_with(&format!("{flag}=")))
+}
+
 #[expect(clippy::too_many_lines, reason = "CLI dispatch — flat match arms")]
 fn main() -> Result<()> {
     // Dynamic shell completion: when invoked with COMPLETE=<shell>, compute
@@ -635,7 +718,61 @@ fn main() -> Result<()> {
     let be: backend::PlatformBackend = backend::PlatformBackend::new();
     tracing::debug!("Using backend: {be}");
 
+    let raw_args: Vec<String> = std::env::args().collect();
     match cli.command {
+        Commands::Up {
+            dir,
+            name,
+            copy,
+            mount,
+            extra_mount,
+            vcpus,
+            mem,
+            disk,
+            no_agents,
+            image,
+            exclude_git,
+            no_prompt,
+            forward_port,
+            post_start,
+            guest_env,
+            devcontainer,
+            no_devcontainer,
+            dry_run,
+        } => {
+            let validated = cfg.validate_and_warn()?;
+            let transport = if mount {
+                ProjectTransport::Mount
+            } else {
+                let _ = copy;
+                ProjectTransport::Copy
+            };
+            let opts = UpOpts {
+                dir: dir.as_deref(),
+                name: name.as_ref(),
+                transport,
+                extra_mount,
+                vcpus,
+                mem,
+                disk,
+                image,
+                image_explicit: raw_args_use_long_flag(&raw_args, "--image"),
+                runtime: UpRuntimeOpts {
+                    no_agents,
+                    exclude_git,
+                    no_prompt,
+                    forward_ports: forward_port,
+                    post_start,
+                    guest_env,
+                },
+                devcontainer: UpDevcontainerOpts {
+                    path: devcontainer,
+                    no_devcontainer,
+                    dry_run,
+                },
+            };
+            cmd_up(&be, &mut cfg, &validated, &cli.config, &opts)
+        }
         Commands::Quickstart {
             no_workspace,
             no_devcontainer,
@@ -746,11 +883,34 @@ fn main() -> Result<()> {
             dry_run,
         } => {
             let validated = cfg.validate_and_warn()?;
-            if raw_args_use_deprecated_no_claude(std::env::args()) {
+            if raw_args_use_deprecated_no_claude(&raw_args) {
                 tracing::warn!(
                     "--no-claude is deprecated and will be removed in a future release; use --no-agents"
                 );
             }
+            if vcpus.is_some() || mem.is_some() {
+                bail!(
+                    "`coop start` only starts stopped instances; VM sizing options belong to `coop up`."
+                );
+            }
+            let preflight_opts = StartOpts {
+                name: name.as_ref(),
+                image: StartImage {
+                    explicit: raw_args_use_long_flag(&raw_args, "--image"),
+                },
+                workspace_dir: workspace.as_deref(),
+                git_repo: git_repo.as_deref(),
+                no_agents,
+                no_prompt,
+                disk,
+                mounts: mounts.clone(),
+                exclude_git,
+                forward_ports: forward_ports.clone(),
+                config_path: &cli.config,
+                post_start_override: post_start.as_deref(),
+                persisted_guest_env: std::collections::BTreeMap::new(),
+            };
+            preflight_start_target(&be, &cfg, &preflight_opts)?;
             let cli_env_keys = guest_env.iter().map(|(k, _)| k.clone()).collect();
             let inputs = devcontainer::TranslatorInputs {
                 cli_vcpus: vcpus,
@@ -832,7 +992,9 @@ fn main() -> Result<()> {
                 &validated,
                 &StartOpts {
                     name: name.as_ref(),
-                    image: &image,
+                    image: StartImage {
+                        explicit: raw_args_use_long_flag(&raw_args, "--image"),
+                    },
                     workspace_dir: workspace.as_deref(),
                     git_repo: git_repo.as_deref(),
                     no_agents,
@@ -1082,6 +1244,425 @@ struct QuickstartOpts {
     no_devcontainer: bool,
 }
 
+struct UpOpts<'a> {
+    dir: Option<&'a str>,
+    name: Option<&'a config::InstanceName>,
+    transport: ProjectTransport,
+    extra_mount: Vec<config::Mount>,
+    vcpus: Option<u8>,
+    mem: Option<config::MiB>,
+    disk: Option<config::GiB>,
+    image: config::ImageName,
+    image_explicit: bool,
+    runtime: UpRuntimeOpts,
+    devcontainer: UpDevcontainerOpts,
+}
+
+struct UpRuntimeOpts {
+    no_agents: bool,
+    exclude_git: bool,
+    no_prompt: bool,
+    forward_ports: Vec<config::PortForward>,
+    post_start: Option<String>,
+    guest_env: Vec<(guest_env_state::EnvVarName, String)>,
+}
+
+struct UpDevcontainerOpts {
+    path: Option<String>,
+    no_devcontainer: bool,
+    dry_run: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProjectTransport {
+    Copy,
+    Mount,
+}
+
+/// Project-oriented start: ensure DIR has a single matching environment.
+///
+/// Unlike `start`, `up` treats the project directory as identity and keeps
+/// transport explicit. Existing instances are found by their recorded
+/// `workspace.json` host path; creation-only inputs are only applied when no
+/// matching instance exists.
+fn cmd_up(
+    be: &backend::PlatformBackend,
+    cfg: &mut config::CoopConfig,
+    _: &config::Validated,
+    config_path: &Path,
+    opts: &UpOpts<'_>,
+) -> Result<()> {
+    let transport = opts.transport;
+    let project_dir = resolve_project_dir(opts.dir)?;
+
+    let project_mount = config::Mount {
+        host_path: project_dir.clone(),
+        guest_path: workspace::default_workspace_path(),
+    };
+    let discovery_mounts = if transport == ProjectTransport::Mount {
+        std::slice::from_ref(&project_mount)
+    } else {
+        &[]
+    };
+
+    if opts.devcontainer.dry_run {
+        let inputs = up_translator_inputs(cfg, opts);
+        resolve_devcontainer(
+            &DevcontainerOpts {
+                explicit_path: opts.devcontainer.path.as_deref(),
+                no_devcontainer: opts.devcontainer.no_devcontainer,
+                dry_run: true,
+                workspace: Some(&project_dir),
+                mounts: discovery_mounts,
+            },
+            &inputs,
+            devcontainer::Stage::Start,
+        )?;
+        return Ok(());
+    }
+
+    if let Some(inst) = find_workspace_instance(cfg, &project_dir)? {
+        ensure_up_project_name_matches(&inst, &project_dir, opts)?;
+        ensure_up_existing_inputs_are_compatible(&inst, transport, opts)?;
+        if be.is_running(&inst) {
+            reject_running_up_restart_inputs(&inst, opts)?;
+            tracing::info!(
+                "Instance '{}' is already running for {}",
+                inst.name,
+                project_dir.display()
+            );
+            return Ok(());
+        }
+
+        let mut restart_opts = runtime_start_opts_from_up(opts, config_path);
+        apply_runtime_guest_env(cfg, &opts.runtime.guest_env, None, &mut restart_opts);
+        restart_instance(be, cfg, &inst, &restart_opts)?;
+        return Ok(());
+    }
+
+    create_up_instance(
+        be,
+        cfg,
+        config_path,
+        opts,
+        &project_dir,
+        &project_mount,
+        discovery_mounts,
+    )
+}
+
+fn up_translator_inputs(
+    cfg: &config::CoopConfig,
+    opts: &UpOpts<'_>,
+) -> devcontainer::TranslatorInputs {
+    devcontainer::TranslatorInputs {
+        cli_vcpus: opts.vcpus,
+        cli_mem_mib: opts.mem,
+        cli_disk_gib: opts.disk,
+        cli_post_start: opts.runtime.post_start.clone(),
+        cli_guest_env_keys: opts
+            .runtime
+            .guest_env
+            .iter()
+            .map(|(k, _)| k.clone())
+            .collect(),
+        cli_forward_ports: opts.runtime.forward_ports.clone(),
+        cli_mounts: opts.extra_mount.clone(),
+        persisted_guest_user: Some(backend::persisted_guest_user(cfg, &opts.image)),
+        cli_workspace_or_git_repo: true,
+        ..devcontainer::TranslatorInputs::default()
+    }
+}
+
+fn create_up_instance(
+    be: &backend::PlatformBackend,
+    cfg: &mut config::CoopConfig,
+    config_path: &Path,
+    opts: &UpOpts<'_>,
+    project_dir: &Path,
+    project_mount: &config::Mount,
+    discovery_mounts: &[config::Mount],
+) -> Result<()> {
+    let inputs = up_translator_inputs(cfg, opts);
+    let translation = resolve_devcontainer(
+        &DevcontainerOpts {
+            explicit_path: opts.devcontainer.path.as_deref(),
+            no_devcontainer: opts.devcontainer.no_devcontainer,
+            dry_run: false,
+            workspace: Some(project_dir),
+            mounts: discovery_mounts,
+        },
+        &inputs,
+        devcontainer::Stage::Start,
+    )?;
+
+    apply_vm_overrides(cfg, opts.vcpus, opts.mem, None)?;
+    if let Some(t) = &translation {
+        devcontainer::apply_to_config(cfg, t)?;
+    }
+
+    let mut forward_ports = opts.runtime.forward_ports.clone();
+    if let Some(t) = &translation {
+        forward_ports = devcontainer::merge_into_forward_ports(&t.forward_ports, &forward_ports);
+    }
+
+    let dc_guest_env = translation
+        .as_ref()
+        .map(|t| t.guest_env.clone())
+        .unwrap_or_default();
+    let cli_guest_env: std::collections::BTreeMap<_, _> =
+        opts.runtime.guest_env.iter().cloned().collect();
+    let persisted_guest_env =
+        guest_env_state::merge_persisted_entries(&dc_guest_env, &cli_guest_env);
+    for (key, value) in &persisted_guest_env {
+        cfg.guest_env.insert(key.clone(), value.clone());
+    }
+
+    let default_translation = devcontainer::Translation::default();
+    let effective_disk = devcontainer::effective_disk(
+        opts.disk,
+        translation.as_ref().unwrap_or(&default_translation),
+    );
+    let post_start_override = opts
+        .runtime
+        .post_start
+        .clone()
+        .or_else(|| translation.as_ref().and_then(|t| t.post_start.clone()));
+
+    let mut mounts = translation
+        .as_ref()
+        .map(|t| t.mounts.clone())
+        .unwrap_or_default();
+    mounts.extend(opts.extra_mount.clone());
+
+    let workspace_dir = match opts.transport {
+        ProjectTransport::Copy => Some(project_dir_to_str(project_dir)?),
+        ProjectTransport::Mount => {
+            mounts.insert(0, project_mount.clone());
+            None
+        }
+    };
+    validate_copy_workspace_mounts(opts.transport, &mounts)?;
+    validate_unique_guest_paths(&mounts)?;
+
+    let start_opts = StartOpts {
+        name: None,
+        image: StartImage {
+            explicit: opts.image_explicit,
+        },
+        workspace_dir: workspace_dir.as_deref(),
+        git_repo: None,
+        no_agents: opts.runtime.no_agents,
+        no_prompt: opts.runtime.no_prompt,
+        disk: effective_disk,
+        mounts,
+        exclude_git: opts.runtime.exclude_git,
+        forward_ports,
+        config_path,
+        post_start_override: post_start_override.as_deref(),
+        persisted_guest_env,
+    };
+
+    allocate_and_start(
+        be,
+        cfg,
+        opts.name,
+        &opts.image,
+        Some(project_dir),
+        &start_opts,
+    )
+    .map(|_| ())
+}
+
+fn resolve_project_dir(dir: Option<&str>) -> Result<PathBuf> {
+    let path = match dir {
+        Some(dir) => PathBuf::from(dir),
+        None => std::env::current_dir().context("Failed to read current directory")?,
+    };
+    let canonical = path
+        .canonicalize()
+        .with_context(|| format!("Failed to resolve project directory {}", path.display()))?;
+    anyhow::ensure!(
+        canonical.is_dir(),
+        "Project directory is not a directory: {}",
+        canonical.display()
+    );
+    Ok(canonical)
+}
+
+fn project_dir_to_str(project_dir: &Path) -> Result<String> {
+    project_dir
+        .to_str()
+        .map(ToOwned::to_owned)
+        .with_context(|| format!("Project path is not valid UTF-8: {}", project_dir.display()))
+}
+
+fn runtime_start_opts_from_up<'a>(opts: &'a UpOpts<'_>, config_path: &'a Path) -> StartOpts<'a> {
+    StartOpts {
+        name: None,
+        image: StartImage { explicit: false },
+        workspace_dir: None,
+        git_repo: None,
+        no_agents: opts.runtime.no_agents,
+        no_prompt: opts.runtime.no_prompt,
+        disk: None,
+        mounts: Vec::new(),
+        exclude_git: false,
+        forward_ports: opts.runtime.forward_ports.clone(),
+        config_path,
+        post_start_override: opts.runtime.post_start.as_deref(),
+        persisted_guest_env: std::collections::BTreeMap::new(),
+    }
+}
+
+fn apply_runtime_guest_env(
+    cfg: &mut config::CoopConfig,
+    cli_guest_env: &[(guest_env_state::EnvVarName, String)],
+    dc_guest_env: Option<&std::collections::BTreeMap<guest_env_state::EnvVarName, String>>,
+    start_opts: &mut StartOpts<'_>,
+) {
+    let cli_guest_env: std::collections::BTreeMap<_, _> = cli_guest_env.iter().cloned().collect();
+    let dc_guest_env = dc_guest_env.cloned().unwrap_or_default();
+    start_opts.persisted_guest_env =
+        guest_env_state::merge_persisted_entries(&dc_guest_env, &cli_guest_env);
+    for (key, value) in &start_opts.persisted_guest_env {
+        cfg.guest_env.insert(key.clone(), value.clone());
+    }
+}
+
+fn ensure_up_existing_inputs_are_compatible(
+    inst: &config::Instance,
+    transport: ProjectTransport,
+    opts: &UpOpts<'_>,
+) -> Result<()> {
+    if opts.image_explicit && inst.image != opts.image {
+        bail!(
+            "Instance '{}' already exists for this project using image '{}'. \
+             `coop up --image {}` only applies when creating a new instance.\n\
+             Use `coop destroy {}` first to recreate it with a different image.",
+            inst.name,
+            inst.image,
+            opts.image,
+            inst.name,
+        );
+    }
+    if opts.disk.is_some()
+        || opts.vcpus.is_some()
+        || opts.mem.is_some()
+        || !opts.extra_mount.is_empty()
+        || opts.runtime.exclude_git
+        || opts.devcontainer.path.is_some()
+    {
+        bail!(
+            "Instance '{}' already exists for this project. \
+             --vcpus, --mem, --disk, --extra-mount, --exclude-git, and \
+             --devcontainer only apply when creating a new instance.\n\
+             Use `coop destroy {}` first to recreate it with those options.",
+            inst.name,
+            inst.name,
+        );
+    }
+
+    let Some(state) =
+        workspace::try_load_or_warn(inst, "project transport check will skip this instance")
+    else {
+        return Ok(());
+    };
+    let existing = match state.source {
+        workspace::WorkspaceSource::Workspace { .. } => ProjectTransport::Copy,
+        workspace::WorkspaceSource::Mount { .. } => ProjectTransport::Mount,
+        workspace::WorkspaceSource::GitRepo { .. } => return Ok(()),
+    };
+    if existing != transport {
+        let existing = match existing {
+            ProjectTransport::Copy => "copy",
+            ProjectTransport::Mount => "mount",
+        };
+        let requested = match transport {
+            ProjectTransport::Copy => "copy",
+            ProjectTransport::Mount => "mount",
+        };
+        bail!(
+            "Instance '{}' already exists for this project using {existing} transport, \
+             but this command requested {requested}.\n\
+             Re-run with the original transport, or `coop destroy {}` first to recreate it.",
+            inst.name,
+            inst.name,
+        );
+    }
+    Ok(())
+}
+
+fn ensure_up_project_name_matches(
+    inst: &config::Instance,
+    project_dir: &Path,
+    opts: &UpOpts<'_>,
+) -> Result<()> {
+    if let Some(name) = opts.name {
+        anyhow::ensure!(
+            &inst.name == name,
+            "Project {} is already associated with instance '{}', not '{}'.",
+            project_dir.display(),
+            inst.name,
+            name,
+        );
+    }
+    Ok(())
+}
+
+fn up_has_restart_only_inputs(opts: &UpOpts<'_>) -> bool {
+    opts.runtime.no_agents
+        || !opts.runtime.forward_ports.is_empty()
+        || opts.runtime.post_start.is_some()
+        || !opts.runtime.guest_env.is_empty()
+}
+
+fn reject_running_up_restart_inputs(inst: &config::Instance, opts: &UpOpts<'_>) -> Result<()> {
+    if up_has_restart_only_inputs(opts) {
+        bail!(
+            "Instance '{}' is already running for this project. \
+             --no-agents, --forward-port, --post-start, and --env only take \
+             effect during start or restart.\n\
+             Run `coop stop {}` first, then repeat `coop up` with those options.",
+            inst.name,
+            inst.name,
+        );
+    }
+    Ok(())
+}
+
+fn validate_unique_guest_paths(mounts: &[config::Mount]) -> Result<()> {
+    let mut seen = std::collections::HashSet::new();
+    for mount in mounts {
+        let guest_path = mount.guest_path.to_string();
+        if !seen.insert(guest_path.clone()) {
+            bail!("Duplicate mount guest path: {guest_path}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_copy_workspace_mounts(
+    transport: ProjectTransport,
+    mounts: &[config::Mount],
+) -> Result<()> {
+    if transport != ProjectTransport::Copy {
+        return Ok(());
+    }
+    let workspace_path = workspace::default_workspace_path().to_string();
+    if mounts
+        .iter()
+        .any(|mount| mount.guest_path.to_string() == workspace_path)
+    {
+        bail!(
+            "`coop up --copy` already uses /workspace for the project. \
+             Give --extra-mount an explicit non-/workspace guest path, or use \
+             `coop up --mount` to mount the project itself."
+        );
+    }
+    Ok(())
+}
+
 /// One-shot `setup → start → claude`. See `Commands::Quickstart`.
 ///
 /// The flow short-circuits any step that's already done:
@@ -1089,9 +1670,8 @@ struct QuickstartOpts {
 /// * reconnects to a running instance for the current workspace, or restarts
 ///   a stopped one, instead of allocating fresh.
 ///
-/// `--no-workspace` skips workspace affinity entirely and falls back to the
-/// same "single running / single stopped" rules used by `coop start` and
-/// `coop claude` when called without a name.
+/// `--no-workspace` skips workspace affinity entirely and creates a fresh
+/// instance when no running workspace instance can be reused.
 fn cmd_quickstart(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
@@ -1136,18 +1716,15 @@ fn cmd_quickstart(
         Some(inst) => {
             tracing::info!("Restarting stopped instance '{}'", inst.name);
             // Use the existing instance's image, not the default — the two
-            // can diverge if the instance was created via `coop start
-            // --image <other>`. On restart this is currently ignored, but
-            // passing `&image` would silently allocate fresh with the
-            // wrong image if `find_stopped_instance` lost the race to a
-            // concurrent destroy.
+            // can diverge if the instance was created with `coop up
+            // --image <other>`.
             cmd_start(
                 be,
                 cfg,
                 &validated,
                 &StartOpts {
                     name: Some(&inst.name),
-                    image: &inst.image,
+                    image: StartImage { explicit: false },
                     workspace_dir: None,
                     git_repo: None,
                     no_agents: false,
@@ -1182,10 +1759,8 @@ fn cmd_quickstart(
 /// `--env`, no forwards, no `--post-start`), folding any discovered
 /// `devcontainer.json` into the start. Returns the started instance.
 ///
-/// With `workspace_dir = None` (i.e. `--no-workspace`) this calls
-/// `allocate_and_start` directly rather than `cmd_start`, deliberately
-/// bypassing `find_stopped_instance`'s "single stopped instance" fallback
-/// — that fallback would silently restart an unrelated stopped instance.
+/// This allocates directly rather than going through `cmd_start`; quickstart
+/// creates project environments while `start` only restarts stopped instances.
 fn quickstart_fresh_start(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
@@ -1248,7 +1823,7 @@ fn quickstart_fresh_start(
 
     let start_opts = StartOpts {
         name: None,
-        image,
+        image: StartImage { explicit: false },
         workspace_dir: workspace_str,
         git_repo: None,
         no_agents: false,
@@ -1262,14 +1837,8 @@ fn quickstart_fresh_start(
         persisted_guest_env,
     };
 
-    if workspace_dir.is_some() {
-        cmd_start(be, cfg, validated, &start_opts)
-    } else {
-        // `--no-workspace`: skip the "single stopped instance" fallback in
-        // `find_stopped_instance` so we never hijack an unrelated VM. Each
-        // quickstart with `--no-workspace` allocates a fresh instance.
-        allocate_and_start(be, cfg, None, image, None, &start_opts)
-    }
+    let _ = validated;
+    allocate_and_start(be, cfg, None, image, workspace_dir, &start_opts)
 }
 
 /// Resolve the workspace directory for `coop quickstart`.
@@ -1463,9 +2032,13 @@ fn cmd_build(cfg: &config::CoopConfig, _: &config::Validated) -> Result<()> {
     Ok(())
 }
 
+struct StartImage {
+    explicit: bool,
+}
+
 struct StartOpts<'a> {
     name: Option<&'a config::InstanceName>,
-    image: &'a config::ImageName,
+    image: StartImage,
     workspace_dir: Option<&'a str>,
     git_repo: Option<&'a str>,
     no_agents: bool,
@@ -1493,19 +2066,76 @@ struct StartOpts<'a> {
     persisted_guest_env: std::collections::BTreeMap<guest_env_state::EnvVarName, String>,
 }
 
-/// Did the user pass creation-only flags (`--mount`, `--git-repo`, `--disk`,
-/// `--exclude-git`) without an identifier (`--name` or `--workspace`) that
-/// could pick out an existing instance?
-///
-/// When true, `cmd_start` must allocate a fresh instance rather than fall
-/// back to the "single stopped instance" shortcut in `find_stopped_instance`.
-fn creation_intent_without_target(opts: &StartOpts<'_>) -> bool {
-    let identifies_existing = opts.name.is_some() || opts.workspace_dir.is_some();
-    let has_creation_only_flags = !opts.mounts.is_empty()
+fn restart_has_ignored_creation_flags(opts: &StartOpts<'_>) -> bool {
+    let workspace_was_restart_key = opts.name.is_none() && opts.workspace_dir.is_some();
+    !opts.mounts.is_empty()
+        || opts.image.explicit
+        || (opts.workspace_dir.is_some() && !workspace_was_restart_key)
         || opts.git_repo.is_some()
         || opts.disk.is_some()
-        || opts.exclude_git;
-    has_creation_only_flags && !identifies_existing
+        || opts.exclude_git
+}
+
+fn no_stopped_instance_message(opts: &StartOpts<'_>, workspace_path: Option<&Path>) -> String {
+    let mut msg = if let Some(name) = opts.name {
+        format!("No stopped instance named '{name}' exists.")
+    } else if let Some(path) = workspace_path {
+        format!(
+            "No stopped instance is associated with workspace {}.",
+            path.display()
+        )
+    } else {
+        "No stopped instances exist.".to_string()
+    };
+
+    if !opts.mounts.is_empty()
+        || opts.git_repo.is_some()
+        || opts.disk.is_some()
+        || opts.image.explicit
+        || opts.exclude_git
+    {
+        msg.push_str(
+            "\n`coop start` only starts stopped instances; creation options belong to `coop up`.",
+        );
+    }
+
+    if let Some(path) = workspace_path {
+        msg.push_str("\nCreate or reconnect to this project with:\n  coop up ");
+        msg.push_str(&path.display().to_string());
+    } else {
+        msg.push_str("\nCreate or reconnect to a project with:\n  coop up [DIR]");
+    }
+    msg.push_str("\nUse `coop list` to see existing instances.");
+    msg
+}
+
+fn creation_options_rejected_message(inst: &config::Instance) -> String {
+    format!(
+        "Instance '{}' already exists (stopped). These creation options \
+         would be silently \
+         ignored on restart.\n\
+         To apply new options, destroy the instance first:\n  \
+         coop destroy {0}\n  coop up [DIR]",
+        inst.name,
+    )
+}
+
+fn preflight_start_target(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    opts: &StartOpts<'_>,
+) -> Result<()> {
+    let ws_path = opts.workspace_dir.map(Path::new);
+
+    let Some(inst) = find_stopped_instance(be, cfg, opts.name, ws_path)? else {
+        bail!("{}", no_stopped_instance_message(opts, ws_path));
+    };
+
+    if restart_has_ignored_creation_flags(opts) {
+        bail!("{}", creation_options_rejected_message(&inst));
+    }
+
+    Ok(())
 }
 
 fn cmd_start(
@@ -1516,49 +2146,22 @@ fn cmd_start(
 ) -> Result<config::Instance> {
     let ws_path = opts.workspace_dir.map(Path::new);
 
-    // Creation-only flags (`--mount`, `--git-repo`, `--disk`, `--exclude-git`)
-    // unambiguously signal "I want a new VM with these settings". When the user
-    // didn't also identify an existing instance (via `--name` or `--workspace`),
-    // skip the single-stopped-instance shortcut in `find_stopped_instance` —
-    // otherwise we'd tell the user to destroy an unrelated stopped instance
-    // when their real intent was to allocate a fresh one (issue #214).
-    let restart_candidate = if creation_intent_without_target(opts) {
-        None
-    } else {
-        find_stopped_instance(be, cfg, opts.name, ws_path)?
+    let Some(inst) = find_stopped_instance(be, cfg, opts.name, ws_path)? else {
+        bail!("{}", no_stopped_instance_message(opts, ws_path));
     };
 
-    if let Some(inst) = restart_candidate {
-        let has_ignored_flags = !opts.mounts.is_empty()
-            || opts.workspace_dir.is_some()
-            || opts.git_repo.is_some()
-            || opts.disk.is_some()
-            || opts.exclude_git;
-
-        if has_ignored_flags {
-            bail!(
-                "Instance '{}' already exists (stopped). The flags \
-                 --mount, --workspace, --git-repo, --disk, and --exclude-git \
-                 are only applied at creation time and would be silently \
-                 ignored on restart.\n\
-                 To apply new options, destroy the instance first:\n  \
-                 coop destroy {0}\n  coop start {0} [options]",
-                inst.name,
-            );
-        }
-
-        restart_instance(be, cfg, &inst, opts)?;
-        return Ok(inst);
+    let has_ignored_flags = restart_has_ignored_creation_flags(opts);
+    if has_ignored_flags {
+        bail!("{}", creation_options_rejected_message(&inst));
     }
 
-    allocate_and_start(be, cfg, opts.name, opts.image, ws_path, opts)
+    restart_instance(be, cfg, &inst, opts)?;
+    Ok(inst)
 }
 
 /// Allocate a fresh instance and run the first-boot start, cleaning up any
-/// partial state on error. Used by `cmd_start`'s "no stopped instance to
-/// restart" path and by `cmd_quickstart`'s `--no-workspace` fresh path
-/// (which skips the `find_stopped_instance` "single stopped" rule to avoid
-/// hijacking an unrelated instance).
+/// partial state on error. Used by project-oriented flows that create
+/// instances (`coop up` and `coop quickstart`).
 fn allocate_and_start(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
@@ -1597,7 +2200,7 @@ fn allocate_and_start(
 /// With a workspace path (no name): looks up instances by their stored
 /// workspace `host_path`. If a match is found and running, errors with
 /// a helpful message. If stopped, returns it for restart. If no match,
-/// returns None so a new instance is allocated.
+/// returns None so the caller can report that `start` is restart-only.
 ///
 /// With neither: returns the single stopped instance if exactly one
 /// exists, errors if multiple stopped instances exist, returns None
@@ -1972,7 +2575,7 @@ fn resolve_running(
             .with_context(|| {
                 format!(
                     "No instance named '{name}'.\n\
-                     Create one with: coop start {name}"
+                     Create one with: coop up . --name {name}"
                 )
             })?;
         return be.as_running(cfg, inst).with_context(|| {
@@ -2004,7 +2607,7 @@ fn resolve_running(
         0 if stopped.is_empty() => {
             bail!(
                 "No instances found.\n\
-                 Create one with: coop start\n\
+                 Create one with: coop up\n\
                  (Run `coop setup` first if you haven't \
                  built an image yet.)"
             )
@@ -3298,19 +3901,13 @@ mod tests {
         assert!(status.success(), "git {args:?} failed");
     }
 
-    static TEST_IMAGE: std::sync::LazyLock<super::config::ImageName> =
-        std::sync::LazyLock::new(|| {
-            super::config::ImageName::new(super::config::DEFAULT_IMAGE)
-                .expect("DEFAULT_IMAGE is valid")
-        });
-
     fn start_opts(
         mounts: Vec<super::config::Mount>,
         config_path: &std::path::Path,
     ) -> super::StartOpts<'_> {
         super::StartOpts {
             name: None,
-            image: &TEST_IMAGE,
+            image: super::StartImage { explicit: false },
             workspace_dir: None,
             git_repo: None,
             no_agents: false,
@@ -3378,10 +3975,28 @@ mod tests {
         assert!(slug.is_none());
     }
 
-    /// Issue #214 regression: bare `coop start --mount <dir>` must signal
-    /// "allocate a new VM" even when an unrelated stopped instance exists.
     #[test]
-    fn creation_intent_without_target_detects_bare_mount() {
+    fn restart_ignored_flags_allows_workspace_affinity_key() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("config.toml");
+        let mut opts = start_opts(Vec::new(), &cfg_path);
+        opts.workspace_dir = Some("/some/workspace");
+        assert!(!super::restart_has_ignored_creation_flags(&opts));
+    }
+
+    #[test]
+    fn restart_ignored_flags_rejects_workspace_with_explicit_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("config.toml");
+        let name = super::config::InstanceName::new("explicit").expect("valid name");
+        let mut opts = start_opts(Vec::new(), &cfg_path);
+        opts.name = Some(&name);
+        opts.workspace_dir = Some("/some/workspace");
+        assert!(super::restart_has_ignored_creation_flags(&opts));
+    }
+
+    #[test]
+    fn no_stopped_instance_message_points_creation_to_up() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mount = super::config::Mount {
             host_path: tmp.path().to_path_buf(),
@@ -3389,75 +4004,173 @@ mod tests {
         };
         let cfg_path = tmp.path().join("config.toml");
         let opts = start_opts(vec![mount], &cfg_path);
-        assert!(super::creation_intent_without_target(&opts));
+        let msg = super::no_stopped_instance_message(&opts, None);
+        assert!(msg.contains("only starts stopped instances"));
+        assert!(msg.contains("coop up [DIR]"));
     }
 
     #[test]
-    fn creation_intent_without_target_detects_git_repo() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let cfg_path = tmp.path().join("config.toml");
-        let mut opts = start_opts(Vec::new(), &cfg_path);
-        opts.git_repo = Some("trailofbits/coop");
-        assert!(super::creation_intent_without_target(&opts));
+    fn up_subcommand_parses_defaults() {
+        let cli = parse(&["up"]);
+        let super::Commands::Up {
+            dir,
+            name,
+            copy,
+            mount,
+            extra_mount,
+            ..
+        } = cli.command
+        else {
+            panic!("expected Up variant");
+        };
+        assert_eq!(dir, None);
+        assert!(name.is_none());
+        assert!(!copy);
+        assert!(!mount);
+        assert!(extra_mount.is_empty());
     }
 
     #[test]
-    fn creation_intent_without_target_detects_disk() {
+    fn up_subcommand_parses_project_and_mount_mode() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let cfg_path = tmp.path().join("config.toml");
-        let mut opts = start_opts(Vec::new(), &cfg_path);
+        let cli = parse(&[
+            "up",
+            tmp.path().to_str().unwrap(),
+            "--mount",
+            "--name",
+            "named-project",
+        ]);
+        let super::Commands::Up {
+            dir, name, mount, ..
+        } = cli.command
+        else {
+            panic!("expected Up variant");
+        };
+        assert_eq!(dir.as_deref(), tmp.path().to_str());
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("named-project")
+        );
+        assert!(mount);
+    }
+
+    #[test]
+    fn up_copy_and_mount_conflict() {
+        let err = parse_err(&["up", "--copy", "--mount"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn validate_unique_guest_paths_rejects_duplicates() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        std::fs::create_dir(&a).expect("create a");
+        std::fs::create_dir(&b).expect("create b");
+        let mounts = vec![
+            super::config::Mount::parse(&format!("{}:/data", a.display())).expect("mount a"),
+            super::config::Mount::parse(&format!("{}:/data", b.display())).expect("mount b"),
+        ];
+        let err = super::validate_unique_guest_paths(&mounts).expect_err("expected duplicate");
+        assert!(format!("{err}").contains("/data"));
+    }
+
+    #[test]
+    fn up_copy_rejects_extra_mount_at_workspace() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data = tmp.path().join("data");
+        std::fs::create_dir(&data).expect("data");
+        let mounts = vec![super::config::Mount::parse(data.to_str().unwrap()).expect("mount")];
+
+        let err = super::validate_copy_workspace_mounts(super::ProjectTransport::Copy, &mounts)
+            .expect_err("expected /workspace collision");
+        assert!(format!("{err}").contains("/workspace"));
+    }
+
+    fn up_opts_for_tests(dir: Option<&str>) -> super::UpOpts<'_> {
+        super::UpOpts {
+            dir,
+            name: None,
+            transport: super::ProjectTransport::Copy,
+            extra_mount: Vec::new(),
+            vcpus: None,
+            mem: None,
+            disk: None,
+            image: super::config::default_image_name(),
+            image_explicit: false,
+            runtime: super::UpRuntimeOpts {
+                no_agents: false,
+                exclude_git: false,
+                no_prompt: true,
+                forward_ports: Vec::new(),
+                post_start: None,
+                guest_env: Vec::new(),
+            },
+            devcontainer: super::UpDevcontainerOpts {
+                path: None,
+                no_devcontainer: true,
+                dry_run: false,
+            },
+        }
+    }
+
+    #[test]
+    fn up_existing_rejects_creation_only_inputs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let project = tmp.path().join("project");
+        std::fs::create_dir(&project).expect("project");
+        let inst = cfg
+            .allocate_instance(None, &img, Some(&project))
+            .expect("inst");
+        let mut opts = up_opts_for_tests(project.to_str());
         opts.disk = super::config::GiB::new(20);
-        assert!(super::creation_intent_without_target(&opts));
+
+        let err = super::ensure_up_existing_inputs_are_compatible(
+            &inst,
+            super::ProjectTransport::Copy,
+            &opts,
+        )
+        .expect_err("expected incompatible");
+        assert!(format!("{err}").contains("--disk"));
     }
 
     #[test]
-    fn creation_intent_without_target_detects_exclude_git() {
+    fn up_existing_rejects_mismatched_explicit_name() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let cfg_path = tmp.path().join("config.toml");
-        let mut opts = start_opts(Vec::new(), &cfg_path);
-        opts.exclude_git = true;
-        assert!(super::creation_intent_without_target(&opts));
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let project = tmp.path().join("project");
+        std::fs::create_dir(&project).expect("project");
+        let inst = cfg
+            .allocate_instance(None, &img, Some(&project))
+            .expect("inst");
+        let other = super::config::InstanceName::new("other").expect("valid name");
+        let mut opts = up_opts_for_tests(project.to_str());
+        opts.name = Some(&other);
+
+        let err = super::ensure_up_project_name_matches(&inst, &project, &opts)
+            .expect_err("expected mismatched explicit name");
+        assert!(format!("{err}").contains("already associated"));
     }
 
-    /// A `--name` defers to the find/restart path even with creation-only
-    /// flags; the bail message there still tells the user how to proceed.
     #[test]
-    fn creation_intent_without_target_false_when_name_given() {
+    fn up_running_rejects_restart_only_inputs() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mount = super::config::Mount {
-            host_path: tmp.path().to_path_buf(),
-            guest_path: super::workspace::default_workspace_path(),
-        };
-        let cfg_path = tmp.path().join("config.toml");
-        let name = super::config::InstanceName::new("explicit").expect("valid name");
-        let mut opts = start_opts(vec![mount], &cfg_path);
-        opts.name = Some(&name);
-        assert!(!super::creation_intent_without_target(&opts));
-    }
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let project = tmp.path().join("project");
+        std::fs::create_dir(&project).expect("project");
+        let inst = cfg
+            .allocate_instance(None, &img, Some(&project))
+            .expect("inst");
+        let mut opts = up_opts_for_tests(project.to_str());
+        opts.runtime.post_start = Some("echo hi".to_string());
 
-    /// A `--workspace` is the affinity key for restart; the find path keeps
-    /// owning that decision so workspace-matched instances can be restarted.
-    #[test]
-    fn creation_intent_without_target_false_when_workspace_given() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let mount = super::config::Mount {
-            host_path: tmp.path().to_path_buf(),
-            guest_path: super::workspace::default_workspace_path(),
-        };
-        let cfg_path = tmp.path().join("config.toml");
-        let mut opts = start_opts(vec![mount], &cfg_path);
-        opts.workspace_dir = Some("/some/workspace");
-        assert!(!super::creation_intent_without_target(&opts));
-    }
-
-    /// `coop start` with no flags must keep going through the
-    /// single-stopped-instance lookup — that's the normal restart UX.
-    #[test]
-    fn creation_intent_without_target_false_for_bare_start() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let cfg_path = tmp.path().join("config.toml");
-        let opts = start_opts(Vec::new(), &cfg_path);
-        assert!(!super::creation_intent_without_target(&opts));
+        let err = super::reject_running_up_restart_inputs(&inst, &opts)
+            .expect_err("expected restart-only rejection");
+        assert!(format!("{err}").contains("--post-start"));
     }
 
     #[test]

--- a/src/pat_prompt.rs
+++ b/src/pat_prompt.rs
@@ -1,5 +1,5 @@
-//! `coop start` pre-flight hook: offer to scope GitHub auth to the resolved
-//! repo before the VM boots.
+//! VM startup pre-flight hook: offer to scope GitHub auth to the resolved repo
+//! before the VM boots.
 //!
 //! Decision logic lives in [`Decision::resolve`]; the side-effecting wrapper
 //! [`maybe_prompt`] is what `start_instance` calls.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -96,7 +96,7 @@ pub fn run(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
         "\nSetup complete. All artifacts are in {}/",
         cfg.data_dir.display()
     );
-    eprintln!("Run `coop start` to launch the VM.");
+    eprintln!("Run `coop up` in a project directory to launch a VM.");
     Ok(())
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -91,7 +91,7 @@ impl WorkspaceState {
                 format!(
                     "Failed to parse {}.\n\
                      If this file was written by a pre-#147 coop the on-disk \
-                     shape changed; delete it and run `coop start` again to \
+                     shape changed; delete it and run `coop up` again to \
                      regenerate, or `coop destroy <name>` if the instance is \
                      no longer needed.",
                     path.display()
@@ -276,7 +276,7 @@ fn join_drainer(handle: std::thread::JoinHandle<Result<Vec<u8>>>) -> Result<Vec<
 }
 
 const GUEST_DISK_HINT: &str = "The guest disk is likely too small for this \
-    workspace. Retry with a larger disk: `coop start --disk <GiB> ...`.";
+    workspace. Recreate it with a larger disk: `coop up --disk <GiB> ...`.";
 
 /// Build a user-facing message from a captured stderr buffer.
 ///
@@ -360,7 +360,7 @@ fn load_or_default(inst: &Instance, dir: Option<&str>, cmd: &str) -> Result<Work
     }
     bail!(
         "No workspace.json found and no --dir given.\n\
-         Either start the VM with --workspace or provide a path: \
+         Either create/reconnect with `coop up <PATH>` or provide a path: \
          coop {cmd} --dir ./my-project"
     )
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -391,25 +391,39 @@ test_setup() {
 
 # ── Primary instance lifecycle ────────────────────────────────
 
-test_start() {
+test_up_creates_primary_instance() {
     echo ""
-    echo "=== Phase: start ==="
+    echo "=== Phase: up creates primary instance ==="
 
     # `--env` exercises the guest_env CLI -> config -> SendEnv path
     # end-to-end. `test_guest_environment` verifies the value is
     # visible inside the guest via `printenv`.
+    mkdir -p "$tmpdir/primary-ws"
     local args=(
-        start "$INSTANCE" --no-agents
+        up "$tmpdir/primary-ws" --name "$INSTANCE" --no-agents --no-devcontainer
         --env "COOP_TEST_GUEST_ENV=hello-from-cli"
     )
     if coop "${args[@]}"; then
         STARTED_INSTANCES+=("$INSTANCE")
-        pass "start exits 0"
+        pass "up creates primary instance"
     else
-        fail "start exits 0" "exit code: $?"
+        fail "up creates primary instance" "exit code: $?"
         echo "stderr: $HARNESS_ERR"
-        echo "FATAL: start failed, cannot continue"
+        echo "FATAL: primary instance creation failed, cannot continue"
         exit 1
+    fi
+}
+
+test_start_rejects_missing_instance() {
+    echo ""
+    echo "=== Phase: start rejects missing instance ==="
+
+    local missing="${INSTANCE}-missing"
+    if moat_fails start "$missing" --no-agents; then
+        pass "start rejects missing instance"
+    else
+        fail "start rejects missing instance" "should have failed"
+        coop destroy "$missing" 2>/dev/null || true
     fi
 }
 
@@ -417,12 +431,21 @@ test_duplicate_name() {
     echo ""
     echo "=== Phase: duplicate instance name ==="
 
-    if moat_fails start "$INSTANCE" --no-agents; then
+    local other_ws="$tmpdir/duplicate-ws"
+    mkdir -p "$other_ws"
+    if moat_fails up "$other_ws" --name "$INSTANCE" --no-agents --no-devcontainer; then
         pass "rejects duplicate instance name"
     else
         fail "rejects duplicate instance name" "should have failed"
         # Clean up the accidental second instance
         coop destroy "$INSTANCE" 2>/dev/null || true
+    fi
+
+    if moat_fails up "$tmpdir/primary-ws" --name "${INSTANCE}-other" --no-agents --no-devcontainer; then
+        pass "rejects mismatched name for existing project"
+    else
+        fail "rejects mismatched name for existing project" "should have failed"
+        coop destroy "${INSTANCE}-other" 2>/dev/null || true
     fi
 }
 
@@ -846,16 +869,17 @@ CFGEOF
         return
     }
 
-    if env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" start \
-            "$pat_instance" \
-            --workspace "$ws_dir" \
+    if env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" up \
+            "$ws_dir" \
+            --name "$pat_instance" \
             --no-agents \
+            --no-devcontainer \
             --no-prompt \
             >"$tmpdir/pat-start.out" 2>&1; then
         STARTED_INSTANCES+=("$pat_instance")
-        pass "pat: start with --workspace whose origin matches the configured slug"
+        pass "pat: up with workspace whose origin matches the configured slug"
     else
-        fail "pat: start with --workspace whose origin matches the configured slug" \
+        fail "pat: up with workspace whose origin matches the configured slug" \
             "$(cat "$tmpdir/pat-start.out")"
         env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" destroy "$pat_instance" 2>/dev/null || true
         return
@@ -1479,6 +1503,13 @@ test_restart_rejects_ignored_flags() {
         coop stop "$INSTANCE" 2>/dev/null || true
     fi
 
+    if moat_fails start "$INSTANCE" --no-agents --vcpus 4; then
+        pass "restart with --vcpus rejected"
+    else
+        fail "restart with --vcpus rejected" "should have failed"
+        coop stop "$INSTANCE" 2>/dev/null || true
+    fi
+
     if moat_fails start "$INSTANCE" --no-agents --exclude-git; then
         pass "restart with --exclude-git rejected"
     else
@@ -1495,73 +1526,6 @@ test_restart_rejects_ignored_flags() {
 
     # Stop again for the destroy phase
     coop stop "$INSTANCE" || true
-    rm -rf "$mount_dir"
-}
-
-# Issue #214 regression: with $INSTANCE stopped and unrelated to the user's
-# intent, `coop start --mount <dir>` (no --name, no --workspace) must allocate
-# a fresh VM rather than reusing the stopped one or bailing with a destroy
-# advisory. The unit tests cover the predicate; this phase exercises the full
-# cmd_start path that uses it.
-test_bare_start_allocates_fresh() {
-    echo ""
-    echo "=== Phase: bare start --mount allocates fresh instance ==="
-
-    local mount_dir
-    mount_dir=$(mktemp -d)
-
-    # Snapshot instance names before allocating. The only entry should be the
-    # stopped $INSTANCE left by the previous phase.
-    local before_names
-    before_names=$(RUST_LOG=off "$BINARY" status 2>/dev/null \
-        | awk '/running|stopped/ {print $1}' | sort -u)
-
-    if ! coop start --no-agents --mount "$mount_dir"; then
-        fail "bare start --mount exits 0" "exit=$?; stderr: $HARNESS_ERR"
-        rm -rf "$mount_dir"
-        return
-    fi
-    pass "bare start --mount exits 0"
-
-    local after_names
-    after_names=$(RUST_LOG=off "$BINARY" status 2>/dev/null \
-        | awk '/running|stopped/ {print $1}' | sort -u)
-
-    local new_name
-    new_name=$(comm -13 <(echo "$before_names") <(echo "$after_names") | head -n1)
-
-    if [[ -z "$new_name" ]]; then
-        fail "fresh instance allocated" "no new name in status; after: $after_names"
-        rm -rf "$mount_dir"
-        return
-    fi
-    STARTED_INSTANCES+=("$new_name")
-    pass "fresh instance allocated ($new_name)"
-
-    if [[ "$new_name" == "$INSTANCE" ]]; then
-        fail "fresh instance is distinct from stopped \$INSTANCE" "got: $new_name"
-    else
-        pass "fresh instance is distinct from stopped \$INSTANCE"
-    fi
-
-    # The pre-existing $INSTANCE must remain stopped and untouched. Capture
-    # `status` output before grep'ing — piping directly into `grep -q` lets
-    # grep exit early on the first match, which closes the pipe and makes
-    # `coop status` exit non-zero (SIGPIPE/BrokenPipe) on the remaining
-    # writes; combined with `set -o pipefail` that turns a passing match
-    # into a spurious failure when other instances follow ours.
-    local status_out
-    status_out=$(RUST_LOG=off "$BINARY" status 2>/dev/null || true)
-    if echo "$status_out" | grep -qE "^${INSTANCE} +stopped\\b"; then
-        pass "pre-existing stopped instance untouched"
-    else
-        fail "pre-existing stopped instance untouched" "status: $status_out"
-    fi
-
-    # Tear down the freshly allocated instance so subsequent phases see the
-    # same world they expect: $INSTANCE stopped, no other coop VMs.
-    coop destroy "$new_name" 2>/dev/null || true
-    untrack_instance "$new_name"
     rm -rf "$mount_dir"
 }
 
@@ -1646,8 +1610,10 @@ test_idempotency() {
 
     # stop idempotency: start an instance, stop it twice
     local inst_name="${INSTANCE}-idem"
-    if ! coop start "$inst_name" --no-agents; then
-        fail "start for stop-idempotency test" "exit code: $?"
+    local idem_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$idem_ws"
+    if ! coop up "$idem_ws" --name "$inst_name" --no-agents --no-devcontainer; then
+        fail "up for stop-idempotency test" "exit code: $?"
         return
     fi
     STARTED_INSTANCES+=("$inst_name")
@@ -1674,7 +1640,7 @@ test_idempotency() {
 # ── Quickstart (--full only) ──────────────────────────────────
 
 # `coop quickstart` chains ensure-image, ensure-instance, launch-claude. The
-# first two steps share code with `coop setup` / `coop start` (covered above);
+# first two steps share code with `coop setup` / `coop up` (covered above);
 # this phase exercises the reconnect/restart logic specific to quickstart and
 # the workspace-affinity lookup that drives it.
 #
@@ -1802,6 +1768,141 @@ test_quickstart() {
     rm -rf "$qs_ws"
 }
 
+# ── Project workflow tests (`coop up`, --full only) ───────────
+
+test_up_project_workflow() {
+    echo ""
+    echo "=== Phase: project up ==="
+
+    local up_ws up_inst_name
+    up_ws=$(mktemp -d "$tmpdir/up-ws-XXXXXX")
+    echo "up-copy-content" > "$up_ws/hello.txt"
+    up_inst_name=${up_ws##*/}
+    up_inst_name=${up_inst_name//[!a-zA-Z0-9_-]/-}
+
+    if coop up "$up_ws" --no-agents --no-devcontainer; then
+        STARTED_INSTANCES+=("$up_inst_name")
+        pass "up copy creates project instance"
+    else
+        fail "up copy creates project instance" "exit code: $? stderr: $HARNESS_ERR"
+        rm -rf "$up_ws"
+        return
+    fi
+
+    GUEST_INSTANCE="$up_inst_name"
+    local content
+    if content=$(guest_exec cat /workspace/hello.txt); then
+        if [[ "$content" == "up-copy-content" ]]; then
+            pass "up copy syncs project into /workspace"
+        else
+            fail "up copy syncs project into /workspace" "got: $content"
+        fi
+    else
+        fail "up copy syncs project into /workspace" "file not found"
+    fi
+    unset GUEST_INSTANCE
+
+    local pre_list post_list
+    pre_list=$("$BINARY" list 2>/dev/null | sort)
+    if coop up "$up_ws" --no-devcontainer; then
+        pass "up copy re-run exits 0 while running"
+    else
+        fail "up copy re-run exits 0 while running" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+    post_list=$("$BINARY" list 2>/dev/null | sort)
+    if [[ "$pre_list" == "$post_list" ]]; then
+        pass "up copy reuses running project instance"
+    else
+        fail "up copy reuses running project instance" \
+            "list changed (diff): $(diff <(echo "$pre_list") <(echo "$post_list"))"
+    fi
+
+    if coop stop "$up_inst_name" && coop up "$up_ws" --no-agents --no-devcontainer; then
+        pass "up copy restarts stopped project instance"
+    else
+        fail "up copy restarts stopped project instance" "stderr: $HARNESS_ERR"
+    fi
+
+    local reject_ws data_dir
+    reject_ws=$(mktemp -d "$tmpdir/up-reject-XXXXXX")
+    data_dir=$(mktemp -d "$tmpdir/up-data-XXXXXX")
+    if moat_fails up "$reject_ws" --extra-mount "$data_dir" --no-devcontainer; then
+        if echo "$HARNESS_ERR" | grep -q "/workspace"; then
+            pass "up copy rejects host-only extra mount at /workspace"
+        else
+            fail "up copy rejects host-only extra mount at /workspace" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "up copy rejects host-only extra mount at /workspace" \
+            "command unexpectedly succeeded"
+    fi
+    rm -rf "$reject_ws" "$data_dir"
+
+    coop destroy "$up_inst_name" 2>/dev/null || true
+    untrack_instance "$up_inst_name"
+    rm -rf "$up_ws"
+
+    local mount_ws mount_inst_name
+    mount_ws=$(mktemp -d "$tmpdir/up-mount-XXXXXX")
+    echo "up-mount-content" > "$mount_ws/marker.txt"
+    mount_inst_name=${mount_ws##*/}
+    mount_inst_name=${mount_inst_name//[!a-zA-Z0-9_-]/-}
+
+    if coop up "$mount_ws" --mount --no-agents --no-devcontainer; then
+        STARTED_INSTANCES+=("$mount_inst_name")
+        pass "up mount creates project instance"
+    else
+        fail "up mount creates project instance" "exit code: $? stderr: $HARNESS_ERR"
+        rm -rf "$mount_ws"
+        return
+    fi
+
+    GUEST_INSTANCE="$mount_inst_name"
+    if content=$(guest_exec cat /workspace/marker.txt); then
+        if [[ "$content" == "up-mount-content" ]]; then
+            pass "up mount exposes project at /workspace"
+        else
+            fail "up mount exposes project at /workspace" "got: $content"
+        fi
+    else
+        fail "up mount exposes project at /workspace" "file not found"
+    fi
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "live-up-update" > "$mount_ws/live.txt"
+        if content=$(guest_exec cat /workspace/live.txt); then
+            if [[ "$content" == "live-up-update" ]]; then
+                pass "up mount is live on Lima"
+            else
+                fail "up mount is live on Lima" "got: $content"
+            fi
+        else
+            fail "up mount is live on Lima" "file not found"
+        fi
+    else
+        skip "up mount live sync" "Firecracker uses one-time rsync sync"
+    fi
+    unset GUEST_INSTANCE
+
+    pre_list=$("$BINARY" list 2>/dev/null | sort)
+    if coop up "$mount_ws" --mount --no-devcontainer; then
+        pass "up mount re-run exits 0 while running"
+    else
+        fail "up mount re-run exits 0 while running" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+    post_list=$("$BINARY" list 2>/dev/null | sort)
+    if [[ "$pre_list" == "$post_list" ]]; then
+        pass "up mount reuses running project instance"
+    else
+        fail "up mount reuses running project instance" \
+            "list changed (diff): $(diff <(echo "$pre_list") <(echo "$post_list"))"
+    fi
+
+    coop destroy "$mount_inst_name" 2>/dev/null || true
+    untrack_instance "$mount_inst_name"
+    rm -rf "$mount_ws"
+}
+
 # ── Workspace sync tests (--full only) ────────────────────────
 
 test_workspace_sync() {
@@ -1825,13 +1926,13 @@ test_workspace_sync() {
         git -c user.email=ci@test -c user.name=CI commit --allow-empty --quiet -m "init"
     ) || fail "set up git repo in workspace tmpdir" "git init/commit failed"
 
-    # Start instance with --workspace
-    local args=(start "$ws_instance" --no-agents --workspace "$ws_tmpdir")
+    # Create instance for the workspace.
+    local args=(up "$ws_tmpdir" --name "$ws_instance" --no-agents --no-devcontainer)
     if coop "${args[@]}"; then
         STARTED_INSTANCES+=("$ws_instance")
-        pass "start with --workspace exits 0"
+        pass "up with workspace exits 0"
     else
-        fail "start with --workspace exits 0" "exit code: $?"
+        fail "up with workspace exits 0" "exit code: $?"
         echo "stderr: $HARNESS_ERR"
         return
     fi
@@ -1922,160 +2023,6 @@ test_workspace_sync() {
     ws_tmpdir=""
 }
 
-# ── Private GitHub clone (--full only) ────────────────────────
-#
-# Exercises the `--git-repo` auth path against the (private) trailofbits/coop
-# repo. Skipped if the host has neither a usable `gh` token nor `GITHUB_TOKEN`,
-# so the test can run on machines that don't have GitHub credentials wired up.
-test_git_repo_private_clone() {
-    echo ""
-    echo "=== Phase: --git-repo against private GitHub repo ==="
-
-    if ! command -v gh >/dev/null 2>&1 || ! gh auth token >/dev/null 2>&1; then
-        if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-            skip "--git-repo clones private trailofbits/coop" \
-                "no gh auth token and GITHUB_TOKEN unset"
-            return
-        fi
-    fi
-
-    local repo_instance="${INSTANCE}-gitrepo"
-    local repo_url="https://github.com/trailofbits/coop.git"
-
-    if coop start "$repo_instance" --no-agents --git-repo "$repo_url"; then
-        STARTED_INSTANCES+=("$repo_instance")
-        pass "start with --git-repo against private repo exits 0"
-    else
-        fail "start with --git-repo against private repo exits 0" "exit code: $?"
-        echo "stderr: $HARNESS_ERR"
-        return
-    fi
-
-    GUEST_INSTANCE="$repo_instance"
-
-    # Verify the clone landed: a few files we know exist in this repo.
-    if guest_exec test -f /workspace/repo/Cargo.toml; then
-        pass "/workspace/repo/Cargo.toml present after private clone"
-    else
-        fail "/workspace/repo/Cargo.toml present after private clone" \
-            "stderr: $(guest_stderr)"
-    fi
-
-    if guest_exec test -f /workspace/repo/src/backend.rs; then
-        pass "/workspace/repo/src/backend.rs present after private clone"
-    else
-        fail "/workspace/repo/src/backend.rs present after private clone" \
-            "stderr: $(guest_stderr)"
-    fi
-
-    # Token must not persist in the cloned repo's git config (remote URL,
-    # credential helper, or otherwise). The clone uses a one-shot
-    # `-c credential.helper=...` which is not written to .git/config.
-    local git_config
-    if git_config=$(guest_exec cat /workspace/repo/.git/config); then
-        if echo "$git_config" | grep -Eq '(x-access-token|ghp_|gho_|ghu_|ghs_|github_pat_|credential\.helper)'; then
-            fail "no token or credential helper persisted in .git/config" \
-                "config contained sensitive markers"
-        else
-            pass "no token or credential helper persisted in .git/config"
-        fi
-    else
-        fail "no token or credential helper persisted in .git/config" \
-            "could not read .git/config: $(guest_stderr)"
-    fi
-
-    # The user's global gitconfig in the guest should not have been written
-    # with a credential helper by this code path (--no-agents skips the
-    # separate `gh auth setup-git` flow).
-    if guest_exec test -f /home/coop/.gitconfig; then
-        local global_config
-        global_config=$(guest_exec cat /home/coop/.gitconfig 2>/dev/null || echo "")
-        if echo "$global_config" | grep -q 'credential.helper'; then
-            fail "no global git credential helper installed" \
-                "found credential.helper in /home/coop/.gitconfig"
-        else
-            pass "no global git credential helper installed"
-        fi
-    else
-        pass "no global git credential helper installed"
-    fi
-
-    unset GUEST_INSTANCE
-
-    coop destroy "$repo_instance" 2>/dev/null || true
-    untrack_instance "$repo_instance"
-}
-
-# ── Push/pull without --workspace (--full only) ──────────────
-
-test_push_pull_no_workspace() {
-    echo ""
-    echo "=== Phase: push/pull without --workspace ==="
-
-    local nw_instance="${INSTANCE}-nw"
-
-    # Start instance WITHOUT --workspace, --git-repo, or --mount
-    if coop start "$nw_instance" --no-agents; then
-        STARTED_INSTANCES+=("$nw_instance")
-        pass "start without --workspace exits 0"
-    else
-        fail "start without --workspace exits 0" "exit code: $?"
-        echo "stderr: $HARNESS_ERR"
-        return
-    fi
-
-    GUEST_INSTANCE="$nw_instance"
-
-    # Pull with explicit dir should work (no workspace.json exists)
-    local pull_dir
-    pull_dir=$(mktemp -d)
-    if coop pull "$nw_instance" --force --dir "$pull_dir"; then
-        pass "pull with explicit dir (no workspace.json)"
-    else
-        fail "pull with explicit dir (no workspace.json)" "exit code: $?"
-    fi
-    rm -rf "$pull_dir"
-
-    # Push with explicit dir should work
-    local push_dir
-    push_dir=$(mktemp -d)
-    echo "no-workspace-push-test" > "$push_dir/marker.txt"
-    if coop push "$nw_instance" --force --dir "$push_dir"; then
-        pass "push with explicit dir (no workspace.json)"
-
-        # Verify the file arrived in guest at /workspace
-        local content
-        content=$(guest_exec cat /workspace/marker.txt) || content=""
-        if echo "$content" | grep -q "no-workspace-push-test"; then
-            pass "push defaulted to guest:/workspace"
-        else
-            fail "push defaulted to guest:/workspace" "got: '$content'"
-        fi
-    else
-        fail "push with explicit dir (no workspace.json)" "exit code: $?"
-    fi
-    rm -rf "$push_dir"
-
-    # Pull without dir and without workspace.json should fail
-    if moat_fails pull "$nw_instance"; then
-        pass "pull without dir or workspace.json fails"
-    else
-        fail "pull without dir or workspace.json fails" "should have failed"
-    fi
-
-    # Push without dir and without workspace.json should fail
-    if moat_fails push "$nw_instance"; then
-        pass "push without dir or workspace.json fails"
-    else
-        fail "push without dir or workspace.json fails" "should have failed"
-    fi
-
-    unset GUEST_INSTANCE
-
-    coop destroy "$nw_instance" 2>/dev/null || true
-    untrack_instance "$nw_instance"
-}
-
 # ── Multi-instance tests (--full only) ────────────────────────
 
 test_multi_instance() {
@@ -2084,21 +2031,24 @@ test_multi_instance() {
 
     local inst_a="${INSTANCE}-a"
     local inst_b="${INSTANCE}-b"
+    local ws_a="$tmpdir/${inst_a}-ws"
+    local ws_b="$tmpdir/${inst_b}-ws"
+    mkdir -p "$ws_a" "$ws_b"
 
-    # Start two instances
-    if coop start "$inst_a" --no-agents; then
+    # Create two project instances
+    if coop up "$ws_a" --name "$inst_a" --no-agents --no-devcontainer; then
         STARTED_INSTANCES+=("$inst_a")
-        pass "start instance A ($inst_a)"
+        pass "up creates instance A ($inst_a)"
     else
-        fail "start instance A ($inst_a)" "exit code: $?"
+        fail "up creates instance A ($inst_a)" "exit code: $?"
         return
     fi
 
-    if coop start "$inst_b" --no-agents; then
+    if coop up "$ws_b" --name "$inst_b" --no-agents --no-devcontainer; then
         STARTED_INSTANCES+=("$inst_b")
-        pass "start instance B ($inst_b)"
+        pass "up creates instance B ($inst_b)"
     else
-        fail "start instance B ($inst_b)" "exit code: $?"
+        fail "up creates instance B ($inst_b)" "exit code: $?"
         coop destroy "$inst_a" 2>/dev/null || true
         return
     fi
@@ -2197,13 +2147,15 @@ test_named_images() {
         fail "images exits 0" "exit code: $?"
     fi
 
-    # Start an instance from the named image
+    # Create an instance from the named image
     local inst_name="${INSTANCE}-img"
-    if coop start "$inst_name" --no-agents --image "$img_name"; then
+    local img_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$img_ws"
+    if coop up "$img_ws" --name "$inst_name" --no-agents --no-devcontainer --image "$img_name"; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start --image $img_name exits 0"
+        pass "up --image $img_name exits 0"
     else
-        fail "start --image $img_name exits 0" "exit code: $?"
+        fail "up --image $img_name exits 0" "exit code: $?"
         coop images --delete "$img_name" 2>/dev/null || true
         return
     fi
@@ -2280,13 +2232,15 @@ CFGEOF
         return
     fi
 
-    # Start instance from custom image
+    # Create instance from custom image
     local inst_name="${INSTANCE}-custom"
-    if "$BINARY" --config "$cfg_file" start "$inst_name" --no-agents --image "$custom_img" 2>"$tmpdir/stderr"; then
+    local custom_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$custom_ws"
+    if "$BINARY" --config "$cfg_file" up "$custom_ws" --name "$inst_name" --no-agents --no-devcontainer --image "$custom_img" 2>"$tmpdir/stderr"; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start with custom profile image exits 0"
+        pass "up with custom profile image exits 0"
     else
-        fail "start with custom profile image exits 0" "exit code: $?"
+        fail "up with custom profile image exits 0" "exit code: $?"
         rm -rf "$cfg_dir"
         return
     fi
@@ -2327,13 +2281,15 @@ test_builtin_profiles() {
         return
     fi
 
-    # Start instance from the profiled image
+    # Create instance from the profiled image
     local inst_name="${INSTANCE}-prof"
-    if coop start "$inst_name" --no-agents --image "$img_name"; then
+    local prof_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$prof_ws"
+    if coop up "$prof_ws" --name "$inst_name" --no-agents --no-devcontainer --image "$img_name"; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start from profiled image exits 0"
+        pass "up from profiled image exits 0"
     else
-        fail "start from profiled image exits 0" "exit code: $?"
+        fail "up from profiled image exits 0" "exit code: $?"
         coop images --delete "$img_name" 2>/dev/null || true
         return
     fi
@@ -2392,12 +2348,12 @@ test_host_mount() {
     mkdir -p "$mount_dir/subdir"
     echo "nested-mount" > "$mount_dir/subdir/deep.txt"
 
-    # Start instance with --mount (defaults to /workspace)
-    if coop start "$mount_instance" --no-agents --mount "$mount_dir"; then
+    # Create instance with project mount at /workspace
+    if coop up "$mount_dir" --name "$mount_instance" --no-agents --no-devcontainer --mount; then
         STARTED_INSTANCES+=("$mount_instance")
-        pass "start with --mount exits 0"
+        pass "up --mount exits 0"
     else
-        fail "start with --mount exits 0" "exit code: $?"
+        fail "up --mount exits 0" "exit code: $?"
         echo "stderr: $HARNESS_ERR"
         rm -rf "$mount_dir"
         return
@@ -2476,12 +2432,14 @@ test_host_mount_custom_guest_path() {
     mount_dir=$(mktemp -d)
     echo "custom-path-test" > "$mount_dir/marker.txt"
 
+    local project_dir="$tmpdir/${mount_instance}-ws"
+    mkdir -p "$project_dir"
     # Mount with explicit guest path
-    if coop start "$mount_instance" --no-agents --mount "$mount_dir:/data/project"; then
+    if coop up "$project_dir" --name "$mount_instance" --no-agents --no-devcontainer --extra-mount "$mount_dir:/data/project"; then
         STARTED_INSTANCES+=("$mount_instance")
-        pass "start with --mount host:guest exits 0"
+        pass "up with --extra-mount host:guest exits 0"
     else
-        fail "start with --mount host:guest exits 0" "exit code: $?"
+        fail "up with --extra-mount host:guest exits 0" "exit code: $?"
         rm -rf "$mount_dir"
         return
     fi
@@ -2520,12 +2478,14 @@ test_port_forwards() {
     local content_file
     content_file=$(mktemp)
     echo "forward-test-payload" > "$content_file"
+    local fwd_ws="$tmpdir/${fwd_instance}-ws"
+    mkdir -p "$fwd_ws"
 
-    if coop start "$fwd_instance" --no-agents --forward-port "${guest_port}:${host_port}"; then
+    if coop up "$fwd_ws" --name "$fwd_instance" --no-agents --no-devcontainer --forward-port "${guest_port}:${host_port}"; then
         STARTED_INSTANCES+=("$fwd_instance")
-        pass "start with --forward-port exits 0"
+        pass "up with --forward-port exits 0"
     else
-        fail "start with --forward-port exits 0" "exit code: $?"
+        fail "up with --forward-port exits 0" "exit code: $?"
         rm -f "$content_file"
         return
     fi
@@ -2573,7 +2533,9 @@ nohup python3 /tmp/fwd.py ${guest_port} ${payload} > /tmp/fwd.log 2>&1 &" || tru
     # outer `2>` redirect here would be shadowed by the wrapper's internal
     # redirect and silently capture nothing.
     local fwd_instance2="${INSTANCE}-fwd2"
-    if coop start "$fwd_instance2" --no-agents --forward-port "9999:${host_port}"; then
+    local fwd_ws2="$tmpdir/${fwd_instance2}-ws"
+    mkdir -p "$fwd_ws2"
+    if coop up "$fwd_ws2" --name "$fwd_instance2" --no-agents --no-devcontainer --forward-port "9999:${host_port}"; then
         STARTED_INSTANCES+=("$fwd_instance2")
         fail "collision detection rejects in-use host port" "start unexpectedly succeeded"
         coop destroy "$fwd_instance2" 2>/dev/null || true
@@ -2639,15 +2601,18 @@ test_destroy_all() {
     # Start two throwaway instances
     local inst_x="${INSTANCE}-x"
     local inst_y="${INSTANCE}-y"
+    local ws_x="$tmpdir/${inst_x}-ws"
+    local ws_y="$tmpdir/${inst_y}-ws"
+    mkdir -p "$ws_x" "$ws_y"
 
-    if ! coop start "$inst_x" --no-agents; then
-        fail "start instance for destroy --all" "exit code: $?"
+    if ! coop up "$ws_x" --name "$inst_x" --no-agents --no-devcontainer; then
+        fail "up instance for destroy --all" "exit code: $?"
         return
     fi
     STARTED_INSTANCES+=("$inst_x")
 
-    if ! coop start "$inst_y" --no-agents; then
-        fail "start second instance for destroy --all" "exit code: $?"
+    if ! coop up "$ws_y" --name "$inst_y" --no-agents --no-devcontainer; then
+        fail "up second instance for destroy --all" "exit code: $?"
         coop destroy "$inst_x" 2>/dev/null || true
         return
     fi
@@ -2739,15 +2704,18 @@ CFGEOF
         return
     fi
 
-    # Start the instance WITH bootstrap. The stub claude handles
+    local mp_ws="$tmpdir/${mp_instance}-ws"
+    mkdir -p "$mp_ws"
+
+    # Create the instance WITH bootstrap. The stub claude handles
     # `marketplace add` calls. Unset tokens to avoid auth steps.
-    if env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" start "$mp_instance" --image "$mp_img" 2>"$tmpdir/stderr"; then
+    if env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" up "$mp_ws" --name "$mp_instance" --image "$mp_img" --no-devcontainer 2>"$tmpdir/stderr"; then
         STARTED_INSTANCES+=("$mp_instance")
-        pass "start with local marketplace exits 0"
+        pass "up with local marketplace exits 0"
     else
         local boot_err
         boot_err=$(cat "$tmpdir/stderr")
-        fail "start with local marketplace exits 0" "stderr: $boot_err"
+        fail "up with local marketplace exits 0" "stderr: $boot_err"
         env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" images --delete "$mp_img" 2>/dev/null || true
         rm -rf "$mp_dir" "$cfg_dir"
         return
@@ -2879,13 +2847,15 @@ CFGEOF
         return $rc
     }
 
-    # ── 1. First start: allowlisted files copied to guest ──
+    # ── 1. First up: allowlisted files copied to guest ──
 
-    if cs start "$inst_name"; then
+    local cd_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$cd_ws"
+    if cs up "$cd_ws" --name "$inst_name" --no-devcontainer; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start with config_dir exits 0"
+        pass "up with config_dir exits 0"
     else
-        fail "start with config_dir exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        fail "up with config_dir exits 0" "exit code: $? stderr: $HARNESS_ERR"
         rm -r "$cs_dir"
         return
     fi
@@ -3017,11 +2987,13 @@ test_interrupted_setup() {
 
     # Verify the image works: start a VM and check basic connectivity
     local inst_name="${INSTANCE}-recovery"
-    if coop start "$inst_name" --no-agents --image "$img"; then
+    local recovery_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$recovery_ws"
+    if coop up "$recovery_ws" --name "$inst_name" --no-agents --no-devcontainer --image "$img"; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start from recovered image exits 0"
+        pass "up from recovered image exits 0"
     else
-        fail "start from recovered image exits 0" "exit code: $?"
+        fail "up from recovered image exits 0" "exit code: $?"
         coop images --delete "$img" 2>/dev/null || true
         return
     fi
@@ -3077,10 +3049,10 @@ test_devcontainer_translator() {
     local dcfile="$dcdir/.devcontainer/devcontainer.json"
 
     # --dry-run with auto-discovery: report is printed to stderr, no VM work.
-    if coop start "${INSTANCE}-dc-dry" --workspace "$dcdir" --dry-run --no-agents; then
-        pass "start --workspace ... --dry-run exits 0"
+    if coop up "$dcdir" --name "${INSTANCE}-dc-dry" --dry-run --no-agents; then
+        pass "up ... --dry-run exits 0"
     else
-        fail "start --workspace ... --dry-run exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        fail "up ... --dry-run exits 0" "exit code: $? stderr: $HARNESS_ERR"
     fi
 
     # Report content lands on stderr (per the CLAUDE.md "tracing → stderr" rule).
@@ -3111,7 +3083,7 @@ test_devcontainer_translator() {
 
     # --no-devcontainer silently skips the file: the report header must NOT appear.
     # `--dry-run` lets us exercise the discovery path without any VM work.
-    if coop start "${INSTANCE}-dc-skip" --workspace "$dcdir" \
+    if coop up "$dcdir" --name "${INSTANCE}-dc-skip" \
         --no-devcontainer --dry-run --no-agents; then
         if grep -q "devcontainer.json:" <<< "$HARNESS_ERR"; then
             fail "--no-devcontainer suppresses discovery" "report header still appeared: $HARNESS_ERR"
@@ -3124,7 +3096,7 @@ test_devcontainer_translator() {
 
     # Non-interactive + discovered file + no escape hatch must error with the
     # hint pointing at --devcontainer / --no-devcontainer.
-    if moat_fails start "${INSTANCE}-dc-noopt" --workspace "$dcdir" --no-agents; then
+    if moat_fails up "$dcdir" --name "${INSTANCE}-dc-noopt" --no-agents; then
         if grep -qi "devcontainer" <<< "$HARNESS_ERR" \
             && grep -q -- "--no-devcontainer" <<< "$HARNESS_ERR"; then
             pass "non-TTY without escape hatch errors with hint"
@@ -3137,11 +3109,11 @@ test_devcontainer_translator() {
 
     # CLI overrides devcontainer.json values — report should mark cpus as
     # "overridden" with source = CLI.
-    if coop start "${INSTANCE}-dc-override" --workspace "$dcdir" \
+    if coop up "$dcdir" --name "${INSTANCE}-dc-override" \
         --vcpus 8 --dry-run --no-agents; then
-        pass "start --dry-run with overriding CLI flag exits 0"
+        pass "up --dry-run with overriding CLI flag exits 0"
     else
-        fail "start --dry-run with overriding CLI flag exits 0" "stderr: $HARNESS_ERR"
+        fail "up --dry-run with overriding CLI flag exits 0" "stderr: $HARNESS_ERR"
         return
     fi
     if grep "hostRequirements.cpus" <<< "$HARNESS_ERR" | grep -q "overridden"; then
@@ -3163,12 +3135,12 @@ test_devcontainer_apply() {
     local inst_name="${INSTANCE}-dc-apply"
 
     # Use explicit --devcontainer to skip the prompt in CI.
-    if coop start "$inst_name" --workspace "$dcdir" \
+    if coop up "$dcdir" --name "$inst_name" \
         --devcontainer "$dcfile" --no-agents; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start with --devcontainer exits 0"
+        pass "up with --devcontainer exits 0"
     else
-        fail "start with --devcontainer exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        fail "up with --devcontainer exits 0" "exit code: $? stderr: $HARNESS_ERR"
         return
     fi
 
@@ -3209,12 +3181,14 @@ test_post_start() {
 
     # --post-start runs the command in the guest after SSH is ready.
     # The marker file written by the hook is the assertion.
-    if coop start "$inst_name" --no-agents \
+    local post_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$post_ws"
+    if coop up "$post_ws" --name "$inst_name" --no-agents --no-devcontainer \
         --post-start "echo hooked > $marker"; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start --post-start exits 0"
+        pass "up --post-start exits 0"
     else
-        fail "start --post-start exits 0" "exit code: $?"
+        fail "up --post-start exits 0" "exit code: $?"
         return
     fi
 
@@ -3229,14 +3203,16 @@ test_post_start() {
         fail "--post-start hook ran in the guest" "marker contents: '$seen'"
     fi
 
-    # Verify a failing hook does not fail `coop start` (warn-and-continue).
+    # Verify a failing hook does not fail `coop up` (warn-and-continue).
     local fail_inst="${INSTANCE}-poststart-fail"
-    if coop start "$fail_inst" --no-agents \
+    local fail_ws="$tmpdir/${fail_inst}-ws"
+    mkdir -p "$fail_ws"
+    if coop up "$fail_ws" --name "$fail_inst" --no-agents --no-devcontainer \
         --post-start "false; exit 1"; then
         STARTED_INSTANCES+=("$fail_inst")
-        pass "start succeeds when --post-start fails (warn-and-continue)"
+        pass "up succeeds when --post-start fails (warn-and-continue)"
     else
-        fail "start succeeds when --post-start fails" "exit code: $?"
+        fail "up succeeds when --post-start fails" "exit code: $?"
     fi
 
     coop destroy "$inst_name" 2>/dev/null || true
@@ -3354,13 +3330,15 @@ test_guest_user_alt() {
         skip "template_config.json records guest_user=$alt_user" "config at $tc_path not found"
     fi
 
-    # Start an instance from the alt-user image — no `--guest-user` flag
+    # Create an instance from the alt-user image — no `--guest-user` flag
     # here on purpose; coop must read the persisted value.
-    if coop start "$inst_name" --no-agents --image "$img_name"; then
+    local alt_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$alt_ws"
+    if coop up "$alt_ws" --name "$inst_name" --no-agents --no-devcontainer --image "$img_name"; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start (alt-user image) exits 0"
+        pass "up (alt-user image) exits 0"
     else
-        fail "start (alt-user image) exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        fail "up (alt-user image) exits 0" "exit code: $? stderr: $HARNESS_ERR"
         coop images --delete "$img_name" 2>/dev/null || true
         return
     fi
@@ -3506,7 +3484,8 @@ main() {
 
     # Setup + primary instance
     test_setup
-    test_start
+    test_up_creates_primary_instance
+    test_start_rejects_missing_instance
     test_duplicate_name
     test_status_running
     test_list_running
@@ -3534,7 +3513,6 @@ main() {
     test_resize_status
     test_restart_stopped
     test_restart_rejects_ignored_flags
-    test_bare_start_allocates_fresh
     test_destroy
     test_auto_resolve_no_instances
     test_list_empty
@@ -3545,13 +3523,12 @@ main() {
     # Extended tests (each manages its own instance lifecycle)
     if [[ "$FULL" == "1" ]]; then
         test_quickstart
+        test_up_project_workflow
         test_mount_conflicts
         test_host_mount
         test_host_mount_custom_guest_path
         test_port_forwards
-        test_push_pull_no_workspace
         test_workspace_sync
-        test_git_repo_private_clone
         test_multi_instance
         test_named_images
         test_guest_user_alt


### PR DESCRIPTION
## Summary
- add `coop up [DIR]` as a project-oriented ensure-running command with copy/mount transport modes
- use project-directory affinity to reuse/restart existing instances instead of allocating unbounded new VMs
- fix `coop start --workspace` so a workspace affinity match is not treated as an ignored restart flag
- document the new workflow in README and workspace/command docs

## Review notes
- subagent review found three issues: copy-mode extra mounts at /workspace, explicit --image on restart, and backend-specific mount wording
- all three review findings were fixed before opening this PR

## Verification
- `cargo test` (657 passed; rerun outside sandbox for port-probe tests)
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

Closes #216