### PR TITLE
Move profile shorthand to up

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 
 - **Two backends**: Firecracker microVMs (Linux/KVM) and Lima VMs (macOS/Virtualization.framework), auto-detected by platform
 - **Workspace sync**: copy or mount a local project directory into the VM with `coop up`
-- **Profiles**: customizable guest environments with apt packages and install scripts; built-in profiles for Python, Node, C, Rust, Go, and fuzzing; `coop start --profile python,node` builds the matching image on demand
+- **Profiles**: customizable guest environments with apt packages and install scripts; built-in profiles for Python, Node, C, Rust, Go, and fuzzing; `coop up --profile python,node` builds the matching image on demand
 - **Named images**: build multiple template images with different profiles (`coop setup --image ml-dev --profile python`)
 - **Claude Code integration**: API key forwarding, CLAUDE.md injection, plugin/marketplace support, MCP server configuration
 - **Codex integration**: API key forwarding, `~/.codex` config sync, MCP server configuration, dedicated `coop codex` launcher
@@ -60,7 +60,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 | `up` | Ensure a project environment exists and is running |
 | `setup` | Install backend runtime, fetch kernel, build template rootfs |
 | `build` | Rebuild rootfs image and fetch kernel |
-| `start` | Restart a stopped VM, or build/start a profile-derived image with `--profile` |
+| `start` | Restart a stopped VM |
 | `stop` | Stop a running VM (preserves disk) |
 | `destroy` | Stop and remove a VM instance |
 | `shell` | Interactive shell session in a running VM |

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -141,8 +141,8 @@ Both backends support the same CLI commands and guest capabilities:
 | Capability | Lima (macOS) | Firecracker (Linux) |
 |---|---|---|
 | `coop setup` | Builds golden image via builder VM | Installs binary + kernel, builds rootfs via chroot |
-| `coop up` | Creates or reconnects/restarts a project VM | Copies rootfs, configures TAP, starts Firecracker |
-| `coop start` | Restarts a stopped Lima VM; `--profile` builds/starts a derived image | Restarts a stopped Firecracker VM; `--profile` builds/starts a derived image |
+| `coop up` | Creates or reconnects/restarts a project VM; `--profile` builds/starts a derived image | Copies rootfs, configures TAP, starts Firecracker; `--profile` builds/starts a derived image |
+| `coop start` | Restarts a stopped Lima VM | Restarts a stopped Firecracker VM |
 | `coop stop` | `limactl stop` | API socket shutdown, SIGTERM, SIGKILL |
 | `coop destroy` | `limactl delete --force` | Kill process, remove TAP, delete instance dir |
 | `coop status` | Queries `limactl list --json` | Reads PID file, queries guest via SSH |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -52,6 +52,7 @@ on Linux/Firecracker it is a one-time sync.
 | `--disk <GiB>` | Instance disk size when creating a new instance |
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
 | `--image <name>` | Named image to use when creating a new instance (default: `default`) |
+| `--profile <list>` | Build or reuse a profile-derived image when creating a new instance, named from the sorted profiles (for example `node-python`) |
 | `--exclude-git` | Skip the `.git/` directory when copying/syncing |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo |
 | `--forward-port <spec>` | Forward a guest port to the host (`GUEST[:HOST]`, repeatable) |
@@ -64,17 +65,23 @@ on Linux/Firecracker it is a one-time sync.
 ```
 coop up .
 coop up ~/code/my-project --mount
+coop up . --profile python,node
 coop up . --copy --forward-port 3000
 coop up . --extra-mount ~/data:/data
 ```
 
 Creation options such as `--vcpus`, `--mem`, `--disk`, `--image`,
-`--extra-mount`, `--exclude-git`, and `--devcontainer` are applied only when
-`up` creates a new instance. If a matching project instance already exists,
-destroy it first to recreate it with different creation options. Runtime
-startup options such as `--forward-port`, `--post-start`, and `--env` can be
-used when `up` creates or restarts an instance; if the matching instance is
-already running, stop it first so those options can take effect.
+`--profile`, `--extra-mount`, `--exclude-git`, and `--devcontainer` are
+applied only when `up` creates a new instance. `coop up --profile <list>`
+derives an image name from the sorted profile list, runs the same stale-image
+check as `coop setup`, and builds or rebuilds that image if needed. Explicit
+named images are unchanged: use `coop setup --image <name> --profile ...`
+followed by `coop up --image <name>` when you want to choose the image name
+yourself. If a matching project instance already exists, destroy it first to
+recreate it with different creation options. Runtime startup options such as
+`--forward-port`, `--post-start`, and `--env` can be used when `up` creates or
+restarts an instance; if the matching instance is already running, stop it
+first so those options can take effect.
 
 ### `init`
 
