### PR TITLE
Document guest user, guest PATH, and startup flag pointers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,31 @@ Firecracker TAP networking. These fields apply to Linux only. The Lima backend o
 | `subnet_mask` | string (CIDR) | `/24` | Subnet mask in CIDR notation. Must be `/0` through `/32`. |
 | `host_iface` | string | `auto` | Host network interface for NAT (e.g., `eth0`, `ens5`). `auto` detects it at runtime. |
 
+## Guest user
+
+The guest VM runs as an unprivileged account, `ubuntu` (uid 1000) by default. Override the username at setup time with `coop setup --guest-user <name>`:
+
+```sh
+coop setup --guest-user vscode
+```
+
+The name is validated against the POSIX-portable pattern `[a-z_][a-z0-9_-]{0,31}`; `root` is rejected because coop assumes an unprivileged uid-1000 account.
+
+The guest user is **baked into the image at setup time and immutable for the image's lifetime** — it is persisted in the image's `template_config.json`, and `up` / `start` / `shell` / `exec` read it back from there. To change it, destroy and recreate the image: `coop destroy && coop setup --guest-user <name>`.
+
+### devcontainer `remoteUser`
+
+When a workspace's `devcontainer.json` declares a `remoteUser` (e.g. `vscode` for the Microsoft devcontainer base images), the handling depends on the stage:
+
+- **At `coop setup`**, a valid `remoteUser` becomes the image's guest user unless `--guest-user` already pins one (the CLI flag wins, and the override is reported).
+- **At `coop up` / `coop start`**, the guest user is already baked in. If the file's `remoteUser` matches the image's persisted user, it is applied; if it differs, coop reports the mismatch, skips forwarding `containerEnv` (its values often reference a `/home/<remoteUser>/...` path that doesn't exist on disk), and points you at `coop destroy && coop setup --guest-user <remoteUser>` to switch.
+
+See [Devcontainer support](devcontainer.md) for the full translation table.
+
+## Guest PATH
+
+Every guest SSH session — login, non-login, and `exec` — has the guest user's `~/.local/bin` on `PATH`. coop prepends it to `PATH` in `/etc/environment`, which `pam_env` applies to all sessions. This is where the Claude Code installer places its per-user `claude` binary.
+
 ## `guest_env` section
 
 Literal environment variables to set inside the guest, independent of the host process environment. Use this when you want a value that isn't (or shouldn't be) on the host — `env_forward` covers the inherit-from-host case.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,6 +47,8 @@ template_size_gib = 20
 
 All VM artifacts (kernel, rootfs images, instance disks) live under `~/.coop/`.
 
+The guest runs as an unprivileged user (`ubuntu`, uid 1000, by default) with `~/.local/bin` on `PATH` for every session. Override the username at setup with `coop setup --guest-user <name>`; see [Guest user](configuration.md#guest-user) for details.
+
 ### Claude Code and Codex integration
 
 Forward your API keys and GitHub credentials into the guest:
@@ -138,6 +140,16 @@ Mount additional data directories when creating the project instance:
 ```
 coop up . --extra-mount ~/data:/data
 ```
+
+Tune a project environment at startup (each flag is repeatable where it makes sense, and works on both `coop up` and `coop start`):
+
+```
+coop up --forward-port 3000        # tunnel a guest port to the host
+coop up --env RUST_LOG=debug       # set a guest env var
+coop up --post-start "npm install" # run a command after every boot
+```
+
+See the [command reference](commands.md) and [configuration reference](configuration.md) for the full behavior of `--forward-port`, `--env`, and `--post-start`.
 
 After the environment is running, connect to it:
 


### PR DESCRIPTION
Fills three documentation gaps identified in issue #253.

In `docs/configuration.md`:
- New `## Guest user` section: documents the default `ubuntu` (uid 1000) account, the `coop setup --guest-user <name>` flag, the validator pattern `[a-z_][a-z0-9_-]{0,31}` and `root` rejection, and that the guest user is baked into the image's `template_config.json` at setup time and read back by `up` / `start` / `shell` / `exec`.
- New `### devcontainer remoteUser` subsection: describes setup-stage adoption (CLI flag wins) versus start-stage match/mismatch handling, including the `containerEnv` skip on mismatch.
- New `## Guest PATH` section: documents that `~/.local/bin` is prepended to `PATH` in `/etc/environment` and applied to every SSH session via `pam_env`.

In `docs/getting-started.md`:
- A guest-user/PATH note linking to the new `## Guest user` section.
- Pointers to `--forward-port`, `--env`, and `--post-start` on `coop up` / `coop start`, linking to the command and configuration references.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)