### PR TITLE
Set guest PATH via /etc/environment

### DIFF
--- a/scripts/guest/guest-config.sh
+++ b/scripts/guest/guest-config.sh
@@ -94,9 +94,20 @@ chown -R "${GUEST_USER}:${GUEST_USER}" "${GUEST_HOME}/.ssh"
 chmod 700 "${GUEST_HOME}/.ssh"
 chmod 600 "${GUEST_HOME}/.ssh/authorized_keys"
 
-echo "  [guest] Configuring ${GUEST_USER} user PATH..."
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${GUEST_HOME}/.profile"
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${GUEST_HOME}/.bashrc"
+echo "  [guest] Adding ${GUEST_USER} ~/.local/bin to /etc/environment PATH..."
+# pam_env reads /etc/environment for every SSH session — login, non-login,
+# and non-interactive (`ssh host cmd`) alike — so this is the one layer that
+# reaches `coop claude` (a remote command), its Bash-tool subshells, and VS
+# Code remote sessions. The .profile/.bashrc appends did not: .profile is
+# login-only and the .bashrc line sat below Ubuntu's non-interactive guard.
+# pam_env does no variable expansion, so the home path is baked in literally.
+if ! grep -q "^PATH=\"${GUEST_HOME}/.local/bin:" /etc/environment 2>/dev/null; then
+    if grep -q '^PATH="' /etc/environment 2>/dev/null; then
+        sed -i "s|^PATH=\"|PATH=\"${GUEST_HOME}/.local/bin:|" /etc/environment
+    else
+        echo "PATH=\"${GUEST_HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games\"" >> /etc/environment
+    fi
+fi
 
 echo '  [guest] Symlinking claude into system PATH...'
 ln -sf "${GUEST_HOME}/.local/bin/claude" /usr/local/bin/claude

--- a/scripts/guest/guest-config.sh
+++ b/scripts/guest/guest-config.sh
@@ -101,6 +101,12 @@ echo "  [guest] Adding ${GUEST_USER} ~/.local/bin to /etc/environment PATH..."
 # Code remote sessions. The .profile/.bashrc appends did not: .profile is
 # login-only and the .bashrc line sat below Ubuntu's non-interactive guard.
 # pam_env does no variable expansion, so the home path is baked in literally.
+#
+# /etc/environment is system-wide, so this prepends the guest user's writable
+# ~/.local/bin to PATH for every account, including root. That's safe here:
+# sudo keeps Ubuntu's default secure_path (we set no override), so it ignores
+# ~/.local/bin, and the guest is a single-user dev VM where that user already
+# has passwordless root — there is no privilege boundary to cross.
 if ! grep -q "^PATH=\"${GUEST_HOME}/.local/bin:" /etc/environment 2>/dev/null; then
     if grep -q '^PATH="' /etc/environment 2>/dev/null; then
         sed -i "s|^PATH=\"|PATH=\"${GUEST_HOME}/.local/bin:|" /etc/environment

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -106,9 +106,10 @@ impl GuestUser {
     }
 
     /// Where the Claude Code installer places the per-user binary.
-    /// The installer writes to `~/.local/bin/claude`; coop calls this
-    /// path directly because non-interactive SSH sessions don't source
-    /// `.bashrc`/`.profile` and so don't have `~/.local/bin` on PATH.
+    /// The installer writes to `~/.local/bin/claude`; coop calls this path
+    /// directly as belt-and-braces. (`~/.local/bin` is also on PATH for every
+    /// SSH session via `/etc/environment`, but the absolute path costs nothing
+    /// and removes any dependence on PATH resolution.)
     pub fn claude_bin(&self) -> GuestPath {
         GuestPath::new(format!("/home/{}/.local/bin/claude", self.0))
     }

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1296,9 +1296,20 @@ chown -R "{user}:{user}" "{home}/.ssh"
 chmod 700 "{home}/.ssh"
 chmod 600 "{home}/.ssh/authorized_keys"
 
-echo "  [guest] Configuring {user} user PATH..."
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> "{home}/.profile"
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> "{home}/.bashrc"
+echo "  [guest] Adding {user} ~/.local/bin to /etc/environment PATH..."
+# pam_env reads /etc/environment for every SSH session — login, non-login,
+# and non-interactive (`ssh host cmd`) alike — so this is the one layer that
+# reaches `coop claude` (a remote command), its Bash-tool subshells, and VS
+# Code remote sessions. The .profile/.bashrc appends did not: .profile is
+# login-only and the .bashrc line sat below Ubuntu's non-interactive guard.
+# pam_env does no variable expansion, so the home path is baked in literally.
+if ! grep -q '^PATH="{home}/.local/bin:' /etc/environment 2>/dev/null; then
+    if grep -q '^PATH="' /etc/environment 2>/dev/null; then
+        sed -i 's|^PATH="|PATH="{home}/.local/bin:|' /etc/environment
+    else
+        echo 'PATH="{home}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"' >> /etc/environment
+    fi
+fi
 
 echo '  [guest] Symlinking claude into system PATH...'
 ln -sf "{home}/.local/bin/claude" /usr/local/bin/claude
@@ -1648,6 +1659,30 @@ mod tests {
                 i + 1,
             );
         }
