### PR TITLE
Add devcontainer check command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -105,6 +105,7 @@ coop setup [FLAGS]
 | `--post-install <path>` | Path to a post-install script to run in the chroot |
 | `--template-size <GiB>` | Template rootfs size in GiB (default: 8) |
 | `--image <name>` | Named image to build (default: `default`) |
+| `--guest-user <name>` | Guest username to bake into the image (default: `ubuntu`). Use this for devcontainers that declare another `remoteUser`, such as `vscode`. |
 | `--workspace <dir>` | Scan for `.devcontainer/devcontainer.json` and offer to apply its `features` / `hostRequirements` to this setup. |
 | `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt). |
 | `--no-devcontainer` | Ignore any discovered `devcontainer.json`. |
@@ -127,6 +128,21 @@ coop build
 ```
 
 No additional flags.
+
+### `devcontainer check`
+
+Parse a `devcontainer.json` file and print the same translation report that `setup --dry-run` and `start --dry-run` use, without loading coop config, checking for updates, setting up an image, or starting a VM.
+
+```
+coop devcontainer check <path> [--stage setup|start|both]
+```
+
+| Flag | Description |
+|------|-------------|
+| `<path>` | Path to the `devcontainer.json` file to inspect |
+| `--stage <stage>` | Which lifecycle translation to report: `setup`, `start`, or `both` (default: `both`) |
+
+Use `--stage setup` to inspect setup-time keys such as `features`, `hostRequirements.cpus`, `hostRequirements.memory`, and `remoteUser`. Use `--stage start` to inspect start-time keys such as `postStartCommand`, `containerEnv`, `forwardPorts`, `mounts`, and `hostRequirements.storage`.
 
 ### `start`
 

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -21,6 +21,7 @@ For CI or scripted use, pass one of:
 - `--devcontainer <path>` — use this specific file, skip the prompt
 - `--no-devcontainer` — ignore any discovered file
 - `--dry-run` — print the report and exit before any VM work
+- `coop devcontainer check <path>` — print setup/start translation reports for a file without loading coop config or touching VM state
 
 A non-TTY invocation that discovers a `devcontainer.json` without any of these flags errors out rather than silently choosing.
 
@@ -39,9 +40,9 @@ CLI flags > `devcontainer.json` > defaults. The reporting table marks overrides 
 | `features` (anything else) | warn and skip | No silent fallback to a custom profile |
 | `hostRequirements.cpus` | `--vcpus` | |
 | `hostRequirements.memory` | `--mem` | Accepts `4GB`/`4GiB`-style values |
-| `hostRequirements.storage` | `--disk` | Accepts `16GB`/`16GiB`-style values |
+| `hostRequirements.storage` | `--disk` | Start-time only; accepts `16GB`/`16GiB`-style values |
 | `mounts` | `--mount` | Docker `type=bind,source=...,target=...` strings and objects supported; non-bind types are rejected |
