### PR TITLE
Harden interactive SSH escape path

### DIFF
--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -32,6 +32,14 @@ coop ca
 
 This runs `claude agents` in the guest, which opens the agent view — an interactive TUI for monitoring background agent sessions. Background sessions are managed by Claude Code (not by coop), so closing the TUI and reconnecting later with `coop ca` keeps you in sync with whatever is still running.
 
+If the remote TUI appears stuck or stops responding, use OpenSSH's local escape: type Enter, then `~.` to disconnect. coop forces the interactive SSH escape character to `~`, so the escape path is available even if your user SSH config changes or disables `EscapeChar`. If your terminal remains in raw/no-echo mode after the disconnect, run:
+
+```bash
+stty sane
+```
+
+This is separate from SSH startup failures that exit with code 255. coop already restores the terminal after those failures; the escape sequence is for sessions where SSH is still connected and forwarding keystrokes to the remote TUI.
+
 `claude agents` accepts `--cwd <path>` (filter sessions by working directory) and `--setting-sources <sources>`; pass them after `--`:
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -162,6 +162,8 @@ coop claude my-project -- --model sonnet
 
 Open the Claude Code agent view (`claude agents`) inside the VM. Claude Code's background agents are managed by its own daemon, so closing the terminal does not stop in-flight sessions; reconnect with `coop claude-agents` to see them again.
 
+If the remote TUI stops responding, type Enter, then `~.` to disconnect the SSH session. coop forces OpenSSH's interactive escape character to `~`, so this works even if your user SSH config disables or changes `EscapeChar`. If the terminal remains in a broken raw/no-echo state afterward, run `stty sane`.
+
 ```
 coop claude-agents [NAME] [FLAGS] [ARGS...]
 coop ca [NAME] [FLAGS] [ARGS...]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2480,6 +2480,7 @@ mod tests {
     /// to a live non-firecracker process, the tests still see the
     /// expected `false` outcome — they assert behavior, not which
     /// branch fired.
+    #[cfg(target_os = "linux")]
     const DEAD_PID: u32 = 999_999;
 
     #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,10 @@ enum Commands {
         args: Vec<String>,
     },
     /// Open the Claude Code agent view inside the VM (`claude agents`)
-    #[command(alias = "ca")]
+    #[command(
+        alias = "ca",
+        after_help = "If the remote TUI stops responding, type Enter, then ~. to disconnect. If your terminal remains broken afterward, run `stty sane`."
+    )]
     ClaudeAgents {
         /// Instance name (required if multiple instances exist)
         #[arg(

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -57,6 +57,23 @@ fn keepalive_opts() -> [String; 4] {
     ]
 }
 
+/// Force a known OpenSSH escape character for emergency disconnects.
+///
+/// OpenSSH only recognizes the escape at the start of a line, so users
+/// should type Enter, then `~.`. Setting it here keeps user SSH config from
+/// disabling or changing the escape path for coop's interactive sessions.
+fn escape_opts() -> [String; 2] {
+    ["-e".into(), "~".into()]
+}
+
+fn interactive_ssh_args(session: &SshSession, remote_cmd: String) -> Vec<String> {
+    let mut args = session.ssh_opts();
+    args.extend(keepalive_opts());
+    args.extend(escape_opts());
+    args.extend(["-t".to_string(), session.target.addr(), remote_cmd]);
+    args
+}
+
 /// Restore the local terminal after an SSH failure.
 ///
 /// When SSH itself fails (exit 255) the remote TUI never restores the
@@ -87,11 +104,11 @@ pub fn run_interactive(session: &SshSession, command: &[String]) -> Result<()> {
         session.target.host,
         session.target.port,
     );
+    tracing::info!(
+        "If the remote session stops responding, type Enter, then ~. to disconnect; run `stty sane` if your terminal remains broken.",
+    );
 
-    let mut args = session.ssh_opts();
-    args.extend(keepalive_opts());
-    args.push(session.target.addr());
-    args.extend(["-t".to_string(), remote_cmd]);
+    let args = interactive_ssh_args(session, remote_cmd);
 
     let status = Command::new("ssh")
         .args(&args)
@@ -169,6 +186,7 @@ pub fn exec_command(session: &SshSession, command: &[String]) -> Result<()> {
 }
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests construct known-valid SSH values")]
 mod tests {
     use super::*;
 
@@ -192,6 +210,52 @@ mod tests {
                 "ServerAliveInterval=30",
                 "-o",
                 "ServerAliveCountMax=3",
+            ],
+        );
+    }
+
+    #[test]
+    fn escape_opts_force_tilde_escape() {
+        assert_eq!(escape_opts(), ["-e", "~"]);
+    }
+
+    #[test]
+    fn interactive_args_force_escape_before_target() {
+        let session = SshSession {
+            target: crate::backend::SshTarget {
+                host: crate::backend::Hostname::new("127.0.0.1")
+                    .expect("test host should be valid"),
+                port: std::num::NonZeroU16::MIN,
+                user: crate::backend::SshUser::new("ubuntu").expect("test user should be valid"),
+                key_path: "/tmp/coop-test-key".into(),
+            },
+            env: crate::backend::EnvForward::default(),
+        };
+
+        assert_eq!(
+            interactive_ssh_args(&session, "cd /workspace && 'claude' 'agents'".into()),
+            [
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "IdentitiesOnly=yes",
+                "-o",
+                "LogLevel=ERROR",
+                "-i",
+                "/tmp/coop-test-key",
+                "-p",
+                "1",
+                "-o",
+                "ServerAliveInterval=30",
+                "-o",
+                "ServerAliveCountMax=3",
+                "-e",
+                "~",
+                "-t",
+                "ubuntu@127.0.0.1",
+                "cd /workspace && 'claude' 'agents'",
             ],
         );
     }


### PR DESCRIPTION
## Summary
- force OpenSSH's interactive escape character to '~' for coop interactive SSH sessions
- print the Enter then ~. recovery hint before interactive SSH handoff
- document the stuck Claude agents TUI escape path and terminal recovery steps
- add tests covering the interactive SSH args

## Scope
This intentionally affects all interactive SSH handoffs through ssh::run_interactive: shell without a command, claude, claude-agents/ca, codex, and quickstart's Claude launch. Non-interactive exec/shell command paths are unchanged.

Fixes #231.

## Testing
- cargo fmt --check
- cargo check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- ca --help