### PR TITLE
Persist devcontainer opt-out per project

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,7 +59,7 @@ on Linux/Firecracker it is a one-time sync.
 | `--post-start <cmd>` | Shell command to run inside the guest after boot |
 | `--env KEY=VALUE` | Literal env var to set in the guest (repeatable) |
 | `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt) |
-| `--no-devcontainer` | Ignore any discovered `devcontainer.json` |
+| `--no-devcontainer` | Ignore any discovered `devcontainer.json` for this invocation |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work |
 
 ```
@@ -121,7 +121,7 @@ coop setup [FLAGS]
 | `--guest-user <name>` | Guest username to bake into the image (default: `ubuntu`). Use this for devcontainers that declare another `remoteUser`, such as `vscode`. |
 | `--workspace <dir>` | Scan for `.devcontainer/devcontainer.json` and offer to apply its `features` / `hostRequirements` to this setup. Supported public `ghcr.io/devcontainers/features/*` entries are resolved and baked into the image. |
 | `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt). |
-| `--no-devcontainer` | Ignore any discovered `devcontainer.json`. |
+| `--no-devcontainer` | Ignore any discovered `devcontainer.json` for this invocation. |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any setup work. |
 
 ```
@@ -157,6 +157,30 @@ coop devcontainer check <path> [--stage setup|start|both]
 
 Use `--stage setup` to inspect setup-time keys such as `features`, `hostRequirements.cpus`, `hostRequirements.memory`, and `remoteUser`. Use `--stage start` to inspect start-time keys such as `postStartCommand`, `containerEnv`, `forwardPorts`, `mounts`, and `hostRequirements.storage`.
 
+### `devcontainer ignore`
+
+Record a persistent opt-out for a project directory. Future automatic discovery for that project skips `.devcontainer/devcontainer.json` and reports that the stored preference was used. Explicit `--devcontainer <path>` still applies a file for that run.
+
+```
+coop devcontainer ignore <project-dir>
+```
+
+### `devcontainer status`
+
+Inspect persistent devcontainer opt-outs. With no project argument, this lists all stored opt-outs.
+
+```
+coop devcontainer status [project-dir]
+```
+
+### `devcontainer clear`
+
+Remove a persistent devcontainer opt-out for a project. If the project directory was moved or deleted, use the absolute path shown by `coop devcontainer status`.
+
+```
+coop devcontainer clear <project-dir>
+```
+
 ### `start`
 
 Restart a stopped VM.
@@ -187,7 +211,7 @@ instances, pass the instance name.
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
 | `--env KEY=VALUE` | Literal env var to set in the guest (repeatable). Overrides `guest_env` config entries and any forwarded values with the same name. |
 | `--devcontainer <path>` | Dry-run translation aid; normal restarts reject devcontainer creation options. |
-| `--no-devcontainer` | Ignore any discovered `devcontainer.json` (escape hatch for CI). |
+| `--no-devcontainer` | Ignore any discovered `devcontainer.json` for this invocation (escape hatch for CI). |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work. |
 
 Normal `start` restarts an existing VM without re-reading or re-applying

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -4,7 +4,7 @@ coop reads a **subset** of [devcontainer.json](https://containers.dev/) and maps
 
 ## How discovery and apply work
 
-When you run `coop up <dir>` or `coop setup --workspace <dir>`, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each mount host root, with the project directory winning ties). For `--git-repo` creation flows, coop can discover `.devcontainer/devcontainer.json` from common GitHub repository URLs before creating the VM.
+When you run `coop up <dir>`, `coop setup --workspace <dir>`, or a fresh `coop quickstart` for the current directory, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each mount host root, with the project directory winning ties). For `--git-repo` creation flows, coop can discover `.devcontainer/devcontainer.json` from common GitHub repository URLs before creating the VM. `coop start --dry-run --workspace <dir>` also uses discovery as a translation preview; normal `coop start` only restarts stopped instances and does not create a VM or re-apply devcontainer changes.
 
 If a file is found, coop prompts:
 
