### PR TITLE
Add [guest_env] config block integration test

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2945,7 +2945,7 @@ CFGEOF
 # `test_guest_environment` covers the `--env` CLI path against the shared
 # primary instance. This phase covers the complementary `[guest_env]`
 # config-file path, plus the literal-over-forwarded precedence (and its
-# WARN) from `resolve_guest_env` in src/backend.rs. It owns a dedicated
+# WARN) from `prepare_env_forwarding` in src/backend.rs. It owns a dedicated
 # config file and instance so it doesn't perturb the primary instance.
 test_guest_env_config() {
     echo ""
@@ -2961,7 +2961,13 @@ test_guest_env_config() {
     # `COOP_TEST_GUEST_ENV_PRECEDENCE` is also listed in `claude.env_forward`
     # and exported on the host below, so the literal must override the
     # forwarded host value (and a WARN must be emitted on the collision).
+    # `post_start` forces the up-time SSH session (and thus
+    # `prepare_env_forwarding`, which emits the precedence WARN) to run even
+    # under `--no-agents`, which otherwise skips all session work. `true` is
+    # a no-op. Without it the WARN is never produced during `up`.
     cat > "$cfg_file" <<CFGEOF
+post_start = "true"
+
 [claude]
 github = "off"
 env_forward = ["COOP_TEST_GUEST_ENV_PRECEDENCE"]
@@ -2978,6 +2984,19 @@ CFGEOF
             "$BINARY" --config "$cfg_file" "$@" 2>"$tmpdir/stderr") || rc=$?
         HARNESS_ERR=$(cat "$tmpdir/stderr")
         return $rc
+    }
+
+    # `coop shell` must run with this config file: config-block `guest_env`
+    # literals are re-derived from `config.toml` on each command (only CLI
+    # `--env` and devcontainer entries are persisted to `guest_env.json`).
+    # A bare `coop shell` would load the default config and never see them.
+    # `RUST_LOG=off` keeps tracing out of captured stdout, mirroring
+    # `guest_exec`; stderr lands in the shared guest_stderr file.
+    ge_exec() {
+        RUST_LOG=off env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY \
+            COOP_TEST_GUEST_ENV_PRECEDENCE="forwarded-loses" \
+            "$BINARY" --config "$cfg_file" shell "$inst_name" -- "$@" \
+            2>"$tmpdir/guest_stderr"
     }
 
     local ge_ws="$tmpdir/${inst_name}-ws"
@@ -2998,11 +3017,9 @@ CFGEOF
         fail "guest_env literal override logs a WARN" "stderr: $HARNESS_ERR"
     fi
 
-    GUEST_INSTANCE="$inst_name"
-
     # The pure config literal must reach the guest process environment.
     local cfg_val
-    if cfg_val=$(guest_exec printenv COOP_TEST_GUEST_ENV_CONFIG); then
+    if cfg_val=$(ge_exec printenv COOP_TEST_GUEST_ENV_CONFIG); then
         if [[ "$cfg_val" == "from-config-file" ]]; then
             pass "guest_env from config block reaches the guest"
         else
@@ -3015,7 +3032,7 @@ CFGEOF
 
     # The literal must win over the forwarded host value of the same name.
     local prec_val
-    if prec_val=$(guest_exec printenv COOP_TEST_GUEST_ENV_PRECEDENCE); then
+    if prec_val=$(ge_exec printenv COOP_TEST_GUEST_ENV_PRECEDENCE); then
         if [[ "$prec_val" == "literal-wins" ]]; then
             pass "guest_env literal overrides forwarded value"
         else
@@ -3025,8 +3042,6 @@ CFGEOF
         fail "guest_env literal overrides forwarded value" \
             "printenv failed; stderr: $(guest_stderr)"
     fi
-
-    unset GUEST_INSTANCE
 
     ge stop "$inst_name" 2>/dev/null || true
     ge destroy "$inst_name" 2>/dev/null || true

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2940,6 +2940,100 @@ CFGEOF
     rm -r "$cs_dir"
 }
 