@@ -97,8 +104,8 @@ coop setup [FLAGS]
 | Flag | Description |
 |------|-------------|
 | `-y`, `--yes` | Skip confirmation prompts (accept all) |
-| `--vcpus <N>` | Number of vCPUs for generated devcontainer/setup settings (overrides config) |
-| `--mem <MiB>` | Memory in MiB for generated devcontainer/setup settings (overrides config) |
+| `--vcpus <N>` | Number of vCPUs (overrides config) |
+| `--mem <MiB>` | Memory in MiB (overrides config) |
 | `--rebuild` | Force rebuild of template rootfs |
 | `--profile <list>` | Comma-separated install profiles: `python`, `node`, `c`, `fuzz`, `rust`, `go` |
 | `--extra-packages <list>` | Comma-separated extra apt packages to install |
@@ -146,7 +153,7 @@ Use `--stage setup` to inspect setup-time keys such as `features`, `hostRequirem
 
 ### `start`
 
-Restart a stopped VM, or build and start a profile-derived image.
+Restart a stopped VM.
 
 ```
 coop start [NAME] [FLAGS]
@@ -155,23 +162,21 @@ coop start [NAME] [FLAGS]
 `start` normally restarts existing stopped instances. Use `coop up [DIR]` to
 create or reconnect to a project environment. Without `NAME`, `start` restarts
 the only stopped instance if exactly one exists; with multiple stopped
-instances, pass the instance name. The profile shorthand
-`coop start --profile <list>` is the creation exception described below.
+instances, pass the instance name.
 
 | Flag | Description |
 |------|-------------|
 | `NAME` | Stopped instance name (optional only when exactly one stopped instance exists) |
-| `--profile <list>` | Build or reuse a profile-derived image for a new instance, named from the sorted profiles (for example `node-python`) |
 | `--workspace <dir>` | Restart the stopped instance associated with this project path (conflicts with `--git-repo`) |
-| `--git-repo <url>` | Deprecated creation option; only applies when creating with `--profile`. For GitHub URLs, coop can discover `.devcontainer/devcontainer.json` before creating the VM. |
+| `--git-repo <url>` | Deprecated creation option; rejected on restart |
 | `--vcpus <N>` | Creation-time option retained only for compatibility; rejected on restart |
 | `--mem <MiB>` | Creation-time option retained only for compatibility; rejected on restart |
-| `--disk <GiB>` | Instance disk size when creating with `--profile`; rejected on restart |
+| `--disk <GiB>` | Creation-time option retained only for compatibility; rejected on restart |
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
 | `--image <name>` | Creation-time option retained only for compatibility; rejected on restart |
-| `--mount <spec>` | Host directory to mount when creating with `--profile`; rejected on restart |
+| `--mount <spec>` | Creation-time option retained only for compatibility; rejected on restart |
 | `--forward-port <spec>` | Forward a guest port to the host (`GUEST[:HOST]`, repeatable). Lives for the lifetime of the VM; torn down on `coop stop`. |
-| `--exclude-git` | Skip `.git/` when copying/syncing a workspace for `--profile`; rejected on restart |
+| `--exclude-git` | Creation-time option retained only for compatibility; rejected on restart |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
 | `--env KEY=VALUE` | Literal env var to set in the guest (repeatable). Overrides `guest_env` config entries and any forwarded values with the same name. |
@@ -181,17 +186,9 @@ instances, pass the instance name. The profile shorthand
 
 When `--workspace <dir>` contains a `.devcontainer/devcontainer.json`, or `--git-repo <url>` points at a GitHub repository with one, coop reads a subset of it and prompts before applying restart-time settings. See [docs/devcontainer.md](devcontainer.md) for the supported keys and discovery rules.
 