@@ -21,11 +21,30 @@ When a local `devcontainer.json` is applied while creating a VM, coop records th
 For CI or scripted use, pass one of:
 
 - `--devcontainer <path>` — use this specific file, skip the prompt
-- `--no-devcontainer` — ignore any discovered file
+- `--no-devcontainer` — ignore any discovered file for this invocation
 - `--dry-run` — print the report and exit before any VM work
 - `coop devcontainer check <path>` — print setup/start translation reports for a file without loading coop config or touching VM state
 
 A non-TTY invocation that discovers a `devcontainer.json` without any of these flags errors out rather than silently choosing. For `--git-repo`, remote discovery is best-effort and currently limited to GitHub URLs that resolve to `owner/repo`; unsupported hosts continue without devcontainer translation unless you pass an explicit local `--devcontainer <path>`.
+
+## Persistent project opt-outs
+
+If a project has a `devcontainer.json` that you do not want coop to read, record an explicit opt-out:
+
+```
+coop devcontainer ignore <project-dir>
+```
+
+Future discovery for that project skips the file and prints a message explaining that the stored opt-out was used. `--devcontainer <path>` still applies an explicit file for a single run, and `--no-devcontainer` remains a non-persistent escape hatch.
+
+Inspect and clear stored opt-outs with:
+
+```
+coop devcontainer status [project-dir]
+coop devcontainer clear <project-dir>
+```
+
+`status` lists the stored absolute project path. If the original directory was moved or deleted, pass that listed path to `clear`.
 
 ## Precedence
 
@@ -64,5 +83,4 @@ Treat Feature install scripts as untrusted project-provided code. The report pri
 
 - OCI feature registries other than public `ghcr.io/devcontainers/features/*`
 - `--git-repo` auto-detection for non-GitHub hosts
-- Sticky `--no-devcontainer` (persistent per-workspace state)
 - Live re-application on an existing VM (destroy + `coop up` to pick up changes)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1827,6 +1827,11 @@ impl CoopConfig {
         self.data_dir.join("instances")
     }
 
+    /// Path to per-project devcontainer discovery preferences.
+    pub fn devcontainer_preferences_path(&self) -> PathBuf {
+        self.data_dir.join("devcontainer_preferences.json")
+    }
+
     /// List all existing instances, sorted by index.
     pub fn list_instances(&self) -> Result<Vec<Instance>> {
         let dir = self.instances_dir();

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -29,6 +29,94 @@ use crate::sha256_hash::Sha256Hash;
 /// Default relative path coop looks for inside a workspace or mount root.
 pub const DEFAULT_DEVCONTAINER_REL_PATH: &str = ".devcontainer/devcontainer.json";
 
+// ── Per-project preferences ──────────────────────────────────
+
+/// Stored devcontainer discovery preference for one project directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectDevcontainerPreference {
+    /// Explicit user opt-out. Missing entries mean "ask/apply normally".
+    #[serde(default)]
+    pub ignore: bool,
+}
+
+/// Persistent project preferences keyed by canonical host project path.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DevcontainerPreferences {
+    #[serde(default)]
+    pub projects: BTreeMap<String, ProjectDevcontainerPreference>,
+}
+
+impl DevcontainerPreferences {
+    pub fn load(path: &Path) -> Result<Self> {
+        match fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {}", path.display())),
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => {
+                Err(anyhow::Error::new(e).context(format!("Failed to read {}", path.display())))
+            }
+        }
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if self.projects.is_empty() {
+            if path.exists() {
+                fs::remove_file(path)
+                    .with_context(|| format!("Failed to remove {}", path.display()))?;
+            }
+            return Ok(());
+        }
+        let json = serde_json::to_string_pretty(self)
+            .context("Failed to serialize devcontainer preferences")?;
+        crate::fs_util::atomic_write_json(path, &json)
+            .with_context(|| format!("Failed to write {}", path.display()))
+    }
+
+    pub fn set_ignored(&mut self, project: &Path) -> Result<String> {
+        let key = project_preference_key(project)?;
+        self.projects
+            .insert(key.clone(), ProjectDevcontainerPreference { ignore: true });
+        Ok(key)
+    }
+
+    pub fn clear(&mut self, project: &Path) -> Result<bool> {
+        let key = project_preference_lookup_key(project)?;
+        Ok(self.projects.remove(&key).is_some())
+    }
+
+    pub fn ignored_project(&self, project: &Path) -> Result<Option<&str>> {
+        let key = project_preference_lookup_key(project)?;
+        Ok(self
+            .projects
+            .get_key_value(&key)
+            .and_then(|(k, pref)| pref.ignore.then_some(k.as_str())))
+    }
+
+    pub fn ignored_projects(&self) -> impl Iterator<Item = &str> {
+        self.projects
+            .iter()
+            .filter_map(|(project, pref)| pref.ignore.then_some(project.as_str()))
+    }
+}
+
+pub fn project_preference_key(project: &Path) -> Result<String> {
+    let canonical = project.canonicalize().with_context(|| {
+        format!(
+            "Failed to resolve project directory {} for devcontainer preference",
+            project.display()
+        )
+    })?;
+    Ok(canonical.to_string_lossy().into_owned())
+}
+
+pub fn project_preference_lookup_key(project: &Path) -> Result<String> {
+    match project_preference_key(project) {
+        Ok(key) => Ok(key),
+        Err(_) if project.is_absolute() => Ok(project.to_string_lossy().into_owned()),
+        Err(e) => Err(e),
+    }
+}
+
 // ── Parsing ──────────────────────────────────────────────────
 
 /// Convert JSONC (`//`, `/* */`, trailing commas) to plain JSON.
