### PR TITLE
Remove dead wrappers and tighten over-broad visibility

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -255,64 +255,8 @@ fn write_stdin_and_close(child: &mut std::process::Child, bytes: &[u8], desc: &s
 
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test code — panics are assertions")]
-#[expect(clippy::unwrap_used, reason = "test code — panics are assertions")]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// Trait for executing commands, enabling test doubles.
-    ///
-    /// When production code starts accepting `&dyn CommandRunner`,
-    /// move this out of `#[cfg(test)]`.
-    trait CommandRunner: Send + Sync {
-        fn run(&self, program: &str, args: &[&str], sudo: bool) -> Result<()>;
-    }
-
-    /// Recorded invocation from [`MockRunner`].
-    #[derive(Debug, Clone)]
-    struct Invocation {
-        program: String,
-        args: Vec<String>,
-        sudo: bool,
-    }
-
-    /// Test double that records invocations and returns configured
-    /// responses. All methods succeed by default.
-    struct MockRunner {
-        invocations: Mutex<Vec<Invocation>>,
-        fail_run: Mutex<Option<String>>,
-    }
-
-    impl MockRunner {
-        fn new() -> Self {
-            Self {
-                invocations: Mutex::new(Vec::new()),
-                fail_run: Mutex::new(None),
-            }
-        }
-
-        fn invocations(&self) -> Vec<Invocation> {
-            self.invocations.lock().expect("lock").clone()
-        }
-
-        fn record(&self, program: &str, args: &[&str], sudo: bool) {
-            self.invocations.lock().expect("lock").push(Invocation {
-                program: program.to_string(),
-                args: args.iter().map(|s| (*s).to_string()).collect(),
-                sudo,
-            });
-        }
-    }
-
-    impl CommandRunner for MockRunner {
-        fn run(&self, program: &str, args: &[&str], sudo: bool) -> Result<()> {
-            self.record(program, args, sudo);
-            if let Some(msg) = self.fail_run.lock().expect("lock").as_ref() {
-                bail!("{msg}");
-            }
-            Ok(())
-        }
-    }
 
     #[test]
     fn cmd_describe_without_sudo() {
@@ -378,34 +322,5 @@ mod tests {
             .stdin_input(b"data".to_vec())
             .run()
             .expect("cat run");
-    }
-
-    #[test]
-    fn mock_runner_records_invocations() {
-        let runner = MockRunner::new();
-        runner
-            .run("mount", &["-o", "loop", "/dev/sda1"], true)
-            .expect("should succeed");
-
-        let inv = runner.invocations();
-        assert_eq!(inv.len(), 1);
-        assert_eq!(inv[0].program, "mount");
-        assert_eq!(inv[0].args, vec!["-o", "loop", "/dev/sda1"]);
-        assert!(inv[0].sudo);
-    }
-
-    #[test]
-    fn mock_runner_can_fail() {
-        let runner = MockRunner::new();
-        *runner.fail_run.lock().expect("lock") = Some("simulated failure".into());
-
-        let result = runner.run("rm", &["-rf", "/"], false);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("simulated failure")
-        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1403,11 +1403,6 @@ impl InstanceName {
         Ok(Self(name.to_string()))
     }
 
-    /// Clap `value_parser` entry point for instance-name arguments.
-    pub fn parse(s: &str) -> Result<Self> {
-        Self::new(s)
-    }
-
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -1478,11 +1473,6 @@ impl ImageName {
     pub fn new(name: &str) -> Result<Self> {
         validate_image_name(name)?;
         Ok(Self(name.to_string()))
-    }
-
-    /// Clap `value_parser` entry point for `--image` arguments.
-    pub fn parse(s: &str) -> Result<Self> {
-        Self::new(s)
     }
 
     pub fn as_str(&self) -> &str {

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -24,10 +24,10 @@ use thiserror::Error;
 
 use crate::cmd::Cmd;
 use crate::config::{CoopConfig, GitHubAuth, resolve_cmd_value};
-use crate::github_repo::{RepoSlug, detect_workspace_repo, parse_repo_slug_from_url};
+use crate::github_repo::{RepoSlug, detect_workspace_repo};
 use crate::github_submodules::{SubmoduleDiscovery, classify_urls, extract_urls};
 use crate::secret_store::{
-    CmdToken, SERVICE, account_for_repo, available_backends, delete_secret, store_secret,
+    AccountName, CmdToken, SERVICE, available_backends, delete_secret, store_secret,
 };
 
 /// Prefix every fine-grained PAT starts with. Surfaced as `pub const` so
@@ -47,7 +47,7 @@ pub struct SetupOpts<'a> {
 /// On success, the on-disk config has a fresh `[github.pat."owner/repo"]`
 /// entry and any matching skip-marker is removed.
 pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
-    let repo = resolve_target_repo(opts.repo, None)?;
+    let repo = resolve_target_repo(opts.repo)?;
 
     let prediscovered = prefetch_submodules(&repo);
     print_form_instructions(&repo, prediscovered.as_ref());
@@ -61,7 +61,7 @@ pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
     let token = handle_submodules(token, &repo, prediscovered)?;
 
     let backend = pick_backend()?;
-    let account = account_for_repo(&repo);
+    let account = AccountName::from_repo(&repo);
     let state_dir = cfg.data_dir.join("state");
     fs::create_dir_all(&state_dir)
         .with_context(|| format!("Failed to create {}", state_dir.display()))?;
@@ -83,7 +83,7 @@ pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
 /// `coop github rotate-pat` — same wizard, but messaging hints that
 /// we're replacing an existing entry.
 pub fn run_rotate_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
-    let repo = resolve_target_repo(opts.repo, None)?;
+    let repo = resolve_target_repo(opts.repo)?;
     if cfg
         .github
         .as_ref()
@@ -158,7 +158,7 @@ pub fn run_forget_pat(cfg: &CoopConfig, repo: &RepoSlug, config_path: &Path) -> 
             format!("No PAT entry for '{repo}' — nothing to forget. Run `coop github status`.")
         })?;
     let backend = CmdToken::parse(entry.token.expose()).map(|t| t.backend());
-    let account = account_for_repo(repo);
+    let account = AccountName::from_repo(repo);
     let state_dir = cfg.data_dir.join("state");
     if let Some(b) = backend {
         if let Err(e) = delete_secret(b, SERVICE, &account, &state_dir) {
@@ -184,14 +184,9 @@ pub fn run_forget_pat(cfg: &CoopConfig, repo: &RepoSlug, config_path: &Path) -> 
 
 /// Resolve the target repo from explicit `--repo`, fall back to a
 /// best-effort scan of the current working directory.
-fn resolve_target_repo(repo_arg: Option<&str>, git_repo_url: Option<&str>) -> Result<RepoSlug> {
+fn resolve_target_repo(repo_arg: Option<&str>) -> Result<RepoSlug> {
     if let Some(repo) = repo_arg {
         return RepoSlug::new(repo.trim());
-    }
-    if let Some(url) = git_repo_url
-        && let Some(slug) = parse_repo_slug_from_url(url)
-    {
-        return Ok(slug);
     }
     if let Ok(cwd) = std::env::current_dir()
         && let Some(slug) = detect_workspace_repo(&cwd)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ enum Commands {
         /// Project directory (default: current directory)
         dir: Option<String>,
         /// Instance name to use when creating the project environment
-        #[arg(long, value_parser = config::InstanceName::parse)]
+        #[arg(long, value_parser = config::InstanceName::new)]
         name: Option<config::InstanceName>,
         /// Copy/sync DIR into the guest as /workspace (default)
         #[arg(long, conflicts_with = "mount")]
@@ -110,7 +110,7 @@ enum Commands {
         /// Named image to use when creating a new instance (default: "default")
         #[arg(
             long,
-            value_parser = config::ImageName::parse,
+            value_parser = config::ImageName::new,
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         image: Option<config::ImageName>,
@@ -204,7 +204,7 @@ enum Commands {
         #[arg(
             long,
             default_value = config::DEFAULT_IMAGE,
-            value_parser = config::ImageName::parse,
+            value_parser = config::ImageName::new,
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         image: config::ImageName,
@@ -241,7 +241,7 @@ enum Commands {
     /// Restart a stopped VM
     Start {
         /// Stopped instance name (optional only when exactly one stopped instance exists)
-        #[arg(value_parser = config::InstanceName::parse)]
+        #[arg(value_parser = config::InstanceName::new)]
         name: Option<config::InstanceName>,
         /// Project directory used to select an associated stopped instance
         #[arg(long)]
@@ -288,7 +288,7 @@ enum Commands {
     Shell {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -300,7 +300,7 @@ enum Commands {
     Claude {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -319,7 +319,7 @@ enum Commands {
     ClaudeAgents {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -331,7 +331,7 @@ enum Commands {
     Codex {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -343,7 +343,7 @@ enum Commands {
     Stop {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -352,7 +352,7 @@ enum Commands {
     Destroy {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -367,7 +367,7 @@ enum Commands {
     Status {
         /// Instance name (shows all if omitted)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -376,7 +376,7 @@ enum Commands {
     Logs {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -388,7 +388,7 @@ enum Commands {
     Push {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -406,7 +406,7 @@ enum Commands {
     Pull {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -428,7 +428,7 @@ enum Commands {
     Exec {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -440,7 +440,7 @@ enum Commands {
     Vscode {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
@@ -459,7 +459,7 @@ enum Commands {
         /// Delete a named image
         #[arg(
             long,
-            value_parser = config::ImageName::parse,
+            value_parser = config::ImageName::new,
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         delete: Option<config::ImageName>,
@@ -468,7 +468,7 @@ enum Commands {
     Resize {
         /// Instance name (required if multiple instances exist)
         #[arg(
-            value_parser = config::InstanceName::parse,
+            value_parser = config::InstanceName::new,
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,

--- a/src/pat_prompt.rs
+++ b/src/pat_prompt.rs
@@ -20,7 +20,7 @@ use crate::github_repo::RepoSlug;
 
 /// Effective answer to "should we offer the user a PAT wizard right now?"
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Decision {
+pub(crate) enum Decision {
     /// Nothing to do — proceed with the start as-is.
     Skip,
     /// Show the prompt; the user decides.
@@ -31,13 +31,13 @@ pub enum Decision {
 /// offered. Grouped into a struct so call sites name each flag at the
 /// keyword position rather than relying on positional booleans.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PromptContext {
+pub(crate) struct PromptContext {
     /// Whether stdin is attached to an interactive terminal.
-    pub is_tty: bool,
+    pub(crate) is_tty: bool,
     /// Whether the `CI` env var is set (non-interactive batch run).
-    pub is_ci: bool,
+    pub(crate) is_ci: bool,
     /// Whether the caller passed `--no-prompt`.
-    pub no_prompt_flag: bool,
+    pub(crate) no_prompt_flag: bool,
 }
 
 impl Decision {
@@ -45,7 +45,7 @@ impl Decision {
     ///
     /// `repo` is the resolved `owner/repo` slug, if any.
     /// `ctx` carries the TTY / CI / `--no-prompt` flags.
-    pub fn resolve(cfg: &CoopConfig, repo: Option<&RepoSlug>, ctx: PromptContext) -> Self {
+    pub(crate) fn resolve(cfg: &CoopConfig, repo: Option<&RepoSlug>, ctx: PromptContext) -> Self {
         // No repo → nothing to scope to.
         let Some(repo) = repo else {
             return Self::Skip;

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -574,11 +574,6 @@ fn shell_quote(s: &str) -> String {
     format!("'{escaped}'")
 }
 
-/// Build the conventional account name for a repo's PAT entry.
-pub fn account_for_repo(repo: &RepoSlug) -> AccountName {
-    AccountName::from_repo(repo)
-}
-
 /// Conventional service name used across all backends.
 pub const SERVICE: &str = "coop-github-pat";
 
@@ -609,7 +604,7 @@ mod tests {
     #[test]
     fn account_replaces_slash() {
         let slug = RepoSlug::new("trailofbits/coop").unwrap();
-        assert_eq!(account_for_repo(&slug).as_str(), "trailofbits-coop");
+        assert_eq!(AccountName::from_repo(&slug).as_str(), "trailofbits-coop");
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -600,7 +600,7 @@ fn rsync_base_args(target: &SshTarget, exclude_git: bool) -> Vec<String> {
     args
 }
 
-pub fn rsync_push(
+pub(crate) fn rsync_push(
     target: &SshTarget,
     source: &Path,
     guest_path: &GuestPath,


### PR DESCRIPTION
Closes #274.

Pure subtraction — removes dead wrappers left from earlier refactors and narrows visibility that no external caller needs.

- **`InstanceName::parse` / `ImageName::parse`** — deleted; clap `value_parser` now points at `new`, which has the identical `(&str) -> Result<Self>` signature.
- **`account_for_repo`** — inlined at its two call sites in `github_pat.rs` as `AccountName::from_repo`, then deleted from `secret_store.rs`.
- **`CommandRunner` trait + `MockRunner`** — removed. The trait was `#[cfg(test)]`-only and no production code accepted `&dyn CommandRunner`; the two tests exercised only the mock itself. The now-unneeded `#[expect(clippy::unwrap_used)]` on the test module is dropped (`expect_used` is retained — surviving tests still use `.expect()`).
- **`resolve_target_repo`'s `git_repo_url` param** — both call sites passed `None`, making the branch unreachable. Parameter and branch removed; the unused `parse_repo_slug_from_url` import in `github_pat.rs` dropped.
- **Visibility** — `rsync_push` (`workspace.rs`), `Decision` / `PromptContext` (`pat_prompt.rs`) narrowed to `pub(crate)`.

`StartImage { explicit: bool }` from the issue was already removed in a prior PR; nothing to do.

`cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and `cargo test` (736 passed) are all green. A review subagent verified no behavioral change and no dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)