+    }
+
+    #[test]
+    fn provision_script_sets_path_via_etc_environment() {
+        let script = compose_provision_script(
+            "ssh-ed25519 AAAA test@test",
+            &[],
+            &[],
+            &GuestUser::default(),
+        );
+
+        // PATH is set in /etc/environment (pam_env applies it to every SSH
+        // session), with the guest home interpolated as a literal path.
+        assert!(
+            script
+                .contains("sed -i 's|^PATH=\"|PATH=\"/home/ubuntu/.local/bin:|' /etc/environment"),
+            "should prepend ~/.local/bin to /etc/environment PATH",
+        );
+        // The old PATH appends to .profile/.bashrc are gone (see issue #248).
+        assert!(
+            !script.contains(">> \"/home/ubuntu/.profile\"")
+                && !script.contains(">> \"/home/ubuntu/.bashrc\""),
+            "should no longer append PATH to .profile/.bashrc",
+        );
     }
 
     #[test]

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1303,6 +1303,12 @@ echo "  [guest] Adding {user} ~/.local/bin to /etc/environment PATH..."
 # Code remote sessions. The .profile/.bashrc appends did not: .profile is
 # login-only and the .bashrc line sat below Ubuntu's non-interactive guard.
 # pam_env does no variable expansion, so the home path is baked in literally.
+#
+# /etc/environment is system-wide, so this prepends the guest user's writable
+# ~/.local/bin to PATH for every account, including root. That's safe here:
+# sudo keeps Ubuntu's default secure_path (we set no override), so it ignores
+# ~/.local/bin, and the guest is a single-user dev VM where that user already
+# has passwordless root — there is no privilege boundary to cross.
 if ! grep -q '^PATH="{home}/.local/bin:' /etc/environment 2>/dev/null; then
     if grep -q '^PATH="' /etc/environment 2>/dev/null; then
         sed -i 's|^PATH="|PATH="{home}/.local/bin:|' /etc/environment

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -657,8 +657,7 @@ test_claude_bin_path() {
     echo "=== Phase: claude binary path ==="
 
     # The Claude Code binary is installed at /home/ubuntu/.local/bin/claude.
-    # Non-interactive SSH sessions don't source .bashrc/.profile, so bare
-    # `claude` won't work. Verify the full path is reachable via coop exec.
+    # Verify the full path is reachable via coop exec.
     if guest_exec test -x /home/ubuntu/.local/bin/claude; then
         pass "claude binary exists at CLAUDE_BIN path"
     else
@@ -685,6 +684,22 @@ test_claude_bin_path() {
         fi
     else
         fail "claude symlink in /usr/local/bin" "not found"
+    fi
+
+    # Verify ~/.local/bin is on PATH in a non-interactive SSH session — the
+    # exact case `coop claude` and claude's Bash-tool subshells hit (issue
+    # #248). `guest_exec` runs `coop shell -- cmd`, which sshs a bare remote
+    # command (no login shell, no .profile), so this pins the fix in
+    # /etc/environment rather than the old .profile/.bashrc appends.
+    local guest_path
+    if guest_path=$(guest_exec printenv PATH); then
+        if [[ ":$guest_path:" == *":/home/ubuntu/.local/bin:"* ]]; then
+            pass "~/.local/bin on PATH in non-interactive session"
+        else
+            fail "~/.local/bin on PATH in non-interactive session" "PATH=$guest_path"
+        fi
+    else
+        fail "~/.local/bin on PATH in non-interactive session" "printenv PATH failed; stderr: $(guest_stderr)"
     fi
 
     # Verify claude-yolo shortcut exists and is executable


### PR DESCRIPTION
## Problem

`claude doctor` warns that `~/.local/bin` is not on PATH inside coop guests (#248). coop runs claude as a non-interactive, non-login SSH remote command (`ssh guest 'claude ...'`). Such shells source neither `.profile` (login-only) nor the PATH export in `.bashrc` (it sits below Ubuntu's non-interactive guard). Provisioning appended the `~/.local/bin` export to both files, so it never took effect for these sessions — leaving `~/.local/bin` (claude, plus uv/pipx/user tools) off PATH in `coop claude` and every Bash-tool subshell claude spawns.

## Fix

Set PATH in `/etc/environment`. With `UsePAM yes`, sshd runs `pam_env` for every session — login, non-login, and bare command execution alike — so `/etc/environment` reaches remote commands, their subshells, and VS Code remote sessions. `pam_env` does no variable expansion, so the guest home is baked in as a literal path and the existing `PATH="..."` line is rewritten in place (idempotent, with a fallback if no line exists).

Applied to both backends (`src/lima.rs` for Lima, `scripts/guest/guest-config.sh` for Firecracker). The `.profile`/`.bashrc` appends are removed; this also drops the duplicate PATH entry login shells previously got (stock `.profile` already adds `~/.local/bin`) and the dead post-guard `.bashrc` line.

The absolute-path invocation in `src/guest.rs` is kept as belt-and-braces; its comment is updated.

## Tests

- `tests/integration.sh`: asserts a non-interactive session (`coop shell -- printenv PATH`) sees `~/.local/bin` — the exact failing path, so it fails if the fix is reverted.
- `src/lima.rs`: unit test pinning the rendered `/etc/environment` edit and the absence of the old dotfile appends.

Unit suite (695 tests), clippy (`-D warnings`), and fmt pass locally. The integration suite must still be run on **both** platforms (Lima and Firecracker) per CLAUDE.md — not exercisable in this environment.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)