### PR TITLE
Thread newtypes through boundaries instead of decaying to String

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -208,6 +208,15 @@ impl Hostname {
     }
 }
 
+impl From<std::net::Ipv4Addr> for Hostname {
+    /// An IPv4 literal is always a valid hostname (printable ASCII, no
+    /// whitespace, well under the length cap), so this conversion is
+    /// infallible.
+    fn from(ip: std::net::Ipv4Addr) -> Self {
+        Self(ip.to_string())
+    }
+}
+
 impl std::fmt::Display for Hostname {
     #[mutants::skip] // equivalent: trivial forwarder over self.0
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -967,7 +976,7 @@ impl VmBackend for FirecrackerBackend {
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget> {
         let guest_user = persisted_guest_user(cfg, &inst.image);
         Ok(SshTarget {
-            host: Hostname::new(inst.guest_ip())?,
+            host: Hostname::from(inst.guest_ip()),
             port: cfg.ssh_port,
             user: SshUser::new(guest_user.as_str())?,
             key_path: cfg.ssh_key_path(),
@@ -1159,7 +1168,7 @@ pub fn detect_instance_repo(
         "GitHub repo detection is disabled (pat-mode tokens will not be forwarded)",
     )?;
     match &state.source {
-        WorkspaceSource::GitRepo { url } => crate::github_repo::parse_repo_slug_from_url(url),
+        WorkspaceSource::GitRepo { url } => url.slug().cloned(),
         WorkspaceSource::Workspace { host_path } | WorkspaceSource::Mount { host_path } => {
             crate::github_repo::detect_workspace_repo(host_path)
                 .ok()

--- a/src/config.rs
+++ b/src/config.rs
@@ -2145,8 +2145,15 @@ impl Instance {
         format!("tap{}", self.index)
     }
 
-    pub fn guest_ip(&self) -> String {
-        format!("172.16.0.{}", self.index.as_u32() + 2)
+    /// The guest's IPv4 address on the `172.16.0.0/24` host network.
+    ///
+    /// Derived from the validated [`InstanceIndex`] (`0..=252`), so the
+    /// last octet is always in `2..=254` and the address never fails to
+    /// form — callers receive an [`Ipv4Addr`] directly rather than a
+    /// string they have to re-parse.
+    pub fn guest_ip(&self) -> std::net::Ipv4Addr {
+        let base = u32::from(std::net::Ipv4Addr::new(172, 16, 0, 2));
+        std::net::Ipv4Addr::from(base + self.index.as_u32())
     }
 
     pub fn guest_mac(&self) -> String {
@@ -2413,13 +2420,13 @@ mod tests {
     #[test]
     fn instance_network_derivations_at_boundaries() {
         let lo = test_inst("test", idx(0), PathBuf::from("/tmp/fake"));
-        assert_eq!(lo.guest_ip(), "172.16.0.2");
+        assert_eq!(lo.guest_ip(), std::net::Ipv4Addr::new(172, 16, 0, 2));
         assert_eq!(lo.guest_mac(), "06:00:AC:10:00:02");
         assert_eq!(lo.tap_device(), "tap0");
         assert_eq!(lo.vsock_cid(), 3);
 
         let hi = test_inst("test", idx(InstanceIndex::MAX), PathBuf::from("/tmp/fake"));
-        assert_eq!(hi.guest_ip(), "172.16.0.254");
+        assert_eq!(hi.guest_ip(), std::net::Ipv4Addr::new(172, 16, 0, 254));
         assert_eq!(hi.guest_mac(), "06:00:AC:10:00:fe");
         assert_eq!(hi.tap_device(), "tap252");
         assert_eq!(hi.vsock_cid(), 255);

--- a/src/devcontainer_oci.rs
+++ b/src/devcontainer_oci.rs
@@ -6,11 +6,13 @@
 //! `ghcr.io/devcontainers/features/*`.
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::cmd::Cmd;
 use crate::sha256_hash::Sha256Hash;
@@ -30,11 +32,70 @@ pub struct FeatureRequest {
     pub options: BTreeMap<String, String>,
 }
 
+/// An OCI content digest restricted to the sha256 algorithm.
+///
+/// Parses and renders as `sha256:<64 lowercase hex>`. The algorithm
+/// prefix is part of the wire form (it is what registry URLs and the
+/// `@digest` reference syntax use), so it is preserved on `Display`; the
+/// hex payload is validated once via [`Sha256Hash`] at parse time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciDigest(Sha256Hash);
+
+impl fmt::Display for OciDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sha256:{}", self.0)
+    }
+}
+
+impl FromStr for OciDigest {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let hex = s
+            .strip_prefix("sha256:")
+            .with_context(|| format!("OCI digest must start with 'sha256:': {s:?}"))?;
+        Ok(Self(hex.parse()?))
+    }
+}
+
+impl Serialize for OciDigest {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for OciDigest {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
+        s.parse()
+            .map_err(|e: anyhow::Error| serde::de::Error::custom(format!("{e:#}")))
+    }
+}
+
+/// How a feature pins its registry artifact: a mutable `:tag` or an
+/// immutable `@sha256:` digest. The two have different syntax and
+/// different guarantees (a digest is content-addressable), so they are
+/// kept distinct rather than conflated in one string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OciRef {
+    Tag(String),
+    Digest(OciDigest),
+}
+
+impl fmt::Display for OciRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tag(tag) => f.write_str(tag),
+            Self::Digest(digest) => write!(f, "{digest}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OciReference {
     pub host: String,
     pub repository: String,
-    pub reference: String,
+    pub reference: OciRef,
 }
 
 impl OciReference {
@@ -48,7 +109,7 @@ impl OciReference {
 pub struct InstalledFeature {
     pub id: String,
     pub reference: String,
-    pub digest: String,
+    pub digest: OciDigest,
     pub install_script_hash: Sha256Hash,
 }
 
@@ -125,13 +186,19 @@ fn parse_supported_reference(raw_id: &str) -> Result<Option<OciReference>> {
         return Ok(None);
     };
     let (name, reference) = if let Some((name, digest)) = repo_and_ref.split_once('@') {
-        (name, digest)
+        let digest: OciDigest = digest
+            .parse()
+            .with_context(|| format!("invalid feature digest in {raw_id:?}"))?;
+        (name, OciRef::Digest(digest))
     } else if let Some((name, tag)) = repo_and_ref.rsplit_once(':') {
-        (name, tag)
+        if tag.is_empty() {
+            bail!("expected ghcr.io/devcontainers/features/<name>[:tag|@digest]");
+        }
+        (name, OciRef::Tag(tag.to_string()))
     } else {
-        (repo_and_ref, "latest")
+        (repo_and_ref, OciRef::Tag("latest".to_string()))
     };
-    if name.is_empty() || reference.is_empty() {
+    if name.is_empty() {
         bail!("expected ghcr.io/devcontainers/features/<name>[:tag|@digest]");
     }
     if !name
@@ -143,7 +210,7 @@ fn parse_supported_reference(raw_id: &str) -> Result<Option<OciReference>> {
     Ok(Some(OciReference {
         host: GHCR_HOST.to_string(),
         repository: format!("{SUPPORTED_REPO_PREFIX}{name}"),
-        reference: reference.to_string(),
+        reference,
     }))
 }
 
@@ -223,11 +290,14 @@ fn resolved_feature_from_archive(
     if install_script.trim().is_empty() {
         bail!("feature install.sh is empty");
     }
+    let digest: OciDigest = manifest_digest.parse().with_context(|| {
+        format!("registry returned unexpected manifest digest {manifest_digest:?}")
+    })?;
     Ok(ResolvedFeature {
         installed: InstalledFeature {
             id,
             reference: req.raw_id.clone(),
-            digest: manifest_digest.to_string(),
+            digest,
             install_script_hash: Sha256Hash::of(&install_script),
         },
         install_script,
@@ -435,6 +505,10 @@ fn shell_single_quote(value: &str) -> String {
 mod tests {
     use super::*;
 
+    // A syntactically valid sha256 OCI digest for fixtures.
+    const SAMPLE_DIGEST: &str =
+        "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+
     #[test]
     fn parse_supported_reference_defaults_to_latest() {
         let req = parse_feature_request(
@@ -447,7 +521,7 @@ mod tests {
             req.reference.repository,
             "devcontainers/features/github-cli"
         );
-        assert_eq!(req.reference.reference, "latest");
+        assert_eq!(req.reference.reference, OciRef::Tag("latest".to_string()));
     }
 
     #[test]
@@ -458,7 +532,7 @@ mod tests {
         )
         .unwrap()
         .unwrap();
-        assert_eq!(req.reference.reference, "1.2.3");
+        assert_eq!(req.reference.reference, OciRef::Tag("1.2.3".to_string()));
         assert_eq!(req.options["version"], "1.24");
         assert_eq!(req.options["moby"], "true");
     }
@@ -479,7 +553,7 @@ mod tests {
             installed: InstalledFeature {
                 id: "github-cli".to_string(),
                 reference: "ghcr.io/devcontainers/features/github-cli:1".to_string(),
-                digest: "sha256:abc".to_string(),
+                digest: SAMPLE_DIGEST.parse().unwrap(),
                 install_script_hash: Sha256Hash::of("echo install"),
             },
             install_script: "echo \"$VERSION\"".to_string(),
@@ -553,13 +627,13 @@ mod tests {
             reference: OciReference {
                 host: GHCR_HOST.to_string(),
                 repository: "devcontainers/features/sample".to_string(),
-                reference: "1".to_string(),
+                reference: OciRef::Tag("1".to_string()),
             },
             options: BTreeMap::new(),
         };
         let resolved = resolved_feature_from_archive(
             &req,
-            "sha256:manifest",
+            SAMPLE_DIGEST,
             FeatureMetadata {
                 id: Some("sample".to_string()),
                 name: None,
@@ -569,7 +643,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(resolved.installed.id, "sample");
-        assert_eq!(resolved.installed.digest, "sha256:manifest");
+        assert_eq!(resolved.installed.digest.to_string(), SAMPLE_DIGEST);
         assert!(resolved.install_script.contains("./helper.sh"));
         assert_eq!(resolved.archive, std::fs::read(&archive).unwrap());
         assert!(compose_install_snippet(&resolved).contains(&base64_encode(&resolved.archive)));
@@ -582,5 +656,66 @@ mod tests {
             parse_docker_content_digest(headers).as_deref(),
             Some("sha256:manifest")
         );
+    }
+
+    #[test]
+    fn oci_digest_round_trips_with_prefix() {
+        let digest: OciDigest = SAMPLE_DIGEST.parse().unwrap();
+        assert_eq!(digest.to_string(), SAMPLE_DIGEST);
+    }
+
+    #[test]
+    fn oci_digest_rejects_missing_prefix() {
+        let bare = SAMPLE_DIGEST.strip_prefix("sha256:").unwrap();
+        assert!(bare.parse::<OciDigest>().is_err());
+    }
+
+    #[test]
+    fn oci_digest_rejects_bad_hex() {
+        assert!("sha256:not-hex".parse::<OciDigest>().is_err());
+        assert!("sha256:abc".parse::<OciDigest>().is_err());
+    }
+
+    #[test]
+    fn oci_digest_serde_round_trips_as_string() {
+        let digest: OciDigest = SAMPLE_DIGEST.parse().unwrap();
+        let json = serde_json::to_string(&digest).unwrap();
+        assert_eq!(json, format!("\"{SAMPLE_DIGEST}\""));
+        let parsed: OciDigest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, digest);
+    }
+
+    #[test]
+    fn parse_supported_reference_accepts_digest() {
+        let req = parse_feature_request(
+            &format!("ghcr.io/devcontainers/features/go@{SAMPLE_DIGEST}"),
+            &serde_json::json!({}),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            req.reference.reference,
+            OciRef::Digest(SAMPLE_DIGEST.parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_supported_reference_rejects_malformed_digest() {
+        let err = parse_feature_request(
+            "ghcr.io/devcontainers/features/go@sha256:nope",
+            &serde_json::json!({}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("digest"),
+            "expected digest error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn oci_ref_display_matches_wire_form() {
+        assert_eq!(OciRef::Tag("1.2.3".to_string()).to_string(), "1.2.3");
+        let digest: OciDigest = SAMPLE_DIGEST.parse().unwrap();
+        assert_eq!(OciRef::Digest(digest).to_string(), SAMPLE_DIGEST);
     }
 }

--- a/src/github_repo.rs
+++ b/src/github_repo.rs
@@ -166,6 +166,71 @@ pub fn detect_workspace_repo(git_dir: &Path) -> Result<Option<RepoSlug>> {
     Ok(parse_repo_slug_from_url(&url))
 }
 
+/// A clone URL passed to `coop up --git-repo`, paired with the
+/// `owner/repo` slug derived from it once at construction.
+///
+/// The slug is computed by [`parse_repo_slug_from_url`] exactly once —
+/// when the value is built or deserialized — rather than re-parsed on
+/// every read. `slug` is `None` for clone URLs that are not GitHub
+/// `owner/repo` URLs (e.g. another host, or a local path); such repos
+/// still clone, they just carry no slug for PAT routing.
+///
+/// On disk the value is a plain URL string (the slug is derived, never
+/// persisted), so `workspace.json` files round-trip unchanged.
+#[derive(Debug, Clone)]
+pub struct GitRepoUrl {
+    url: String,
+    slug: Option<RepoSlug>,
+}
+
+impl GitRepoUrl {
+    /// Build from a clone URL, deriving the slug once.
+    pub fn new(url: impl Into<String>) -> Self {
+        let url = url.into();
+        let slug = parse_repo_slug_from_url(&url);
+        Self { url, slug }
+    }
+
+    /// The original clone URL.
+    pub fn as_str(&self) -> &str {
+        &self.url
+    }
+
+    /// The `owner/repo` slug derived from the URL, if it is a GitHub URL.
+    pub fn slug(&self) -> Option<&RepoSlug> {
+        self.slug.as_ref()
+    }
+}
+
+/// Two `GitRepoUrl`s are equal when their clone URLs match; the slug is
+/// derived and never diverges for a given URL.
+impl PartialEq for GitRepoUrl {
+    fn eq(&self, other: &Self) -> bool {
+        self.url == other.url
+    }
+}
+
+impl Eq for GitRepoUrl {}
+
+impl fmt::Display for GitRepoUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.url)
+    }
+}
+
+impl Serialize for GitRepoUrl {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.url)
+    }
+}
+
+impl<'de> Deserialize<'de> for GitRepoUrl {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let url = String::deserialize(deserializer)?;
+        Ok(Self::new(url))
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
@@ -329,5 +394,46 @@ mod tests {
         let s = slug("a/b");
         let json = serde_json::to_string(&s).unwrap();
         assert_eq!(json, "\"a/b\"");
+    }
+
+    #[test]
+    fn git_repo_url_derives_slug_for_github_url() {
+        let url = GitRepoUrl::new("https://github.com/trailofbits/coop.git");
+        assert_eq!(url.as_str(), "https://github.com/trailofbits/coop.git");
+        assert_eq!(url.slug(), Some(&slug("trailofbits/coop")));
+    }
+
+    #[test]
+    fn git_repo_url_has_no_slug_for_non_github_url() {
+        let url = GitRepoUrl::new("https://gitlab.com/group/project.git");
+        assert_eq!(url.slug(), None);
+        // A repo with no slug still round-trips its clone URL.
+        assert_eq!(url.as_str(), "https://gitlab.com/group/project.git");
+    }
+
+    #[test]
+    fn git_repo_url_serializes_as_bare_string() {
+        let url = GitRepoUrl::new("https://github.com/a/b.git");
+        let json = serde_json::to_string(&url).unwrap();
+        assert_eq!(json, "\"https://github.com/a/b.git\"");
+    }
+
+    #[test]
+    fn git_repo_url_deserializes_and_reparses_slug() {
+        let url: GitRepoUrl = serde_json::from_str("\"https://github.com/a/b\"").unwrap();
+        assert_eq!(url.as_str(), "https://github.com/a/b");
+        assert_eq!(url.slug(), Some(&slug("a/b")));
+    }
+
+    #[test]
+    fn git_repo_url_equality_is_by_url() {
+        assert_eq!(
+            GitRepoUrl::new("https://github.com/a/b"),
+            GitRepoUrl::new("https://github.com/a/b")
+        );
+        assert_ne!(
+            GitRepoUrl::new("https://github.com/a/b"),
+            GitRepoUrl::new("https://github.com/a/c")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2273,7 +2273,7 @@ fn find_git_repo_instance(
                 .is_some_and(|s| {
                     matches!(
                         s.source,
-                        workspace::WorkspaceSource::GitRepo { ref url } if url == repo_url
+                        workspace::WorkspaceSource::GitRepo { ref url } if url.as_str() == repo_url
                     )
                 })
         })
@@ -2552,7 +2552,7 @@ fn resolve_oci_feature_requests(translation: &mut devcontainer::Translation) {
                     key,
                     devcontainer::ReportStatus::Applied,
                     devcontainer::ReportSource::Devcontainer,
-                    feature.installed.digest.clone(),
+                    feature.installed.digest.to_string(),
                     format!(
                         "OCI feature '{}' install.sh sha256 {} will run during setup",
                         feature.installed.id, feature.installed.install_script_hash
@@ -3226,7 +3226,7 @@ fn start_instance(
         let state = workspace::WorkspaceState {
             guest_path: workspace::default_workspace_path(),
             source: workspace::WorkspaceSource::GitRepo {
-                url: repo_url.to_string(),
+                url: github_repo::GitRepoUrl::new(repo_url),
             },
         };
         state.save(inst)?;
@@ -5018,7 +5018,7 @@ mod tests {
             let state = super::workspace::WorkspaceState {
                 guest_path: super::workspace::default_workspace_path(),
                 source: super::workspace::WorkspaceSource::GitRepo {
-                    url: repo_url.to_string(),
+                    url: super::github_repo::GitRepoUrl::new(repo_url),
                 },
             };
             state.save(&inst).expect("save workspace state");
@@ -5179,7 +5179,7 @@ mod tests {
         let state = super::workspace::WorkspaceState {
             guest_path: super::workspace::default_workspace_path(),
             source: super::workspace::WorkspaceSource::GitRepo {
-                url: repo_url.to_string(),
+                url: super::github_repo::GitRepoUrl::new(repo_url),
             },
         };
         state.save(&inst).expect("save workspace state");

--- a/src/update.rs
+++ b/src/update.rs
@@ -17,11 +17,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, bail, ensure};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest as _, Sha256};
 
 use crate::cmd::Cmd;
 use crate::fs_util::atomic_write_json;
 use crate::prompt::confirm;
+use crate::sha256_hash::Sha256Hash;
 
 const REPO: &str = "trailofbits/coop";
 const DEFAULT_API_BASE: &str = "https://api.github.com";
@@ -332,11 +332,14 @@ fn gh_release_download(tag: &str, asset_name: &str, dest: &Path) -> Result<()> {
 
 // ── Checksum verification ────────────────────────────────────────────────────
 
-/// Parse a `sha256sum`-style `SHA256SUMS` file and return the hex digest for
+/// Parse a `sha256sum`-style `SHA256SUMS` file and return the digest for
 /// `target_filename`. Handles both `<hash>  <file>` (binary mode) and
 /// `<hash> *<file>` variants; tolerates blank lines and `#` comments.
+///
+/// Malformed digests for the target filename are skipped (parsing
+/// continues), so the first well-formed entry wins.
 #[must_use]
-pub fn parse_sha256sums(content: &str, target_filename: &str) -> Option<String> {
+pub fn parse_sha256sums(content: &str, target_filename: &str) -> Option<Sha256Hash> {
     for line in content.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -345,25 +348,21 @@ pub fn parse_sha256sums(content: &str, target_filename: &str) -> Option<String> 
         let (hash, rest) = line.split_once(|c: char| c.is_ascii_whitespace())?;
         let file = rest.trim_start().trim_start_matches('*');
         if file == target_filename
-            && hash.len() == 64
-            && hash.bytes().all(|b| b.is_ascii_hexdigit())
+            && let Ok(parsed) = hash.parse::<Sha256Hash>()
         {
-            return Some(hash.to_ascii_lowercase());
+            return Some(parsed);
         }
     }
     None
 }
 
-fn verify_sha256(file: &Path, expected_hex: &str) -> Result<()> {
+fn verify_sha256(file: &Path, expected: &Sha256Hash) -> Result<()> {
     let bytes = fs::read(file)
         .with_context(|| format!("Failed to read {} for checksum", file.display()))?;
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    let digest = hasher.finalize();
-    let actual = hex::encode(digest);
+    let actual = Sha256Hash::of(&bytes);
     ensure!(
-        actual.eq_ignore_ascii_case(expected_hex),
-        "SHA-256 mismatch for {}: expected {expected_hex}, got {actual}",
+        actual == *expected,
+        "SHA-256 mismatch for {}: expected {expected}, got {actual}",
         file.display()
     );
     Ok(())
@@ -776,7 +775,7 @@ mod tests {
         );
         let got = parse_sha256sums(content, "coop-v1.tar.gz").unwrap();
         assert_eq!(
-            got,
+            got.to_string(),
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         );
     }
@@ -787,7 +786,11 @@ mod tests {
             "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc *coop.tar.gz\n";
         assert_eq!(
             parse_sha256sums(content, "coop.tar.gz"),
-            Some("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".to_string())
+            Some(
+                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    .parse()
+                    .unwrap()
+            )
         );
     }
 
@@ -800,7 +803,11 @@ mod tests {
         );
         assert_eq!(
             parse_sha256sums(content, "x.tar.gz"),
-            Some("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string())
+            Some(
+                "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    .parse()
+                    .unwrap()
+            )
         );
     }
 
@@ -871,9 +878,13 @@ mod tests {
         fs::write(&path, b"hello world").unwrap();
 
         // sha256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-        let correct = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
-        verify_sha256(&path, correct).unwrap();
-        verify_sha256(&path, &"0".repeat(64)).unwrap_err();
+        let correct: Sha256Hash =
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+                .parse()
+                .unwrap();
+        verify_sha256(&path, &correct).unwrap();
+        let wrong: Sha256Hash = "0".repeat(64).parse().unwrap();
+        verify_sha256(&path, &wrong).unwrap_err();
     }
 
     #[test]
@@ -884,7 +895,11 @@ mod tests {
         );
         assert_eq!(
             parse_sha256sums(content, "x.tar.gz"),
-            Some("1111111111111111111111111111111111111111111111111111111111111111".to_string())
+            Some(
+                "1111111111111111111111111111111111111111111111111111111111111111"
+                    .parse()
+                    .unwrap()
+            )
         );
     }
 
@@ -894,7 +909,11 @@ mod tests {
             "3333333333333333333333333333333333333333333333333333333333333333  x.tar.gz\r\n";
         assert_eq!(
             parse_sha256sums(content, "x.tar.gz"),
-            Some("3333333333333333333333333333333333333333333333333333333333333333".to_string())
+            Some(
+                "3333333333333333333333333333333333333333333333333333333333333333"
+                    .parse()
+                    .unwrap()
+            )
         );
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -380,7 +380,7 @@ impl<'a> FirecrackerVm<'a, Running> {
 
         let guest_user = crate::backend::persisted_guest_user(self.cfg, &self.inst.image);
         let target = crate::backend::SshTarget {
-            host: crate::backend::Hostname::new(self.inst.guest_ip())?,
+            host: crate::backend::Hostname::from(self.inst.guest_ip()),
             port: self.cfg.ssh_port,
             user: crate::backend::SshUser::new(guest_user.as_str())?,
             key_path: self.cfg.ssh_key_path(),

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -47,7 +47,7 @@ pub struct WorkspaceState {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum WorkspaceSource {
     Workspace { host_path: PathBuf },
-    GitRepo { url: String },
+    GitRepo { url: crate::github_repo::GitRepoUrl },
     Mount { host_path: PathBuf },
 }
 
@@ -1176,14 +1176,14 @@ mod tests {
         let state = WorkspaceState {
             guest_path: GuestPath::absolute(GUEST_WORKSPACE).unwrap(),
             source: WorkspaceSource::GitRepo {
-                url: "https://github.com/x/y.git".to_string(),
+                url: crate::github_repo::GitRepoUrl::new("https://github.com/x/y.git"),
             },
         };
         state.save(&inst).expect("save");
         let loaded = try_load_or_warn(&inst, "test").expect("state should load");
         assert!(matches!(
             loaded.source,
-            WorkspaceSource::GitRepo { ref url } if url == "https://github.com/x/y.git"
+            WorkspaceSource::GitRepo { ref url } if url.as_str() == "https://github.com/x/y.git"
         ));
     }
 
@@ -1194,7 +1194,7 @@ mod tests {
         let state = WorkspaceState {
             guest_path: GuestPath::absolute("/custom").unwrap(),
             source: WorkspaceSource::GitRepo {
-                url: "https://github.com/x/y.git".to_string(),
+                url: crate::github_repo::GitRepoUrl::new("https://github.com/x/y.git"),
             },
         };
         state.save(&inst).expect("save");
@@ -1202,7 +1202,7 @@ mod tests {
         assert_eq!(loaded.guest_path.to_string(), "/custom");
         assert!(matches!(
             loaded.source,
-            WorkspaceSource::GitRepo { ref url } if url == "https://github.com/x/y.git"
+            WorkspaceSource::GitRepo { ref url } if url.as_str() == "https://github.com/x/y.git"
         ));
     }
 
@@ -1449,5 +1449,31 @@ Host coop-0\n\
             msg.contains("coop start") || msg.contains("coop destroy"),
             "expected remediation pointer: {msg}"
         );
+    }
+
+    #[test]
+    fn git_repo_source_persists_url_as_bare_string() {
+        // The on-disk format must not change when the url field became a
+        // `GitRepoUrl` newtype: it must still serialize as the tagged
+        // enum with a bare `url` string, and a file written in that exact
+        // shape must still load.
+        let state = WorkspaceState {
+            guest_path: GuestPath::absolute(GUEST_WORKSPACE).unwrap(),
+            source: WorkspaceSource::GitRepo {
+                url: crate::github_repo::GitRepoUrl::new("https://github.com/x/y.git"),
+            },
+        };
+        let value: serde_json::Value = serde_json::to_value(&state).expect("serialize to value");
+        assert_eq!(value["source"]["kind"], "git_repo");
+        assert_eq!(value["source"]["url"], "https://github.com/x/y.git");
+
+        let from_disk: WorkspaceState = serde_json::from_str(&format!(
+            r#"{{"guest_path": "{GUEST_WORKSPACE}", "source": {{"kind": "git_repo", "url": "https://github.com/x/y.git"}}}}"#
+        ))
+        .expect("load on-disk shape");
+        assert!(matches!(
+            from_disk.source,
+            WorkspaceSource::GitRepo { ref url } if url.as_str() == "https://github.com/x/y.git"
+        ));
     }
 }


### PR DESCRIPTION
Closes #267.

Applies "parse, don't validate" to four boundaries where validated values were stored or returned as `String` and re-parsed (or never validated) on read.

## Changes

- **`GitRepoUrl` newtype** (`github_repo.rs`): `WorkspaceSource::GitRepo` holds it instead of a raw URL string. The `owner/repo` slug is derived once at construction/deserialize rather than re-parsed on every read in `detect_instance_repo`. It serializes as a bare string, so existing `workspace.json` files round-trip unchanged. `find_git_repo_instance` matches on `.as_str()`, preserving the existing idempotency behavior.
- **`Sha256Hash::of` reuse** (`update.rs`): replaces the hand-rolled `Sha256::new()`/`hex::encode`. `parse_sha256sums` returns `Option<Sha256Hash>` and `verify_sha256` takes `&Sha256Hash`.
- **`guest_ip()` returns `Ipv4Addr`** (`config.rs`): derived from the validated `InstanceIndex`, so it can never fail to parse. Adds infallible `From<Ipv4Addr> for Hostname`; callers (`vm.rs`, `backend.rs`) drop the fallible `Hostname::new(...)?` wrap.
- **`OciDigest` and `OciRef`** (`devcontainer_oci.rs`): `OciDigest(Sha256Hash)` renders as `sha256:<hex>` and validates the hex once. `OciRef { Tag(String), Digest(OciDigest) }` replaces the `OciReference.reference: String` that conflated tags and digests. `InstalledFeature.digest` is now `OciDigest`, validated at construction.

## Out of scope

`guest_mac()` and `tap_device()` also return `String`, but their values are never re-parsed and no newtype exists for them; adding one would be speculative.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (732 passing) are all clean.
- Added unit tests for `GitRepoUrl` slug derivation / non-GitHub / serde, the `GitRepo` on-disk format guard, `OciDigest` parse/Display/serde, and `@digest` reference parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)