-`coop start --profile <list>` is the exception to the restart-only rule. It
-derives an image name from the sorted profile list, runs the same stale-image
-check as `coop setup`, builds or rebuilds that image if needed, and then starts
-a new instance from it. Explicit named images are unchanged: use `coop setup
---image <name> --profile ...` followed by `coop up --image <name>` when you
-want to choose the image name yourself.
-
 ```
 coop start
 coop start my-project
-coop start --profile python,node
 coop start my-project --no-agents
 coop start --env RUST_LOG=info --env MY_FLAG=1
 coop start --forward-port 3000 --forward-port 8080:18080
@@ -385,7 +382,8 @@ coop logs my-project -f
 
 ### `push`
 
-Copy a local directory into the running VM at `/workspace`. Defaults to the host path recorded when the instance was started with `--workspace`.
+Copy a local directory into the running VM at `/workspace`. Defaults to the
+host path recorded when the instance was created with `coop up`.
 
 ```
 coop push [NAME] [FLAGS]
@@ -405,7 +403,8 @@ coop push my-project --dir ./src --force
 
 ### `pull`
 
-Copy the VM's `/workspace` to a local directory. Defaults to the host path recorded when the instance was started with `--workspace`.
+Copy the VM's `/workspace` to a local directory. Defaults to the host path
+recorded when the instance was created with `coop up`.
 
 ```
 coop pull [NAME] [FLAGS]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,8 +104,8 @@ VM resource allocation and boot configuration.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `vcpu_count` | integer | `2` | Number of vCPUs. Must be > 0. Overridable with `--vcpus` on `setup` and `start`. |
-| `mem_size_mib` | integer | `4096` | Memory in MiB. Must be >= 128. Overridable with `--mem` on `setup` and `start`. |
+| `vcpu_count` | integer | `2` | Number of vCPUs. Must be > 0. Overridable with `--vcpus` on `setup` and `up`. |
+| `mem_size_mib` | integer | `4096` | Memory in MiB. Must be >= 128. Overridable with `--mem` on `setup` and `up`. |
 | `template_size_gib` | integer | `8` | Template rootfs disk size in GiB. Must be > 0. Overridable with `--template-size` on `setup`. |
 | `kernel_path` | string (path) | `~/.coop/vmlinux` | Path to the vmlinux kernel image. Linux/Firecracker only. |
 | `boot_args` | string | `console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw` | Kernel boot arguments. Linux/Firecracker only. |
@@ -266,11 +266,11 @@ Several config values accept per-invocation overrides via flags:
 
 | Flag | Applies to | Overrides |
 |------|-----------|-----------|
-| `--vcpus <N>` | `setup`, `start` | `vm.vcpu_count` |
-| `--mem <MiB>` | `setup`, `start` | `vm.mem_size_mib` |
+| `--vcpus <N>` | `setup`, `up` | `vm.vcpu_count` |
+| `--mem <MiB>` | `setup`, `up` | `vm.mem_size_mib` |
 | `--template-size <GiB>` | `setup` | `vm.template_size_gib` |
-| `--disk <GiB>` | `start` | Per-instance disk size (grows from template if larger) |
-| `--env KEY=VALUE` | `start` | Adds or overrides a `guest_env` entry (repeatable) |
+| `--disk <GiB>` | `up` | Per-instance disk size (grows from template if larger) |
+| `--env KEY=VALUE` | `up`, `start` | Adds or overrides a `guest_env` entry (repeatable) |
 | `--config <path>` | all commands | Config file path (default: `~/.coop/config.toml`) |
 
 ## Examples

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -36,7 +36,7 @@ CLI flags > `devcontainer.json` > defaults. The reporting table marks overrides 
 | `postStartCommand` | `post_start` | String or `[string,...]`; arrays are joined with ` && ` |
 | `containerEnv` | `guest_env` (`--env KEY=VALUE`) | CLI `--env` wins on conflict |
 | `forwardPorts` | `--forward-port` | Items may be integers or `"GUEST[:HOST]"` strings |
-| `features` (`rust`, `node`, `python`, `go`, `c`, `fuzz`) | built-in `--profile` | Only at `coop setup`; ignored at `coop start` |
+| `features` (`rust`, `node`, `python`, `go`, `c`, `fuzz`) | built-in `--profile` | Only at `coop setup`; ignored during VM start/restart |
 | `features` (anything else) | warn and skip | No silent fallback to a custom profile |
 | `hostRequirements.cpus` | `--vcpus` | |
 | `hostRequirements.memory` | `--mem` | Accepts `4GB`/`4GiB`-style values |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,14 +94,14 @@ coop setup --profile python,node
 
 Built-in profiles: `python`, `node`, `c`, `fuzz`, `rust`, `go`. Combine them with commas (e.g. `--profile python,node,rust`). Use `coop profiles list` to inspect what each one installs.
 
-You can also let `start` build a profile-derived image on demand:
+You can also let `up` build a profile-derived image on demand:
 
 ```
