### PR TITLE
Move --git-repo to coop up

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,10 +35,12 @@ running, `up` reports success without creating another VM. If a matching
 instance is stopped, `up` restarts it. If no matching instance exists, `up`
 creates one.
 
-By default, `up` copies/syncs the project into `/workspace`. Pass `--mount` to use the mount transport for the
-project at `/workspace` instead. On macOS/Lima this is a live virtiofs mount;
-on Linux/Firecracker it is a one-time sync.
-`--copy` is accepted as an explicit spelling of the default.
+By default, `up` copies/syncs the project into `/workspace`. Pass `--mount`
+to use the mount transport for the project at `/workspace` instead. On
+macOS/Lima this is a live virtiofs mount; on Linux/Firecracker it is a
+one-time sync. `--copy` is accepted as an explicit spelling of the default.
+Use `--git-repo <url>` instead of `DIR` to clone a remote repository into
+`/workspace` inside the guest.
 
 | Flag | Description |
 |------|-------------|
@@ -47,13 +49,14 @@ on Linux/Firecracker it is a one-time sync.
 | `--copy` | Copy/sync `DIR` into `/workspace` (default) |
 | `--mount` | Mount `DIR` at `/workspace` instead of using `--copy` |
 | `--extra-mount <spec>` | Additional host directory to mount into the guest (`HOST_PATH[:GUEST_PATH]`, repeatable; specify a guest path other than `/workspace` when using `--copy`) |
+| `--git-repo <url>` | Clone a git repository into `/workspace` instead of copying a local project directory |
 | `--vcpus <N>` | Number of vCPUs when creating a new instance |
 | `--mem <MiB>` | Memory in MiB when creating a new instance |
 | `--disk <GiB>` | Instance disk size when creating a new instance |
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
 | `--image <name>` | Named image to use when creating a new instance (default: `default`) |
 | `--profile <list>` | Build or reuse a profile-derived image when creating a new instance, named from the sorted profiles (for example `node-python`) |
-| `--exclude-git` | Skip the `.git/` directory when copying/syncing |
+| `--exclude-git` | Skip `.git/` when copying/syncing local directories; does not strip `.git` from a `--git-repo` clone |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo |
 | `--forward-port <spec>` | Forward a guest port to the host (`GUEST[:HOST]`, repeatable) |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot |
@@ -68,11 +71,13 @@ coop up ~/code/my-project --mount
 coop up . --profile python,node
 coop up . --copy --forward-port 3000
 coop up . --extra-mount ~/data:/data
+coop up --git-repo https://github.com/trailofbits/coop.git
 ```
 
 Creation options such as `--vcpus`, `--mem`, `--disk`, `--image`,
-`--profile`, `--extra-mount`, `--exclude-git`, and `--devcontainer` are
-applied only when `up` creates a new instance. `coop up --profile <list>`
+`--profile`, `--extra-mount`, `--git-repo`, `--exclude-git`, and
+`--devcontainer` are applied only when `up` creates a new instance. `coop up
+--profile <list>`
 derives an image name from the sorted profile list, runs the same stale-image
 check as `coop setup`, and builds or rebuilds that image if needed. Explicit
 named images are unchanged: use `coop setup --image <name> --profile ...`

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -4,7 +4,7 @@ coop reads a **subset** of [devcontainer.json](https://containers.dev/) and maps
 
 ## How discovery and apply work
 
-When you run `coop up <dir>`, `coop setup --workspace <dir>`, or a fresh `coop quickstart` for the current directory, coop looks for `.devcontainer/devcontainer.json` in that directory (and in each mount host root, with the project directory winning ties). For `--git-repo` creation flows, coop can discover `.devcontainer/devcontainer.json` from common GitHub repository URLs before creating the VM. `coop start --dry-run --workspace <dir>` also uses discovery as a translation preview; normal `coop start` only restarts stopped instances and does not create a VM or re-apply devcontainer changes.
+When you run `coop up <dir>`, `coop up --git-repo <url>`, `coop setup --workspace <dir>`, or a fresh `coop quickstart` for the current directory, coop looks for `.devcontainer/devcontainer.json` in that workspace source (and in each mount host root, with the project directory winning ties). For `--git-repo` creation flows, coop can discover `.devcontainer/devcontainer.json` from common GitHub repository URLs before creating the VM. `coop start --dry-run --workspace <dir>` also uses discovery as a translation preview; normal `coop start` only restarts stopped instances and does not create a VM or re-apply devcontainer changes.
 
 If a file is found, coop prompts:
 
@@ -25,7 +25,7 @@ For CI or scripted use, pass one of:
 - `--dry-run` — print the report and exit before any VM work
 - `coop devcontainer check <path>` — print setup/start translation reports for a file without loading coop config or touching VM state
 
-A non-TTY invocation that discovers a `devcontainer.json` without any of these flags errors out rather than silently choosing. For `--git-repo`, remote discovery is best-effort and currently limited to GitHub URLs that resolve to `owner/repo`; unsupported hosts continue without devcontainer translation unless you pass an explicit local `--devcontainer <path>`.
+A non-TTY invocation that discovers a `devcontainer.json` without any of these flags errors out rather than silently choosing. For `coop up --git-repo <url>` and `coop start --dry-run --git-repo <url>`, remote discovery is best-effort and currently limited to GitHub URLs that resolve to `owner/repo`; unsupported hosts continue without devcontainer translation unless you pass an explicit local `--devcontainer <path>`. Normal `coop start --git-repo` is rejected because `--git-repo` moved to `coop up --git-repo`.
 
 ## Persistent project opt-outs
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -148,6 +148,12 @@ Mount additional data directories when creating the project instance:
 coop up . --extra-mount ~/data:/data
 ```
 
