### PR TITLE
Support OCI devcontainer features

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -113,7 +113,7 @@ coop setup [FLAGS]
 | `--template-size <GiB>` | Template rootfs size in GiB (default: 8) |
 | `--image <name>` | Named image to build (default: `default`) |
 | `--guest-user <name>` | Guest username to bake into the image (default: `ubuntu`). Use this for devcontainers that declare another `remoteUser`, such as `vscode`. |
-| `--workspace <dir>` | Scan for `.devcontainer/devcontainer.json` and offer to apply its `features` / `hostRequirements` to this setup. |
+| `--workspace <dir>` | Scan for `.devcontainer/devcontainer.json` and offer to apply its `features` / `hostRequirements` to this setup. Supported public `ghcr.io/devcontainers/features/*` entries are resolved and baked into the image. |
 | `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt). |
 | `--no-devcontainer` | Ignore any discovered `devcontainer.json`. |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any setup work. |
@@ -138,7 +138,7 @@ No additional flags.
 
 ### `devcontainer check`
 
-Parse a `devcontainer.json` file and print the same translation report that `setup --dry-run` and `start --dry-run` use, without loading coop config, checking for updates, setting up an image, or starting a VM.
+Parse a `devcontainer.json` file and print the same translation report that `setup --dry-run` and `start --dry-run` use, without loading coop config, checking for updates, setting up an image, or starting a VM. Setup-stage checks resolve supported public GHCR OCI Features so the report can show the digest and `install.sh` hash that would run.
 
 ```
 coop devcontainer check <path> [--stage setup|start|both]

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,6 +1,6 @@
 # Reading `devcontainer.json`
 
