### PR TITLE
Build profile images on demand from start

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 
 - **Two backends**: Firecracker microVMs (Linux/KVM) and Lima VMs (macOS/Virtualization.framework), auto-detected by platform
 - **Workspace sync**: copy or mount a local project directory into the VM with `coop up`
-- **Profiles**: customizable guest environments with apt packages and install scripts; built-in profiles for Python, Node, C, Rust, Go, and fuzzing
+- **Profiles**: customizable guest environments with apt packages and install scripts; built-in profiles for Python, Node, C, Rust, Go, and fuzzing; `coop start --profile python,node` builds the matching image on demand
 - **Named images**: build multiple template images with different profiles (`coop setup --image ml-dev --profile python`)
 - **Claude Code integration**: API key forwarding, CLAUDE.md injection, plugin/marketplace support, MCP server configuration
 - **Codex integration**: API key forwarding, `~/.codex` config sync, MCP server configuration, dedicated `coop codex` launcher
@@ -60,7 +60,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 | `up` | Ensure a project environment exists and is running |
 | `setup` | Install backend runtime, fetch kernel, build template rootfs |
 | `build` | Rebuild rootfs image and fetch kernel |
-| `start` | Start an existing stopped VM instance |
+| `start` | Restart a stopped VM, or build/start a profile-derived image with `--profile` |
 | `stop` | Stop a running VM (preserves disk) |
 | `destroy` | Stop and remove a VM instance |
 | `shell` | Interactive shell session in a running VM |

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -142,7 +142,7 @@ Both backends support the same CLI commands and guest capabilities:
 |---|---|---|
 | `coop setup` | Builds golden image via builder VM | Installs binary + kernel, builds rootfs via chroot |
 | `coop up` | Creates or reconnects/restarts a project VM | Copies rootfs, configures TAP, starts Firecracker |
-| `coop start` | Starts an existing stopped Lima VM | Starts an existing stopped Firecracker VM |
+| `coop start` | Restarts a stopped Lima VM; `--profile` builds/starts a derived image | Restarts a stopped Firecracker VM; `--profile` builds/starts a derived image |
 | `coop stop` | `limactl stop` | API socket shutdown, SIGTERM, SIGKILL |
 | `coop destroy` | `limactl delete --force` | Kill process, remove TAP, delete instance dir |
 | `coop status` | Queries `limactl list --json` | Reads PID file, queries guest via SSH |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -146,30 +146,32 @@ Use `--stage setup` to inspect setup-time keys such as `features`, `hostRequirem
 
 ### `start`
 
-Start an existing stopped VM instance.
+Restart a stopped VM, or build and start a profile-derived image.
 
 ```
 coop start [NAME] [FLAGS]
 ```
 
-`start` is restart-only: it never creates a new instance. Use `coop up [DIR]`
-to create or reconnect to a project environment. Without `NAME`, `start`
-restarts the only stopped instance if exactly one exists; with multiple stopped
-instances, pass the instance name.
+`start` normally restarts existing stopped instances. Use `coop up [DIR]` to
+create or reconnect to a project environment. Without `NAME`, `start` restarts
+the only stopped instance if exactly one exists; with multiple stopped
+instances, pass the instance name. The profile shorthand
+`coop start --profile <list>` is the creation exception described below.
 
 | Flag | Description |
 |------|-------------|
 | `NAME` | Stopped instance name (optional only when exactly one stopped instance exists) |
+| `--profile <list>` | Build or reuse a profile-derived image for a new instance, named from the sorted profiles (for example `node-python`) |
 | `--workspace <dir>` | Restart the stopped instance associated with this project path (conflicts with `--git-repo`) |
-| `--git-repo <url>` | Creation-time option retained only for compatibility; use `coop up` for new project environments |
+| `--git-repo <url>` | Deprecated creation option; only applies when creating with `--profile` |
 | `--vcpus <N>` | Creation-time option retained only for compatibility; rejected on restart |
 | `--mem <MiB>` | Creation-time option retained only for compatibility; rejected on restart |
-| `--disk <GiB>` | Creation-time option retained only for compatibility; rejected on restart |
+| `--disk <GiB>` | Instance disk size when creating with `--profile`; rejected on restart |
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
 | `--image <name>` | Creation-time option retained only for compatibility; rejected on restart |
-| `--mount <spec>` | Creation-time option retained only for compatibility; rejected on restart |
+| `--mount <spec>` | Host directory to mount when creating with `--profile`; rejected on restart |
 | `--forward-port <spec>` | Forward a guest port to the host (`GUEST[:HOST]`, repeatable). Lives for the lifetime of the VM; torn down on `coop stop`. |
-| `--exclude-git` | Creation-time option retained only for compatibility; rejected on restart |
+| `--exclude-git` | Skip `.git/` when copying/syncing a workspace for `--profile`; rejected on restart |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
 | `--env KEY=VALUE` | Literal env var to set in the guest (repeatable). Overrides `guest_env` config entries and any forwarded values with the same name. |
@@ -179,9 +181,17 @@ instances, pass the instance name.
 
 When `--workspace <dir>` contains a `.devcontainer/devcontainer.json`, coop reads a subset of it and prompts before applying restart-time settings. See [docs/devcontainer.md](devcontainer.md) for the supported keys and discovery rules.
 
+`coop start --profile <list>` is the exception to the restart-only rule. It
+derives an image name from the sorted profile list, runs the same stale-image
+check as `coop setup`, builds or rebuilds that image if needed, and then starts
+a new instance from it. Explicit named images are unchanged: use `coop setup
+--image <name> --profile ...` followed by `coop up --image <name>` when you
+want to choose the image name yourself.
+
 ```
 coop start
 coop start my-project