-coop start --profile python,node
+coop up --profile python,node
 ```
 
 This creates or refreshes an image named from the sorted profile list
-(`node-python` here), then starts a new instance from it.
+(`node-python` here), then creates the project instance from it.
 
 Skip confirmation prompts with `-y`:
 
@@ -153,8 +153,8 @@ coop codex
 coop start
 ```
 
-`coop start` only starts existing stopped instances. Use it after `coop stop`
-when you want to boot the same VM disk again. If exactly one stopped instance
+`coop start` starts existing stopped instances. Use it after `coop stop` when
+you want to boot the same VM disk again. If exactly one stopped instance
 exists, the name is optional.
 
 Restart a specific stopped instance:
@@ -169,10 +169,11 @@ Restart by project path when the instance was created for that project:
 coop start --workspace ~/code/my-project
 ```
 
-Creation options belong to `coop up`, not `coop start`:
+Project creation options belong to `coop up`, not `coop start`:
 
 ```
 coop up ~/code/my-project --disk 40 --mount
+coop up ~/code/my-project --profile python,node
 ```
 
 Skip Claude Code and Codex credential/config injection:

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -78,16 +78,16 @@ coop setup --profile ml
 coop setup --profile ml,node
 ```
 
-## Build-on-demand from `start`
+## Build-on-demand from `up`
 
-For profile-only workflows, `coop start --profile <list>` builds the matching
+For profile-only workflows, `coop up --profile <list>` builds the matching
 image automatically before starting a new instance. The image name is derived
 from the sorted profile list, so these commands all target the same
 `node-python` image:
 
 ```bash
-coop start --profile python,node
-coop start --profile node,python
+coop up --profile python,node
+coop up --profile node,python
 ```
 
 coop runs the same recipe-hash staleness check used by `coop setup`. If the

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -55,7 +55,7 @@ Restart the shell (or `source` your rc) after the first install.
 
 ## Dynamic completion
 
-Dynamic completion lets `coop` itself compute candidates on TAB — so `coop shell <TAB>` lists your running instances, `coop up --image <TAB>` lists existing images, and `coop setup --profile <TAB>` lists builtin and custom profiles.
+Dynamic completion lets `coop` itself compute candidates on TAB — so `coop shell <TAB>` lists your running instances, `coop up --image <TAB>` lists existing images, and `coop setup --profile <TAB>` / `coop up --profile <TAB>` list builtin and custom profiles.
 
 Add one line to your shell rc:
 