-| `remoteUser` | warn and skip unless `ubuntu` | coop hardcodes the guest user |
+| `remoteUser` | `--guest-user` at setup time | Baked into the image at setup; start reports a mismatch and skips `containerEnv` if the image uses a different guest user |
 | `image`, `build`, `dockerComposeFile`, `customizations`, `name` | warn and skip | coop manages its own rootfs |
 
 ## JSON with comments

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -423,7 +423,7 @@ pub fn translate(
     t.report.source_path = Some(file.path.clone());
 
     if let Some(reqs) = &file.raw.host_requirements {
-        translate_host_requirements(reqs, inputs, &mut t);
+        translate_host_requirements(reqs, inputs, stage, &mut t);
     }
 
     if let Some(cmd) = &file.raw.post_start_command {
@@ -559,6 +559,7 @@ pub fn translate(
 fn translate_host_requirements(
     reqs: &RawHostRequirements,
     inputs: &TranslatorInputs,
+    stage: Stage,
     t: &mut Translation,
 ) {
     if let Some(cpus) = reqs.cpus {
@@ -618,7 +619,15 @@ fn translate_host_requirements(
     if let Some(storage) = reqs.storage {
         let key = "hostRequirements.storage";
         let gib = storage.as_gib();
-        if let Some(cli) = inputs.cli_disk_gib {
+        if stage == Stage::Setup {
+            t.report.push(
+                key,
+                ReportStatus::Unsupported,
+                ReportSource::Devcontainer,
+                format!("{gib} GiB"),
+                "instance disk size is applied at `coop start` time, not during setup",
+            );
+        } else if let Some(cli) = inputs.cli_disk_gib {
             t.report.push(
                 key,
                 ReportStatus::Overridden,
@@ -1504,6 +1513,20 @@ mod tests {
         assert_eq!(cmd.status, ReportStatus::Overridden);
         assert!(t.vcpus.is_none());
         assert!(t.post_start.is_none());
+    }
+
+    #[test]
+    fn translate_setup_reports_storage_as_start_time_only() {
+        let f = parse(r#"{ "hostRequirements": { "storage": "16GiB" } }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Setup);
+        let storage = t
+            .report
+            .entries
+            .iter()
+            .find(|e| e.key == "hostRequirements.storage")
+            .unwrap();
+        assert_eq!(storage.status, ReportStatus::Unsupported);
+        assert!(t.disk_gib.is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::engine::ArgValueCandidates;
 
 use backend::VmBackend as _;
@@ -225,6 +225,11 @@ enum Commands {
     },
     /// Build rootfs image and fetch kernel (use `setup` for first-time install)
     Build,
+    /// Inspect devcontainer.json support without starting setup or a VM
+    Devcontainer {
+        #[command(subcommand)]
+        command: DevcontainerCommands,
+    },
     /// Start an existing stopped VM instance
     Start {
         /// Stopped instance name (optional only when exactly one stopped instance exists)
@@ -609,6 +614,28 @@ enum GithubAction {
     },
 }
 
+#[derive(Subcommand)]
+enum DevcontainerCommands {
+    /// Parse devcontainer.json and print coop's translation report.
+    Check {
+        /// Path to the devcontainer.json file to inspect
+        path: PathBuf,
+        /// Which lifecycle translation to report
+        #[arg(long, value_enum, default_value_t = DevcontainerCheckStage::Both)]
+        stage: DevcontainerCheckStage,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum DevcontainerCheckStage {
+    /// Report setup-time keys such as features, hostRequirements, and remoteUser
+    Setup,
+    /// Report start-time keys such as postStartCommand, containerEnv, ports, and mounts
+    Start,
+    /// Report both setup and start translations
+    Both,
+}
+
 fn init_tracing(verbosity: u8) {
     let filter = match verbosity {
         0 => "coop=info",
@@ -712,6 +739,10 @@ fn main() -> Result<()> {
         );
     }
 
+    if let Commands::Devcontainer { ref command } = cli.command {
+        return cmd_devcontainer(command);
+    }
+
     let mut cfg = config::CoopConfig::load(&cli.config)?;
     update::maybe_print_notify(&cfg.updates);
     update::maybe_run_background_check(&cfg.updates);
@@ -812,7 +843,7 @@ fn main() -> Result<()> {
             };
             let translation = resolve_devcontainer(
                 &DevcontainerOpts {
-                    explicit_path: devcontainer.as_deref(),
+                    explicit_path: devcontainer.as_deref().map(Path::new),
                     no_devcontainer,
                     dry_run,
                     workspace: ws_path,
@@ -863,6 +894,7 @@ fn main() -> Result<()> {
             let validated = cfg.validate_and_warn()?;
             cmd_build(&cfg, &validated)
         }
+        Commands::Devcontainer { .. } => unreachable!("handled before config load"),
         Commands::Start {
             name,
             workspace,
@@ -928,7 +960,7 @@ fn main() -> Result<()> {
             let ws_path = workspace.as_deref().map(Path::new);
             let translation = resolve_devcontainer(
                 &DevcontainerOpts {
-                    explicit_path: devcontainer.as_deref(),
+                    explicit_path: devcontainer.as_deref().map(Path::new),
                     no_devcontainer,
                     dry_run,
                     workspace: ws_path,
@@ -1309,7 +1341,7 @@ fn cmd_up(
         let inputs = up_translator_inputs(cfg, opts);
         resolve_devcontainer(
             &DevcontainerOpts {
-                explicit_path: opts.devcontainer.path.as_deref(),
+                explicit_path: opts.devcontainer.path.as_deref().map(Path::new),
                 no_devcontainer: opts.devcontainer.no_devcontainer,
                 dry_run: true,
                 workspace: Some(&project_dir),
@@ -1386,7 +1418,7 @@ fn create_up_instance(
     let inputs = up_translator_inputs(cfg, opts);
     let translation = resolve_devcontainer(
         &DevcontainerOpts {
-            explicit_path: opts.devcontainer.path.as_deref(),
+            explicit_path: opts.devcontainer.path.as_deref().map(Path::new),
             no_devcontainer: opts.devcontainer.no_devcontainer,
             dry_run: false,
             workspace: Some(project_dir),
@@ -1951,7 +1983,7 @@ fn apply_vm_overrides(
 /// prompt). `no_devcontainer` opts out entirely (skips discovery).
 /// `dry_run` prints the report and exits before any side effects.
 struct DevcontainerOpts<'a> {
-    explicit_path: Option<&'a str>,
+    explicit_path: Option<&'a Path>,
     no_devcontainer: bool,
     dry_run: bool,
     workspace: Option<&'a Path>,
@@ -1982,7 +2014,7 @@ fn resolve_devcontainer(
     }
 
     let (path, losers) = if let Some(p) = opts.explicit_path {
-        (PathBuf::from(p), Vec::new())
+        (p.to_path_buf(), Vec::new())
     } else {
         let found = devcontainer::discover(opts.workspace, opts.mounts);
         if let Some((winner, losers)) = devcontainer::pick_winner(found) {
@@ -2023,6 +2055,61 @@ fn resolve_devcontainer(
     eprintln!("{}", translation.report.render());
 
     Ok(Some(translation))
+}
+
+#[expect(
+    clippy::print_stderr,
+    reason = "devcontainer check report is intentional user-facing CLI output"
+)]
+fn cmd_devcontainer(command: &DevcontainerCommands) -> Result<()> {
+    match command {
+        DevcontainerCommands::Check { path, stage } => {
+            let opts = DevcontainerOpts {
+                explicit_path: Some(path.as_path()),
+                no_devcontainer: false,
+                dry_run: true,
+                workspace: None,
+                mounts: &[],
+            };
+            let setup_inputs = devcontainer::TranslatorInputs::default();
+
+            match stage {
+                DevcontainerCheckStage::Setup => {
+                    resolve_devcontainer(&opts, &setup_inputs, devcontainer::Stage::Setup)?;
+                }
+                DevcontainerCheckStage::Start => {
+                    let start_inputs = devcontainer::TranslatorInputs {
+                        persisted_guest_user: Some(guest::GuestUser::default()),
+                        ..devcontainer::TranslatorInputs::default()
+                    };
+                    resolve_devcontainer(&opts, &start_inputs, devcontainer::Stage::Start)?;
+                }
+                DevcontainerCheckStage::Both => {
+                    eprintln!("setup-stage translation:");
+                    let setup_translation =
+                        resolve_devcontainer(&opts, &setup_inputs, devcontainer::Stage::Setup)?;
+                    let assumed_guest_user =
+                        devcontainer_check_assumed_guest_user(setup_translation.as_ref());
+                    let start_inputs = devcontainer::TranslatorInputs {
+                        persisted_guest_user: Some(assumed_guest_user),
+                        ..devcontainer::TranslatorInputs::default()
+                    };
+                    eprintln!();
+                    eprintln!("start-stage translation:");
+                    resolve_devcontainer(&opts, &start_inputs, devcontainer::Stage::Start)?;
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn devcontainer_check_assumed_guest_user(
+    setup_translation: Option<&devcontainer::Translation>,
+) -> guest::GuestUser {
+    setup_translation
+        .and_then(|t| t.guest_user.clone())
+        .unwrap_or_default()
 }
 
 fn cmd_build(cfg: &config::CoopConfig, _: &config::Validated) -> Result<()> {
@@ -4212,6 +4299,56 @@ mod tests {
     fn quickstart_rejects_unknown_flag() {
         let err = parse_err(&["quickstart", "--name", "foo"]);
         assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn devcontainer_check_subcommand_parses_with_defaults() {
+        let cli = parse(&["devcontainer", "check", ".devcontainer/devcontainer.json"]);
+        let super::Commands::Devcontainer { command } = cli.command else {
+            panic!("expected Devcontainer variant");
+        };
+        let super::DevcontainerCommands::Check { path, stage } = command;
+        assert_eq!(
+            path,
+            std::path::PathBuf::from(".devcontainer/devcontainer.json")
+        );
+        assert!(matches!(stage, super::DevcontainerCheckStage::Both));
+    }
+
+    #[test]
+    fn devcontainer_check_stage_flag_parses() {
+        let cli = parse(&[
+            "devcontainer",
+            "check",
+            ".devcontainer/devcontainer.json",
+            "--stage",
+            "start",
+        ]);
+        let super::Commands::Devcontainer { command } = cli.command else {
+            panic!("expected Devcontainer variant");
+        };
+        let super::DevcontainerCommands::Check { stage, .. } = command;
+        assert!(matches!(stage, super::DevcontainerCheckStage::Start));
+    }
+
+    #[test]
+    fn devcontainer_check_both_stage_reuses_setup_guest_user() {
+        let translation = super::devcontainer::Translation {
+            guest_user: Some(super::guest::GuestUser::new("vscode").unwrap()),
+            ..super::devcontainer::Translation::default()
+        };
+        assert_eq!(
+            super::devcontainer_check_assumed_guest_user(Some(&translation)).to_string(),
+            "vscode"
+        );
+    }
+
+    #[test]
+    fn devcontainer_check_both_stage_defaults_without_setup_guest_user() {
+        assert_eq!(
+            super::devcontainer_check_assumed_guest_user(None).to_string(),
+            "ubuntu"
+        );
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3081,6 +3081,21 @@ test_devcontainer_translator() {
         fail "remoteUser=root is reported invalid" "stderr: $HARNESS_ERR"
     fi
 
+    # Dedicated check command: validates the same file without discovery,
+    # config loading, setup, or VM work.
+    if coop devcontainer check "$dcfile" --stage both; then
+        pass "devcontainer check exits 0"
+    else
+        fail "devcontainer check exits 0" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+    if grep -q "setup-stage translation:" <<< "$HARNESS_ERR" \
+        && grep -q "start-stage translation:" <<< "$HARNESS_ERR" \
+        && grep -q "remoteUser" <<< "$HARNESS_ERR"; then
+        pass "devcontainer check reports setup and start stages"
+    else
+        fail "devcontainer check reports setup and start stages" "stderr: $HARNESS_ERR"
+    fi
+
     # --no-devcontainer silently skips the file: the report header must NOT appear.
     # `--dry-run` lets us exercise the discovery path without any VM work.
     if coop up "$dcdir" --name "${INSTANCE}-dc-skip" \


### PR DESCRIPTION
## Summary

- Add `coop devcontainer check <path>` with `--stage setup|start|both` for devcontainer translation dry-runs without config loading, update checks, setup, or VM start
- Make check `both` mode carry setup `remoteUser` into the start-stage assumption so reports are internally consistent
- Make setup-stage `hostRequirements.storage` reporting truthful and document the start-time behavior
- Document `--guest-user` and the new check command

Closes #233
Part of #27

## Review

Critical subagent review completed before PR. Findings fixed: inconsistent `remoteUser` assumption in `both` mode, setup-stage storage false-positive, lossy path conversion, and missing `--guest-user` docs.

## Tests

- `cargo fmt --check`
- `cargo check`
- `cargo test devcontainer`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `cargo run --quiet -- devcontainer check /private/tmp/coop-devcontainer-check.json --stage both`
- `cargo run --quiet -- --config /private/tmp/coop-bad-config.toml devcontainer check /private/tmp/coop-devcontainer-check.json --stage setup`