+Or clone a remote repository directly into `/workspace` inside the guest:
+
+```
+coop up --git-repo https://github.com/trailofbits/coop.git
+```
+
 Tune a project environment at startup (each flag is repeatable where it makes sense, and works on both `coop up` and `coop start`):
 
 ```
@@ -157,7 +163,6 @@ coop up --post-start "npm install" # run a command after every boot
 ```
 
 See the [command reference](commands.md) and [configuration reference](configuration.md) for the full behavior of `--forward-port`, `--env`, and `--post-start`.
-
 After the environment is running, connect to it:
 
 ```
@@ -193,6 +198,7 @@ Project creation options belong to `coop up`, not `coop start`:
 ```
 coop up ~/code/my-project --disk 40 --mount
 coop up ~/code/my-project --profile python,node
+coop up --git-repo https://github.com/trailofbits/coop.git
 ```
 
 Skip Claude Code and Codex credential/config injection:

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -9,6 +9,7 @@ coop moves code between the host and guest VM. The normal way to get code in is 
 ```bash
 coop up ./my-project
 coop up ./my-project --mount
+coop up --git-repo https://github.com/trailofbits/coop.git
 ```
 
 `coop up` treats the directory as the project identity. Re-running the same
@@ -36,6 +37,11 @@ by backend:
 Additional host data can be mounted at creation time with
 `coop up --extra-mount HOST_PATH:GUEST_PATH`. In copy mode, extra mounts must
 not target `/workspace`, because the copied project owns that path.
+
+`coop up --git-repo <url>` clones the repository inside the guest at
+`/workspace` and records the original URL in `workspace.json`. Because there
+is no host workspace path for that source, later `push` and `pull` commands
+need an explicit `--dir` if you want to sync files back to the host.
 
 #### Mounting a git repository (live-mount caveat)
 
@@ -68,9 +74,9 @@ Creating a project VM with `coop up` writes a `workspace.json` in the instance d
 
 | Field        | Description                                                    |
 |-------------|----------------------------------------------------------------|
-| `host_path`  | Absolute path on the host                                     |
+| `host_path`  | Absolute path on the host for local workspace and mount sources |
 | `guest_path` | Path inside the guest VM (always `/workspace`)                 |
-| `source`     | How the workspace was created: `workspace` or `mount`          |
+| `source`     | How the workspace was created: `workspace`, `mount`, or `git_repo` |
 
 `push` and `pull` read this file to resolve default paths.
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1936,7 +1936,7 @@ pub fn clone_git_repo(
         }
     })?;
 
-    tracing::info!("Repository cloned to /workspace/repo");
+    tracing::info!("Repository cloned to /workspace");
     Ok(())
 }
 
@@ -1976,8 +1976,8 @@ fn clone_without_auth(target: &SshTarget, repo_url: &str) -> Result<()> {
     let cmd = format!(
         "sudo mkdir -p /workspace && \
          sudo chown $(whoami):$(whoami) /workspace && \
-         git clone {} /workspace/repo && \
-         echo 'Repository cloned to /workspace/repo'",
+         git clone {} /workspace && \
+         echo 'Repository cloned to /workspace'",
         shell_escape(repo_url),
     );
     target.exec(&cmd)
@@ -2007,8 +2007,8 @@ fn build_clone_with_token_script(repo_url: &str) -> String {
          export GH_TOKEN\n\
          sudo mkdir -p /workspace\n\
          sudo chown \"$(whoami):$(whoami)\" /workspace\n\
-         git -c credential.helper='!f() {{ echo username=x-access-token; echo \"password=$GH_TOKEN\"; }}; f' clone {url} /workspace/repo\n\
-         echo 'Repository cloned to /workspace/repo'\n",
+         git -c credential.helper='!f() {{ echo username=x-access-token; echo \"password=$GH_TOKEN\"; }}; f' clone {url} /workspace\n\
+         echo 'Repository cloned to /workspace'\n",
         url = shell_escape(repo_url),
     )
 }
@@ -2505,7 +2505,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             "credential helper malformed: {script}"
         );
         assert!(
-            script.contains(" clone 'https://github.com/owner/repo.git' /workspace/repo\n"),
+            script.contains(" clone 'https://github.com/owner/repo.git' /workspace\n"),
             "missing escaped clone target: {script}"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,9 @@ enum Commands {
         /// Additional host directory to mount into the guest (`HOST_PATH[:GUEST_PATH]`, repeatable)
         #[arg(long, value_parser = config::Mount::parse)]
         extra_mount: Vec<config::Mount>,
+        /// Clone a git repository into /workspace instead of copying a local project directory
+        #[arg(long, conflicts_with_all = ["dir", "copy", "mount"])]
+        git_repo: Option<String>,
         /// Number of vCPUs (overrides config when creating a new instance)
         #[arg(long)]
         vcpus: Option<u8>,
@@ -120,7 +123,7 @@ enum Commands {
             add = ArgValueCandidates::new(completions::profile_candidates),
         )]
         profile: Vec<String>,
-        /// Skip the `.git` directory when copying/syncing the project
+        /// Skip `.git/` when copying/syncing local directories
         #[arg(long)]
         exclude_git: bool,
         /// Suppress the interactive prompt to set up a scoped GitHub PAT
@@ -786,6 +789,7 @@ fn main() -> Result<()> {
             copy,
             mount,
             extra_mount,
+            git_repo,
             vcpus,
             mem,
             disk,
@@ -829,6 +833,7 @@ fn main() -> Result<()> {
                 name: name.as_ref(),
                 transport,
                 extra_mount,
+                git_repo: git_repo.as_deref(),
                 vcpus,
                 mem,
                 disk,
@@ -1284,6 +1289,7 @@ struct UpOpts<'a> {
     name: Option<&'a config::InstanceName>,
     transport: ProjectTransport,
     extra_mount: Vec<config::Mount>,
+    git_repo: Option<&'a str>,
     vcpus: Option<u8>,
     mem: Option<config::MiB>,
     disk: Option<config::GiB>,
@@ -1328,6 +1334,10 @@ fn cmd_up(
     config_path: &Path,
     opts: &UpOpts<'_>,
 ) -> Result<()> {
+    if let Some(repo_url) = opts.git_repo {
+        return cmd_up_git_repo(be, cfg, validated, config_path, opts, repo_url);
+    }
+
     let transport = opts.transport;
     let project_dir = resolve_project_dir(opts.dir)?;
 
@@ -1391,6 +1401,52 @@ fn cmd_up(
         &project_mount,
         discovery_mounts,
     )
+}
+
+fn cmd_up_git_repo(
+    be: &backend::PlatformBackend,
+    cfg: &mut config::CoopConfig,
+    validated: &config::Validated,
+    config_path: &Path,
+    opts: &UpOpts<'_>,
+    repo_url: &str,
+) -> Result<()> {
+    if opts.devcontainer.dry_run {
+        let inputs = up_translator_inputs(cfg, opts);
+        resolve_devcontainer(
+            &DevcontainerOpts {
+                explicit_path: opts.devcontainer.path.as_deref().map(Path::new),
+                no_devcontainer: opts.devcontainer.no_devcontainer,
+                dry_run: true,
+                workspace: None,
+                mounts: &[],
+                git_repo: Some(repo_url),
+                github_auth: cfg.github.as_ref(),
+                preference_path: Some(&cfg.devcontainer_preferences_path()),
+            },
+            &inputs,
+            devcontainer::Stage::Start,
+        )?;
+        return Ok(());
+    }
+
+    if let Some(inst) = find_git_repo_instance(cfg, repo_url)? {
+        ensure_up_git_repo_name_matches(&inst, repo_url, opts)?;
+        ensure_up_existing_inputs_are_compatible_for_git_repo(&inst, opts)?;
+        if be.is_running(&inst) {
+            reject_running_up_restart_inputs(&inst, opts)?;
+            tracing::info!("Instance '{}' is already running for {repo_url}", inst.name);
+            return Ok(());
+        }
+
+        let mut restart_opts = runtime_start_opts_from_up(opts, config_path);
+        apply_runtime_guest_env(cfg, &opts.runtime.guest_env, None, &mut restart_opts);
+        restart_instance(be, cfg, &inst, &restart_opts)?;
+        return Ok(());
+    }
+
+    ensure_profile_image(be, cfg, validated, opts.profile_target.as_ref())?;
+    create_git_repo_instance(be, cfg, config_path, opts, repo_url)
 }
 
 fn up_translator_inputs(
@@ -1521,6 +1577,105 @@ fn create_up_instance(
         opts.name,
         &opts.image,
         Some(project_dir),
+        &start_opts,
+    )
+    .map(|_| ())
+}
+
+fn create_git_repo_instance(
+    be: &backend::PlatformBackend,
+    cfg: &mut config::CoopConfig,
+    config_path: &Path,
+    opts: &UpOpts<'_>,
+    repo_url: &str,
+) -> Result<()> {
+    let inputs = up_translator_inputs(cfg, opts);
+    let translation = resolve_devcontainer(
+        &DevcontainerOpts {
+            explicit_path: opts.devcontainer.path.as_deref().map(Path::new),
+            no_devcontainer: opts.devcontainer.no_devcontainer,
+            dry_run: false,
+            workspace: None,
+            mounts: &[],
+            git_repo: Some(repo_url),
+            github_auth: cfg.github.as_ref(),
+            preference_path: Some(&cfg.devcontainer_preferences_path()),
+        },
+        &inputs,
+        devcontainer::Stage::Start,
+    )?;
+
+    apply_vm_overrides(cfg, opts.vcpus, opts.mem, None)?;
+    if let Some(t) = &translation {
+        devcontainer::apply_to_config(cfg, t)?;
+    }
+
+    let mut forward_ports = opts.runtime.forward_ports.clone();
+    if let Some(t) = &translation {
+        forward_ports = devcontainer::merge_into_forward_ports(&t.forward_ports, &forward_ports);
+    }
+
+    let dc_guest_env = translation
+        .as_ref()
+        .map(|t| t.guest_env.clone())
+        .unwrap_or_default();
+    let cli_guest_env: std::collections::BTreeMap<_, _> =
+        opts.runtime.guest_env.iter().cloned().collect();
+    let persisted_guest_env =
+        guest_env_state::merge_persisted_entries(&dc_guest_env, &cli_guest_env);
+    for (key, value) in &persisted_guest_env {
+        cfg.guest_env.insert(key.clone(), value.clone());
+    }
+
+    let default_translation = devcontainer::Translation::default();
+    let effective_disk = devcontainer::effective_disk(
+        opts.disk,
+        translation.as_ref().unwrap_or(&default_translation),
+    );
+    let post_start_override = opts
+        .runtime
+        .post_start
+        .clone()
+        .or_else(|| translation.as_ref().and_then(|t| t.post_start.clone()));
+
+    let mut mounts = translation
+        .as_ref()
+        .map(|t| t.mounts.clone())
+        .unwrap_or_default();
+    mounts.extend(opts.extra_mount.clone());
+    validate_git_repo_workspace_mounts(&mounts)?;
+    validate_unique_guest_paths(&mounts)?;
+
+    let start_opts = StartOpts {
+        name: None,
+        image: StartImage {
+            explicit: opts.image_explicit,
+        },
+        workspace_dir: None,
+        git_repo: Some(repo_url),
+        no_agents: opts.runtime.no_agents,
+        no_prompt: opts.runtime.no_prompt,
+        disk: effective_disk,
+        mounts,
+        exclude_git: opts.runtime.exclude_git,
+        forward_ports,
+        config_path,
+        post_start_override: post_start_override.as_deref(),
+        persisted_guest_env,
+        devcontainer_path: None,
+        applied_devcontainer: translation.as_ref().and_then(|t| t.applied.clone()),
+    };
+
+    let derived_name = opts
+        .name
+        .cloned()
+        .or_else(|| git_repo_default_instance_name(repo_url));
+    allocate_and_start(
+        be,
+        cfg,
+        derived_name.as_ref(),
+        &opts.image,
+        None,
         &start_opts,
     )
     .map(|_| ())
@@ -1688,6 +1843,53 @@ fn ensure_up_existing_inputs_are_compatible(
     Ok(())
 }
 
+fn ensure_up_existing_inputs_are_compatible_for_git_repo(
+    inst: &config::Instance,
+    opts: &UpOpts<'_>,
+) -> Result<()> {
+    if opts.image_explicit && inst.image != opts.image {
+        bail!(
+            "Instance '{}' already exists for this git repo using image '{}'. \
+             `coop up --image {}` only applies when creating a new instance.\n\
+             Use `coop destroy {}` first to recreate it with a different image.",
+            inst.name,
+            inst.image,
+            opts.image,
+            inst.name,
+        );
+    }
+    if let Some(target) = &opts.profile_target
+        && inst.image != target.image
+    {
+        bail!(
+            "Instance '{}' already exists for this git repo using image '{}'. \
+             `coop up --profile {}` would use image '{}', but profiles only apply when creating a new instance.\n\
+             Use `coop destroy {}` first to recreate it with those profiles.",
+            inst.name,
+            inst.image,
+            target.profiles.join(","),
+            target.image,
+            inst.name,
+        );
+    }
+    if opts.disk.is_some()
+        || opts.vcpus.is_some()
+        || opts.mem.is_some()
+        || !opts.extra_mount.is_empty()
+        || opts.devcontainer.path.is_some()
+    {
+        bail!(
+            "Instance '{}' already exists for this git repo. \
+             --vcpus, --mem, --disk, --extra-mount, and --devcontainer only \
+             apply when creating a new instance.\n\
+             Use `coop destroy {}` first to recreate it with those options.",
+            inst.name,
+            inst.name,
+        );
+    }
+    Ok(())
+}
+
 fn ensure_up_project_name_matches(
     inst: &config::Instance,
     project_dir: &Path,
@@ -1698,6 +1900,22 @@ fn ensure_up_project_name_matches(
             &inst.name == name,
             "Project {} is already associated with instance '{}', not '{}'.",
             project_dir.display(),
+            inst.name,
+            name,
+        );
+    }
+    Ok(())
+}
+
+fn ensure_up_git_repo_name_matches(
+    inst: &config::Instance,
+    repo_url: &str,
+    opts: &UpOpts<'_>,
+) -> Result<()> {
+    if let Some(name) = opts.name {
+        anyhow::ensure!(
+            &inst.name == name,
+            "Git repo {repo_url} is already associated with instance '{}', not '{}'.",
             inst.name,
             name,
         );
@@ -1733,6 +1951,20 @@ fn validate_unique_guest_paths(mounts: &[config::Mount]) -> Result<()> {
         if !seen.insert(guest_path.clone()) {
             bail!("Duplicate mount guest path: {guest_path}");
         }
+    }
+    Ok(())
+}
+
+fn validate_git_repo_workspace_mounts(mounts: &[config::Mount]) -> Result<()> {
+    let workspace_path = workspace::default_workspace_path().to_string();
+    if mounts
+        .iter()
+        .any(|mount| mount.guest_path.to_string() == workspace_path)
+    {
+        bail!(
+            "`coop up --git-repo` clones into /workspace. \
+             Give --extra-mount an explicit non-/workspace guest path."
+        );
     }
     Ok(())
 }
@@ -2031,6 +2263,66 @@ fn find_workspace_instance(
             )
         }
     }
+}
+
+fn find_git_repo_instance(
+    cfg: &config::CoopConfig,
+    repo_url: &str,
+) -> Result<Option<config::Instance>> {
+    let instances = cfg.list_instances()?;
+    let mut matching: Vec<config::Instance> = instances
+        .into_iter()
+        .filter(|inst| {
+            workspace::try_load_or_warn(inst, "git-repo matching will skip this instance")
+                .is_some_and(|s| {
+                    matches!(
+                        s.source,
+                        workspace::WorkspaceSource::GitRepo { ref url } if url == repo_url
+                    )
+                })
+        })
+        .collect();
+    match matching.len() {
+        0 => Ok(None),
+        1 => Ok(Some(matching.swap_remove(0))),
+        _ => {
+            let names: Vec<_> = matching.iter().map(|i| i.name.as_str()).collect();
+            bail!(
+                "Multiple instances share git repo {repo_url}:\n  {}\n\
+                 Pick one explicitly with `coop start <name>` (for a stopped\n\
+                 instance) or `coop claude <name>` (for a running one).",
+                names.join(", "),
+            )
+        }
+    }
+}
+
+fn git_repo_default_instance_name(repo_url: &str) -> Option<config::InstanceName> {
+    let base = github_repo::parse_repo_slug_from_url(repo_url)
+        .and_then(|slug| slug.as_str().rsplit('/').next().map(ToOwned::to_owned))
+        .or_else(|| {
+            repo_url
+                .trim_end_matches('/')
+                .rsplit(['/', ':'])
+                .next()
+                .map(|s| s.trim_end_matches(".git").to_string())
+        })?;
+    let sanitized: String = base
+        .chars()
+        .map(|c| {
+            if matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let sanitized = sanitized.trim_matches('-');
+    if sanitized.is_empty() {
+        return None;
+    }
+    let max = 60.min(sanitized.len());
+    config::InstanceName::new(&sanitized[..max]).ok()
 }
 
 fn apply_vm_overrides(
@@ -2907,9 +3199,11 @@ fn start_instance(
 
     signal::check_shutdown()?;
 
-    // Workspace sync: tar-pipe for --workspace, git clone for --git-repo,
-    // rsync for --mount on Firecracker (Lima mounts are live via virtiofs).
-    if let Some(ws_dir) = opts.workspace_dir {
+    // Workspace sync: tar-pipe for --workspace, git clone for --git-repo.
+    // Mounts may be additional data directories or the workspace source
+    // itself. Only mount-only instances record the first mount as the
+    // workspace identity.
+    let workspace_source_written = if let Some(ws_dir) = opts.workspace_dir {
         let ws_path = std::path::Path::new(ws_dir);
         anyhow::ensure!(
             ws_path.is_dir(),
@@ -2929,6 +3223,7 @@ fn start_instance(
             },
         };
         state.save(inst)?;
+        true
     } else if let Some(repo_url) = opts.git_repo {
         backend::clone_git_repo(&target, cfg.github.as_ref(), repo_url)?;
 
@@ -2939,15 +3234,26 @@ fn start_instance(
             },
         };
         state.save(inst)?;
-    } else if !opts.mounts.is_empty() {
+        true
+    } else {
+        false
+    };
+
+    if !opts.mounts.is_empty() {
         if be.mounts_are_live() {
             // Lima: virtiofs already serves the host directory live. No
             // sync step, but we still record state so `push`/`pull` and
             // PAT slug detection work for follow-up commands.
-            workspace::record_mount_state(inst, &opts.mounts)?;
+            if !workspace_source_written {
+                workspace::record_mount_state(inst, &opts.mounts)?;
+            }
             warn_on_live_git_mounts(&opts.mounts);
         } else {
-            workspace::sync_mounts(&target, inst, &opts.mounts, opts.exclude_git)?;
+            if workspace_source_written {
+                workspace::sync_mount_contents(&target, &opts.mounts, opts.exclude_git)?;
+            } else {
+                workspace::sync_mounts(&target, inst, &opts.mounts, opts.exclude_git)?;
+            }
             tracing::warn!(
                 "Firecracker mounts use one-time sync, not live filesystem sharing. \
                  Use `coop push` / `coop pull` to sync changes."
@@ -4523,6 +4829,143 @@ mod tests {
     }
 
     #[test]
+    fn up_git_repo_parses_as_workspace_source() {
+        let cli = parse(&[
+            "up",
+            "--git-repo",
+            "https://github.com/trailofbits/coop.git",
+        ]);
+        let super::Commands::Up { git_repo, .. } = cli.command else {
+            panic!("expected Up variant");
+        };
+        assert_eq!(
+            git_repo.as_deref(),
+            Some("https://github.com/trailofbits/coop.git")
+        );
+    }
+
+    #[test]
+    fn up_git_repo_conflicts_with_local_workspace_sources() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let err = parse_err(&[
+            "up",
+            tmp.path().to_str().unwrap(),
+            "--git-repo",
+            "https://github.com/trailofbits/coop.git",
+        ]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+
+        let err = parse_err(&[
+            "up",
+            "--git-repo",
+            "https://github.com/trailofbits/coop.git",
+            "--mount",
+        ]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn git_repo_default_instance_name_uses_repo_basename() {
+        let name = super::git_repo_default_instance_name("https://github.com/trailofbits/coop.git")
+            .expect("name");
+        assert_eq!(name.as_str(), "coop");
+
+        let name =
+            super::git_repo_default_instance_name("git@example.com:org/my.repo.git").expect("name");
+        assert_eq!(name.as_str(), "my-repo");
+    }
+
+    #[test]
+    fn git_repo_default_instance_name_handles_url_edges() {
+        // Trailing slash, no `.git` suffix.
+        let name =
+            super::git_repo_default_instance_name("https://example.com/org/widget/").expect("name");
+        assert_eq!(name.as_str(), "widget");
+
+        // scp-style without a `.git` suffix.
+        let name =
+            super::git_repo_default_instance_name("git@example.com:org/tools").expect("name");
+        assert_eq!(name.as_str(), "tools");
+
+        // Bare path with no host.
+        let name = super::git_repo_default_instance_name("/srv/git/repo.git").expect("name");
+        assert_eq!(name.as_str(), "repo");
+    }
+
+    #[test]
+    fn git_repo_default_instance_name_rejects_unusable_basenames() {
+        // A basename that sanitizes to nothing has no usable instance name.
+        assert!(super::git_repo_default_instance_name("https://example.com/org/.git").is_none());
+        assert!(super::git_repo_default_instance_name("https://example.com/org/---").is_none());
+    }
+
+    #[test]
+    fn git_repo_default_instance_name_caps_long_basenames() {
+        let long = format!("https://example.com/org/{}.git", "a".repeat(200));
+        let name = super::git_repo_default_instance_name(&long).expect("name");
+        assert_eq!(name.as_str().len(), 60);
+        assert!(name.as_str().chars().all(|c| c == 'a'));
+    }
+
+    #[test]
+    fn git_repo_rejects_extra_mount_at_workspace() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data = tmp.path().join("data");
+        std::fs::create_dir(&data).expect("data");
+        let mounts = vec![super::config::Mount::parse(data.to_str().unwrap()).expect("mount")];
+
+        let err = super::validate_git_repo_workspace_mounts(&mounts)
+            .expect_err("expected /workspace collision");
+        assert!(format!("{err}").contains("/workspace"));
+    }
+
+    #[test]
+    fn find_git_repo_instance_returns_none_when_unmatched() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let found = super::find_git_repo_instance(&cfg, "https://example.com/org/absent.git")
+            .expect("lookup");
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_git_repo_instance_errors_on_multiple_matches() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let repo_url = "https://github.com/trailofbits/coop.git";
+        for _ in 0..2 {
+            let inst = cfg.allocate_instance(None, &img, None).expect("inst");
+            let state = super::workspace::WorkspaceState {
+                guest_path: super::workspace::default_workspace_path(),
+                source: super::workspace::WorkspaceSource::GitRepo {
+                    url: repo_url.to_string(),
+                },
+            };
+            state.save(&inst).expect("save workspace state");
+        }
+        let err = super::find_git_repo_instance(&cfg, repo_url).expect_err("expected ambiguity");
+        assert!(format!("{err}").contains("Multiple instances"));
+    }
+
+    #[test]
+    fn ensure_up_git_repo_name_matches_rejects_mismatch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let inst = cfg.allocate_instance(None, &img, None).expect("inst");
+        let repo_url = "https://github.com/trailofbits/coop.git";
+
+        let mut opts = up_opts_for_tests(None);
+        let requested = super::config::InstanceName::new("other-name").expect("name");
+        opts.name = Some(&requested);
+
+        let err = super::ensure_up_git_repo_name_matches(&inst, repo_url, &opts)
+            .expect_err("expected name mismatch");
+        assert!(format!("{err}").contains("already associated"));
+    }
+
+    #[test]
     fn validate_unique_guest_paths_rejects_duplicates() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let a = tmp.path().join("a");
@@ -4555,6 +4998,7 @@ mod tests {
             name: None,
             transport: super::ProjectTransport::Copy,
             extra_mount: Vec::new(),
+            git_repo: None,
             vcpus: None,
             mem: None,
             disk: None,
@@ -4644,6 +5088,35 @@ mod tests {
         let err = super::ensure_up_project_name_matches(&inst, &project, &opts)
             .expect_err("expected mismatched explicit name");
         assert!(format!("{err}").contains("already associated"));
+    }
+
+    #[test]
+    fn up_existing_git_repo_rejects_creation_only_inputs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
+        let img = super::config::default_image_name();
+        let repo_url = "https://github.com/trailofbits/coop.git";
+        let inst = cfg.allocate_instance(None, &img, None).expect("inst");
+        let state = super::workspace::WorkspaceState {
+            guest_path: super::workspace::default_workspace_path(),
+            source: super::workspace::WorkspaceSource::GitRepo {
+                url: repo_url.to_string(),
+            },
+        };
+        state.save(&inst).expect("save workspace state");
+
+        let mut opts = up_opts_for_tests(None);
+        opts.git_repo = Some(repo_url);
+        opts.disk = super::config::GiB::new(20);
+
+        let found = super::find_git_repo_instance(&cfg, repo_url)
+            .expect("lookup")
+            .expect("match");
+        assert_eq!(found.name.as_str(), inst.name.as_str());
+
+        let err = super::ensure_up_existing_inputs_are_compatible_for_git_repo(&inst, &opts)
+            .expect_err("expected incompatible");
+        assert!(format!("{err}").contains("--disk"));
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -131,9 +131,20 @@ pub fn try_load_or_warn(inst: &Instance, consequence: &str) -> Option<WorkspaceS
 /// just the extracted tree. Integrity relies on SSH's MAC over the
 /// localhost transport plus tar's per-header checksums.
 pub fn tar_pipe_transfer(target: &SshTarget, source_dir: &Path, exclude_git: bool) -> Result<()> {
+    let workspace = GuestPath::absolute(GUEST_WORKSPACE)?;
+    tar_pipe_transfer_to(target, source_dir, &workspace, exclude_git)
+}
+
+/// Transfer a local directory to an arbitrary guest path via tar-pipe.
+pub fn tar_pipe_transfer_to(
+    target: &SshTarget,
+    source_dir: &Path,
+    guest_path: &GuestPath,
+    exclude_git: bool,
+) -> Result<()> {
     tracing::info!(
-        "Transferring {} to guest:{GUEST_WORKSPACE} via tar-pipe",
-        source_dir.display()
+        "Transferring {} to guest:{guest_path} via tar-pipe",
+        source_dir.display(),
     );
 
     let mut tar_cmd = Command::new("tar");
@@ -165,7 +176,7 @@ pub fn tar_pipe_transfer(target: &SshTarget, source_dir: &Path, exclude_git: boo
         .take()
         .context("Failed to get tar stderr")?;
 
-    let extract_cmd = format!("tar xf - -C {GUEST_WORKSPACE}");
+    let extract_cmd = format!("tar xf - -C {guest_path}");
     let mut ssh_args = target.ssh_opts();
     ssh_args.push(target.addr());
     ssh_args.push(extract_cmd);
@@ -454,6 +465,16 @@ pub fn sync_mounts(
     mounts: &[crate::config::Mount],
     exclude_git: bool,
 ) -> Result<()> {
+    sync_mount_contents(target, mounts, exclude_git)?;
+    record_mount_state(inst, mounts)
+}
+
+/// Sync mount directories to the guest without changing workspace metadata.
+pub fn sync_mount_contents(
+    target: &SshTarget,
+    mounts: &[crate::config::Mount],
+    exclude_git: bool,
+) -> Result<()> {
     for m in mounts {
         let guest = &m.guest_path;
         target.exec(&format!(
@@ -466,11 +487,10 @@ pub fn sync_mounts(
             rsync_push(target, &m.host_path, guest, exclude_git)?;
         } else {
             tracing::info!("rsync not available on guest, using tar-pipe");
-            tar_pipe_transfer(target, &m.host_path, exclude_git)?;
+            tar_pipe_transfer_to(target, &m.host_path, guest, exclude_git)?;
         }
     }
-
-    record_mount_state(inst, mounts)
+    Ok(())
 }
 
 /// Persist mount metadata to `workspace.json`.

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1906,6 +1906,120 @@ test_up_project_workflow() {
     rm -rf "$mount_ws"
 }
 
+# ── git-repo source (--full only) ─────────────────────────────
+
+# Exercise `coop up --git-repo`: the clone runs inside the guest, so this
+# needs guest network access (already required by test_network). Uses
+# octocat/Hello-World, GitHub's canonical tiny public repo, cloned
+# anonymously (no [github] config). Instance-name derivation is covered
+# by unit tests; here we pass --name for deterministic cleanup.
+test_git_repo() {
+    echo ""
+    echo "=== Phase: up --git-repo (clone) ==="
+
+    local repo_url="https://github.com/octocat/Hello-World.git"
+    local gr_instance="${INSTANCE}-gitrepo"
+    local data_dir
+    data_dir=$(mktemp -d "$tmpdir/gitrepo-data-XXXXXX")
+    echo "extra-mount-marker" > "$data_dir/marker.txt"
+
+    # --git-repo conflicts with the local-directory sources (arg parsing,
+    # no VM boot).
+    local some_dir
+    some_dir=$(mktemp -d "$tmpdir/gitrepo-dir-XXXXXX")
+    if moat_fails up "$some_dir" --git-repo "$repo_url" --no-devcontainer; then
+        pass "up --git-repo conflicts with a positional directory"
+    else
+        fail "up --git-repo conflicts with a positional directory" "should have failed"
+    fi
+    if moat_fails up --git-repo "$repo_url" --mount --no-devcontainer; then
+        pass "up --git-repo conflicts with --mount"
+    else
+        fail "up --git-repo conflicts with --mount" "should have failed"
+    fi
+    rm -rf "$some_dir"
+
+    # --extra-mount targeting /workspace collides with the clone; rejected
+    # before boot (--no-devcontainer avoids remote devcontainer discovery).
+    if moat_fails up --git-repo "$repo_url" --name "$gr_instance" \
+            --extra-mount "$data_dir:/workspace" --no-agents --no-devcontainer; then
+        if echo "$HARNESS_ERR" | grep -q "/workspace"; then
+            pass "up --git-repo rejects --extra-mount at /workspace"
+        else
+            fail "up --git-repo rejects --extra-mount at /workspace" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "up --git-repo rejects --extra-mount at /workspace" \
+            "command unexpectedly succeeded"
+    fi
+
+    # Clone happy path plus an extra data mount in a single boot. The
+    # git-repo + extra-mount combination is the workspace-sync path that
+    # regressed on Firecracker before this change.
+    if coop up --git-repo "$repo_url" --name "$gr_instance" \
+            --extra-mount "$data_dir:/data" --no-agents --no-devcontainer; then
+        STARTED_INSTANCES+=("$gr_instance")
+        pass "up --git-repo creates an instance"
+    else
+        fail "up --git-repo creates an instance" "exit code: $? stderr: $HARNESS_ERR"
+        rm -rf "$data_dir"
+        return
+    fi
+
+    GUEST_INSTANCE="$gr_instance"
+
+    if guest_exec test -d /workspace/.git; then
+        pass "up --git-repo clones the repository into /workspace"
+    else
+        fail "up --git-repo clones the repository into /workspace" \
+            "no .git at /workspace; stderr: $(guest_stderr)"
+    fi
+
+    local head
+    if head=$(guest_exec git -C /workspace rev-parse HEAD); then
+        if [[ -n "$head" ]]; then
+            pass "cloned repository has a valid HEAD"
+        else
+            fail "cloned repository has a valid HEAD" "empty rev-parse output"
+        fi
+    else
+        fail "cloned repository has a valid HEAD" "git rev-parse failed: $(guest_stderr)"
+    fi
+
+    local marker
+    if marker=$(guest_exec cat /data/marker.txt); then
+        if [[ "$marker" == "extra-mount-marker" ]]; then
+            pass "up --git-repo also syncs --extra-mount data"
+        else
+            fail "up --git-repo also syncs --extra-mount data" "got: $marker"
+        fi
+    else
+        fail "up --git-repo also syncs --extra-mount data" "file not found at /data"
+    fi
+
+    unset GUEST_INSTANCE
+
+    # Re-running while the instance is up reuses it: exit 0, no new instance.
+    local pre_list post_list
+    pre_list=$("$BINARY" list 2>/dev/null | sort)
+    if coop up --git-repo "$repo_url" --name "$gr_instance" --no-devcontainer; then
+        pass "up --git-repo re-run exits 0 while running"
+    else
+        fail "up --git-repo re-run exits 0 while running" "exit code: $? stderr: $HARNESS_ERR"
+    fi
+    post_list=$("$BINARY" list 2>/dev/null | sort)
+    if [[ "$pre_list" == "$post_list" ]]; then
+        pass "up --git-repo reuses the running instance"
+    else
+        fail "up --git-repo reuses the running instance" \
+            "list changed: $(diff <(echo "$pre_list") <(echo "$post_list"))"
+    fi
+
+    coop destroy "$gr_instance" 2>/dev/null || true
+    untrack_instance "$gr_instance"
+    rm -rf "$data_dir"
+}
+
 # ── Workspace sync tests (--full only) ────────────────────────
 
 test_workspace_sync() {
@@ -3941,6 +4055,7 @@ main() {
     if [[ "$FULL" == "1" ]]; then
         test_quickstart
         test_up_project_workflow
+        test_git_repo
         test_mount_conflicts
         test_host_mount
         test_host_mount_custom_guest_path


### PR DESCRIPTION
## What this does

Adds `--git-repo <url>` to `coop up` as a workspace source alongside a local directory. The flag clones a remote repository into `/workspace` inside the guest and records the URL in `workspace.json`.

- **Idempotent**, like the rest of `up`: a repo already associated with an instance is reused if running, restarted if stopped, and created otherwise — matched by the recorded URL.
- **Instance name** is derived from the repo basename when `--name` is not given (e.g. `…/coop.git` → `coop`).
- **Creation-only flags** (`--image`, `--profile`, `--vcpus`, `--mem`, `--disk`, `--extra-mount`, `--devcontainer`) are rejected against an existing instance, with a message pointing at `coop destroy`.
- `--git-repo` conflicts with the local-directory sources and with `--copy`/`--mount`.
- `--extra-mount` targeting `/workspace` is rejected under `--git-repo`, mirroring the existing `--copy` guard.

The clone lands **directly in `/workspace`** (not a `/workspace/repo` subdirectory), so it matches `--copy`/`--mount` and the `cd /workspace` that `coop shell`/`claude`/`codex` use. This moves the git-repo creation path off `coop start` (now a pure restart command) and onto `coop up`, alongside the local-directory and `--profile` sources.

## Workspace-sync refactor

Reworks the workspace-sync block in `start_instance` so extra mounts always sync while only mount-only instances record the workspace identity. Side effects:

- Fixes a case on Firecracker where `coop up --copy DIR --extra-mount …` dropped the extra mount (the `else if !mounts.is_empty()` branch was unreachable when a workspace/git-repo source was set; the integration test only covered Lima, where mounts are live).
- Fixes a tar-pipe fallback in `sync_mounts` that extracted to `/workspace` regardless of the mount's actual guest path.

## Tests

- **Unit:** name derivation (URL edges, unusable basenames, length cap), `find_git_repo_instance` (no-match and ambiguity), `--name` mismatch, the `--git-repo` arg conflicts, the `/workspace` collision guard, and the updated clone-target script. `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (707 passing) are green.
- **Integration:** new `test_git_repo` phase (`--full` bucket) covering arg conflicts, the `/workspace` extra-mount rejection, the clone landing in `/workspace`, an accompanying `--extra-mount`, and idempotent reuse. Clones `octocat/Hello-World` anonymously; the clone runs inside the guest, which already requires network (per `test_network`).

## Not yet run

The integration suite (`tests/run-integration.sh`) has not been run on Lima or Firecracker — both are required before merge. The Firecracker run matters most since this changes that mount-sync path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)