-coop reads a **subset** of [devcontainer.json](https://containers.dev/) and maps recognised keys to its own primitives. This is not full devcontainer support — coop builds its own rootfs and does not run Dockerfiles, compose files, or arbitrary OCI feature images. The supported subset is listed below; everything else is reported as `unsupported` and skipped.
+coop reads a **subset** of [devcontainer.json](https://containers.dev/) and maps recognised keys to its own primitives. This is not full devcontainer support — coop builds its own rootfs and does not run Dockerfiles or compose files. The supported subset is listed below; everything else is reported as `unsupported` and skipped.
 
 ## How discovery and apply work
 
@@ -37,7 +37,8 @@ CLI flags > `devcontainer.json` > defaults. The reporting table marks overrides 
 | `containerEnv` | `guest_env` (`--env KEY=VALUE`) | CLI `--env` wins on conflict |
 | `forwardPorts` | `--forward-port` | Items may be integers or `"GUEST[:HOST]"` strings |
 | `features` (`rust`, `node`, `python`, `go`, `c`, `fuzz`) | built-in `--profile` | Only at `coop setup`; ignored during VM start/restart |
-| `features` (anything else) | warn and skip | No silent fallback to a custom profile |
+| `features` (`ghcr.io/devcontainers/features/*`) | OCI Feature `install.sh` baked into the image | Public GHCR devcontainer Features only; report includes the resolved digest and script hash |
+| `features` (anything else) | warn and skip | No silent fallback to a custom profile or unsupported registry |
 | `hostRequirements.cpus` | `--vcpus` | |
 | `hostRequirements.memory` | `--mem` | Accepts `4GB`/`4GiB`-style values |
 | `hostRequirements.storage` | `--disk` | Start-time only; accepts `16GB`/`16GiB`-style values |
@@ -49,9 +50,17 @@ CLI flags > `devcontainer.json` > defaults. The reporting table marks overrides 
 
 `devcontainer.json` officially allows `//` and `/* */` comments and trailing commas. coop parses these correctly.
 
+## OCI Feature installs
+
+For public `ghcr.io/devcontainers/features/<name>[:tag|@digest]` entries that do not map to a built-in profile, `coop setup --workspace ... --devcontainer ...` fetches the Feature metadata and layer from GHCR, validates that the layer contains `devcontainer-feature.json` and `install.sh`, and bakes the Feature payload into the image setup recipe. Features run in deterministic `features` key order after profile post-install scripts and guest-user setup, before coop's agent setup.
+
+Feature option values must be strings, numbers, booleans, or `null`. They are exposed to the Feature script as uppercased environment variables, along with `_REMOTE_USER` and `_REMOTE_USER_HOME`.
+
+Treat Feature install scripts as untrusted project-provided code. The report prints the resolved digest and `install.sh` SHA-256 before setup continues; use `--dry-run` or `coop devcontainer check <path> --stage setup` to inspect this without building an image.
+
 ## Out of scope in v1
 
-- OCI feature registry pulls (`ghcr.io/devcontainers/features/*` features other than the built-in name match)
+- OCI feature registries other than public `ghcr.io/devcontainers/features/*`
 - `--git-repo` auto-detection for non-GitHub hosts
 - Sticky `--no-devcontainer` (persistent per-workspace state)
 - Live re-application on an existing VM (destroy + `coop up` to pick up changes)

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -19,6 +19,7 @@ use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
 use crate::config::{self, CoopConfig, GiB, MiB, Mount, PortForward};
+use crate::devcontainer_oci::{FeatureRequest, ResolvedFeature};
 use crate::guest::{BuiltinProfile, GuestUser, builtin_for_feature};
 use crate::guest_env_state::EnvVarName;
 
@@ -257,7 +258,7 @@ pub struct Report {
 }
 
 impl Report {
-    fn push(
+    pub fn push(
         &mut self,
         key: impl Into<String>,
         status: ReportStatus,
@@ -395,6 +396,8 @@ pub struct Translation {
     pub guest_env: BTreeMap<EnvVarName, String>,
     pub forward_ports: Vec<PortForward>,
     pub mounts: Vec<Mount>,
+    pub oci_feature_requests: Vec<FeatureRequest>,
+    pub oci_features: Vec<ResolvedFeature>,
     pub profiles: Vec<String>,
     /// Guest user requested by the devcontainer's `remoteUser`, when
     /// no CLI `--guest-user` overrode it. Only set at `Stage::Setup`;
@@ -924,48 +927,71 @@ fn translate_features(
     }
     let cli_profiles: std::collections::HashSet<&str> =
         inputs.cli_profiles.iter().map(String::as_str).collect();
-    for raw_id in features.keys() {
+    for (raw_id, raw_options) in features {
         let key = format!("features.{raw_id}");
-        let Some(builtin) = map_feature_to_profile(raw_id) else {
+        if let Some(builtin) = map_feature_to_profile(raw_id) {
+            let name = builtin.name;
+            if stage == Stage::Start {
+                t.report.push(
+                    key,
+                    ReportStatus::Unsupported,
+                    ReportSource::Devcontainer,
+                    name.to_string(),
+                    "features are baked into the template at `coop setup` time, \
+                     not selected per-start",
+                );
+                continue;
+            }
+            if cli_profiles.contains(&name) {
+                t.report.push(
+                    key,
+                    ReportStatus::Overridden,
+                    ReportSource::Cli,
+                    name.to_string(),
+                    "CLI --profile already includes this profile",
+                );
+                continue;
+            }
+            t.profiles.push(name.to_string());
             t.report.push(
                 key,
-                ReportStatus::Unsupported,
+                ReportStatus::Applied,
                 ReportSource::Devcontainer,
-                raw_id.clone(),
-                "no built-in profile match; coop does not pull OCI feature images in v1",
+                name.to_string(),
+                format!("mapped to built-in profile '{name}'"),
             );
             continue;
-        };
-        let name = builtin.name;
+        }
         if stage == Stage::Start {
             t.report.push(
                 key,
                 ReportStatus::Unsupported,
                 ReportSource::Devcontainer,
-                name.to_string(),
+                raw_id.clone(),
                 "features are baked into the template at `coop setup` time, \
                  not selected per-start",
             );
             continue;
         }
-        if cli_profiles.contains(&name) {
-            t.report.push(
+        match crate::devcontainer_oci::parse_feature_request(raw_id, raw_options) {
+            Ok(Some(req)) => {
+                t.oci_feature_requests.push(req);
+            }
+            Ok(None) => t.report.push(
                 key,
-                ReportStatus::Overridden,
-                ReportSource::Cli,
-                name.to_string(),
-                "CLI --profile already includes this profile",
-            );
-            continue;
+                ReportStatus::Unsupported,
+                ReportSource::Devcontainer,
+                raw_id.clone(),
+                "no built-in profile match and only ghcr.io/devcontainers/features/* OCI features are supported",
+            ),
+            Err(e) => t.report.push(
+                key,
+                ReportStatus::Invalid,
+                ReportSource::Devcontainer,
+                render_value(raw_options),
+                e.to_string(),
+            ),
         }
-        t.profiles.push(name.to_string());
-        t.report.push(
-            key,
-            ReportStatus::Applied,
-            ReportSource::Devcontainer,
-            name.to_string(),
-            format!("mapped to built-in profile '{name}'"),
-        );
     }
 }
 
@@ -1541,16 +1567,26 @@ mod tests {
         let t = translate(&f, &TranslatorInputs::default(), Stage::Setup);
         assert!(t.profiles.contains(&"rust".to_string()));
         assert!(t.profiles.contains(&"node".to_string()));
-        let docker = t
-            .report
-            .entries
-            .iter()
-            .find(|e| {
-                e.key
-                    .starts_with("features.ghcr.io/devcontainers/features/docker")
-            })
-            .unwrap();
-        assert_eq!(docker.status, ReportStatus::Unsupported);
+        assert!(t.oci_feature_requests.iter().any(|req| {
+            req.raw_id
+                .starts_with("ghcr.io/devcontainers/features/docker")
+        }));
+    }
+
+    #[test]
+    fn translate_features_collects_supported_oci_requests() {
+        let f = parse(
+            r#"{ "features": {
+                "ghcr.io/devcontainers/features/github-cli:1": { "version": "latest" }
+            } }"#,
+        );
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Setup);
+        assert_eq!(t.oci_feature_requests.len(), 1);
+        assert_eq!(
+            t.oci_feature_requests[0].reference.repository,
+            "devcontainers/features/github-cli"
+        );
+        assert_eq!(t.oci_feature_requests[0].options["version"], "latest");
     }
 
     #[test]

--- a/src/devcontainer_oci.rs
+++ b/src/devcontainer_oci.rs
@@ -1,0 +1,586 @@
+//! OCI-backed devcontainer Feature resolution.
+//!
+//! Devcontainer Features are registry artifacts that contain at least
+//! `devcontainer-feature.json` and `install.sh`. Coop resolves a conservative
+//! subset for setup-time image builds: public GHCR features under
+//! `ghcr.io/devcontainers/features/*`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::cmd::Cmd;
+use crate::sha256_hash::Sha256Hash;
+
+const GHCR_HOST: &str = "ghcr.io";
+const SUPPORTED_REPO_PREFIX: &str = "devcontainers/features/";
+const MANIFEST_ACCEPT: &str = concat!(
+    "application/vnd.oci.image.manifest.v1+json,",
+    "application/vnd.oci.artifact.manifest.v1+json,",
+    "application/vnd.docker.distribution.manifest.v2+json"
+);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureRequest {
+    pub raw_id: String,
+    pub reference: OciReference,
+    pub options: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciReference {
+    pub host: String,
+    pub repository: String,
+    pub reference: String,
+}
+
+impl OciReference {
+    #[must_use]
+    pub fn canonical(&self) -> String {
+        format!("{}/{}/{}", self.host, self.repository, self.reference)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InstalledFeature {
+    pub id: String,
+    pub reference: String,
+    pub digest: String,
+    pub install_script_hash: Sha256Hash,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedFeature {
+    pub installed: InstalledFeature,
+    pub install_script: String,
+    pub archive: Vec<u8>,
+    pub options: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    token: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OciManifest {
+    #[serde(default)]
+    config: Option<Descriptor>,
+    #[serde(default)]
+    layers: Vec<Descriptor>,
+    #[serde(default)]
+    annotations: BTreeMap<String, String>,
+}
+
+struct FetchedManifest {
+    manifest: OciManifest,
+    digest: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Descriptor {
+    digest: String,
+    #[serde(default)]
+    annotations: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FeatureMetadata {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+pub fn parse_feature_request(
+    raw_id: &str,
+    raw_options: &serde_json::Value,
+) -> Result<Option<FeatureRequest>> {
+    let Some(reference) = parse_supported_reference(raw_id)? else {
+        return Ok(None);
+    };
+    let options = parse_options(raw_options)?;
+    Ok(Some(FeatureRequest {
+        raw_id: raw_id.to_string(),
+        reference,
+        options,
+    }))
+}
+
+fn parse_supported_reference(raw_id: &str) -> Result<Option<OciReference>> {
+    let without_scheme = raw_id
+        .strip_prefix("oci://")
+        .or_else(|| raw_id.strip_prefix("https://"))
+        .unwrap_or(raw_id);
+    let Some(rest) = without_scheme.strip_prefix("ghcr.io/") else {
+        return Ok(None);
+    };
+    let Some(repo_and_ref) = rest.strip_prefix(SUPPORTED_REPO_PREFIX) else {
+        return Ok(None);
+    };
+    let (name, reference) = if let Some((name, digest)) = repo_and_ref.split_once('@') {
+        (name, digest)
+    } else if let Some((name, tag)) = repo_and_ref.rsplit_once(':') {
+        (name, tag)
+    } else {
+        (repo_and_ref, "latest")
+    };
+    if name.is_empty() || reference.is_empty() {
+        bail!("expected ghcr.io/devcontainers/features/<name>[:tag|@digest]");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    {
+        bail!("feature name contains unsupported characters");
+    }
+    Ok(Some(OciReference {
+        host: GHCR_HOST.to_string(),
+        repository: format!("{SUPPORTED_REPO_PREFIX}{name}"),
+        reference: reference.to_string(),
+    }))
+}
+
+fn parse_options(raw: &serde_json::Value) -> Result<BTreeMap<String, String>> {
+    let serde_json::Value::Object(map) = raw else {
+        bail!("expected feature options object");
+    };
+    let mut out = BTreeMap::new();
+    for (key, value) in map {
+        if !key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        {
+            bail!("feature option {key:?} contains unsupported characters");
+        }
+        let rendered = match value {
+            serde_json::Value::Bool(v) => v.to_string(),
+            serde_json::Value::Number(v) => v.to_string(),
+            serde_json::Value::String(v) => v.clone(),
+            serde_json::Value::Null => String::new(),
+            _ => bail!("feature option {key:?} must be a string, number, boolean, or null"),
+        };
+        out.insert(key.clone(), rendered);
+    }
+    Ok(out)
+}
+
+pub fn resolve_features(requests: &[FeatureRequest]) -> Vec<Result<ResolvedFeature>> {
+    requests.iter().map(resolve_feature).collect()
+}
+
+fn resolve_feature(req: &FeatureRequest) -> Result<ResolvedFeature> {
+    let token = fetch_token(&req.reference)?;
+    let fetched = fetch_manifest(&req.reference, &token)?;
+    let manifest = fetched.manifest;
+    let metadata = feature_metadata(&manifest).unwrap_or_default();
+    let blob = feature_blob(&manifest)?;
+    let tmp = tempfile::tempdir().context("Failed to create feature extraction directory")?;
+    let blob_path = tmp.path().join("feature.tgz");
+    download_blob(&req.reference, &blob.digest, &token, &blob_path)?;
+    resolved_feature_from_archive(req, &fetched.digest, metadata, &blob_path)
+}
+
+fn resolved_feature_from_archive(
+    req: &FeatureRequest,
+    manifest_digest: &str,
+    metadata: FeatureMetadata,
+    blob_path: &Path,
+) -> Result<ResolvedFeature> {
+    let id = metadata
+        .id
+        .or(metadata.name)
+        .unwrap_or_else(|| req.raw_id.clone());
+    let archive = fs::read(blob_path).with_context(|| {
+        format!(
+            "Failed to read downloaded feature layer {}",
+            blob_path.display()
+        )
+    })?;
+    let tmp = tempfile::tempdir().context("Failed to create feature validation directory")?;
+    let extracted = tmp.path().join("feature");
+    fs::create_dir(&extracted).context("Failed to create feature extraction target")?;
+    Cmd::new("tar")
+        .args(["-xzf"])
+        .arg(blob_path)
+        .args(["-C"])
+        .arg(&extracted)
+        .run()
+        .context("Failed to extract devcontainer feature layer")?;
+    let install_path = extracted.join("install.sh");
+    let metadata_path = extracted.join("devcontainer-feature.json");
+    if !metadata_path.exists() {
+        bail!("feature layer does not contain devcontainer-feature.json");
+    }
+    let install_script = fs::read_to_string(&install_path)
+        .with_context(|| format!("Failed to read {}", install_path.display()))?;
+    if install_script.trim().is_empty() {
+        bail!("feature install.sh is empty");
+    }
+    Ok(ResolvedFeature {
+        installed: InstalledFeature {
+            id,
+            reference: req.raw_id.clone(),
+            digest: manifest_digest.to_string(),
+            install_script_hash: Sha256Hash::of(&install_script),
+        },
+        install_script,
+        archive,
+        options: req.options.clone(),
+    })
+}
+
+fn fetch_token(reference: &OciReference) -> Result<String> {
+    let url = format!(
+        "https://{GHCR_HOST}/token?scope=repository:{}:pull&service={GHCR_HOST}",
+        reference.repository
+    );
+    let body = Cmd::new("curl")
+        .args(["-fsSL"])
+        .arg(url)
+        .capture()
+        .context("Failed to fetch GHCR registry token")?;
+    let token: TokenResponse = serde_json::from_str(&body).context("Failed to parse token JSON")?;
+    Ok(token.token)
+}
+
+fn fetch_manifest(reference: &OciReference, token: &str) -> Result<FetchedManifest> {
+    let url = format!(
+        "https://{GHCR_HOST}/v2/{}/manifests/{}",
+        reference.repository, reference.reference
+    );
+    let tmp = tempfile::tempdir().context("Failed to create manifest download directory")?;
+    let headers_path = tmp.path().join("headers");
+    let body_path = tmp.path().join("manifest.json");
+    Cmd::new("curl")
+        .args(["-fsSL"])
+        .args(["-D"])
+        .arg(&headers_path)
+        .args(["-o"])
+        .arg(&body_path)
+        .args(["-H"])
+        .arg(format!("Accept: {MANIFEST_ACCEPT}"))
+        .redacted_arg("-H")
+        .redacted_arg(format!("Authorization: Bearer {token}"))
+        .arg(url)
+        .run()
+        .with_context(|| {
+            format!(
+                "Failed to fetch feature manifest for {}",
+                reference.canonical()
+            )
+        })?;
+    let headers = fs::read_to_string(&headers_path)
+        .with_context(|| format!("Failed to read {}", headers_path.display()))?;
+    let body = fs::read_to_string(&body_path)
+        .with_context(|| format!("Failed to read {}", body_path.display()))?;
+    let manifest: OciManifest =
+        serde_json::from_str(&body).context("Failed to parse OCI manifest")?;
+    let digest = match parse_docker_content_digest(&headers) {
+        Some(digest) => digest,
+        None => manifest_digest(&manifest)?,
+    };
+    Ok(FetchedManifest { manifest, digest })
+}
+
+fn download_blob(reference: &OciReference, digest: &str, token: &str, output: &Path) -> Result<()> {
+    let url = format!(
+        "https://{GHCR_HOST}/v2/{}/blobs/{digest}",
+        reference.repository
+    );
+    Cmd::new("curl")
+        .args(["-fsSL"])
+        .redacted_arg("-H")
+        .redacted_arg(format!("Authorization: Bearer {token}"))
+        .arg(url)
+        .args(["-o"])
+        .arg(output)
+        .run()
+        .with_context(|| format!("Failed to download feature layer {digest}"))
+}
+
+fn manifest_digest(manifest: &OciManifest) -> Result<String> {
+    if let Some(digest) = manifest
+        .annotations
+        .get("org.opencontainers.image.digest")
+        .or_else(|| manifest.annotations.get("dev.containers.digest"))
+    {
+        return Ok(digest.clone());
+    }
+    if let Some(config) = &manifest.config {
+        return Ok(config.digest.clone());
+    }
+    bail!("OCI manifest has no digest-bearing config descriptor")
+}
+
+fn parse_docker_content_digest(headers: &str) -> Option<String> {
+    headers.lines().rev().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        if name.eq_ignore_ascii_case("docker-content-digest") {
+            Some(value.trim().to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn feature_blob(manifest: &OciManifest) -> Result<&Descriptor> {
+    manifest
+        .layers
+        .iter()
+        .find(|d| {
+            d.annotations
+                .get("org.opencontainers.image.title")
+                .is_some_and(|title| {
+                    Path::new(title).extension().is_some_and(|ext| {
+                        ext.eq_ignore_ascii_case("tgz") || ext.eq_ignore_ascii_case("gz")
+                    })
+                })
+        })
+        .or_else(|| manifest.layers.first())
+        .context("OCI manifest has no downloadable feature layer")
+}
+
+fn feature_metadata(manifest: &OciManifest) -> Option<FeatureMetadata> {
+    manifest
+        .annotations
+        .get("dev.containers.metadata")
+        .and_then(|raw| serde_json::from_str(raw).ok())
+}
+
+pub fn compose_install_snippet(feature: &ResolvedFeature) -> String {
+    let mut out = String::new();
+    out.push_str("\necho '  [guest] Installing devcontainer Feature ");
+    out.push_str(&shell_single_quote(&feature.installed.reference));
+    out.push_str("'\n");
+    out.push_str("(\n");
+    out.push_str("feature_dir=$(mktemp -d)\n");
+    out.push_str("trap 'rm -rf \"$feature_dir\"' EXIT\n");
+    out.push_str("archive=\"$feature_dir/feature.tgz\"\n");
+    let archive_delimiter = format!(
+        "COOP_FEATURE_ARCHIVE_{}",
+        &feature.installed.install_script_hash.to_string()[..16]
+    );
+    out.push_str("base64 -d > \"$archive\" <<'");
+    out.push_str(&archive_delimiter);
+    out.push_str("'\n");
+    out.push_str(&base64_encode(&feature.archive));
+    out.push('\n');
+    out.push_str(&archive_delimiter);
+    out.push('\n');
+    out.push_str("tar -xzf \"$archive\" -C \"$feature_dir\"\n");
+    out.push_str("chmod +x \"$feature_dir/install.sh\"\n");
+    out.push_str("export _REMOTE_USER=\"$GUEST_USER\"\n");
+    out.push_str("export _REMOTE_USER_HOME=\"/home/$GUEST_USER\"\n");
+    for (key, value) in &feature.options {
+        out.push_str("export ");
+        out.push_str(&option_env_name(key));
+        out.push('=');
+        out.push_str(&shell_single_quote(value));
+        out.push('\n');
+    }
+    out.push_str("cd \"$feature_dir\"\n");
+    out.push_str("./install.sh\n");
+    out.push_str(")\n");
+    out
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = *chunk.get(1).unwrap_or(&0);
+        let b2 = *chunk.get(2).unwrap_or(&0);
+        out.push(TABLE[(b0 >> 2) as usize] as char);
+        out.push(TABLE[(((b0 & 0b0000_0011) << 4) | (b1 >> 4)) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(TABLE[(((b1 & 0b0000_1111) << 2) | (b2 >> 6)) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        if chunk.len() > 2 {
+            out.push(TABLE[(b2 & 0b0011_1111) as usize] as char);
+        } else {
+            out.push('=');
+        }
+    }
+    out
+}
+
+fn option_env_name(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests use unwrap for brevity")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_supported_reference_defaults_to_latest() {
+        let req = parse_feature_request(
+            "ghcr.io/devcontainers/features/github-cli",
+            &serde_json::json!({}),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            req.reference.repository,
+            "devcontainers/features/github-cli"
+        );
+        assert_eq!(req.reference.reference, "latest");
+    }
+
+    #[test]
+    fn parse_supported_reference_accepts_tag() {
+        let req = parse_feature_request(
+            "ghcr.io/devcontainers/features/go:1.2.3",
+            &serde_json::json!({ "version": "1.24", "moby": true }),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(req.reference.reference, "1.2.3");
+        assert_eq!(req.options["version"], "1.24");
+        assert_eq!(req.options["moby"], "true");
+    }
+
+    #[test]
+    fn parse_rejects_nested_options() {
+        let err = parse_feature_request(
+            "ghcr.io/devcontainers/features/go:1",
+            &serde_json::json!({ "version": { "nested": true } }),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("must be a string"));
+    }
+
+    #[test]
+    fn compose_install_snippet_exports_options_and_script() {
+        let feature = ResolvedFeature {
+            installed: InstalledFeature {
+                id: "github-cli".to_string(),
+                reference: "ghcr.io/devcontainers/features/github-cli:1".to_string(),
+                digest: "sha256:abc".to_string(),
+                install_script_hash: Sha256Hash::of("echo install"),
+            },
+            install_script: "echo \"$VERSION\"".to_string(),
+            archive: b"archive-bytes".to_vec(),
+            options: BTreeMap::from([("version".to_string(), "latest".to_string())]),
+        };
+        let snippet = compose_install_snippet(&feature);
+        assert!(snippet.contains("export VERSION='latest'"));
+        assert!(snippet.contains("YXJjaGl2ZS1ieXRlcw=="));
+        assert!(snippet.contains("tar -xzf \"$archive\""));
+        assert!(snippet.contains("./install.sh"));
+    }
+
+    #[test]
+    fn base64_encoder_matches_known_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"archive-bytes"), "YXJjaGl2ZS1ieXRlcw==");
+    }
+
+    #[test]
+    fn parses_sample_manifest_metadata() {
+        let manifest: OciManifest = serde_json::from_value(serde_json::json!({
+            "config": { "digest": "sha256:config" },
+            "layers": [
+                {
+                    "digest": "sha256:layer",
+                    "annotations": { "org.opencontainers.image.title": "devcontainer-feature-go.tgz" }
+                }
+            ],
+            "annotations": {
+                "dev.containers.metadata": "{\"id\":\"go\",\"name\":\"Go\"}"
+            }
+        }))
+        .unwrap();
+        assert_eq!(manifest_digest(&manifest).unwrap(), "sha256:config");
+        assert_eq!(feature_blob(&manifest).unwrap().digest, "sha256:layer");
+        assert_eq!(
+            feature_metadata(&manifest).unwrap().id.as_deref(),
+            Some("go")
+        );
+    }
+
+    #[test]
+    fn resolves_sample_feature_archive_with_payload_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let feature_dir = tmp.path().join("feature");
+        std::fs::create_dir(&feature_dir).unwrap();
+        std::fs::write(
+            feature_dir.join("devcontainer-feature.json"),
+            r#"{ "id": "sample", "name": "Sample" }"#,
+        )
+        .unwrap();
+        std::fs::write(feature_dir.join("helper.sh"), "echo helper\n").unwrap();
+        std::fs::write(feature_dir.join("install.sh"), "#!/bin/sh\n. ./helper.sh\n").unwrap();
+        let archive = tmp.path().join("feature.tgz");
+        let status = std::process::Command::new("tar")
+            .args(["-czf"])
+            .arg(&archive)
+            .args(["-C"])
+            .arg(&feature_dir)
+            .arg(".")
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let req = FeatureRequest {
+            raw_id: "ghcr.io/devcontainers/features/sample:1".to_string(),
+            reference: OciReference {
+                host: GHCR_HOST.to_string(),
+                repository: "devcontainers/features/sample".to_string(),
+                reference: "1".to_string(),
+            },
+            options: BTreeMap::new(),
+        };
+        let resolved = resolved_feature_from_archive(
+            &req,
+            "sha256:manifest",
+            FeatureMetadata {
+                id: Some("sample".to_string()),
+                name: None,
+            },
+            &archive,
+        )
+        .unwrap();
+
+        assert_eq!(resolved.installed.id, "sample");
+        assert_eq!(resolved.installed.digest, "sha256:manifest");
+        assert!(resolved.install_script.contains("./helper.sh"));
+        assert_eq!(resolved.archive, std::fs::read(&archive).unwrap());
+        assert!(compose_install_snippet(&resolved).contains(&base64_encode(&resolved.archive)));
+    }
+
+    #[test]
+    fn parses_registry_manifest_digest_header() {
+        let headers = "HTTP/2 200\r\ndocker-content-digest: sha256:manifest\r\n\r\n";
+        assert_eq!(
+            parse_docker_content_digest(headers).as_deref(),
+            Some("sha256:manifest")
+        );
+    }
+}

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::backend::{Hostname, LogMode, SshTarget, SshUser};
 use crate::config::{CoopConfig, GiB, ImageName, Instance, InstanceName};
+use crate::devcontainer_oci::{InstalledFeature, ResolvedFeature};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
     SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
@@ -31,7 +32,13 @@ pub fn setup(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
     let base_img = cfg.lima_base_path(image);
     if base_img.exists()
         && !opts.rebuild
-        && !needs_rebuild(cfg, image, &opts.profiles, &opts.guest_user)
+        && !needs_rebuild(
+            cfg,
+            image,
+            &opts.profiles,
+            &opts.oci_features,
+            &opts.guest_user,
+        )
     {
         eprintln!(
             "\n=> Golden image '{image}': up to date ({})",
@@ -41,7 +48,13 @@ pub fn setup(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
         if base_img.exists() && !opts.rebuild {
             eprintln!("\n=> Golden image '{image}' is stale — rebuilding");
         }
-        build_golden_image(cfg, image, &opts.profiles, &opts.guest_user)?;
+        build_golden_image(
+            cfg,
+            image,
+            &opts.profiles,
+            &opts.oci_features,
+            &opts.guest_user,
+        )?;
     }
 
     generate_start_template(cfg, image)?;
@@ -486,11 +499,12 @@ fn ensure_ssh_key(cfg: &CoopConfig) -> Result<()> {
 fn provision_script_hash(
     cfg: &CoopConfig,
     profiles: &[ProfileDef],
+    oci_features: &[ResolvedFeature],
     guest_user: &GuestUser,
 ) -> Sha256Hash {
     let pubkey_path = cfg.ssh_key_path().with_extension("pub");
     let pubkey = fs::read_to_string(&pubkey_path).unwrap_or_default();
-    let script = compose_provision_script(pubkey.trim(), profiles, guest_user);
+    let script = compose_provision_script(pubkey.trim(), profiles, oci_features, guest_user);
     Sha256Hash::of(&script)
 }
 
@@ -504,9 +518,10 @@ fn needs_rebuild(
     cfg: &CoopConfig,
     image: &ImageName,
     profiles: &[ProfileDef],
+    oci_features: &[ResolvedFeature],
     guest_user: &GuestUser,
 ) -> bool {
-    let current_hash = provision_script_hash(cfg, profiles, guest_user);
+    let current_hash = provision_script_hash(cfg, profiles, oci_features, guest_user);
     let Ok(existing) = TemplateConfig::load_for(cfg, image) else {
         tracing::info!("Template config missing — treating golden image as stale");
         return true;
@@ -532,6 +547,7 @@ fn build_golden_image(
     cfg: &CoopConfig,
     image: &ImageName,
     profiles: &[ProfileDef],
+    oci_features: &[ResolvedFeature],
     guest_user: &GuestUser,
 ) -> Result<()> {
     eprintln!(
@@ -562,7 +578,8 @@ fn build_golden_image(
 
     // Generate builder template with full provisioning
     let builder_template = cfg.data_dir.join("lima-builder.yaml");
-    let provision_script = compose_provision_script(pubkey.trim(), profiles, guest_user);
+    let provision_script =
+        compose_provision_script(pubkey.trim(), profiles, oci_features, guest_user);
     let yaml = compose_template_yaml(cfg, &provision_script);
     fs::write(&builder_template, &yaml).with_context(|| {
         format!(
@@ -574,6 +591,13 @@ fn build_golden_image(
     if !profiles.is_empty() {
         let names: Vec<&str> = profiles.iter().map(|p| p.name.as_str()).collect();
         eprintln!("  Profiles: {}", names.join(", "));
+    }
+    if !oci_features.is_empty() {
+        let names: Vec<&str> = oci_features
+            .iter()
+            .map(|f| f.installed.id.as_str())
+            .collect();
+        eprintln!("  Devcontainer OCI features: {}", names.join(", "));
     }
 
     // Build to staging path — old image is never touched
@@ -621,17 +645,22 @@ fn build_golden_image(
     let template_config = TemplateConfig {
         version: TEMPLATE_VERSION,
         created: utc_timestamp(),
-        install_script_hash: provision_script_hash(cfg, profiles, guest_user),
+        install_script_hash: provision_script_hash(cfg, profiles, oci_features, guest_user),
         profiles: profiles.iter().map(|p| p.name.clone()).collect(),
         extra_packages: Vec::new(),
         post_install_hash: None,
         marketplaces,
         plugins,
         guest_user: guest_user.clone(),
+        oci_features: installed_features(oci_features),
     };
     template_config.save_for(cfg, image)?;
 
     Ok(())
+}
+
+fn installed_features(features: &[ResolvedFeature]) -> Vec<InstalledFeature> {
+    features.iter().map(|f| f.installed.clone()).collect()
 }
 
 /// Start the builder VM, install marketplaces/plugins, clean
@@ -1127,6 +1156,7 @@ provision:
 fn compose_provision_script(
     ssh_pubkey: &str,
     profiles: &[ProfileDef],
+    oci_features: &[ResolvedFeature],
     guest_user: &GuestUser,
 ) -> String {
     let mut s = String::with_capacity(8192);
@@ -1199,6 +1229,9 @@ fn compose_provision_script(
 
     // Guest configuration configures the guest user — must come before claude-code install
     s.push_str(&compose_lima_guest_config(ssh_pubkey, guest_user));
+    for feature in oci_features {
+        s.push_str(&crate::devcontainer_oci::compose_install_snippet(feature));
+    }
 
     // Claude Code (direct binary download, runs as root, chowns to claude)
     s.push_str(SCRIPT_CLAUDE_CODE);
@@ -1623,6 +1656,7 @@ mod tests {
         let script = compose_provision_script(
             "ssh-ed25519 AAAA test@test",
             &profiles,
+            &[],
             &GuestUser::default(),
         );
 
@@ -1644,6 +1678,7 @@ mod tests {
         let script = compose_provision_script(
             "ssh-ed25519 AAAA test@test",
             &profiles,
+            &[],
             &GuestUser::default(),
         );
 
@@ -1663,6 +1698,7 @@ mod tests {
         let script = compose_provision_script(
             "ssh-ed25519 AAAA test@test",
             &profiles,
+            &[],
             &GuestUser::default(),
         );
 
@@ -1678,8 +1714,12 @@ mod tests {
 
     #[test]
     fn provision_script_installs_codex() {
-        let script =
-            compose_provision_script("ssh-ed25519 AAAA test@test", &[], &GuestUser::default());
+        let script = compose_provision_script(
+            "ssh-ed25519 AAAA test@test",
+            &[],
+            &[],
+            &GuestUser::default(),
+        );
 
         assert!(
             script.contains("Installing Codex CLI"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cmd;
 mod completions;
 mod config;
 mod devcontainer;
+mod devcontainer_oci;
 mod fs_util;
 mod git_repo_devcontainer;
 mod github_pat;
@@ -914,6 +915,10 @@ fn main() -> Result<()> {
                     skip_confirm: yes,
                     rebuild,
                     profiles: resolved_profiles,
+                    oci_features: translation
+                        .as_ref()
+                        .map(|t| t.oci_features.clone())
+                        .unwrap_or_default(),
                     extra_packages,
                     post_install: post_install.map(PathBuf::from),
                     image,
@@ -1579,6 +1584,7 @@ fn ensure_profile_image(
             skip_confirm: true,
             rebuild: false,
             profiles: resolved_profiles,
+            oci_features: Vec::new(),
             extra_packages: Vec::new(),
             post_install: None,
             image: target.image.clone(),
@@ -1821,6 +1827,7 @@ fn cmd_quickstart(
                 skip_confirm: true,
                 rebuild: false,
                 profiles: Vec::new(),
+                oci_features: Vec::new(),
                 extra_packages: Vec::new(),
                 post_install: None,
                 image: image.clone(),
@@ -2201,10 +2208,49 @@ fn resolve_devcontainer(
     };
     let mut translation = devcontainer::translate(&parsed, inputs, stage);
     translation.report.ignored_paths = losers;
+    resolve_oci_feature_requests(&mut translation);
 
     eprintln!("{}", translation.report.render());
 
     Ok(Some(translation))
+}
+
+fn resolve_oci_feature_requests(translation: &mut devcontainer::Translation) {
+    if translation.oci_feature_requests.is_empty() {
+        return;
+    }
+    for (request, resolved) in
+        translation
+            .oci_feature_requests
+            .iter()
+            .zip(devcontainer_oci::resolve_features(
+                &translation.oci_feature_requests,
+            ))
+    {
+        let key = format!("features.{}", request.raw_id);
+        match resolved {
+            Ok(feature) => {
+                translation.report.push(
+                    key,
+                    devcontainer::ReportStatus::Applied,
+                    devcontainer::ReportSource::Devcontainer,
+                    feature.installed.digest.clone(),
+                    format!(
+                        "OCI feature '{}' install.sh sha256 {} will run during setup",
+                        feature.installed.id, feature.installed.install_script_hash
+                    ),
+                );
+                translation.oci_features.push(feature);
+            }
+            Err(e) => translation.report.push(
+                key,
+                devcontainer::ReportStatus::Invalid,
+                devcontainer::ReportSource::Devcontainer,
+                request.raw_id.clone(),
+                format!("failed to resolve OCI feature: {e:#}"),
+            ),
+        }
+    }
 }
 
 #[expect(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cmd::Cmd;
 use crate::config::{CoopConfig, ImageName, Instance};
+use crate::devcontainer_oci::{InstalledFeature, ResolvedFeature};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
     SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, resolve_profiles,
@@ -29,6 +30,7 @@ pub struct SetupOptions {
     pub skip_confirm: bool,
     pub rebuild: bool,
     pub profiles: Vec<ProfileDef>,
+    pub oci_features: Vec<ResolvedFeature>,
     pub extra_packages: Vec<String>,
     pub post_install: Option<PathBuf>,
     pub image: ImageName,
@@ -56,6 +58,8 @@ pub struct TemplateConfig {
     pub plugins: Vec<String>,
     #[serde(default)]
     pub guest_user: GuestUser,
+    #[serde(default)]
+    pub oci_features: Vec<InstalledFeature>,
 }
 
 impl TemplateConfig {
@@ -302,7 +306,12 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
     let (profiles, extra_packages) = resolve_template_config(cfg, opts)?;
 
     // Compose recipe and compute hashes
-    let recipe = compose_recipe(&profiles, &extra_packages, &opts.guest_user);
+    let recipe = compose_recipe(
+        &profiles,
+        &opts.oci_features,
+        &extra_packages,
+        &opts.guest_user,
+    );
     let script_hash = Sha256Hash::of(&recipe);
     let post_install_content = load_post_install(opts.post_install.as_ref())?;
     let post_install_hash = post_install_content.as_ref().map(Sha256Hash::of);
@@ -370,6 +379,7 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
         marketplaces: Vec::new(),
         plugins: Vec::new(),
         guest_user: opts.guest_user.clone(),
+        oci_features: installed_features(&opts.oci_features),
     };
     template_config.save_for(cfg, image)?;
 
@@ -378,6 +388,10 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
 
 fn profile_names(profiles: &[ProfileDef]) -> Vec<String> {
     profiles.iter().map(|p| p.name.clone()).collect()
+}
+
+fn installed_features(features: &[ResolvedFeature]) -> Vec<InstalledFeature> {
+    features.iter().map(|f| f.installed.clone()).collect()
 }
 
 /// Returns `true` if the template needs rebuilding.
@@ -419,6 +433,15 @@ fn build_template(
     eprintln!("  URL: {rootfs_url}");
     if !profiles.is_empty() {
         eprintln!("  Profiles: {}", profile_names(profiles).join(", "));
+    }
+    if !opts.oci_features.is_empty() {
+        let features = opts
+            .oci_features
+            .iter()
+            .map(|f| format!("{} ({})", f.installed.id, f.installed.digest))
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!("  Devcontainer OCI features: {features}");
     }
     if !extra_packages.is_empty() {
         eprintln!("  Extra packages: {}", extra_packages.join(", "));
@@ -462,6 +485,7 @@ fn build_template(
         marketplaces: Vec::new(),
         plugins: Vec::new(),
         guest_user: opts.guest_user.clone(),
+        oci_features: installed_features(&opts.oci_features),
     };
     let marker_json = serde_json::to_string_pretty(&marker_config)
         .context("Failed to serialize version marker")?;
@@ -494,7 +518,8 @@ fn resolve_template_config(
     cfg: &CoopConfig,
     opts: &SetupOptions,
 ) -> Result<(Vec<ProfileDef>, Vec<String>)> {
-    if !opts.profiles.is_empty() || !opts.extra_packages.is_empty() {
+    if !opts.profiles.is_empty() || !opts.extra_packages.is_empty() || !opts.oci_features.is_empty()
+    {
         return Ok((opts.profiles.clone(), opts.extra_packages.clone()));
     }
 
@@ -525,6 +550,7 @@ fn load_post_install(path: Option<&PathBuf>) -> Result<Option<String>> {
 /// Does NOT include version marker, post-install script, or cleanup.
 fn compose_recipe(
     profiles: &[ProfileDef],
+    oci_features: &[ResolvedFeature],
     extra_packages: &[String],
     guest_user: &GuestUser,
 ) -> String {
@@ -627,6 +653,9 @@ fn compose_recipe(
 
     // Guest config configures the guest user — must come before claude-code.
     s.push_str(SCRIPT_GUEST_CONFIG);
+    for feature in oci_features {
+        s.push_str(&crate::devcontainer_oci::compose_install_snippet(feature));
+    }
     // Direct binary download (runs as root in chroot, installs for guest user).
     s.push_str(SCRIPT_CLAUDE_CODE);
     // Codex installs as a standalone binary under /usr/local/bin.
@@ -1413,7 +1442,7 @@ mod tests {
 
     #[test]
     fn compose_recipe_no_profiles_succeeds() {
-        let script = compose_recipe(&[], &[], &GuestUser::default());
+        let script = compose_recipe(&[], &[], &[], &GuestUser::default());
         assert!(script.contains("apt-get"));
         assert!(
             script.contains("Installing Codex CLI"),
@@ -1425,7 +1454,7 @@ mod tests {
     #[test]
     fn compose_recipe_exports_guest_user() {
         let user = GuestUser::new("vscode").unwrap();
-        let script = compose_recipe(&[], &[], &user);
+        let script = compose_recipe(&[], &[], &[], &user);
         assert!(
             script.contains("export GUEST_USER='vscode'"),
             "recipe must export GUEST_USER for the chroot scripts:\n{script}"
@@ -1452,7 +1481,7 @@ mod tests {
     #[test]
     fn compose_recipe_post_install_without_trailing_newline() {
         let profiles = vec![profile("test", &["curl"], None, Some("echo done"))];
-        let script = compose_recipe(&profiles, &[], &GuestUser::default());
+        let script = compose_recipe(&profiles, &[], &[], &GuestUser::default());
 
         // The post_install "echo done" must be on its own line
         assert!(
@@ -1470,7 +1499,7 @@ mod tests {
             Some("curl -fsSL https://example.com | bash"),
             None,
         )];
-        let script = compose_recipe(&profiles, &[], &GuestUser::default());
+        let script = compose_recipe(&profiles, &[], &[], &GuestUser::default());
 
         assert!(
             script.contains("| bash\n"),
@@ -1482,7 +1511,7 @@ mod tests {
     #[test]
     fn compose_recipe_scripts_with_trailing_newline_no_double() {
         let profiles = vec![profile("test", &[], Some("pre-cmd\n"), Some("post-cmd\n"))];
-        let script = compose_recipe(&profiles, &[], &GuestUser::default());
+        let script = compose_recipe(&profiles, &[], &[], &GuestUser::default());
 
         // Should not produce triple+ newlines from double-adding
         assert!(
@@ -1498,7 +1527,7 @@ mod tests {
             profile("a", &[], None, Some("echo a-done")),
             profile("b", &[], None, Some("echo b-done")),
         ];
-        let script = compose_recipe(&profiles, &[], &GuestUser::default());
+        let script = compose_recipe(&profiles, &[], &[], &GuestUser::default());
 
         // Each post_install must be on its own line
         assert!(script.contains("echo a-done\n"));

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3091,6 +3091,29 @@ test_devcontainer_translator() {
         fail "devcontainer check reports setup and start stages" "stderr: $HARNESS_ERR"
     fi
 
+    local oci_bad="$tmpdir/devcontainer-oci-bad.json"
+    cat > "$oci_bad" <<'EOF'
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": { "nested": true }
+    }
+  }
+}
+EOF
+    if coop devcontainer check "$oci_bad" --stage setup; then
+        pass "devcontainer check handles invalid OCI feature options"
+    else
+        fail "devcontainer check handles invalid OCI feature options" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+    if grep -q "features.ghcr.io/devcontainers/features/github-cli:1" <<< "$HARNESS_ERR" \
+        && grep -q "invalid" <<< "$HARNESS_ERR" \
+        && grep -q "must be a string" <<< "$HARNESS_ERR"; then
+        pass "invalid OCI feature options are reported loudly"
+    else
+        fail "invalid OCI feature options are reported loudly" "stderr: $HARNESS_ERR"
+    fi
+
     # --no-devcontainer silently skips the file: the report header must NOT appear.
     # `--dry-run` lets us exercise the discovery path without any VM work.
     if coop up "$dcdir" --name "${INSTANCE}-dc-skip" \


### PR DESCRIPTION
## Summary

- Add a devcontainer OCI Feature resolver for public `ghcr.io/devcontainers/features/*` entries, including registry token/manifest/blob fetch, manifest digest reporting, layer validation, and install script hashing
- Bake resolved Feature payloads into Firecracker and Lima setup recipes in deterministic devcontainer feature-key order, preserving sibling files and running after guest-user setup
- Persist resolved Feature provenance in template config so setup staleness tracks Feature script/archive changes through the install recipe hash
- Update devcontainer docs and command docs for supported OCI Feature behavior and trust boundaries
- Add reproducible unit coverage with sample OCI manifest metadata and sample Feature tarball payloads, plus integration coverage for loud invalid OCI option reporting

Closes #238

## Review

Subagent review completed. Findings fixed: untracked module staging, dropped Feature payload files, missing manifest Accept header, Feature execution before guest-user creation, and missing reproducible payload-preservation test.

## Tests

- `cargo fmt --check`
- `cargo check`
- `cargo test devcontainer`
- `cargo test devcontainer_oci`
- `cargo test compose_recipe`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `tests/run-integration.sh`