@@ -2149,5 +2237,55 @@ mod tests {
         };
 
         assert!(state.changed_warning("demo").unwrap().is_none());
+    }
+
+    #[test]
+    fn devcontainer_preferences_round_trip_and_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir(&project).unwrap();
+        let path = dir.path().join("prefs.json");
+
+        let mut prefs = DevcontainerPreferences::default();
+        let key = prefs.set_ignored(&project).unwrap();
+        prefs.save(&path).unwrap();
+
+        let loaded = DevcontainerPreferences::load(&path).unwrap();
+        assert_eq!(
+            loaded.ignored_project(&project).unwrap(),
+            Some(key.as_str())
+        );
+        assert_eq!(loaded.ignored_projects().collect::<Vec<_>>(), vec![key]);
+
+        let mut loaded = loaded;
+        assert!(loaded.clear(&project).unwrap());
+        loaded.save(&path).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn devcontainer_preferences_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.json");
+        let prefs = DevcontainerPreferences::load(&path).unwrap();
+        assert!(prefs.ignored_projects().next().is_none());
+    }
+
+    #[test]
+    fn devcontainer_preferences_clear_deleted_project_by_stored_absolute_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir(&project).unwrap();
+
+        let mut prefs = DevcontainerPreferences::default();
+        let key = prefs.set_ignored(&project).unwrap();
+        fs::remove_dir(&project).unwrap();
+
+        assert_eq!(
+            prefs.ignored_project(Path::new(&key)).unwrap(),
+            Some(key.as_str())
+        );
+        assert!(prefs.clear(Path::new(&key)).unwrap());
+        assert!(prefs.ignored_projects().next().is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,6 +636,21 @@ enum DevcontainerCommands {
         #[arg(long, value_enum, default_value_t = DevcontainerCheckStage::Both)]
         stage: DevcontainerCheckStage,
     },
+    /// Persistently ignore discovered devcontainer.json for a project.
+    Ignore {
+        /// Project directory whose discovered devcontainer.json should be ignored
+        project: PathBuf,
+    },
+    /// Show persistent devcontainer opt-outs.
+    Status {
+        /// Project directory to inspect; omitted lists every stored opt-out
+        project: Option<PathBuf>,
+    },
+    /// Clear a persistent devcontainer opt-out for a project.
+    Clear {
+        /// Project directory whose opt-out should be cleared
+        project: PathBuf,
+    },
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -751,8 +766,10 @@ fn main() -> Result<()> {
         );
     }
 