@@ -80,5 +80,5 @@ Dynamic and static completion can coexist — static fills in subcommand and fla
 | Argument | Source |
 |----------|--------|
 | Instance name (`shell`, `claude`, `claude-agents`, `codex`, `stop`, `destroy`, `status`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`) | `~/.coop/instances/` |
-| `--image` (`start`, `setup`), `images --delete` | `~/.coop/images/` |
-| `--profile` (`setup`), `profiles show <name>` | builtin profiles plus `[profiles.*]` from `~/.coop/config.toml` |
+| `--image` (`up`, `setup`, `start` compatibility flag), `images --delete` | `~/.coop/images/` |
+| `--profile` (`setup`, `up`), `profiles show <name>` | builtin profiles plus `[profiles.*]` from `~/.coop/config.toml` |

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,13 @@ enum Commands {
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         image: config::ImageName,
+        /// Build or reuse a profile-derived image when creating a new instance
+        #[arg(
+            long,
+            value_delimiter = ',',
+            add = ArgValueCandidates::new(completions::profile_candidates),
+        )]
+        profile: Vec<String>,
         /// Skip the `.git` directory when copying/syncing the project
         #[arg(long)]
         exclude_git: bool,
@@ -231,22 +238,18 @@ enum Commands {
         #[command(subcommand)]
         command: DevcontainerCommands,
     },
-    /// Restart a stopped VM, or build/start a profile-derived image
+    /// Restart a stopped VM
     Start {
         /// Stopped instance name (optional only when exactly one stopped instance exists)
         #[arg(value_parser = config::InstanceName::parse)]
         name: Option<config::InstanceName>,
-        /// Install profiles for a new profile-derived image, building it on demand
-        #[arg(
-            long,
-            value_delimiter = ',',
-            add = ArgValueCandidates::new(completions::profile_candidates),
-        )]
+        /// Deprecated profile shorthand; use `coop up --profile`.
+        #[arg(long, value_delimiter = ',', hide = true)]
         profile: Vec<String>,
         /// Project directory used to select an associated stopped instance
         #[arg(long, conflicts_with = "git_repo")]
         workspace: Option<String>,
-        /// Deprecated creation option; only applies when creating with --profile
+        /// Deprecated creation option; rejected by `coop start`
         #[arg(long, conflicts_with = "workspace")]
         git_repo: Option<String>,
         /// Creation-time option; rejected by `coop start`
@@ -255,13 +258,13 @@ enum Commands {
         /// Creation-time option; rejected by `coop start`
         #[arg(long, value_parser = config::MiB::parse_cli)]
         mem: Option<config::MiB>,
-        /// Creation-time option; only applies when creating with --profile
+        /// Creation-time option; rejected by `coop start`
         #[arg(long, value_parser = config::GiB::parse_cli)]
         disk: Option<config::GiB>,
         /// Skip injecting Claude Code and Codex credentials/config into the VM
         #[arg(long, alias = "no-claude")]
         no_agents: bool,
-        /// Creation-time option; only applies when creating with --profile
+        /// Creation-time option; rejected by `coop start`
         #[arg(
             long,
             conflicts_with_all = ["workspace", "git_repo"],
@@ -281,7 +284,7 @@ enum Commands {
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         image: config::ImageName,
-        /// Creation-time option; only applies when creating with --profile
+        /// Creation-time option; rejected by `coop start`
         #[arg(long, conflicts_with = "git_repo")]
         exclude_git: bool,
         /// Suppress the interactive prompt to set up a scoped GitHub PAT
@@ -770,6 +773,7 @@ fn main() -> Result<()> {
             disk,
             no_agents,
             image,
+            profile,
             exclude_git,
             no_prompt,
             forward_port,
@@ -786,6 +790,22 @@ fn main() -> Result<()> {
                 let _ = copy;
                 ProjectTransport::Copy
             };
+            let image_explicit = raw_args_use_long_flag(&raw_args, "--image");
+            let profile_target = if profile.is_empty() {
+                None
+            } else {
+                if image_explicit {
+                    bail!(
+                        "`coop up --profile` derives the image name from the sorted profile list; \
+                         use `coop setup --image {image} --profile ...` and then `coop up --image {image}` \
+                         for an explicit named image."
+                    );
+                }
+                Some(ProfileImageTarget::new(&profile)?)
+            };
+            let effective_image = profile_target
+                .as_ref()
+                .map_or_else(|| image.clone(), |target| target.image.clone());
             let opts = UpOpts {
                 dir: dir.as_deref(),
                 name: name.as_ref(),
@@ -794,8 +814,9 @@ fn main() -> Result<()> {
                 vcpus,
                 mem,
                 disk,
-                image,
-                image_explicit: raw_args_use_long_flag(&raw_args, "--image"),
+                image: effective_image,
+                image_explicit,
+                profile_target,
                 runtime: UpRuntimeOpts {
                     no_agents,
                     exclude_git,
@@ -931,15 +952,14 @@ fn main() -> Result<()> {
                     "--no-claude is deprecated and will be removed in a future release; use --no-agents"
                 );
             }
+            if !profile.is_empty() {
+                bail!(
+                    "`coop start --profile` has moved to `coop up --profile`.\n\
+                     Run `coop up --profile {}` to create or reuse a project environment with that profile-derived image.",
+                    canonical_profile_list(&profile).join(","),
+                );
+            }
             let image_explicit = raw_args_use_long_flag(&raw_args, "--image");
-            let profile_target = if profile.is_empty() {
-                None
-            } else {
-                Some(ProfileImageTarget::new(&profile)?)
-            };
-            let effective_image = profile_target
-                .as_ref()
-                .map_or(&image, |target| &target.image);
             if dry_run {
                 let cli_env_keys = guest_env.iter().map(|(k, _)| k.clone()).collect();
                 let inputs = devcontainer::TranslatorInputs {
@@ -950,11 +970,7 @@ fn main() -> Result<()> {
                     cli_guest_env_keys: cli_env_keys,
                     cli_forward_ports: forward_ports.clone(),
                     cli_mounts: mounts.clone(),
-                    cli_profiles: profile.clone(),
-                    persisted_guest_user: Some(backend::persisted_guest_user(
-                        &cfg,
-                        effective_image,
-                    )),
+                    persisted_guest_user: Some(backend::persisted_guest_user(&cfg, &image)),
                     cli_workspace_or_git_repo: workspace.is_some() || git_repo.is_some(),
                     ..devcontainer::TranslatorInputs::default()
                 };
@@ -999,28 +1015,7 @@ fn main() -> Result<()> {
                 persisted_guest_env: std::collections::BTreeMap::new(),
                 devcontainer_path: devcontainer.as_deref().map(Path::new),
             };
-            if profile.is_empty() {
-                preflight_start_target(&be, &cfg, &start_opts)?;
-            } else if image_explicit {
-                bail!(
-                    "`coop start --profile` derives the image name from the sorted profile list; \
-                     use `coop setup --image {image} --profile ...` and then `coop up --image {image}` \
-                     for an explicit named image."
-                );
-            } else if (start_opts.name.is_some() || start_opts.workspace_dir.is_some())
-                && find_stopped_instance(
-                    &be,
-                    &cfg,
-                    start_opts.name,
-                    start_opts.workspace_dir.map(Path::new),
-                )?
-                .is_some()
-            {
-                bail!(
-                    "`coop start --profile` creates a new profile-derived instance; \
-                     it cannot change an existing stopped instance's image."
-                );
-            }
+            preflight_start_target(&be, &cfg, &start_opts)?;
             let cli_env_keys = guest_env.iter().map(|(k, _)| k.clone()).collect();
             let inputs = devcontainer::TranslatorInputs {
                 cli_vcpus: vcpus,
@@ -1030,8 +1025,7 @@ fn main() -> Result<()> {
                 cli_guest_env_keys: cli_env_keys,
                 cli_forward_ports: start_opts.forward_ports.clone(),
                 cli_mounts: start_opts.mounts.clone(),
-                cli_profiles: profile.clone(),
-                persisted_guest_user: Some(backend::persisted_guest_user(&cfg, effective_image)),
+                persisted_guest_user: Some(backend::persisted_guest_user(&cfg, &image)),
                 cli_workspace_or_git_repo: workspace.is_some() || git_repo.is_some(),
                 ..devcontainer::TranslatorInputs::default()
             };
@@ -1088,46 +1082,7 @@ fn main() -> Result<()> {
                 translation.as_ref().map(|t| &t.guest_env),
                 &mut start_opts,
             );
-            if let Some(profile_target) = profile_target {
-                let resolved_profiles =
-                    guest::resolve_profiles(&profile_target.profiles, &cfg.profiles)?;
-                let _guard = signal::install_handlers();
-                be.setup(
-                    &cfg,
-                    &validated,
-                    &setup::SetupOptions {
-                        skip_confirm: true,
-                        rebuild: false,
-                        profiles: resolved_profiles,
-                        extra_packages: Vec::new(),
-                        post_install: None,
-                        image: profile_target.image.clone(),
-                        guest_user: guest::GuestUser::default(),
-                    },
-                )?;
-                let workspace_path = workspace
-                    .as_deref()
-                    .map(Path::new)
-                    .map(Path::canonicalize)
-                    .transpose()
-                    .with_context(|| {
-                        format!(
-                            "Failed to resolve workspace path {}",
-                            workspace.as_deref().unwrap_or_default()
-                        )
-                    })?;
-                allocate_and_start(
-                    &be,
-                    &mut cfg,
-                    name.as_ref(),
-                    &profile_target.image,
-                    workspace_path.as_deref(),
-                    &start_opts,
-                )
-                .map(|_| ())
-            } else {
-                cmd_start(&be, &mut cfg, &validated, &start_opts).map(|_| ())
-            }
+            cmd_start(&be, &mut cfg, &validated, &start_opts).map(|_| ())
         }
         Commands::Shell { name, command } => cmd_shell(&be, &cfg, name.as_ref(), &command),
         Commands::Claude {
@@ -1373,6 +1328,7 @@ struct UpOpts<'a> {
     disk: Option<config::GiB>,
     image: config::ImageName,
     image_explicit: bool,
+    profile_target: Option<ProfileImageTarget>,
     runtime: UpRuntimeOpts,
     devcontainer: UpDevcontainerOpts,
 }
@@ -1407,7 +1363,7 @@ enum ProjectTransport {
 fn cmd_up(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
-    _: &config::Validated,
+    validated: &config::Validated,
     config_path: &Path,
     opts: &UpOpts<'_>,
 ) -> Result<()> {
@@ -1461,6 +1417,8 @@ fn cmd_up(
         return Ok(());
     }
 
+    ensure_profile_image(be, cfg, validated, opts.profile_target.as_ref())?;
+
     create_up_instance(
         be,
         cfg,
@@ -1489,6 +1447,11 @@ fn up_translator_inputs(
             .collect(),
         cli_forward_ports: opts.runtime.forward_ports.clone(),
         cli_mounts: opts.extra_mount.clone(),
+        cli_profiles: opts
+            .profile_target
+            .as_ref()
+            .map(|target| target.profiles.clone())
+            .unwrap_or_default(),
         persisted_guest_user: Some(backend::persisted_guest_user(cfg, &opts.image)),
         cli_workspace_or_git_repo: true,
         ..devcontainer::TranslatorInputs::default()
@@ -1598,6 +1561,32 @@ fn create_up_instance(
     .map(|_| ())
 }
 
+fn ensure_profile_image(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    validated: &config::Validated,
+    target: Option<&ProfileImageTarget>,
+) -> Result<()> {
+    let Some(target) = target else {
+        return Ok(());
+    };
+    let resolved_profiles = guest::resolve_profiles(&target.profiles, &cfg.profiles)?;
+    let _guard = signal::install_handlers();
+    be.setup(
+        cfg,
+        validated,
+        &setup::SetupOptions {
+            skip_confirm: true,
+            rebuild: false,
+            profiles: resolved_profiles,
+            extra_packages: Vec::new(),
+            post_install: None,
+            image: target.image.clone(),
+            guest_user: guest::GuestUser::default(),
+        },
+    )
+}
+
 fn resolve_project_dir(dir: Option<&str>) -> Result<PathBuf> {
     let path = match dir {
         Some(dir) => PathBuf::from(dir),
@@ -1668,6 +1657,20 @@ fn ensure_up_existing_inputs_are_compatible(
             inst.name,
             inst.image,
             opts.image,
+            inst.name,
+        );
+    }
+    if let Some(target) = &opts.profile_target
+        && inst.image != target.image
+    {
+        bail!(
+            "Instance '{}' already exists for this project using image '{}'. \
+             `coop up --profile {}` would use image '{}', but profiles only apply when creating a new instance.\n\
+             Use `coop destroy {}` first to recreate it with those profiles.",
+            inst.name,
+            inst.image,
+            target.profiles.join(","),
+            target.image,
             inst.name,
         );
     }
@@ -3650,7 +3653,16 @@ mod tests {
     }
 
     #[test]
-    fn start_profile_flag_parses_comma_list() {
+    fn up_profile_flag_parses_comma_list() {
+        let cli = parse(&["up", "--profile", "python,node"]);
+        let super::Commands::Up { profile, .. } = cli.command else {
+            panic!("expected Up variant");
+        };
+        assert_eq!(profile, vec!["python", "node"]);
+    }
+
+    #[test]
+    fn start_profile_flag_parses_for_migration_hint() {
         let cli = parse(&["start", "--profile", "python,node"]);
         let super::Commands::Start { profile, .. } = cli.command else {
             panic!("expected Start variant");
@@ -4381,6 +4393,7 @@ mod tests {
             disk: None,
             image: super::config::default_image_name(),
             image_explicit: false,
+            profile_target: None,
             runtime: super::UpRuntimeOpts {
                 no_agents: false,
                 exclude_git: false,
@@ -4417,6 +4430,34 @@ mod tests {
         )
         .expect_err("expected incompatible");
         assert!(format!("{err}").contains("--disk"));
+    }
+
+    #[test]
+    fn up_existing_rejects_mismatched_profile_target() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let project = tmp.path().join("project");
+        std::fs::create_dir(&project).expect("project");
+        let inst = cfg
+            .allocate_instance(None, &img, Some(&project))
+            .expect("inst");
+        let mut opts = up_opts_for_tests(project.to_str());
+        opts.profile_target = Some(
+            super::ProfileImageTarget::new(&["python".to_string(), "node".to_string()])
+                .expect("profile target"),
+        );
+        opts.image = opts.profile_target.as_ref().unwrap().image.clone();
+
+        let err = super::ensure_up_existing_inputs_are_compatible(
+            &inst,
+            super::ProjectTransport::Copy,
+            &opts,
+        )
+        .expect_err("expected profile mismatch rejection");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("coop up --profile node,python"));
+        assert!(msg.contains("profiles only apply when creating a new instance"));
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2258,19 +2258,23 @@ test_builtin_profiles() {
     echo ""
     echo "=== Phase: built-in profiles ==="
 
-    # Build-on-demand via start. The sorted profile list derives the
+    # Build-on-demand via up. The sorted profile list derives the
     # node-python image name. These cover apt-only (python) and
     # pre-install script (node/NodeSource).
     local img_name="node-python"
     coop images --delete "$img_name" 2>/dev/null || true
 
     local inst_name="${INSTANCE}-prof"
-    if coop start "$inst_name" --profile python,node --no-agents; then
+    local prof_ws
+    prof_ws=$(mktemp -d)
+    echo "profile workspace" > "$prof_ws/README.md"
+    if coop up "$prof_ws" --name "$inst_name" --profile python,node --no-agents; then
         STARTED_INSTANCES+=("$inst_name")
-        pass "start --profile python,node exits 0"
+        pass "up --profile python,node exits 0"
     else
-        fail "start --profile python,node exits 0" "exit code: $?"
+        fail "up --profile python,node exits 0" "exit code: $?"
         echo "stderr: $HARNESS_ERR"
+        rm -rf "$prof_ws"
         return
     fi
 
@@ -2281,7 +2285,7 @@ test_builtin_profiles() {
             fail "derived profile image is listed" "output: $HARNESS_OUT"
         fi
     else
-        fail "images exits 0 after start --profile" "exit code: $?"
+        fail "images exits 0 after up --profile" "exit code: $?"
     fi
 
     GUEST_INSTANCE="$inst_name"
@@ -2320,6 +2324,7 @@ test_builtin_profiles() {
     coop destroy "$inst_name" 2>/dev/null || true
     untrack_instance "$inst_name"
     coop images --delete "$img_name" 2>/dev/null || true
+    rm -rf "$prof_ws"
 }
 
 # ── Host mount tests (--full only) ────────────────────────────


### PR DESCRIPTION
## Summary

- Move profile-derived image creation from `coop start --profile` to `coop up --profile`
- Keep `coop start --profile` as a hidden compatibility path that exits with a migration hint instead of a generic unknown-argument error
- Keep `coop start` documented and surfaced as restart-only, while updating profile docs, backend parity docs, completions docs, and command reference
- Add regression coverage for profile parsing and rejecting profile changes on existing project instances

## Review

Subagent review completed. Findings fixed:
- `coop start --profile` now returns an explicit migration hint to `coop up --profile`
- Added coverage for existing project instances rejecting mismatched profile-derived images

## Tests

- `cargo fmt --check`
- `cargo test profile`
- `cargo run --quiet -- start --profile python,node`
- `cargo check`
- `cargo test`
- `cargo run --quiet -- start --help`
- `git diff --check`