### PR TITLE
Discover devcontainer.json for git repo starts

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -163,7 +163,7 @@ instances, pass the instance name. The profile shorthand
 | `NAME` | Stopped instance name (optional only when exactly one stopped instance exists) |
 | `--profile <list>` | Build or reuse a profile-derived image for a new instance, named from the sorted profiles (for example `node-python`) |
 | `--workspace <dir>` | Restart the stopped instance associated with this project path (conflicts with `--git-repo`) |
-| `--git-repo <url>` | Deprecated creation option; only applies when creating with `--profile` |
+| `--git-repo <url>` | Deprecated creation option; only applies when creating with `--profile`. For GitHub URLs, coop can discover `.devcontainer/devcontainer.json` before creating the VM. |
 | `--vcpus <N>` | Creation-time option retained only for compatibility; rejected on restart |
 | `--mem <MiB>` | Creation-time option retained only for compatibility; rejected on restart |
 | `--disk <GiB>` | Instance disk size when creating with `--profile`; rejected on restart |
@@ -179,7 +179,7 @@ instances, pass the instance name. The profile shorthand
 | `--no-devcontainer` | Ignore any discovered `devcontainer.json` (escape hatch for CI). |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work. |
 
-When `--workspace <dir>` contains a `.devcontainer/devcontainer.json`, coop reads a subset of it and prompts before applying restart-time settings. See [docs/devcontainer.md](devcontainer.md) for the supported keys and discovery rules.
+When `--workspace <dir>` contains a `.devcontainer/devcontainer.json`, or `--git-repo <url>` points at a GitHub repository with one, coop reads a subset of it and prompts before applying restart-time settings. See [docs/devcontainer.md](devcontainer.md) for the supported keys and discovery rules.
 
 `coop start --profile <list>` is the exception to the restart-only rule. It
 derives an image name from the sorted profile list, runs the same stale-image

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -4,7 +4,7 @@ coop reads a **subset** of [devcontainer.json](https://containers.dev/) and maps
 
 ## How discovery and apply work
 
-When you run `coop up <dir>` or `coop setup --workspace <dir>`, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each mount host root, with the project directory winning ties). On restart, `coop start --workspace <dir>` can also read the project's devcontainer file for restart-time settings.
+When you run `coop up <dir>` or `coop setup --workspace <dir>`, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each mount host root, with the project directory winning ties). On restart, `coop start --workspace <dir>` can also read the project's devcontainer file for restart-time settings. For `coop start --git-repo <url>`, coop can discover `.devcontainer/devcontainer.json` from common GitHub repository URLs before creating the VM.
 
 If a file is found, coop prompts:
 
@@ -23,7 +23,7 @@ For CI or scripted use, pass one of:
 - `--dry-run` — print the report and exit before any VM work
 - `coop devcontainer check <path>` — print setup/start translation reports for a file without loading coop config or touching VM state
 
-A non-TTY invocation that discovers a `devcontainer.json` without any of these flags errors out rather than silently choosing.
+A non-TTY invocation that discovers a `devcontainer.json` without any of these flags errors out rather than silently choosing. For `--git-repo`, remote discovery is best-effort and currently limited to GitHub URLs that resolve to `owner/repo`; unsupported hosts continue without devcontainer translation unless you pass an explicit local `--devcontainer <path>`.
 
 ## Precedence
 
@@ -52,6 +52,6 @@ CLI flags > `devcontainer.json` > defaults. The reporting table marks overrides 
 ## Out of scope in v1
 
 - OCI feature registry pulls (`ghcr.io/devcontainers/features/*` features other than the built-in name match)
-- `--git-repo` auto-detection — the file lives inside the repo before coop has cloned it
+- `--git-repo` auto-detection for non-GitHub hosts
 - Sticky `--no-devcontainer` (persistent per-workspace state)
 - Live re-application on an existing VM (destroy + `coop up` to pick up changes)

