### PR TITLE
Test port forwards re-established across restart

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2571,6 +2571,54 @@ nohup python3 /tmp/fwd.py ${guest_port} ${payload} > /tmp/fwd.log 2>&1 &" || tru
         pass "host port released after stop"
     fi
 
+    # Restart WITHOUT re-passing --forward-port. The forward set persisted to
+    # forwards.json at `up` time must be reloaded and respawned, proving the
+    # tunnel survives a stop/start cycle without the caller restating it.
+    if coop start "$fwd_instance" --no-agents; then
+        STARTED_INSTANCES+=("$fwd_instance")
+        pass "restart without --forward-port exits 0"
+    else
+        fail "restart without --forward-port exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        coop destroy "$fwd_instance" 2>/dev/null || true
+        untrack_instance "$fwd_instance"
+        rm -f "$content_file" "$content_file.got"
+        return
+    fi
+
+    GUEST_INSTANCE="$fwd_instance"
+
+    # The previous listener died with the guest on stop; re-launch it so there
+    # is something to reach through the respawned tunnel.
+    guest_exec sh -c "cat > /tmp/fwd.py <<'PYEOF'
+import socket, sys
+port = int(sys.argv[1])
+body = sys.argv[2].encode()
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', port))
+s.listen(1)
+c, _ = s.accept()
+c.recv(65536)
+c.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s' % (len(body), body))
+c.close()
+PYEOF
+nohup python3 /tmp/fwd.py ${guest_port} ${payload} > /tmp/fwd.log 2>&1 &" || true
+    sleep 1
+
+    if curl -fsS --max-time 3 "http://127.0.0.1:${host_port}/" > "$content_file.got"; then
+        local got_restart
+        got_restart=$(cat "$content_file.got")
+        if [[ "$got_restart" == "$payload" ]]; then
+            pass "forwarded port reachable again after restart"
+        else
+            fail "forwarded port reachable again after restart" "got: $got_restart"
+        fi
+    else
+        fail "forwarded port reachable again after restart" "curl failed"
+    fi
+
+    unset GUEST_INSTANCE
+
     coop destroy "$fwd_instance" 2>/dev/null || true
     untrack_instance "$fwd_instance"
     rm -f "$content_file" "$content_file.got"

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2574,8 +2574,9 @@ nohup python3 /tmp/fwd.py ${guest_port} ${payload} > /tmp/fwd.log 2>&1 &" || tru
     # Restart WITHOUT re-passing --forward-port. The forward set persisted to
     # forwards.json at `up` time must be reloaded and respawned, proving the
     # tunnel survives a stop/start cycle without the caller restating it.
+    # Already tracked from the initial `up`; `coop stop` does not untrack, so
+    # the instance stays in STARTED_INSTANCES across the restart.
     if coop start "$fwd_instance" --no-agents; then
-        STARTED_INSTANCES+=("$fwd_instance")
         pass "restart without --forward-port exits 0"
     else
         fail "restart without --forward-port exits 0" "exit code: $? stderr: $HARNESS_ERR"


### PR DESCRIPTION
Extends `test_port_forwards` in `tests/integration.sh` to cover that persisted port forwards are reloaded and respawned across a stop/start cycle (issue #255).

After the existing "host port released after stop" step, the test:

- Restarts the instance by name with `coop start <inst> --no-agents` and no `--forward-port` re-passed. This routes through the restart path, which loads `forwards.json` via `ForwardsState::try_load`, merges with the (empty) CLI forwards, and re-spawns the SSH tunnels. A by-name start with no CLI forwards is the correct trigger for reload+respawn.
- Re-launches the guest HTTP listener, since the previous one died with the guest on stop. It reuses the same `$guest_port` and `$payload` locals.
- Curls through the host port and asserts the response equals the payload, proving the forward was reloaded from `forwards.json` rather than restated by the caller. If persistence were broken, the merged forward set would be empty, no tunnel would respawn, and the curl would fail.
- Destroys and untracks the instance and cleans up temp files.

The instance stays tracked in `STARTED_INSTANCES` from the initial `up` (`coop stop` does not untrack), matching the restart convention in `test_restart_stopped` and `test_guest_user_alt`.

Validated with `bash -n tests/integration.sh` only. Not executed: this environment has no KVM/Firecracker/Lima host to run the suite against.

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)