### PR TITLE
Warn when applied devcontainer changes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -83,6 +83,12 @@ recreate it with different creation options. Runtime startup options such as
 restarts an instance; if the matching instance is already running, stop it
 first so those options can take effect.
 
+When a local `devcontainer.json` was applied while creating the instance, coop stores
+its path and content hash. Later `coop up` reconnects or restarts warn if that
+file changed, but the existing VM is not mutated automatically. Destroy and
+recreate the instance to apply creation-time devcontainer changes such as
+`features`, `hostRequirements`, `mounts`, `image`/`build`, or `remoteUser`.
+
 ### `init`
 
 Generate a starter config file at `~/.coop/config.toml`.
@@ -180,11 +186,15 @@ instances, pass the instance name.
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
 | `--env KEY=VALUE` | Literal env var to set in the guest (repeatable). Overrides `guest_env` config entries and any forwarded values with the same name. |
-| `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt). |
+| `--devcontainer <path>` | Dry-run translation aid; normal restarts reject devcontainer creation options. |
 | `--no-devcontainer` | Ignore any discovered `devcontainer.json` (escape hatch for CI). |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work. |
 
-When `--workspace <dir>` contains a `.devcontainer/devcontainer.json`, or `--git-repo <url>` points at a GitHub repository with one, coop reads a subset of it and prompts before applying restart-time settings. See [docs/devcontainer.md](devcontainer.md) for the supported keys and discovery rules.
+Normal `start` restarts an existing VM without re-reading or re-applying
+`devcontainer.json`. If the instance was created with a devcontainer file, coop
+warns when the recorded file path now has different contents. See
+[docs/devcontainer.md](devcontainer.md) for the supported keys, discovery
+rules, and recreate guidance.
 
 ```
 coop start

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -4,7 +4,7 @@ coop reads a **subset** of [devcontainer.json](https://containers.dev/) and maps
 
 ## How discovery and apply work
 
-When you run `coop up <dir>` or `coop setup --workspace <dir>`, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each mount host root, with the project directory winning ties). On restart, `coop start --workspace <dir>` can also read the project's devcontainer file for restart-time settings. For `coop start --git-repo <url>`, coop can discover `.devcontainer/devcontainer.json` from common GitHub repository URLs before creating the VM.
+When you run `coop up <dir>` or `coop setup --workspace <dir>`, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each mount host root, with the project directory winning ties). For `--git-repo` creation flows, coop can discover `.devcontainer/devcontainer.json` from common GitHub repository URLs before creating the VM.
 
 If a file is found, coop prompts:
 