-    if let Commands::Devcontainer { ref command } = cli.command {
-        return cmd_devcontainer(command);
+    if let Commands::Devcontainer { ref command } = cli.command
+        && matches!(command, DevcontainerCommands::Check { .. })
+    {
+        return cmd_devcontainer_check(command);
     }
 
     let mut cfg = config::CoopConfig::load(&cli.config)?;
@@ -880,6 +897,7 @@ fn main() -> Result<()> {
                     mounts: &[],
                     git_repo: None,
                     github_auth: cfg.github.as_ref(),
+                    preference_path: Some(&cfg.devcontainer_preferences_path()),
                 },
                 &inputs,
                 devcontainer::Stage::Setup,
@@ -930,7 +948,7 @@ fn main() -> Result<()> {
             let validated = cfg.validate_and_warn()?;
             cmd_build(&cfg, &validated)
         }
-        Commands::Devcontainer { .. } => unreachable!("handled before config load"),
+        Commands::Devcontainer { command } => cmd_devcontainer(&cfg, &command),
         Commands::Start {
             name,
             profile,
@@ -989,6 +1007,7 @@ fn main() -> Result<()> {
                         mounts: &mounts,
                         git_repo: git_repo.as_deref(),
                         github_auth: cfg.github.as_ref(),
+                        preference_path: Some(&cfg.devcontainer_preferences_path()),
                     },
                     &inputs,
                     devcontainer::Stage::Start,
@@ -1333,6 +1352,7 @@ fn cmd_up(
                 mounts: discovery_mounts,
                 git_repo: None,
                 github_auth: cfg.github.as_ref(),
+                preference_path: Some(&cfg.devcontainer_preferences_path()),
             },
             &inputs,
             devcontainer::Stage::Start,
@@ -1420,6 +1440,7 @@ fn create_up_instance(
             mounts: discovery_mounts,
             git_repo: None,
             github_auth: cfg.github.as_ref(),
+            preference_path: Some(&cfg.devcontainer_preferences_path()),
         },
         &inputs,
         devcontainer::Stage::Start,
@@ -1860,6 +1881,7 @@ fn quickstart_fresh_start(
             mounts: &[],
             git_repo: None,
             github_auth: cfg.github.as_ref(),
+            preference_path: Some(&cfg.devcontainer_preferences_path()),
         },
         &inputs,
         devcontainer::Stage::Start,
@@ -2042,6 +2064,7 @@ struct DevcontainerOpts<'a> {
     mounts: &'a [config::Mount],
     git_repo: Option<&'a str>,
     github_auth: Option<&'a config::GitHubAuth>,
+    preference_path: Option<&'a Path>,
 }
 
 enum DevcontainerSource {
@@ -2050,6 +2073,58 @@ enum DevcontainerSource {
         display_path: PathBuf,
         contents: String,
     },
+}
+
+fn discovered_local_devcontainer(opts: &DevcontainerOpts<'_>, source: &DevcontainerSource) -> bool {
+    opts.explicit_path.is_none() && matches!(source, DevcontainerSource::Path(_))
+}
+
+fn maybe_skip_stored_devcontainer_opt_out(
+    opts: &DevcontainerOpts<'_>,
+    source: &DevcontainerSource,
+    display_path: &Path,
+) -> Result<bool> {
+    if !discovered_local_devcontainer(opts, source) {
+        return Ok(false);
+    }
+    let (Some(preference_path), Some(project)) = (opts.preference_path, opts.workspace) else {
+        return Ok(false);
+    };
+    let preferences = devcontainer::DevcontainerPreferences::load(preference_path)?;
+    let Some(project_key) = preferences.ignored_project(project)? else {
+        return Ok(false);
+    };
+
+    let mut stderr = std::io::stderr();
+    writeln!(
+        stderr,
+        "Skipping {} because a stored devcontainer opt-out is set for project {}.\n\
+         Run `coop devcontainer clear {}` to re-enable discovery, or pass --devcontainer {} to apply this file once.",
+        display_path.display(),
+        project_key,
+        project_key,
+        display_path.display(),
+    )
+    .context("Failed to write devcontainer opt-out message")?;
+    Ok(true)
+}
+
+fn maybe_record_devcontainer_opt_out(opts: &DevcontainerOpts<'_>, project: &Path) -> Result<()> {
+    let Some(preference_path) = opts.preference_path else {
+        return Ok(());
+    };
+    if !prompt::confirm(&format!(
+        "Always ignore devcontainer.json for project {}?",
+        project.display()
+    ))? {
+        return Ok(());
+    }
+
+    let mut preferences = devcontainer::DevcontainerPreferences::load(preference_path)?;
+    let project_key = preferences.set_ignored(project)?;
+    preferences.save(preference_path)?;
+    tracing::info!("Recorded persistent devcontainer opt-out for project {project_key}");
+    Ok(())
 }
 
 /// Discover, prompt, and translate a `devcontainer.json` for the given
@@ -2100,6 +2175,10 @@ fn resolve_devcontainer(
         DevcontainerSource::Contents { display_path, .. } => display_path,
     };
 
+    if maybe_skip_stored_devcontainer_opt_out(opts, &source, display_path)? {
+        return Ok(None);
+    }
+
     // When discovery (not an explicit flag) found the file, defer to the
     // user. CI/scripted callers must pass --devcontainer or --no-devcontainer.
     if opts.explicit_path.is_none() && !opts.dry_run {
@@ -2127,11 +2206,16 @@ fn resolve_devcontainer(
         ))?;
         if !answer {
             match &source {
-                DevcontainerSource::Path(_) => tracing::info!(
-                    "Skipping {}. Re-run with --devcontainer {} to apply it later.",
-                    display_path.display(),
-                    display_path.display()
-                ),
+                DevcontainerSource::Path(_) => {
+                    tracing::info!(
+                        "Skipping {}. Re-run with --devcontainer {} to apply it later.",
+                        display_path.display(),
+                        display_path.display()
+                    );
+                    if let Some(project) = opts.workspace {
+                        maybe_record_devcontainer_opt_out(opts, project)?;
+                    }
+                }
                 DevcontainerSource::Contents { .. } => tracing::info!(
                     "Skipping {}. Re-run interactively to apply it later.",
                     display_path.display()
@@ -2203,7 +2287,7 @@ fn resolve_oci_feature_requests(translation: &mut devcontainer::Translation) {
     clippy::print_stderr,
     reason = "devcontainer check report is intentional user-facing CLI output"
 )]
-fn cmd_devcontainer(command: &DevcontainerCommands) -> Result<()> {
+fn cmd_devcontainer_check(command: &DevcontainerCommands) -> Result<()> {
     match command {
         DevcontainerCommands::Check { path, stage } => {
             let opts = DevcontainerOpts {
@@ -2214,6 +2298,7 @@ fn cmd_devcontainer(command: &DevcontainerCommands) -> Result<()> {
                 mounts: &[],
                 git_repo: None,
                 github_auth: None,
+                preference_path: None,
             };
             let setup_inputs = devcontainer::TranslatorInputs::default();
 
@@ -2242,6 +2327,85 @@ fn cmd_devcontainer(command: &DevcontainerCommands) -> Result<()> {
                     eprintln!("start-stage translation:");
                     resolve_devcontainer(&opts, &start_inputs, devcontainer::Stage::Start)?;
                 }
+            }
+            Ok(())
+        }
+        DevcontainerCommands::Ignore { .. }
+        | DevcontainerCommands::Status { .. }
+        | DevcontainerCommands::Clear { .. } => {
+            unreachable!("devcontainer preference commands require config")
+        }
+    }
+}
+
+fn cmd_devcontainer(cfg: &config::CoopConfig, command: &DevcontainerCommands) -> Result<()> {
+    let preference_path = cfg.devcontainer_preferences_path();
+    match command {
+        DevcontainerCommands::Check { .. } => cmd_devcontainer_check(command),
+        DevcontainerCommands::Ignore { project } => {
+            let mut preferences = devcontainer::DevcontainerPreferences::load(&preference_path)?;
+            let project_key = preferences.set_ignored(project)?;
+            preferences.save(&preference_path)?;
+            let mut stdout = std::io::stdout();
+            writeln!(
+                stdout,
+                "Devcontainer discovery disabled for project {project_key}"
+            )
+            .context("Failed to write devcontainer ignore status")?;
+            Ok(())
+        }
+        DevcontainerCommands::Status { project } => {
+            let preferences = devcontainer::DevcontainerPreferences::load(&preference_path)?;
+            let mut stdout = std::io::stdout();
+            if let Some(project) = project {
+                if let Some(project_key) = preferences.ignored_project(project)? {
+                    writeln!(
+                        stdout,
+                        "Devcontainer discovery disabled for project {project_key}"
+                    )
+                    .context("Failed to write devcontainer status")?;
+                } else {
+                    let project_key = devcontainer::project_preference_lookup_key(project)?;
+                    writeln!(
+                        stdout,
+                        "Devcontainer discovery enabled for project {project_key}"
+                    )
+                    .context("Failed to write devcontainer status")?;
+                }
+            } else {
+                let ignored: Vec<_> = preferences.ignored_projects().collect();
+                if ignored.is_empty() {
+                    writeln!(stdout, "No persistent devcontainer opt-outs recorded.")
+                        .context("Failed to write devcontainer status")?;
+                } else {
+                    writeln!(stdout, "Persistent devcontainer opt-outs:")
+                        .context("Failed to write devcontainer status")?;
+                    for project in ignored {
+                        writeln!(stdout, "  {project}")
+                            .context("Failed to write devcontainer status")?;
+                    }
+                }
+            }
+            Ok(())
+        }
+        DevcontainerCommands::Clear { project } => {
+            let mut preferences = devcontainer::DevcontainerPreferences::load(&preference_path)?;
+            let project_key = devcontainer::project_preference_lookup_key(project)?;
+            let removed = preferences.clear(project)?;
+            preferences.save(&preference_path)?;
+            let mut stdout = std::io::stdout();
+            if removed {
+                writeln!(
+                    stdout,
+                    "Cleared devcontainer opt-out for project {project_key}"
+                )
+                .context("Failed to write devcontainer clear status")?;
+            } else {
+                writeln!(
+                    stdout,
+                    "No persistent devcontainer opt-out recorded for project {project_key}"
+                )
+                .context("Failed to write devcontainer clear status")?;
             }
             Ok(())
         }
@@ -4556,7 +4720,9 @@ mod tests {
         let super::Commands::Devcontainer { command } = cli.command else {
             panic!("expected Devcontainer variant");
         };
-        let super::DevcontainerCommands::Check { path, stage } = command;
+        let super::DevcontainerCommands::Check { path, stage } = command else {
+            panic!("expected devcontainer check variant");
+        };
         assert_eq!(
             path,
             std::path::PathBuf::from(".devcontainer/devcontainer.json")
@@ -4576,8 +4742,55 @@ mod tests {
         let super::Commands::Devcontainer { command } = cli.command else {
             panic!("expected Devcontainer variant");
         };
-        let super::DevcontainerCommands::Check { stage, .. } = command;
+        let super::DevcontainerCommands::Check { stage, .. } = command else {
+            panic!("expected devcontainer check variant");
+        };
         assert!(matches!(stage, super::DevcontainerCheckStage::Start));
+    }
+
+    #[test]
+    fn devcontainer_ignore_subcommand_parses() {
+        let cli = parse(&["devcontainer", "ignore", "."]);
+        let super::Commands::Devcontainer { command } = cli.command else {
+            panic!("expected Devcontainer variant");
+        };
+        let super::DevcontainerCommands::Ignore { project } = command else {
+            panic!("expected devcontainer ignore variant");
+        };
+        assert_eq!(project, std::path::PathBuf::from("."));
+    }
+
+    #[test]
+    fn devcontainer_status_subcommand_parses_optional_project() {
+        let cli = parse(&["devcontainer", "status"]);
+        let super::Commands::Devcontainer { command } = cli.command else {
+            panic!("expected Devcontainer variant");
+        };
+        let super::DevcontainerCommands::Status { project } = command else {
+            panic!("expected devcontainer status variant");
+        };
+        assert!(project.is_none());
+
+        let cli = parse(&["devcontainer", "status", "."]);
+        let super::Commands::Devcontainer { command } = cli.command else {
+            panic!("expected Devcontainer variant");
+        };
+        let super::DevcontainerCommands::Status { project } = command else {
+            panic!("expected devcontainer status variant");
+        };
+        assert_eq!(project, Some(std::path::PathBuf::from(".")));
+    }
+
+    #[test]
+    fn devcontainer_clear_subcommand_parses() {
+        let cli = parse(&["devcontainer", "clear", "."]);
+        let super::Commands::Devcontainer { command } = cli.command else {
+            panic!("expected Devcontainer variant");
+        };
+        let super::DevcontainerCommands::Clear { project } = command else {
+            panic!("expected devcontainer clear variant");
+        };
+        assert_eq!(project, std::path::PathBuf::from("."));
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3127,6 +3127,104 @@ EOF
         fail "--no-devcontainer suppresses discovery" "exit code: $? stderr: $HARNESS_ERR"
     fi
 
+    local pref_cfg="$tmpdir/devcontainer-pref-config.toml"
+    local pref_data="$tmpdir/devcontainer-pref-data"
+    mkdir -p "$pref_data"
+    cat > "$pref_cfg" <<EOF
+data_dir = "$pref_data"
+EOF
+
+    if coop --config "$pref_cfg" devcontainer ignore "$dcdir"; then
+        pass "devcontainer ignore records persistent opt-out"
+    else
+        fail "devcontainer ignore records persistent opt-out" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    if coop --config "$pref_cfg" devcontainer status "$dcdir" \
+        && grep -q "disabled" <<< "$HARNESS_OUT" \
+        && grep -q "$dcdir" <<< "$HARNESS_OUT"; then
+        pass "devcontainer status reports project opt-out"
+    else
+        fail "devcontainer status reports project opt-out" "stdout: $HARNESS_OUT stderr: $HARNESS_ERR"
+    fi
+
+    if coop --config "$pref_cfg" up "$dcdir" --name "${INSTANCE}-dc-pref" \
+        --dry-run --no-agents; then
+        if grep -q "stored opt-out" <<< "$HARNESS_ERR" \
+            && ! grep -q "devcontainer.json:" <<< "$HARNESS_ERR"; then
+            pass "stored devcontainer opt-out skips discovery"
+        else
+            fail "stored devcontainer opt-out skips discovery" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "stored devcontainer opt-out skips discovery" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    if coop --config "$pref_cfg" setup --workspace "$dcdir" --dry-run; then
+        if grep -q "stored opt-out" <<< "$HARNESS_ERR" \
+            && ! grep -q "setup-stage translation" <<< "$HARNESS_ERR"; then
+            pass "stored devcontainer opt-out skips setup --workspace dry-run discovery"
+        else
+            fail "stored devcontainer opt-out skips setup --workspace dry-run discovery" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "stored devcontainer opt-out skips setup --workspace dry-run discovery" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    if coop --config "$pref_cfg" start --workspace "$dcdir" --dry-run; then
+        if grep -q "stored opt-out" <<< "$HARNESS_ERR" \
+            && ! grep -q "start-stage translation" <<< "$HARNESS_ERR"; then
+            pass "stored devcontainer opt-out skips start --workspace dry-run discovery"
+        else
+            fail "stored devcontainer opt-out skips start --workspace dry-run discovery" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "stored devcontainer opt-out skips start --workspace dry-run discovery" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    if coop --config "$pref_cfg" up "$dcdir" --name "${INSTANCE}-dc-pref-explicit" \
+        --devcontainer "$dcfile" --dry-run --no-agents; then
+        if grep -q "devcontainer.json:" <<< "$HARNESS_ERR"; then
+            pass "explicit --devcontainer bypasses stored opt-out"
+        else
+            fail "explicit --devcontainer bypasses stored opt-out" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "explicit --devcontainer bypasses stored opt-out" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    if coop --config "$pref_cfg" devcontainer clear "$dcdir"; then
+        pass "devcontainer clear removes persistent opt-out"
+    else
+        fail "devcontainer clear removes persistent opt-out" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+
+    local stale_ws
+    stale_ws=$(mktemp -d "$tmpdir/devcontainer-stale-XXXXXX")
+    _write_devcontainer "$stale_ws"
+    if coop --config "$pref_cfg" devcontainer ignore "$stale_ws"; then
+        rm -rf "$stale_ws"
+        if coop --config "$pref_cfg" devcontainer clear "$stale_ws" \
+            && grep -q "Cleared devcontainer opt-out" <<< "$HARNESS_OUT"; then
+            pass "devcontainer clear removes stale deleted-project opt-out"
+        else
+            fail "devcontainer clear removes stale deleted-project opt-out" "stdout: $HARNESS_OUT stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "devcontainer clear removes stale deleted-project opt-out" "ignore failed: $HARNESS_ERR"
+    fi
+
+    if moat_fails --config "$pref_cfg" up "$dcdir" --name "${INSTANCE}-dc-pref-cleared" --no-agents; then
+        if grep -qi "devcontainer" <<< "$HARNESS_ERR" \
+            && grep -q -- "--no-devcontainer" <<< "$HARNESS_ERR"; then
+            pass "cleared devcontainer opt-out restores non-TTY prompt error"
+        else
+            fail "cleared devcontainer opt-out restores non-TTY prompt error" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "cleared devcontainer opt-out restores non-TTY prompt error" "expected non-zero exit"
+    fi
+
     # Non-interactive + discovered file + no escape hatch must error with the
     # hint pointing at --devcontainer / --no-devcontainer.
     if moat_fails up "$dcdir" --name "${INSTANCE}-dc-noopt" --no-agents; then


### PR DESCRIPTION
## Summary

- Add persistent per-project devcontainer opt-outs stored under coop data, with `coop devcontainer ignore/status/clear` for inspection and cleanup
- Keep `--no-devcontainer` as a one-shot escape hatch and let explicit `--devcontainer <path>` bypass stored opt-outs
- Report when a stored opt-out skips discovery, including the clear command to re-enable it
- Document the new workflow and extend integration coverage for up/setup/start dry-run discovery paths plus stale deleted-project cleanup

Closes #236
Part of #27

## Review

Critical subagent review completed before PR. Findings fixed: deleted/moved project opt-outs can be cleared by their listed absolute path; setup/start dry-run integration coverage added; discovery docs now distinguish fresh quickstart and start dry-run from normal start restarts. Quickstart has no dry-run and was not added to pre-VM integration to avoid starting or setting up VMs during that phase.

## Tests

- `cargo fmt --check`
- `bash -n tests/integration.sh`
- `cargo test devcontainer_preferences`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `cargo test`
- `cargo build`
- Direct no-VM smoke test with `target/debug/coop` covering ignore/status/up --dry-run/setup --dry-run/start --dry-run/explicit --devcontainer/stale clear/clear
