### PR TITLE
Document the quickstart command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -116,7 +116,7 @@ is skipped. Setup runs non-interactively (no confirmation prompts).
 
 | Flag | Description |
 |------|-------------|
-| `--no-workspace` | Skip mounting the current directory as the workspace. Creates a fresh instance with no workspace affinity when no running instance can be reused. |
+| `--no-workspace` | Skip mounting the current directory as the workspace. Without a workspace there is no instance to match, so quickstart always creates a fresh instance rather than reusing an existing one. |
 | `--no-devcontainer` | Ignore any discovered `devcontainer.json` (escape hatch for CI). |
 
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -89,6 +89,47 @@ file changed, but the existing VM is not mutated automatically. Destroy and
 recreate the instance to apply creation-time devcontainer changes such as
 `features`, `hostRequirements`, `mounts`, `image`/`build`, or `remoteUser`.
 
+### `quickstart`
+
+One-shot entry point: ensure the default image exists, bring up an instance for
+the current directory, and launch Claude Code inside it. Runs `setup`, `up`, and
+`claude` in sequence, short-circuiting any step that is already done.
+
+```
+coop quickstart [FLAGS]
+```
+
+`quickstart` resolves the workspace to the current directory (unless
+`--no-workspace`) and uses it as the project identity, the same way `coop up`
+does. It then takes one of three branches based on the instance for that
+workspace:
+
+- **A running instance exists.** coop reconnects to it and launches Claude Code —
+  no setup, restart, or recreation.
+- **A stopped instance exists.** coop restarts it (reusing the instance's own
+  image, not necessarily `default`) and launches Claude Code.
+- **No instance exists.** coop creates one for the workspace, folding in any
+  discovered `devcontainer.json`, then launches Claude Code.
+
+Image setup runs only when the `default` template image is missing; otherwise it
+is skipped. Setup runs non-interactively (no confirmation prompts).
+
+| Flag | Description |
+|------|-------------|
+| `--no-workspace` | Skip mounting the current directory as the workspace. Creates a fresh instance with no workspace affinity when no running instance can be reused. |
+| `--no-devcontainer` | Ignore any discovered `devcontainer.json` (escape hatch for CI). |
+
+```
+coop quickstart
+coop quickstart --no-devcontainer
+coop quickstart --no-workspace
+```
+
+`quickstart` takes no instance name or per-instance tuning flags. For control
+over profiles, mounts, image, resources, or named instances, use `coop setup`
+and `coop up` directly. When run from your `$HOME` or `/`, coop prompts before
+mounting (or bails in a non-TTY); pass `--no-workspace` to skip the mount.
+
 ### `init`
 
 Generate a starter config file at `~/.coop/config.toml`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,6 +80,13 @@ coop picks up `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from your environment aut
 
 ## First run
 
+In a hurry? From your project directory, `coop quickstart` runs setup, brings up
+an instance, and launches Claude Code in one command — building the default
+image only if it is missing and reconnecting to an existing instance when one is
+already running. The steps below walk through the same flow one command at a
+time and give you per-instance control. See the [`quickstart`
+reference](commands.md#quickstart) for details.
+
 ### 1. Setup
 
 `coop setup` downloads the Firecracker binary and kernel (Linux) or configures Lima (macOS), then builds a template rootfs image. The template ships with base packages (git, curl, build-essential, Docker, and others), the GitHub CLI, Claude Code, and Codex.


### PR DESCRIPTION
Documents the `coop quickstart` command.

- Adds a `### quickstart` section to `docs/commands.md` describing the one-shot
  setup + up + claude flow, the three instance branches (running reconnect,
  stopped restart on the instance's own image, no instance fresh create), the
  image-setup short-circuit, and the `--no-workspace` / `--no-devcontainer`
  flags.
- Adds a pointer to the quickstart reference at the top of the "First run"
  section in `docs/getting-started.md`.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)