### PR TITLE
Type the PAT repo probe with a ProbeError enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "thiserror",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1"
 semver = "1"
 sha2 = "0.11"
 tempfile = "3"
+thiserror = "2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hex = "0.4.3"
 mutants = "0.0.4"

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
+use thiserror::Error;
 
 use crate::cmd::Cmd;
 use crate::config::{CoopConfig, GitHubAuth, resolve_cmd_value};
@@ -377,24 +378,66 @@ fn probe_user(token: &str) -> Result<()> {
     Ok(())
 }
 
-fn probe_repo(token: &str, repo: &RepoSlug) -> Result<()> {
+/// Distinct outcomes of probing `GET /repos/{owner}/{repo}` with a PAT.
+///
+/// The recovery path ([`crate::pat_prompt`]) branches on these: a 404
+/// usually means the slug is wrong or the token's resource owner doesn't
+/// match, while a 403 is almost always the org's fine-grained-PAT policy
+/// blocking an otherwise-valid token. Folding both into one `bail!` string
+/// forced recovery to string-match the message; the enum lets it react per
+/// case. Errors propagate through `anyhow` and are recovered with
+/// `downcast_ref::<ProbeError>()`.
+#[derive(Debug, Error)]
+pub enum ProbeError {
+    /// HTTP 403 — typically the org's fine-grained-PAT approval policy.
+    #[error(
+        "GET /repos/{repo} returned 403. This is often the org's \
+         fine-grained PAT policy: ask an org admin to approve \
+         fine-grained PATs, or to approve your specific token."
+    )]
+    OrgPolicyBlock { repo: RepoSlug },
+    /// HTTP 404 — wrong slug, or the PAT's resource owner doesn't match.
+    #[error(
+        "GET /repos/{repo} returned 404. Check the repo slug and \
+         that the PAT was generated with the right resource owner."
+    )]
+    NotFound { repo: RepoSlug },
+    /// Any other non-200 status.
+    #[error("GET /repos/{repo} returned HTTP {status}")]
+    Unexpected { repo: RepoSlug, status: u16 },
+    /// The request itself failed (curl error or an unparsable response).
+    #[error("failed to query GET /repos/{repo}")]
+    Transport {
+        repo: RepoSlug,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+fn probe_repo(token: &str, repo: &RepoSlug) -> Result<(), ProbeError> {
     let url = format!("https://api.github.com/repos/{repo}");
-    let (status, _body) = curl_with_token(token, &url)?;
+    let (status, _body) = curl_with_token(token, &url).map_err(|source| ProbeError::Transport {
+        repo: repo.clone(),
+        source: source.into(),
+    })?;
+    classify_repo_probe(status, repo)?;
+    eprintln!("  ✓ /repos/{repo}");
+    Ok(())
+}
+
+/// Map an HTTP status from `GET /repos/{repo}` to a [`ProbeError`].
+///
+/// Pure (no I/O) so the status-to-variant mapping can be unit-tested
+/// without shelling out to `curl`.
+fn classify_repo_probe(status: u16, repo: &RepoSlug) -> Result<(), ProbeError> {
     match status {
-        200 => {
-            eprintln!("  ✓ /repos/{repo}");
-            Ok(())
-        }
-        403 => bail!(
-            "GET /repos/{repo} returned 403. This is often the org's \
-             fine-grained PAT policy: ask an org admin to approve \
-             fine-grained PATs, or to approve your specific token."
-        ),
-        404 => bail!(
-            "GET /repos/{repo} returned 404. Check the repo slug and \
-             that the PAT was generated with the right resource owner."
-        ),
-        other => bail!("GET /repos/{repo} returned HTTP {other}"),
+        200 => Ok(()),
+        403 => Err(ProbeError::OrgPolicyBlock { repo: repo.clone() }),
+        404 => Err(ProbeError::NotFound { repo: repo.clone() }),
+        other => Err(ProbeError::Unexpected {
+            repo: repo.clone(),
+            status: other,
+        }),
     }
 }
 
@@ -939,6 +982,32 @@ mod tests {
 
     fn slug(s: &str) -> RepoSlug {
         RepoSlug::new(s).unwrap()
+    }
+
+    #[test]
+    fn classify_repo_probe_ok_on_200() {
+        assert!(classify_repo_probe(200, &slug("trailofbits/coop")).is_ok());
+    }
+
+    #[test]
+    fn classify_repo_probe_403_is_org_policy_block() {
+        let err = classify_repo_probe(403, &slug("trailofbits/coop")).unwrap_err();
+        assert!(matches!(err, ProbeError::OrgPolicyBlock { .. }));
+        assert!(err.to_string().contains("fine-grained PAT policy"));
+    }
+
+    #[test]
+    fn classify_repo_probe_404_is_not_found() {
+        let err = classify_repo_probe(404, &slug("trailofbits/nope")).unwrap_err();
+        assert!(matches!(err, ProbeError::NotFound { .. }));
+        assert!(err.to_string().contains("Check the repo slug"));
+    }
+
+    #[test]
+    fn classify_repo_probe_other_status_is_unexpected() {
+        let err = classify_repo_probe(500, &slug("trailofbits/coop")).unwrap_err();
+        assert!(matches!(err, ProbeError::Unexpected { status: 500, .. }));
+        assert!(err.to_string().contains("HTTP 500"));
     }
 
     #[test]

--- a/src/pat_prompt.rs
+++ b/src/pat_prompt.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::config::{CoopConfig, GitHubAuth};
-use crate::github_pat::{self, SetupOpts};
+use crate::github_pat::{self, ProbeError, SetupOpts};
 use crate::github_repo::RepoSlug;
 
 /// Effective answer to "should we offer the user a PAT wizard right now?"
@@ -163,6 +163,7 @@ fn run_wizard_or_recover(cfg: &CoopConfig, config_path: &Path, repo: &RepoSlug) 
     match github_pat::run_setup_pat(cfg, &opts) {
         Ok(()) => Ok(()),
         Err(e) => {
+            explain_probe_failure(&e);
             tracing::warn!("PAT setup failed ({e}); falling back to unauthenticated start");
             eprint!("continue without GitHub auth? [y/N] ");
             std::io::stderr().flush().ok();
@@ -174,6 +175,31 @@ fn run_wizard_or_recover(cfg: &CoopConfig, config_path: &Path, repo: &RepoSlug) 
                 Err(e)
             }
         }
+    }
+}
+
+/// Print recovery guidance tailored to a [`ProbeError`], if that is what
+/// the wizard failed on. A 404 means the slug or resource owner is wrong —
+/// continuing unauthenticated won't help a private repo, so the user should
+/// fix and retry. A 403 means the token is valid but the org blocks it —
+/// public clones still work, only private operations fail. Other failures
+/// fall through to the generic continue prompt with no extra guidance.
+fn explain_probe_failure(err: &anyhow::Error) {
+    match err.downcast_ref::<ProbeError>() {
+        Some(ProbeError::NotFound { repo }) => {
+            eprintln!(
+                "'{repo}' wasn't found with this token. Check the slug and that the \
+                 PAT's resource owner matches, then retry: coop github setup-pat --repo {repo}"
+            );
+        }
+        Some(ProbeError::OrgPolicyBlock { .. }) => {
+            eprintln!(
+                "The token is valid but the org blocks fine-grained PATs. Public repos \
+                 still clone unauthenticated; private pushes will fail until an org admin \
+                 approves the token."
+            );
+        }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
Closes #270.

## What

`probe_repo` (github_pat.rs) folded HTTP 403 and 404 into indistinguishable `bail!` strings. The start-time recovery path `run_wizard_or_recover` (pat_prompt.rs) caught any error and could only offer a generic "continue without auth?" prompt — it couldn't tell "repo doesn't exist / wrong resource owner" (404) from "org blocks fine-grained PATs" (403).

This introduces a focused `thiserror` enum, `ProbeError`, with variants `OrgPolicyBlock`, `NotFound`, `Unexpected { status }`, and `Transport`. `probe_repo` now returns `Result<(), ProbeError>`. The status-to-variant mapping is extracted into a pure `classify_repo_probe` helper covered by unit tests. `run_wizard_or_recover` downcasts the bubbled `anyhow` error and prints guidance tailored to 404 vs 403 before the existing continue prompt.

## Scope

Issue 270 also suggested a `BackendError` enum for `as_running`. That was intentionally skipped: since the issue was filed, `as_running` already models "not running" as `Ok(None)`, and none of its five callers branch on the error kind — they all `?`-propagate or discard via `if let Ok(Some(..))`. Adding the enum would create a dead `NotRunning` variant and variants no caller distinguishes, which the issue's own "only where callers branch" rule argues against. The `ProbeError` recovery branch is the one site with a real consumer.

The existing 403/404/other user-facing messages are preserved verbatim in the `#[error(...)]` attributes.

## Testing

- `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check` — clean
- `cargo test --bins` — 738 pass, including 4 new `classify_repo_probe_*` tests asserting variant and message per status

🤖 Generated with [Claude Code](https://claude.com/claude-code)