+# ── [guest_env] config block end-to-end (--full only) ─────────
+
+# `test_guest_environment` covers the `--env` CLI path against the shared
+# primary instance. This phase covers the complementary `[guest_env]`
+# config-file path, plus the literal-over-forwarded precedence (and its
+# WARN) from `resolve_guest_env` in src/backend.rs. It owns a dedicated
+# config file and instance so it doesn't perturb the primary instance.
+test_guest_env_config() {
+    echo ""
+    echo "=== Phase: [guest_env] config block ==="
+
+    local inst_name="${INSTANCE}-genv"
+
+    local ge_dir
+    ge_dir=$(mktemp -d)
+    local cfg_file="$ge_dir/config.toml"
+
+    # `COOP_TEST_GUEST_ENV_CONFIG` is a pure config literal.
+    # `COOP_TEST_GUEST_ENV_PRECEDENCE` is also listed in `claude.env_forward`
+    # and exported on the host below, so the literal must override the
+    # forwarded host value (and a WARN must be emitted on the collision).
+    cat > "$cfg_file" <<CFGEOF
+[claude]
+github = "off"
+env_forward = ["COOP_TEST_GUEST_ENV_PRECEDENCE"]
+
+[guest_env]
+COOP_TEST_GUEST_ENV_CONFIG = "from-config-file"
+COOP_TEST_GUEST_ENV_PRECEDENCE = "literal-wins"
+CFGEOF
+
+    ge() {
+        local rc=0
+        HARNESS_OUT=$(env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY \
+            COOP_TEST_GUEST_ENV_PRECEDENCE="forwarded-loses" \
+            "$BINARY" --config "$cfg_file" "$@" 2>"$tmpdir/stderr") || rc=$?
+        HARNESS_ERR=$(cat "$tmpdir/stderr")
+        return $rc
+    }
+
+    local ge_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$ge_ws"
+    if ge up "$ge_ws" --name "$inst_name" --no-agents --no-devcontainer; then
+        STARTED_INSTANCES+=("$inst_name")
+        pass "up with [guest_env] config exits 0"
+    else
+        fail "up with [guest_env] config exits 0" "exit code: $? stderr: $HARNESS_ERR"
+        rm -r "$ge_dir"
+        return
+    fi
+
+    # The override WARN is emitted during `up` (stderr, INFO default level).
+    if echo "$HARNESS_ERR" | grep -q "COOP_TEST_GUEST_ENV_PRECEDENCE.*overrides"; then
+        pass "guest_env literal override logs a WARN"
+    else
+        fail "guest_env literal override logs a WARN" "stderr: $HARNESS_ERR"
+    fi
+
+    GUEST_INSTANCE="$inst_name"
+
+    # The pure config literal must reach the guest process environment.
+    local cfg_val
+    if cfg_val=$(guest_exec printenv COOP_TEST_GUEST_ENV_CONFIG); then
+        if [[ "$cfg_val" == "from-config-file" ]]; then
+            pass "guest_env from config block reaches the guest"
+        else
+            fail "guest_env from config block reaches the guest" "got: $cfg_val"
+        fi
+    else
+        fail "guest_env from config block reaches the guest" \
+            "printenv failed; stderr: $(guest_stderr)"
+    fi
+
+    # The literal must win over the forwarded host value of the same name.
+    local prec_val
+    if prec_val=$(guest_exec printenv COOP_TEST_GUEST_ENV_PRECEDENCE); then
+        if [[ "$prec_val" == "literal-wins" ]]; then
+            pass "guest_env literal overrides forwarded value"
+        else
+            fail "guest_env literal overrides forwarded value" "got: $prec_val"
+        fi
+    else
+        fail "guest_env literal overrides forwarded value" \
+            "printenv failed; stderr: $(guest_stderr)"
+    fi
+
+    unset GUEST_INSTANCE
+
+    ge stop "$inst_name" 2>/dev/null || true
+    ge destroy "$inst_name" 2>/dev/null || true
+    untrack_instance "$inst_name"
+    rm -r "$ge_dir"
+}
+
 # ── Interrupted setup test (--full only) ──────────────────────
 
 test_interrupted_setup() {
@@ -3742,6 +3836,9 @@ main() {
 
         # Config sources: CLAUDE.md + rules copy
         test_config_dir
+
+        # [guest_env] config block + literal-over-forwarded precedence
+        test_guest_env_config
 
         # Interrupted setup: SIGKILL mid-build, verify clean recovery
         test_interrupted_setup


### PR DESCRIPTION
Adds a `--full`-gated integration phase `test_guest_env_config` (registered after `test_config_dir`) that exercises the `[guest_env]` config-file path end-to-end on a dedicated instance.

The phase:
- Writes a config file with a top-level `[guest_env]` table and `claude.env_forward`, then runs `coop up --config <file> --no-agents --no-devcontainer`.
- Asserts a pure config literal (`COOP_TEST_GUEST_ENV_CONFIG`) reaches the guest process environment via `coop shell --config <file> -- printenv`.
- Asserts a `guest_env` literal overrides a same-named value forwarded through `claude.env_forward` (literal wins), and that the override WARN from `prepare_env_forwarding` (src/backend.rs) appears on stderr during `up`.

Implementation notes:
- `coop shell` is run with `--config <file>` because config-block `guest_env` literals are re-derived from `config.toml` on each command rather than persisted to `guest_env.json` (only CLI `--env` and devcontainer entries are persisted). A bare `coop shell` loads the default config and would not see them.
- The config sets `post_start = "true"` so the up-time SSH session runs even under `--no-agents` (which otherwise skips all session work), which is what emits the precedence WARN. `true` is a no-op.
- Owns its own temp config file and instance, tracks it in `STARTED_INSTANCES`, and stops/destroys/untracks it plus removes the temp dir on exit.

Validated with `bash -n tests/integration.sh` only. The suite was not executed here — this environment has no KVM/Firecracker/Lima host.

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)