@@ -13,6 +13,8 @@ Use devcontainer.json at <path>? [Y/n]
 ```
 
 After your reply (or non-interactive escape hatches, below), coop prints a per-key report showing exactly which devcontainer.json keys took effect, which were overridden by CLI flags, and which are unsupported.
+
+When a local `devcontainer.json` is applied while creating a VM, coop records the file path and SHA-256 content hash in the instance state. Later `coop up` reconnects and `coop start` restarts compare the current file at that path with the recorded hash. If it changed or disappeared, coop prints an informational warning and leaves the existing VM unchanged. Destroy and recreate the VM to apply creation-time changes such as `features`, `hostRequirements`, `mounts`, `image`/`build`, or `remoteUser`. Start-time values from the old file, including `containerEnv`, `forwardPorts`, and `postStartCommand`, are not re-applied automatically on restart.
 
 ## Non-interactive escape hatches
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2128,6 +2128,10 @@ impl Instance {
         self.dir.join("guest_env.json")
     }
 
+    pub fn devcontainer_state_path(&self) -> PathBuf {
+        self.dir.join("devcontainer_state.json")
+    }
+
     pub fn tap_device(&self) -> String {
         format!("tap{}", self.index)
     }

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -12,16 +12,19 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write as _;
+use std::fs;
+use std::io::ErrorKind;
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{self, CoopConfig, GiB, MiB, Mount, PortForward};
 use crate::devcontainer_oci::{FeatureRequest, ResolvedFeature};
 use crate::guest::{BuiltinProfile, GuestUser, builtin_for_feature};
 use crate::guest_env_state::EnvVarName;
+use crate::sha256_hash::Sha256Hash;
 
 /// Default relative path coop looks for inside a workspace or mount root.
 pub const DEFAULT_DEVCONTAINER_REL_PATH: &str = ".devcontainer/devcontainer.json";
@@ -173,6 +176,7 @@ struct RawHostRequirements {
 #[derive(Debug)]
 pub struct ParsedDevcontainer {
     pub path: PathBuf,
+    pub content_hash: Sha256Hash,
     raw: RawDevcontainer,
 }
 
@@ -182,14 +186,135 @@ impl ParsedDevcontainer {
         let json = jsonc_to_json(text);
         let raw: RawDevcontainer = serde_json::from_str(&json)
             .with_context(|| format!("Failed to parse {}", path.display()))?;
-        Ok(Self { path, raw })
+        Ok(Self {
+            path,
+            content_hash: Sha256Hash::of(text),
+            raw,
+        })
     }
 
     /// Read and parse a file from disk.
     pub fn load(path: &Path) -> Result<Self> {
         let text = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
-        Self::from_str(path.to_path_buf(), &text)
+        let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        Self::from_str(canonical_path, &text)
+    }
+}
+
+/// Devcontainer file that was applied when an instance was created.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppliedDevcontainer {
+    pub path: PathBuf,
+    pub content_hash: Sha256Hash,
+    #[serde(default)]
+    pub source: AppliedDevcontainerSource,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppliedDevcontainerSource {
+    #[default]
+    LocalFile,
+    RemoteContents,
+}
+
+impl AppliedDevcontainer {
+    fn current_hash(&self) -> Result<Option<Sha256Hash>> {
+        if self.source != AppliedDevcontainerSource::LocalFile {
+            return Ok(None);
+        }
+        match fs::read(&self.path) {
+            Ok(bytes) => Ok(Some(Sha256Hash::of(bytes))),
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+            Err(e) => {
+                Err(anyhow::Error::new(e)
+                    .context(format!("Failed to read {}", self.path.display())))
+            }
+        }
+    }
+}
+
+/// Persisted devcontainer snapshot written per instance after start.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DevcontainerState {
+    pub applied: AppliedDevcontainer,
+}
+
+impl DevcontainerState {
+    pub fn save(&self, inst: &config::Instance) -> Result<()> {
+        let path = inst.devcontainer_state_path();
+        let json =
+            serde_json::to_string_pretty(self).context("Failed to serialize devcontainer state")?;
+        crate::fs_util::atomic_write_json(&path, &json)
+            .context("Failed to write devcontainer_state.json")?;
+        tracing::debug!("Wrote devcontainer state to {}", path.display());
+        Ok(())
+    }
+
+    pub fn try_load(inst: &config::Instance) -> Result<Option<Self>> {
+        let path = inst.devcontainer_state_path();
+        match fs::read_to_string(&path) {
+            Ok(content) => {
+                let state = serde_json::from_str(&content)
+                    .context("Failed to parse devcontainer_state.json")?;
+                Ok(Some(state))
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+            Err(e) => {
+                Err(anyhow::Error::new(e).context(format!("Failed to read {}", path.display())))
+            }
+        }
+    }
+
+    pub fn changed_warning(&self, instance_name: &str) -> Result<Option<String>> {
+        if self.applied.source != AppliedDevcontainerSource::LocalFile {
+            return Ok(None);
+        }
+
+        let Some(current_hash) = self.applied.current_hash()? else {
+            return Ok(Some(format!(
+                "devcontainer.json previously applied to instance '{instance_name}' is no longer readable at {}. \
+                 The existing VM was not changed. Destroy and recreate it to apply creation-time devcontainer changes \
+                 such as features, hostRequirements, mounts, image/build, or remoteUser.",
+                self.applied.path.display()
+            )));
+        };
+
+        if current_hash == self.applied.content_hash {
+            return Ok(None);
+        }
+
+        Ok(Some(format!(
+            "devcontainer.json changed since instance '{instance_name}' was created: {}. \
+             The existing VM was not changed. Destroy and recreate it to apply creation-time devcontainer changes \
+             such as features, hostRequirements, mounts, image/build, or remoteUser. \
+             Restart-time values from the old file, including containerEnv, forwardPorts, and postStartCommand, \
+             are not re-applied automatically.",
+            self.applied.path.display()
+        )))
+    }
+}
+
+pub fn warn_if_applied_devcontainer_changed(inst: &config::Instance) {
+    let state = match DevcontainerState::try_load(inst) {
+        Ok(Some(state)) => state,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!(
+                "Could not read devcontainer state for '{}'; devcontainer change check skipped. {e:#}",
+                inst.name,
+            );
+            return;
+        }
+    };
+    match state.changed_warning(inst.name.as_str()) {
+        Ok(Some(message)) => tracing::warn!("{message}"),
+        Ok(None) => {}
+        Err(e) => tracing::warn!(
+            "Could not compare devcontainer.json for '{}'; devcontainer change check skipped. {e:#}",
+            inst.name,
+        ),
     }
 }
 
@@ -389,6 +514,7 @@ pub enum Stage {
 /// Result of `translate` — the values to push into config plus a report.
 #[derive(Debug, Default)]
 pub struct Translation {
+    pub applied: Option<AppliedDevcontainer>,
     pub vcpus: Option<u8>,
     pub mem_mib: Option<MiB>,
     pub disk_gib: Option<GiB>,
@@ -422,7 +548,14 @@ pub fn translate(
     inputs: &TranslatorInputs,
     stage: Stage,
 ) -> Translation {
-    let mut t = Translation::default();
+    let mut t = Translation {
+        applied: Some(AppliedDevcontainer {
+            path: file.path.clone(),
+            content_hash: file.content_hash,
+            source: AppliedDevcontainerSource::LocalFile,
+        }),
+        ..Translation::default()
+    };
     t.report.source_path = Some(file.path.clone());
 
     if let Some(reqs) = &file.raw.host_requirements {
@@ -1951,5 +2084,70 @@ mod tests {
             .unwrap();
         assert!(invalid.note.contains("1BAD"));
         assert!(invalid.note.contains("AL SO"));
+    }
+
+    #[test]
+    fn translation_records_applied_path_and_content_hash() {
+        let f = parse(r#"{ "containerEnv": { "GOOD": "1" } }"#);
+        let t = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        let applied = t.applied.as_ref().unwrap();
+        assert_eq!(applied.path, PathBuf::from("test.json"));
+        assert_eq!(applied.source, AppliedDevcontainerSource::LocalFile);
+        assert_eq!(
+            applied.content_hash,
+            Sha256Hash::of(r#"{ "containerEnv": { "GOOD": "1" } }"#),
+        );
+    }
+
+    #[test]
+    fn devcontainer_state_warns_when_file_hash_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("devcontainer.json");
+        fs::write(&path, r#"{ "name": "old" }"#).unwrap();
+        let state = DevcontainerState {
+            applied: AppliedDevcontainer {
+                path: path.clone(),
+                content_hash: Sha256Hash::of(r#"{ "name": "old" }"#),
+                source: AppliedDevcontainerSource::LocalFile,
+            },
+        };
+
+        assert!(state.changed_warning("demo").unwrap().is_none());
+
+        fs::write(&path, r#"{ "name": "new" }"#).unwrap();
+        let warning = state.changed_warning("demo").unwrap().unwrap();
+        assert!(warning.contains("devcontainer.json changed"));
+        assert!(warning.contains("features"));
+        assert!(warning.contains("hostRequirements"));
+        assert!(warning.contains("remoteUser"));
+        assert!(warning.contains("not re-applied automatically"));
+    }
+
+    #[test]
+    fn devcontainer_state_warns_when_file_disappears() {
+        let state = DevcontainerState {
+            applied: AppliedDevcontainer {
+                path: PathBuf::from("/path/does/not/exist/devcontainer.json"),
+                content_hash: Sha256Hash::of("{}"),
+                source: AppliedDevcontainerSource::LocalFile,
+            },
+        };
+
+        let warning = state.changed_warning("demo").unwrap().unwrap();
+        assert!(warning.contains("no longer readable"));
+        assert!(warning.contains("Destroy and recreate"));
+    }
+
+    #[test]
+    fn devcontainer_state_does_not_local_compare_remote_contents() {
+        let state = DevcontainerState {
+            applied: AppliedDevcontainer {
+                path: PathBuf::from("github.com/owner/repo/.devcontainer/devcontainer.json"),
+                content_hash: Sha256Hash::of("{}"),
+                source: AppliedDevcontainerSource::RemoteContents,
+            },
+        };
+
+        assert!(state.changed_warning("demo").unwrap().is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1019,74 +1019,11 @@ fn main() -> Result<()> {
                 post_start_override: post_start.as_deref(),
                 persisted_guest_env: std::collections::BTreeMap::new(),
                 devcontainer_path: devcontainer.as_deref().map(Path::new),
+                applied_devcontainer: None,
             };
             preflight_start_target(&be, &cfg, &start_opts)?;
-            let cli_env_keys = guest_env.iter().map(|(k, _)| k.clone()).collect();
-            let inputs = devcontainer::TranslatorInputs {
-                cli_vcpus: vcpus,
-                cli_mem_mib: mem,
-                cli_disk_gib: disk,
-                cli_post_start: post_start.clone(),
-                cli_guest_env_keys: cli_env_keys,
-                cli_forward_ports: start_opts.forward_ports.clone(),
-                cli_mounts: start_opts.mounts.clone(),
-                persisted_guest_user: Some(backend::persisted_guest_user(&cfg, &image)),
-                cli_workspace_or_git_repo: workspace.is_some() || git_repo.is_some(),
-                ..devcontainer::TranslatorInputs::default()
-            };
-            let ws_path = workspace.as_deref().map(Path::new);
-            let translation = resolve_devcontainer(
-                &DevcontainerOpts {
-                    explicit_path: devcontainer.as_deref().map(Path::new),
-                    no_devcontainer,
-                    dry_run,
-                    workspace: ws_path,
-                    mounts: &start_opts.mounts,
-                    git_repo: git_repo.as_deref(),
-                    github_auth: cfg.github.as_ref(),
-                },
-                &inputs,
-                devcontainer::Stage::Start,
-            )?;
-            if dry_run {
-                return Ok(());
-            }
-            // CLI flags are applied first; the translation only carries
-            // values that survived the "CLI > devcontainer.json" precedence
-            // check inside `translate`, so the two cannot fight here.
             apply_vm_overrides(&mut cfg, vcpus, mem, None)?;
-            if let Some(t) = &translation {
-                devcontainer::apply_to_config(&mut cfg, t)?;
-                start_opts.forward_ports = devcontainer::merge_into_forward_ports(
-                    &t.forward_ports,
-                    &start_opts.forward_ports,
-                );
-            }
-            let default_translation = devcontainer::Translation::default();
-            start_opts.disk = devcontainer::effective_disk(
-                disk,
-                translation.as_ref().unwrap_or(&default_translation),
-            );
-            let dc_post_start = (post_start.is_none())
-                .then(|| translation.as_ref().and_then(|t| t.post_start.clone()))
-                .flatten();
-            start_opts.post_start_override = post_start.as_deref().or(dc_post_start.as_deref());
-            // `--mount` and devcontainer `mounts` aren't combined: --mount is
-            // a complete replacement of the mount set (its `conflicts_with`
-            // rules with --workspace/--git-repo encode this). The CLI-wins
-            // outcome is reported by `translate`.
-            if start_opts.mounts.is_empty() {
-                start_opts.mounts = translation
-                    .as_ref()
-                    .map(|t| t.mounts.clone())
-                    .unwrap_or_default();
-            }
-            apply_runtime_guest_env(
-                &mut cfg,
-                &guest_env,
-                translation.as_ref().map(|t| &t.guest_env),
-                &mut start_opts,
-            );
+            apply_runtime_guest_env(&mut cfg, &guest_env, None, &mut start_opts);
             cmd_start(&be, &mut cfg, &validated, &start_opts).map(|_| ())
         }
         Commands::Shell { name, command } => cmd_shell(&be, &cfg, name.as_ref(), &command),
@@ -1407,6 +1344,7 @@ fn cmd_up(
         ensure_up_project_name_matches(&inst, &project_dir, opts)?;
         ensure_up_existing_inputs_are_compatible(&inst, transport, opts)?;
         if be.is_running(&inst) {
+            devcontainer::warn_if_applied_devcontainer_changed(&inst);
             reject_running_up_restart_inputs(&inst, opts)?;
             tracing::info!(
                 "Instance '{}' is already running for {}",
@@ -1553,6 +1491,7 @@ fn create_up_instance(
         post_start_override: post_start_override.as_deref(),
         persisted_guest_env,
         devcontainer_path: None,
+        applied_devcontainer: translation.as_ref().and_then(|t| t.applied.clone()),
     };
 
     allocate_and_start(
@@ -1632,6 +1571,7 @@ fn runtime_start_opts_from_up<'a>(opts: &'a UpOpts<'_>, config_path: &'a Path) -
         post_start_override: opts.runtime.post_start.as_deref(),
         persisted_guest_env: std::collections::BTreeMap::new(),
         devcontainer_path: None,
+        applied_devcontainer: None,
     }
 }
 
@@ -1872,6 +1812,7 @@ fn cmd_quickstart(
                     post_start_override: None,
                     persisted_guest_env: std::collections::BTreeMap::new(),
                     devcontainer_path: None,
+                    applied_devcontainer: None,
                 },
             )?
         }
@@ -1977,6 +1918,7 @@ fn quickstart_fresh_start(
         post_start_override: post_start_override.as_deref(),
         persisted_guest_env,
         devcontainer_path: None,
+        applied_devcontainer: translation.as_ref().and_then(|t| t.applied.clone()),
     };
 
     let _ = validated;
@@ -2199,6 +2141,7 @@ fn resolve_devcontainer(
         }
     }
 
+    let source_is_remote = matches!(source, DevcontainerSource::Contents { .. });
     let parsed = match source {
         DevcontainerSource::Path(path) => devcontainer::ParsedDevcontainer::load(&path)?,
         DevcontainerSource::Contents {
@@ -2207,6 +2150,9 @@ fn resolve_devcontainer(
         } => devcontainer::ParsedDevcontainer::from_str(display_path, &contents)?,
     };
     let mut translation = devcontainer::translate(&parsed, inputs, stage);
+    if source_is_remote && let Some(applied) = &mut translation.applied {
+        applied.source = devcontainer::AppliedDevcontainerSource::RemoteContents;
+    }
     translation.report.ignored_paths = losers;
     resolve_oci_feature_requests(&mut translation);
 
@@ -2372,6 +2318,9 @@ struct StartOpts<'a> {
     /// translation before this struct is built; normal `start` only uses this
     /// marker to reject silently ignored creation options on restart.
     devcontainer_path: Option<&'a Path>,
+    /// Devcontainer path/hash that was applied to a newly-created instance.
+    /// Empty on restarts and when no devcontainer was used.
+    applied_devcontainer: Option<devcontainer::AppliedDevcontainer>,
 }
 
 fn restart_has_ignored_creation_flags(opts: &StartOpts<'_>) -> bool {
@@ -2615,6 +2564,7 @@ fn restart_instance(
     opts: &StartOpts<'_>,
 ) -> Result<()> {
     tracing::info!("Restarting stopped instance '{}'", inst.name);
+    devcontainer::warn_if_applied_devcontainer_changed(inst);
 
     let _guard = signal::install_handlers();
 
@@ -2769,6 +2719,12 @@ fn start_instance(
         entries: opts.persisted_guest_env.clone(),
     }
     .save(inst)?;
+    if let Some(applied) = &opts.applied_devcontainer {
+        devcontainer::DevcontainerState {
+            applied: applied.clone(),
+        }
+        .save(inst)?;
+    }
 
     let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
     if opts.no_agents && post_start.is_none() {
@@ -4260,6 +4216,7 @@ mod tests {
             post_start_override: None,
             persisted_guest_env: std::collections::BTreeMap::new(),
             devcontainer_path: None,
+            applied_devcontainer: None,
         }
     }
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3197,6 +3197,56 @@ test_devcontainer_apply() {
         fail "postStartCommand ran in the guest" "marker contents: '$seen_marker'"
     fi
 
+    cat > "$dcfile" <<'EOF'
+{
+    "name": "coop-it-demo-changed",
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "2GiB"
+    },
+    "containerEnv": {
+        "COOP_TEST_DEVCONTAINER": "changed"
+    },
+    "forwardPorts": [3001],
+    "postStartCommand": "echo changed > /tmp/coop-dc-marker",
+    "remoteUser": "root"
+}
+EOF
+
+    if coop stop "$inst_name"; then
+        pass "stop devcontainer apply instance exits 0"
+    else
+        fail "stop devcontainer apply instance exits 0" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    if coop start --workspace "$dcdir" --no-agents; then
+        pass "start --workspace after devcontainer change exits 0"
+    else
+        fail "start --workspace after devcontainer change exits 0" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+    if grep -q "devcontainer.json changed" <<< "$HARNESS_ERR" \
+        && grep -q "Destroy and recreate" <<< "$HARNESS_ERR" \
+        && grep -q "features, hostRequirements, mounts" <<< "$HARNESS_ERR" \
+        && grep -q "not re-applied automatically" <<< "$HARNESS_ERR"; then
+        pass "changed devcontainer warning is informational"
+    else
+        fail "changed devcontainer warning is informational" "stderr: $HARNESS_ERR"
+    fi
+
+    seen_env=$(guest_exec printenv COOP_TEST_DEVCONTAINER 2>/dev/null) || seen_env=""
+    if [[ "$seen_env" == "applied" ]]; then
+        pass "changed containerEnv is not re-applied on restart"
+    else
+        fail "changed containerEnv is not re-applied on restart" "got: '$seen_env'"
+    fi
+
+    seen_marker=$(guest_exec cat /tmp/coop-dc-marker 2>/dev/null) || seen_marker=""
+    if [[ "$seen_marker" != *changed* ]]; then
+        pass "changed postStartCommand is not re-applied on restart"
+    else
+        fail "changed postStartCommand is not re-applied on restart" "marker contents: '$seen_marker'"
+    fi
+
     unset GUEST_INSTANCE
 
     coop destroy "$inst_name" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Persist the local devcontainer path, content hash, and source metadata applied when creating a VM
- Warn on later `coop up` reconnects and `coop start` restarts when the recorded local file changes or disappears, without mutating the existing VM
- Stop normal `coop start` restarts from re-reading/re-applying discovered devcontainer files; keep `start --dry-run` translation behavior
- Document the recreate guidance and extend integration coverage for `start --workspace` after a changed devcontainer

Closes #237
Part of #27

## Review

Critical subagent review completed. Initial findings fixed: `coop start --workspace` no longer applies current devcontainer contents or fails on non-TTY discovery during normal restart. Re-review returned no findings.

## Tests

- `cargo fmt`
- `cargo check`
- `cargo test devcontainer`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `cargo build --release`
- Targeted VM smoke test: create with devcontainer, mutate file, `coop start --workspace`, verify warning, env remains old value, changed postStartCommand does not run
- `tests/run-integration.sh --full --name issue237-devcontainer-change` reached and passed the issue 237 devcontainer apply/restart assertion; overall run had 252 passed, 1 failed, 2 skipped due an unrelated builder VM failure where the Claude native installer was killed during custom-profile setup