--- a/src/git_repo_devcontainer.rs
+++ b/src/git_repo_devcontainer.rs
@@ -1,0 +1,179 @@
+//! Host-side discovery of `.devcontainer/devcontainer.json` for `--git-repo`.
+//!
+//! The repository has not been cloned into the guest when start-time
+//! devcontainer translation runs, so local filesystem discovery cannot see the
+//! file. This module keeps the remote path intentionally narrow: GitHub repo
+//! URLs only, one contents API request, and no cache.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+use crate::cmd::Cmd;
+use crate::config::{GitHubAuth, resolve_cmd_value};
+use crate::devcontainer::DEFAULT_DEVCONTAINER_REL_PATH;
+use crate::github_repo::{RepoSlug, parse_repo_slug_from_url};
+
+/// A devcontainer file discovered from a repository before the clone exists.
+#[derive(Debug, Clone)]
+pub struct GitRepoDevcontainer {
+    /// User-facing source path used in prompts and reports.
+    pub display_path: PathBuf,
+    /// File contents returned by the provider.
+    pub contents: String,
+}
+
+/// Best-effort discovery for `--git-repo`.
+///
+/// Returns `Ok(None)` for unsupported repository URLs, missing files, missing
+/// credentials for private repositories, rate limits, or provider errors. Those
+/// cases should not prevent the normal VM startup path from cloning the repo.
+pub fn discover(repo_url: &str, auth: Option<&GitHubAuth>) -> Result<Option<GitRepoDevcontainer>> {
+    let Some(slug) = parse_repo_slug_from_url(repo_url) else {
+        return Ok(None);
+    };
+    let url = github_contents_url(&slug);
+    let token = discovery_token(auth, &slug)?;
+    match curl_github_contents(&url, token.as_deref()) {
+        Ok((200, body)) => Ok(Some(GitRepoDevcontainer {
+            display_path: github_display_path(&slug),
+            contents: body,
+        })),
+        Ok((404, _)) => {
+            tracing::debug!("No remote devcontainer.json found for {slug}");
+            Ok(None)
+        }
+        Ok((status, _)) => {
+            tracing::debug!(
+                "GitHub devcontainer discovery for {slug} returned HTTP {status}; skipping"
+            );
+            Ok(None)
+        }
+        Err(e) => {
+            tracing::debug!("GitHub devcontainer discovery for {slug} failed: {e:#}");
+            Ok(None)
+        }
+    }
+}
+
+fn github_contents_url(slug: &RepoSlug) -> String {
+    format!("https://api.github.com/repos/{slug}/contents/{DEFAULT_DEVCONTAINER_REL_PATH}")
+}
+
+fn github_display_path(slug: &RepoSlug) -> PathBuf {
+    PathBuf::from(format!("github.com/{slug}/{DEFAULT_DEVCONTAINER_REL_PATH}"))
+}
+
+fn discovery_token(auth: Option<&GitHubAuth>, slug: &RepoSlug) -> Result<Option<String>> {
+    if let Some(entry) = auth.and_then(|a| a.pat_entry(slug)) {
+        let token = resolve_cmd_value(entry.token.expose())
+            .with_context(|| format!("Failed to resolve token for [github.pat.\"{slug}\"]"))?;
+        return Ok(normalize_token(&token));
+    }
+    Ok(select_host_token(
+        gh_auth_token().as_deref(),
+        std::env::var("GITHUB_TOKEN").ok().as_deref(),
+    ))
+}
+
+fn curl_github_contents(url: &str, token: Option<&str>) -> Result<(u16, String)> {
+    let mut cmd = Cmd::new("curl")
+        .arg("-sSL")
+        .arg("--connect-timeout")
+        .arg("5")
+        .arg("--max-time")
+        .arg("15")
+        .arg("-H")
+        .arg("User-Agent: coop")
+        .arg("-H")
+        .arg("Accept: application/vnd.github.raw+json")
+        .arg("-w")
+        .arg("\n%{http_code}");
+    if let Some(token) = token {
+        cmd = cmd
+            .arg("-H")
+            .arg("@-")
+            .stdin_input(format!("Authorization: token {token}\n"));
+    }
+    let out = cmd
+        .arg(url)
+        .capture()
+        .with_context(|| format!("curl GET {url} failed"))?;
+    parse_curl_status_body(&out)
+}
+
+fn parse_curl_status_body(out: &str) -> Result<(u16, String)> {
+    let (body, status_str) = out.rsplit_once('\n').unwrap_or(("", out.trim()));
+    let status: u16 = status_str
+        .trim()
+        .parse()
+        .with_context(|| format!("Failed to parse HTTP status from curl output: '{status_str}'"))?;
+    Ok((status, body.to_string()))
+}
+
+fn gh_auth_token() -> Option<String> {
+    Command::new("gh")
+        .args(["auth", "token"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| normalize_token(&s))
+}
+
+fn select_host_token(gh: Option<&str>, env: Option<&str>) -> Option<String> {
+    gh.and_then(normalize_token)
+        .or_else(|| env.and_then(normalize_token))
+}
+
+fn normalize_token(token: &str) -> Option<String> {
+    let token = token.trim();
+    (!token.is_empty()).then(|| token.to_string())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests use expect for clear assertions")]
+mod tests {
+    use super::*;
+
+    fn slug(s: &str) -> RepoSlug {
+        RepoSlug::new(s).expect("valid slug")
+    }
+
+    #[test]
+    fn github_contents_url_targets_default_branch_contents_api() {
+        assert_eq!(
+            github_contents_url(&slug("owner/repo")),
+            "https://api.github.com/repos/owner/repo/contents/.devcontainer/devcontainer.json"
+        );
+    }
+
+    #[test]
+    fn github_display_path_is_user_facing() {
+        assert_eq!(
+            github_display_path(&slug("owner/repo")),
+            PathBuf::from("github.com/owner/repo/.devcontainer/devcontainer.json")
+        );
+    }
+
+    #[test]
+    fn parse_curl_status_body_splits_body_and_status() {
+        let (status, body) = parse_curl_status_body("{\"name\":\"x\"}\n200").expect("parsed");
+        assert_eq!(status, 200);
+        assert_eq!(body, "{\"name\":\"x\"}");
+    }
+
+    #[test]
+    fn select_host_token_prefers_gh_then_env_and_trims() {
+        assert_eq!(
+            select_host_token(Some(" ghp_abc \n"), Some("ghp_env")),
+            Some("ghp_abc".to_string())
+        );
+        assert_eq!(
+            select_host_token(Some("   "), Some(" ghp_env\n")),
+            Some("ghp_env".to_string())
+        );
+        assert_eq!(select_host_token(Some(""), Some(" ")), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod completions;
 mod config;
 mod devcontainer;
 mod fs_util;
+mod git_repo_devcontainer;
 mod github_pat;
 mod github_repo;
 mod github_submodules;
@@ -855,6 +856,8 @@ fn main() -> Result<()> {
                     dry_run,
                     workspace: ws_path,
                     mounts: &[],
+                    git_repo: None,
+                    github_auth: cfg.github.as_ref(),
                 },
                 &inputs,
                 devcontainer::Stage::Setup,
@@ -963,6 +966,8 @@ fn main() -> Result<()> {
                         dry_run,
                         workspace: ws_path,
                         mounts: &mounts,
+                        git_repo: git_repo.as_deref(),
+                        github_auth: cfg.github.as_ref(),
                     },
                     &inputs,
                     devcontainer::Stage::Start,
@@ -1016,7 +1021,73 @@ fn main() -> Result<()> {
                      it cannot change an existing stopped instance's image."
                 );
             }
-            apply_runtime_guest_env(&mut cfg, &guest_env, None, &mut start_opts);
+            let cli_env_keys = guest_env.iter().map(|(k, _)| k.clone()).collect();
+            let inputs = devcontainer::TranslatorInputs {
+                cli_vcpus: vcpus,
+                cli_mem_mib: mem,
+                cli_disk_gib: disk,
+                cli_post_start: post_start.clone(),
+                cli_guest_env_keys: cli_env_keys,
+                cli_forward_ports: start_opts.forward_ports.clone(),
+                cli_mounts: start_opts.mounts.clone(),
+                cli_profiles: profile.clone(),
+                persisted_guest_user: Some(backend::persisted_guest_user(&cfg, effective_image)),
+                cli_workspace_or_git_repo: workspace.is_some() || git_repo.is_some(),
+                ..devcontainer::TranslatorInputs::default()
+            };
+            let ws_path = workspace.as_deref().map(Path::new);
+            let translation = resolve_devcontainer(
+                &DevcontainerOpts {
+                    explicit_path: devcontainer.as_deref().map(Path::new),
+                    no_devcontainer,
+                    dry_run,
+                    workspace: ws_path,
+                    mounts: &start_opts.mounts,
+                    git_repo: git_repo.as_deref(),
+                    github_auth: cfg.github.as_ref(),
+                },
+                &inputs,
+                devcontainer::Stage::Start,
+            )?;
+            if dry_run {
+                return Ok(());
+            }
+            // CLI flags are applied first; the translation only carries
+            // values that survived the "CLI > devcontainer.json" precedence
+            // check inside `translate`, so the two cannot fight here.
+            apply_vm_overrides(&mut cfg, vcpus, mem, None)?;
+            if let Some(t) = &translation {
+                devcontainer::apply_to_config(&mut cfg, t)?;
+                start_opts.forward_ports = devcontainer::merge_into_forward_ports(
+                    &t.forward_ports,
+                    &start_opts.forward_ports,
+                );
+            }
+            let default_translation = devcontainer::Translation::default();
+            start_opts.disk = devcontainer::effective_disk(
+                disk,
+                translation.as_ref().unwrap_or(&default_translation),
+            );
+            let dc_post_start = (post_start.is_none())
+                .then(|| translation.as_ref().and_then(|t| t.post_start.clone()))
+                .flatten();
+            start_opts.post_start_override = post_start.as_deref().or(dc_post_start.as_deref());
+            // `--mount` and devcontainer `mounts` aren't combined: --mount is
+            // a complete replacement of the mount set (its `conflicts_with`
+            // rules with --workspace/--git-repo encode this). The CLI-wins
+            // outcome is reported by `translate`.
+            if start_opts.mounts.is_empty() {
+                start_opts.mounts = translation
+                    .as_ref()
+                    .map(|t| t.mounts.clone())
+                    .unwrap_or_default();
+            }
+            apply_runtime_guest_env(
+                &mut cfg,
+                &guest_env,
+                translation.as_ref().map(|t| &t.guest_env),
+                &mut start_opts,
+            );
             if let Some(profile_target) = profile_target {
                 let resolved_profiles =
                     guest::resolve_profiles(&profile_target.profiles, &cfg.profiles)?;
@@ -1362,6 +1433,8 @@ fn cmd_up(
                 dry_run: true,
                 workspace: Some(&project_dir),
                 mounts: discovery_mounts,
+                git_repo: None,
+                github_auth: cfg.github.as_ref(),
             },
             &inputs,
             devcontainer::Stage::Start,
@@ -1439,6 +1512,8 @@ fn create_up_instance(
             dry_run: false,
             workspace: Some(project_dir),
             mounts: discovery_mounts,
+            git_repo: None,
+            github_auth: cfg.github.as_ref(),
         },
         &inputs,
         devcontainer::Stage::Start,
@@ -1832,6 +1907,8 @@ fn quickstart_fresh_start(
             dry_run: false,
             workspace: workspace_dir,
             mounts: &[],
+            git_repo: None,
+            github_auth: cfg.github.as_ref(),
         },
         &inputs,
         devcontainer::Stage::Start,
@@ -2011,6 +2088,16 @@ struct DevcontainerOpts<'a> {
     dry_run: bool,
     workspace: Option<&'a Path>,
     mounts: &'a [config::Mount],
+    git_repo: Option<&'a str>,
+    github_auth: Option<&'a config::GitHubAuth>,
+}
+
+enum DevcontainerSource {
+    Path(PathBuf),
+    Contents {
+        display_path: PathBuf,
+        contents: String,
+    },
 }
 
 /// Discover, prompt, and translate a `devcontainer.json` for the given
@@ -2036,42 +2123,79 @@ fn resolve_devcontainer(
         return Ok(None);
     }
 
-    let (path, losers) = if let Some(p) = opts.explicit_path {
-        (p.to_path_buf(), Vec::new())
+    let (source, losers) = if let Some(p) = opts.explicit_path {
+        (DevcontainerSource::Path(p.to_path_buf()), Vec::new())
     } else {
         let found = devcontainer::discover(opts.workspace, opts.mounts);
         if let Some((winner, losers)) = devcontainer::pick_winner(found) {
-            (winner.path, losers)
+            (DevcontainerSource::Path(winner.path), losers)
+        } else if let Some(repo_url) = opts.git_repo
+            && let Some(remote) = git_repo_devcontainer::discover(repo_url, opts.github_auth)?
+        {
+            (
+                DevcontainerSource::Contents {
+                    display_path: remote.display_path,
+                    contents: remote.contents,
+                },
+                Vec::new(),
+            )
         } else {
             return Ok(None);
         }
+    };
+    let display_path = match &source {
+        DevcontainerSource::Path(path) => path,
+        DevcontainerSource::Contents { display_path, .. } => display_path,
     };
 
     // When discovery (not an explicit flag) found the file, defer to the
     // user. CI/scripted callers must pass --devcontainer or --no-devcontainer.
     if opts.explicit_path.is_none() && !opts.dry_run {
         if !std::io::stdin().is_terminal() {
-            bail!(
-                "Found {} but stdin is not a TTY.\n\
-                 Pass --devcontainer {} to apply it, or --no-devcontainer to ignore.\n\
-                 coop reads a subset of devcontainer.json — see docs/devcontainer.md for the supported keys.",
-                path.display(),
-                path.display()
-            );
+            match &source {
+                DevcontainerSource::Path(_) => bail!(
+                    "Found {} but stdin is not a TTY.\n\
+                     Pass --devcontainer {} to apply it, or --no-devcontainer to ignore.\n\
+                     coop reads a subset of devcontainer.json — see docs/devcontainer.md for the supported keys.",
+                    display_path.display(),
+                    display_path.display()
+                ),
+                DevcontainerSource::Contents { .. } => bail!(
+                    "Found {} but stdin is not a TTY.\n\
+                     Run interactively to confirm the remote file, pass --no-devcontainer to ignore it, \
+                     or pass --devcontainer <local-path> to apply an explicit file.\n\
+                     coop reads a subset of devcontainer.json — see docs/devcontainer.md for the supported keys.",
+                    display_path.display()
+                ),
+            }
         }
-        let answer =
-            prompt::confirm_default_yes(&format!("Use devcontainer.json at {}?", path.display()))?;
+        let answer = prompt::confirm_default_yes(&format!(
+            "Use devcontainer.json at {}?",
+            display_path.display()
+        ))?;
         if !answer {
-            tracing::info!(
-                "Skipping {}. Re-run with --devcontainer {} to apply it later.",
-                path.display(),
-                path.display()
-            );
+            match &source {
+                DevcontainerSource::Path(_) => tracing::info!(
+                    "Skipping {}. Re-run with --devcontainer {} to apply it later.",
+                    display_path.display(),
+                    display_path.display()
+                ),
+                DevcontainerSource::Contents { .. } => tracing::info!(
+                    "Skipping {}. Re-run interactively to apply it later.",
+                    display_path.display()
+                ),
+            }
             return Ok(None);
         }
     }
 
-    let parsed = devcontainer::ParsedDevcontainer::load(&path)?;
+    let parsed = match source {
+        DevcontainerSource::Path(path) => devcontainer::ParsedDevcontainer::load(&path)?,
+        DevcontainerSource::Contents {
+            display_path,
+            contents,
+        } => devcontainer::ParsedDevcontainer::from_str(display_path, &contents)?,
+    };
     let mut translation = devcontainer::translate(&parsed, inputs, stage);
     translation.report.ignored_paths = losers;
 
@@ -2093,6 +2217,8 @@ fn cmd_devcontainer(command: &DevcontainerCommands) -> Result<()> {
                 dry_run: true,
                 workspace: None,
                 mounts: &[],
+                git_repo: None,
+                github_auth: None,
             };
             let setup_inputs = devcontainer::TranslatorInputs::default();
 


### PR DESCRIPTION
## Summary

- Add best-effort GitHub contents API discovery for `.devcontainer/devcontainer.json` when `coop start --git-repo <url>` is used before the VM/repo clone exists
- Keep precedence intact: explicit `--devcontainer` wins, `--no-devcontainer` skips all discovery, local workspace/mount discovery still wins before remote lookup
- Preserve deterministic non-TTY behavior by refusing to auto-apply discovered remote files outside `--dry-run`
- Reuse existing devcontainer translation/reporting from in-memory remote contents and document the GitHub-only scope

Closes #239

## Review

Local review completed before PR. Finding fixed: bounded the remote API lookup with curl timeouts and added a User-Agent so a slow provider probe cannot stall startup indefinitely.

## Tests

- `cargo fmt --check`
- `cargo check`
- `cargo test git_repo_devcontainer`
- `cargo test devcontainer`
- `cargo test` (initial rerun hit an unrelated transient occupied-port failure in `port_forward::tests::collision_check_passes_when_ports_free`; the test passed in isolation)
- `cargo test -- --test-threads=1`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `cargo run --quiet -- --config /private/tmp/coop-issue239-config.toml start --git-repo https://github.com/microsoft/vscode.git --profile rust --dry-run --no-agents --no-prompt`
- `cargo run --quiet -- --config /private/tmp/coop-issue239-config.toml start --git-repo https://github.com/microsoft/vscode.git --profile rust --no-agents --no-prompt` (expected non-TTY refusal before VM work)