+coop start --profile python,node
 coop start my-project --no-agents
 coop start --env RUST_LOG=info --env MY_FLAG=1
 coop start --forward-port 3000 --forward-port 8080:18080

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,6 +94,15 @@ coop setup --profile python,node
 
 Built-in profiles: `python`, `node`, `c`, `fuzz`, `rust`, `go`. Combine them with commas (e.g. `--profile python,node,rust`). Use `coop profiles list` to inspect what each one installs.
 
+You can also let `start` build a profile-derived image on demand:
+
+```
+coop start --profile python,node
+```
+
+This creates or refreshes an image named from the sorted profile list
+(`node-python` here), then starts a new instance from it.
+
 Skip confirmation prompts with `-y`:
 
 ```

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -78,6 +78,30 @@ coop setup --profile ml
 coop setup --profile ml,node
 ```
 
+## Build-on-demand from `start`
+
+For profile-only workflows, `coop start --profile <list>` builds the matching
+image automatically before starting a new instance. The image name is derived
+from the sorted profile list, so these commands all target the same
+`node-python` image:
+
+```bash
+coop start --profile python,node
+coop start --profile node,python
+```
+
+coop runs the same recipe-hash staleness check used by `coop setup`. If the
+derived image is missing or stale, it is built or rebuilt first; if it is
+current, startup reuses it.
+
+Explicitly named images are not affected by this shorthand. To choose the
+image name yourself, build it with `setup` and start a project from that image:
+
+```bash
+coop setup --image ml-dev --profile python,node
+coop up . --image ml-dev
+```
+
 ## Extra packages
 
 For one-off additions without a full profile, use `--extra-packages`:

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,15 +230,22 @@ enum Commands {
         #[command(subcommand)]
         command: DevcontainerCommands,
     },
-    /// Start an existing stopped VM instance
+    /// Restart a stopped VM, or build/start a profile-derived image
     Start {
         /// Stopped instance name (optional only when exactly one stopped instance exists)
         #[arg(value_parser = config::InstanceName::parse)]
         name: Option<config::InstanceName>,
+        /// Install profiles for a new profile-derived image, building it on demand
+        #[arg(
+            long,
+            value_delimiter = ',',
+            add = ArgValueCandidates::new(completions::profile_candidates),
+        )]
+        profile: Vec<String>,
         /// Project directory used to select an associated stopped instance
         #[arg(long, conflicts_with = "git_repo")]
         workspace: Option<String>,
-        /// Deprecated creation option; rejected by `coop start`
+        /// Deprecated creation option; only applies when creating with --profile
         #[arg(long, conflicts_with = "workspace")]
         git_repo: Option<String>,
         /// Creation-time option; rejected by `coop start`
@@ -247,13 +254,13 @@ enum Commands {
         /// Creation-time option; rejected by `coop start`
         #[arg(long, value_parser = config::MiB::parse_cli)]
         mem: Option<config::MiB>,
-        /// Creation-time option; rejected by `coop start`
+        /// Creation-time option; only applies when creating with --profile
         #[arg(long, value_parser = config::GiB::parse_cli)]
         disk: Option<config::GiB>,
         /// Skip injecting Claude Code and Codex credentials/config into the VM
         #[arg(long, alias = "no-claude")]
         no_agents: bool,
-        /// Creation-time option; rejected by `coop start`
+        /// Creation-time option; only applies when creating with --profile
         #[arg(
             long,
             conflicts_with_all = ["workspace", "git_repo"],
@@ -265,7 +272,7 @@ enum Commands {
         /// `--forward-port 3000:3001` forwards guest 3000 to host 3001.
         #[arg(long, value_parser = config::PortForward::parse)]
         forward_port: Vec<config::PortForward>,
-        /// Creation-time option; rejected by `coop start`
+        /// Explicit named image; rejected by `coop start`
         #[arg(
             long,
             default_value = config::DEFAULT_IMAGE,
@@ -273,7 +280,7 @@ enum Commands {
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         image: config::ImageName,
-        /// Creation-time option; rejected by `coop start`
+        /// Creation-time option; only applies when creating with --profile
         #[arg(long, conflicts_with = "git_repo")]
         exclude_git: bool,
         /// Suppress the interactive prompt to set up a scoped GitHub PAT
@@ -897,6 +904,7 @@ fn main() -> Result<()> {
         Commands::Devcontainer { .. } => unreachable!("handled before config load"),
         Commands::Start {
             name,
+            profile,
             workspace,
             git_repo,
             vcpus,
@@ -925,10 +933,19 @@ fn main() -> Result<()> {
                     "`coop start` only starts stopped instances; VM sizing options belong to `coop up`."
                 );
             }
+            let image_explicit = raw_args_use_long_flag(&raw_args, "--image");
+            let profile_target = if profile.is_empty() {
+                None
+            } else {
+                Some(ProfileImageTarget::new(&profile)?)
+            };
+            let effective_image = profile_target
+                .as_ref()
+                .map_or(&image, |target| &target.image);
             let preflight_opts = StartOpts {
                 name: name.as_ref(),
                 image: StartImage {
-                    explicit: raw_args_use_long_flag(&raw_args, "--image"),
+                    explicit: image_explicit,
                 },
                 workspace_dir: workspace.as_deref(),
                 git_repo: git_repo.as_deref(),
@@ -942,7 +959,28 @@ fn main() -> Result<()> {
                 post_start_override: post_start.as_deref(),
                 persisted_guest_env: std::collections::BTreeMap::new(),
             };
-            preflight_start_target(&be, &cfg, &preflight_opts)?;
+            if profile.is_empty() {
+                preflight_start_target(&be, &cfg, &preflight_opts)?;
+            } else if image_explicit {
+                bail!(
+                    "`coop start --profile` derives the image name from the sorted profile list; \
+                     use `coop setup --image {image} --profile ...` and then `coop up --image {image}` \
+                     for an explicit named image."
+                );
+            } else if (preflight_opts.name.is_some() || preflight_opts.workspace_dir.is_some())
+                && find_stopped_instance(
+                    &be,
+                    &cfg,
+                    preflight_opts.name,
+                    preflight_opts.workspace_dir.map(Path::new),
+                )?
+                .is_some()
+            {
+                bail!(
+                    "`coop start --profile` creates a new profile-derived instance; \
+                     it cannot change an existing stopped instance's image."
+                );
+            }
             let cli_env_keys = guest_env.iter().map(|(k, _)| k.clone()).collect();
             let inputs = devcontainer::TranslatorInputs {
                 cli_vcpus: vcpus,
@@ -952,8 +990,8 @@ fn main() -> Result<()> {
                 cli_guest_env_keys: cli_env_keys,
                 cli_forward_ports: forward_ports.clone(),
                 cli_mounts: mounts.clone(),
-                cli_profiles: Vec::new(),
-                persisted_guest_user: Some(backend::persisted_guest_user(&cfg, &image)),
+                cli_profiles: profile.clone(),
+                persisted_guest_user: Some(backend::persisted_guest_user(&cfg, effective_image)),
                 cli_workspace_or_git_repo: workspace.is_some() || git_repo.is_some(),
                 ..devcontainer::TranslatorInputs::default()
             };
@@ -1018,29 +1056,63 @@ fn main() -> Result<()> {
             } else {
                 mounts
             };
-            cmd_start(
-                &be,
-                &mut cfg,
-                &validated,
-                &StartOpts {
-                    name: name.as_ref(),
-                    image: StartImage {
-                        explicit: raw_args_use_long_flag(&raw_args, "--image"),
-                    },
-                    workspace_dir: workspace.as_deref(),
-                    git_repo: git_repo.as_deref(),
-                    no_agents,
-                    no_prompt,
-                    disk: effective_disk,
-                    mounts: final_mounts,
-                    exclude_git,
-                    forward_ports,
-                    config_path: &cli.config,
-                    post_start_override: post_start_override.as_deref(),
-                    persisted_guest_env,
+            let start_opts = StartOpts {
+                name: name.as_ref(),
+                image: StartImage {
+                    explicit: image_explicit,
                 },
-            )
-            .map(|_| ())
+                workspace_dir: workspace.as_deref(),
+                git_repo: git_repo.as_deref(),
+                no_agents,
+                no_prompt,
+                disk: effective_disk,
+                mounts: final_mounts,
+                exclude_git,
+                forward_ports,
+                config_path: &cli.config,
+                post_start_override: post_start_override.as_deref(),
+                persisted_guest_env,
+            };
+            if let Some(profile_target) = profile_target {
+                let resolved_profiles =
+                    guest::resolve_profiles(&profile_target.profiles, &cfg.profiles)?;
+                let _guard = signal::install_handlers();
+                be.setup(
+                    &cfg,
+                    &validated,
+                    &setup::SetupOptions {
+                        skip_confirm: true,
+                        rebuild: false,
+                        profiles: resolved_profiles,
+                        extra_packages: Vec::new(),
+                        post_install: None,
+                        image: profile_target.image.clone(),
+                        guest_user: guest::GuestUser::default(),
+                    },
+                )?;
+                let workspace_path = workspace
+                    .as_deref()
+                    .map(Path::new)
+                    .map(Path::canonicalize)
+                    .transpose()
+                    .with_context(|| {
+                        format!(
+                            "Failed to resolve workspace path {}",
+                            workspace.as_deref().unwrap_or_default()
+                        )
+                    })?;
+                allocate_and_start(
+                    &be,
+                    &mut cfg,
+                    name.as_ref(),
+                    &profile_target.image,
+                    workspace_path.as_deref(),
+                    &start_opts,
+                )
+                .map(|_| ())
+            } else {
+                cmd_start(&be, &mut cfg, &validated, &start_opts).map(|_| ())
+            }
         }
         Commands::Shell { name, command } => cmd_shell(&be, &cfg, name.as_ref(), &command),
         Commands::Claude {
@@ -2119,8 +2191,33 @@ fn cmd_build(cfg: &config::CoopConfig, _: &config::Validated) -> Result<()> {
     Ok(())
 }
 
+struct ProfileImageTarget {
+    profiles: Vec<String>,
+    image: config::ImageName,
+}
+
+impl ProfileImageTarget {
+    fn new(profiles: &[String]) -> Result<Self> {
+        let profiles = canonical_profile_list(profiles);
+        let image = config::ImageName::new(&profiles.join("-")).with_context(|| {
+            format!(
+                "Cannot derive an image name from profile list: {}",
+                profiles.join(", ")
+            )
+        })?;
+        Ok(Self { profiles, image })
+    }
+}
+
 struct StartImage {
     explicit: bool,
+}
+
+fn canonical_profile_list(profiles: &[String]) -> Vec<String> {
+    let mut names = profiles.to_vec();
+    names.sort();
+    names.dedup();
+    names
 }
 
 struct StartOpts<'a> {
@@ -3473,6 +3570,27 @@ mod tests {
             panic!("expected Start variant");
         };
         assert!(no_agents);
+    }
+
+    #[test]
+    fn start_profile_flag_parses_comma_list() {
+        let cli = parse(&["start", "--profile", "python,node"]);
+        let super::Commands::Start { profile, .. } = cli.command else {
+            panic!("expected Start variant");
+        };
+        assert_eq!(profile, vec!["python", "node"]);
+    }
+
+    #[test]
+    fn profile_image_target_sorts_and_deduplicates_profiles() {
+        let profiles = vec![
+            "python".to_string(),
+            "node".to_string(),
+            "python".to_string(),
+        ];
+        let target = super::ProfileImageTarget::new(&profiles).expect("image target");
+        assert_eq!(target.image.as_str(), "node-python");
+        assert_eq!(target.profiles, vec!["node", "python"]);
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2270,28 +2270,30 @@ test_builtin_profiles() {
     echo ""
     echo "=== Phase: built-in profiles ==="
 
-    # Build a named image with python and node profiles.
-    # These cover apt-only (python) and pre-install script (node/NodeSource).
-    local img_name="profiles-test-$$"
-    if coop setup -y --image "$img_name" --profile python,node; then
-        pass "setup --profile python,node exits 0"
+    # Build-on-demand via start. The sorted profile list derives the
+    # node-python image name. These cover apt-only (python) and
+    # pre-install script (node/NodeSource).
+    local img_name="node-python"
+    coop images --delete "$img_name" 2>/dev/null || true
+
+    local inst_name="${INSTANCE}-prof"
+    if coop start "$inst_name" --profile python,node --no-agents; then
+        STARTED_INSTANCES+=("$inst_name")
+        pass "start --profile python,node exits 0"
     else
-        fail "setup --profile python,node exits 0" "exit code: $?"
+        fail "start --profile python,node exits 0" "exit code: $?"
         echo "stderr: $HARNESS_ERR"
         return
     fi
 
-    # Create instance from the profiled image
-    local inst_name="${INSTANCE}-prof"
-    local prof_ws="$tmpdir/${inst_name}-ws"
-    mkdir -p "$prof_ws"
-    if coop up "$prof_ws" --name "$inst_name" --no-agents --no-devcontainer --image "$img_name"; then
-        STARTED_INSTANCES+=("$inst_name")
-        pass "up from profiled image exits 0"
+    if coop images; then
+        if echo "$HARNESS_OUT" | grep -q "^${img_name} "; then
+            pass "derived profile image is listed"
+        else
+            fail "derived profile image is listed" "output: $HARNESS_OUT"
+        fi
     else
-        fail "up from profiled image exits 0" "exit code: $?"
-        coop images --delete "$img_name" 2>/dev/null || true
-        return
+        fail "images exits 0 after start --profile" "exit code: $?"
     fi
 
     GUEST_INSTANCE="$inst_name"


### PR DESCRIPTION
## Summary

- Add `coop start --profile <list>` as a profile-derived image creation path that builds or refreshes the sorted-profile image before starting a new instance
- Canonicalize the profile list once so image naming and setup recipe hashing use the same sorted, deduplicated inputs
- Preserve explicit named-image behavior by rejecting `--image` with the profile shorthand and documenting the setup/up path for named images
- Update command docs, getting started, profile docs, backend parity docs, and README
- Extend the built-in profile integration phase to exercise `start --profile python,node` and verify the derived `node-python` image

Closes #20

## Review

Subagent review completed. Findings fixed: canonical recipe inputs for derived profile images, and contradictory restart-only docs/help text.

## Tests

- `cargo fmt --check`
- `cargo check`
- `cargo test start_profile_flag`
- `cargo test profile_image_target`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `cargo run --quiet -- start --help`