### PR TITLE
Extract near-identical function pairs into shared helpers

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1521,7 +1521,19 @@ fn copy_claude_config(target: &SshTarget, config_dir: &ConfigDir) -> Result<()> 
     };
 
     let staged = stage_allowed_files(&source_dir).context("Failed to stage Claude config files")?;
+    copy_staged_to_guest(target, &staged, ".claude", "Claude")
+}
 
+/// Copy every entry staged in `staged` into the guest's `~/<guest_subdir>/`,
+/// creating the directory first. Files go via `scp_to`, subdirectories via
+/// `scp_to_recursive`. An empty staging dir is a no-op (debug-logged).
+/// `label` names the config in the log lines (e.g. "Claude", "Codex").
+fn copy_staged_to_guest(
+    target: &SshTarget,
+    staged: &tempfile::TempDir,
+    guest_subdir: &str,
+    label: &str,
+) -> Result<()> {
     let staging_path = staged.path();
     let has_entries = staging_path
         .read_dir()
@@ -1530,29 +1542,29 @@ fn copy_claude_config(target: &SshTarget, config_dir: &ConfigDir) -> Result<()> 
         .is_some();
 
     if !has_entries {
-        tracing::debug!("No allowlisted files found in {}", source_dir.display());
+        tracing::debug!("No {label} config content to copy");
         return Ok(());
     }
 
-    target.exec("mkdir -p ~/.claude")?;
+    target.exec(&format!("mkdir -p ~/{guest_subdir}"))?;
 
-    let guest_claude = GuestPath::new("./.claude");
+    let guest_dir = GuestPath::new(format!("./{guest_subdir}"));
     for entry in std::fs::read_dir(staging_path).context("Failed to read staging directory")? {
         let entry = entry.context("Failed to read staging entry")?;
         let path = entry.path();
         let local = HostPath::new(&path);
         if path.is_dir() {
             target
-                .scp_to_recursive(&local, &guest_claude)
+                .scp_to_recursive(&local, &guest_dir)
                 .with_context(|| format!("Failed to copy {} to guest", path.display()))?;
         } else {
             target
-                .scp_to(&local, &guest_claude)
+                .scp_to(&local, &guest_dir)
                 .with_context(|| format!("Failed to copy {} to guest", path.display()))?;
         }
     }
 
-    tracing::info!("Copied Claude config from {}", source_dir.display());
+    tracing::info!("Copied {label} config into guest");
     Ok(())
 }
 
@@ -1605,39 +1617,7 @@ fn copy_codex_config(
 ) -> Result<()> {
     let staged = stage_codex_files(source_dir, &codex.mcp_servers)
         .context("Failed to stage Codex config files")?;
-
-    let staging_path = staged.path();
-    let has_entries = staging_path
-        .read_dir()
-        .context("Failed to read staging directory")?
-        .next()
-        .is_some();
-
-    if !has_entries {
-        tracing::debug!("No Codex config content to copy");
-        return Ok(());
-    }
-
-    target.exec("mkdir -p ~/.codex")?;
-
-    let guest_codex = GuestPath::new("./.codex");
-    for entry in std::fs::read_dir(staging_path).context("Failed to read staging directory")? {
-        let entry = entry.context("Failed to read staging entry")?;
-        let path = entry.path();
-        let local = HostPath::new(&path);
-        if path.is_dir() {
-            target
-                .scp_to_recursive(&local, &guest_codex)
-                .with_context(|| format!("Failed to copy {} to guest", path.display()))?;
-        } else {
-            target
-                .scp_to(&local, &guest_codex)
-                .with_context(|| format!("Failed to copy {} to guest", path.display()))?;
-        }
-    }
-
-    tracing::info!("Copied Codex config into guest");
-    Ok(())
+    copy_staged_to_guest(target, &staged, ".codex", "Codex")
 }
 
 fn resolve_config_source_dir(

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -235,6 +235,17 @@ impl Cmd {
     }
 }
 
+/// Returns `true` if `program` is found on the current `PATH`.
+///
+/// Uses the portable `command -v` shell builtin rather than the `which`
+/// binary, which need not be installed on every host.
+pub fn command_exists(program: &str) -> bool {
+    Cmd::new("sh")
+        .arg("-c")
+        .arg(format!("command -v {program} >/dev/null 2>&1"))
+        .status_ok()
+}
+
 /// Write `bytes` to the child's stdin, then close it so the child sees EOF.
 ///
 /// Used by [`Cmd::run`] and [`Cmd::capture`] when [`Cmd::stdin_input`] was
@@ -322,5 +333,14 @@ mod tests {
             .stdin_input(b"data".to_vec())
             .run()
             .expect("cat run");
+    }
+
+    #[test]
+    fn command_exists_detects_present_and_absent_programs() {
+        assert!(command_exists("sh"), "sh must be on PATH in any POSIX env");
+        assert!(
+            !command_exists("coop-definitely-not-a-real-binary-xyz"),
+            "a nonexistent program must not be reported as present",
+        );
     }
 }

--- a/src/devcontainer_oci.rs
+++ b/src/devcontainer_oci.rs
@@ -121,6 +121,13 @@ pub struct ResolvedFeature {
     pub options: BTreeMap<String, String>,
 }
 
+/// Project the persistable [`InstalledFeature`] records out of resolved
+/// features, dropping the install scripts and archives that are not part
+/// of the persisted template config.
+pub fn installed_features(features: &[ResolvedFeature]) -> Vec<InstalledFeature> {
+    features.iter().map(|f| f.installed.clone()).collect()
+}
+
 #[derive(Debug, Deserialize)]
 struct TokenResponse {
     token: String,

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -19,7 +19,7 @@ use std::io::{BufRead as _, Write as _};
 use std::path::Path;
 use std::process::Command;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use thiserror::Error;
 
 use crate::cmd::Cmd;
@@ -361,14 +361,25 @@ fn warn_token_format(token: &str) {
     }
 }
 
-fn probe_user(token: &str) -> Result<()> {
+/// Issue `GET https://api.github.com/user` with `token` and return the
+/// authenticated user's login.
+///
+/// Errors if the request fails, the status is non-200 (token invalid or
+/// revoked), or the response carries no `login` field.
+pub fn probe_user_login(token: &str) -> Result<String> {
     let (status, body) = curl_with_token(token, "https://api.github.com/user")?;
     if status != 200 {
         bail!("GET /user returned HTTP {status} (token may be invalid or revoked)");
     }
-    if !body.contains("\"login\"") {
-        bail!("Token authentication failed: /user returned unexpected response");
-    }
+    body.split("\"login\"")
+        .nth(1)
+        .and_then(|s| s.split('"').nth(1))
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("Token authentication failed: /user returned unexpected response"))
+}
+
+fn probe_user(token: &str) -> Result<()> {
+    probe_user_login(token)?;
     eprintln!("  ✓ /user");
     Ok(())
 }

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -174,6 +174,44 @@ pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 4] {
     ]
 }
 
+/// Verify that every required guest binary is present, bailing with a
+/// uniform error if any are missing.
+///
+/// `probe` answers "does this binary exist in the image?" — its mechanism
+/// differs per backend (a chroot `symlink_metadata` for Firecracker, a
+/// `test -x` over `limactl shell` for Lima). `source_label` names what
+/// produced the image ("install script" vs "provision script"), and
+/// `diagnostics` supplies any trailing detail (e.g. a build-log tail),
+/// evaluated lazily only when something is missing.
+#[expect(
+    clippy::print_stderr,
+    reason = "verification progress is interactive CLI — stderr is user communication"
+)]
+pub fn verify_required_binaries(
+    guest_user: &GuestUser,
+    source_label: &str,
+    probe: impl Fn(&GuestPath) -> bool,
+    diagnostics: impl FnOnce() -> String,
+) -> Result<()> {
+    eprintln!("  Verifying installed binaries...");
+    let missing: Vec<String> = required_guest_binaries(guest_user)
+        .into_iter()
+        .filter(|path| !probe(path))
+        .map(|path| path.to_string())
+        .collect();
+
+    if !missing.is_empty() {
+        bail!(
+            "Golden image is missing required binaries: {}\n\
+             The {source_label} completed but these tools were \
+             not installed correctly.{}",
+            missing.join(", "),
+            diagnostics(),
+        );
+    }
+    Ok(())
+}
+
 pub const SCRIPT_GH_REPO: &str = include_str!("../scripts/guest/gh-cli-repo.sh");
 pub const SCRIPT_DOCKER_REPO: &str = include_str!("../scripts/guest/docker-repo.sh");
 pub const SCRIPT_CLAUDE_CODE: &str = include_str!("../scripts/guest/claude-code.sh");
@@ -556,5 +594,59 @@ mod tests {
             bins.iter().any(|b| b.to_string() == "/usr/local/bin/codex"),
             "guest image should include codex in the default PATH",
         );
+    }
+
+    #[test]
+    fn verify_required_binaries_ok_when_all_present_and_skips_diagnostics() {
+        let user = GuestUser::default();
+        let diag_called = std::cell::Cell::new(false);
+        let result = verify_required_binaries(
+            &user,
+            "install script",
+            |_path| true,
+            || {
+                diag_called.set(true);
+                String::new()
+            },
+        );
+        assert!(result.is_ok());
+        assert!(
+            !diag_called.get(),
+            "diagnostics must not be evaluated when nothing is missing",
+        );
+    }
+
+    #[test]
+    fn verify_required_binaries_bails_with_missing_names_and_diagnostics() {
+        let user = GuestUser::default();
+        let result = verify_required_binaries(
+            &user,
+            "provision script",
+            |path| path.to_string() != "/usr/bin/docker",
+            || "\n\ntail of log".to_string(),
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("/usr/bin/docker"),
+            "missing binary listed: {err}"
+        );
+        assert!(
+            err.contains("provision script"),
+            "source label included: {err}"
+        );
+        assert!(
+            err.contains("tail of log"),
+            "diagnostics suffix appended: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_required_binaries_lists_every_missing_binary() {
+        let user = GuestUser::default();
+        let result = verify_required_binaries(&user, "install script", |_path| false, String::new);
+        let err = result.unwrap_err().to_string();
+        for expected in ["/usr/bin/docker", "/usr/bin/gh", "/usr/local/bin/codex"] {
+            assert!(err.contains(expected), "{expected} missing from: {err}");
+        }
     }
 }

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::backend::{Hostname, LogMode, SshTarget, SshUser};
 use crate::config::{CoopConfig, GiB, ImageName, Instance, InstanceName};
-use crate::devcontainer_oci::{InstalledFeature, ResolvedFeature};
+use crate::devcontainer_oci::{ResolvedFeature, installed_features};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
     SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
@@ -699,10 +699,6 @@ fn build_golden_image(
     Ok(())
 }
 
-fn installed_features(features: &[ResolvedFeature]) -> Vec<InstalledFeature> {
-    features.iter().map(|f| f.installed.clone()).collect()
-}
-
 /// Start the builder VM, install marketplaces/plugins, clean
 /// cloud-init, stop it, and extract the disk image to `output_path`.
 fn run_builder_vm(
@@ -1021,59 +1017,55 @@ fn check_cloud_init_output(exit_code: Option<i32>, stdout: &str) -> Result<()> {
 /// image. Catches silent install failures (e.g. network timeouts)
 /// that cloud-init doesn't flag as errors.
 fn verify_builder_binaries(guest_user: &GuestUser) -> Result<()> {
-    use crate::guest::required_guest_binaries;
+    crate::guest::verify_required_binaries(
+        guest_user,
+        "provision script",
+        |path| {
+            Command::new("limactl")
+                .args([
+                    "shell",
+                    BUILDER_NAME,
+                    "--",
+                    "bash",
+                    "-c",
+                    &format!("test -x {path}"),
+                ])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .is_ok_and(|s| s.success())
+        },
+        builder_log_tail,
+    )
+}
 
-    eprintln!("  Verifying installed binaries...");
-    let mut missing: Vec<String> = Vec::new();
+/// Tail of the builder's cloud-init log, formatted as a trailing section for
+/// the missing-binaries error. Empty when the log is unavailable or blank.
+fn builder_log_tail() -> String {
+    let log_tail = Command::new("limactl")
+        .args([
+            "shell",
+            BUILDER_NAME,
+            "--",
+            "sudo",
+            "tail",
+            "-n",
+            "50",
+            "/var/log/cloud-init-output.log",
+        ])
+        .output()
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+        .unwrap_or_default();
 
-    for path in required_guest_binaries(guest_user) {
-        let check_cmd = format!("test -x {path}");
-        let status = Command::new("limactl")
-            .args(["shell", BUILDER_NAME, "--", "bash", "-c", &check_cmd])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-
-        if !status.is_ok_and(|s| s.success()) {
-            missing.push(path.to_string());
-        }
+    if log_tail.trim().is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\n\nLast 50 lines of cloud-init-output.log:\n{}",
+            log_tail.trim()
+        )
     }
-
-    if !missing.is_empty() {
-        let log_tail = Command::new("limactl")
-            .args([
-                "shell",
-                BUILDER_NAME,
-                "--",
-                "sudo",
-                "tail",
-                "-n",
-                "50",
-                "/var/log/cloud-init-output.log",
-            ])
-            .output()
-            .ok()
-            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
-            .unwrap_or_default();
-
-        let log_section = if log_tail.trim().is_empty() {
-            String::new()
-        } else {
-            format!(
-                "\n\nLast 50 lines of cloud-init-output.log:\n{}",
-                log_tail.trim()
-            )
-        };
-
-        bail!(
-            "Golden image is missing required binaries: {}\n\
-             The provision script completed but these tools were \
-             not installed correctly.{log_section}",
-            missing.join(", "),
-        );
-    }
-
-    Ok(())
 }
 
 fn generate_start_template(cfg: &CoopConfig, image: &ImageName) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1152,7 +1152,7 @@ fn cmd_validate(
                         .ok();
                     }
                     if probe {
-                        match probe_pat_token(&token) {
+                        match github_pat::probe_user_login(&token) {
                             Ok(login) => {
                                 writeln!(std::io::stdout(), "    probe: /user as '{login}'").ok();
                             }
@@ -1175,28 +1175,6 @@ fn cmd_validate(
 
     writeln!(std::io::stdout(), "Config OK").ok();
     Ok(())
-}
-
-/// Issue `GET https://api.github.com/user` with `token`. Returns the
-/// authenticated user's login on success.
-fn probe_pat_token(token: &str) -> Result<String> {
-    let body = cmd::Cmd::new("curl")
-        .arg("-fsSL")
-        .arg("-H")
-        .arg("Accept: application/vnd.github+json")
-        .arg("-H")
-        .arg("@-")
-        .stdin_input(format!("Authorization: token {token}\n"))
-        .arg("https://api.github.com/user")
-        .capture()
-        .context("curl /user failed")?;
-    // Naive extraction: grab the first `"login": "..."`. Avoids a JSON dep.
-    let login = body
-        .split("\"login\"")
-        .nth(1)
-        .and_then(|s| s.split('"').nth(1))
-        .unwrap_or("?");
-    Ok(login.to_string())
 }
 
 struct QuickstartOpts {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -7,9 +7,9 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::cmd::Cmd;
+use crate::cmd::{Cmd, command_exists};
 use crate::config::{CoopConfig, ImageName, Instance};
-use crate::devcontainer_oci::{InstalledFeature, ResolvedFeature};
+use crate::devcontainer_oci::{InstalledFeature, ResolvedFeature, installed_features};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
     SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, resolve_profiles,
@@ -314,20 +314,26 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
     let template = cfg.template_path_for(image);
     let (profiles, extra_packages) = resolve_template_config(cfg, opts)?;
 
-    // Compose recipe and compute hashes
-    let recipe = compose_recipe(
+    // Compose the install recipe and compute its hashes.
+    let recipe_script = compose_recipe(
         &profiles,
         &opts.oci_features,
         &extra_packages,
         &opts.guest_user,
     );
-    let script_hash = Sha256Hash::of(&recipe);
     let post_install_content = load_post_install(opts.post_install.as_ref())?;
-    let post_install_hash = post_install_content.as_ref().map(Sha256Hash::of);
+    let recipe = BuildRecipe {
+        profiles: &profiles,
+        extra_packages: &extra_packages,
+        script_hash: Sha256Hash::of(&recipe_script),
+        post_install_hash: post_install_content.as_ref().map(Sha256Hash::of),
+        script: &recipe_script,
+        post_install_content: post_install_content.as_deref(),
+    };
 
     // Check existing template — rebuild automatically if stale
     if template.exists() && !opts.rebuild {
-        if !needs_rebuild(cfg, image, script_hash, post_install_hash) {
+        if !needs_rebuild(cfg, image, recipe.script_hash, recipe.post_install_hash) {
             step("Template rootfs: up to date");
             return Ok(());
         }
@@ -346,18 +352,23 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
         tracing::debug!("Failed to remove stale staging image (non-fatal): {e}");
     }
 
-    let result = build_template(
-        cfg,
-        opts,
-        image,
-        &profiles,
-        &extra_packages,
-        &recipe,
-        script_hash,
-        post_install_content.as_deref(),
-        post_install_hash,
-        &staging,
-    );
+    // Build the persisted config once: `build_template` embeds it as the
+    // in-guest version marker, and we save the same value after the image
+    // swap. Constructing it once also pins a single `created` timestamp.
+    let template_config = TemplateConfig {
+        version: TEMPLATE_VERSION,
+        created: utc_timestamp(),
+        install_script_hash: recipe.script_hash,
+        profiles: profile_names(recipe.profiles),
+        extra_packages: recipe.extra_packages.to_vec(),
+        post_install_hash: recipe.post_install_hash,
+        marketplaces: Vec::new(),
+        plugins: Vec::new(),
+        guest_user: opts.guest_user.clone(),
+        oci_features: installed_features(&opts.oci_features),
+    };
+
+    let result = build_template(cfg, opts, image, &recipe, &template_config, &staging);
 
     if let Err(e) = result {
         // Clean up failed staging image
@@ -378,18 +389,6 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
     // Write template config only after image swap succeeds.
     // If we crash between swap and config write, staleness
     // detection triggers a rebuild on next run (safe).
-    let template_config = TemplateConfig {
-        version: TEMPLATE_VERSION,
-        created: utc_timestamp(),
-        install_script_hash: script_hash,
-        profiles: profile_names(&profiles),
-        extra_packages,
-        post_install_hash,
-        marketplaces: Vec::new(),
-        plugins: Vec::new(),
-        guest_user: opts.guest_user.clone(),
-        oci_features: installed_features(&opts.oci_features),
-    };
     template_config.save_for(cfg, image)?;
 
     Ok(())
@@ -397,10 +396,6 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
 
 fn profile_names(profiles: &[ProfileDef]) -> Vec<String> {
     profiles.iter().map(|p| p.name.clone()).collect()
-}
-
-fn installed_features(features: &[ResolvedFeature]) -> Vec<InstalledFeature> {
-    features.iter().map(|f| f.installed.clone()).collect()
 }
 
 /// Returns `true` if the template needs rebuilding.
@@ -420,17 +415,24 @@ fn needs_rebuild(
     existing.install_script_hash != current_hash || existing.post_install_hash != current_post_hash
 }
 
-#[expect(clippy::too_many_arguments, reason = "template build orchestration")]
+/// The recipe inputs for a template build: the composed install script,
+/// its hash, the resolved profiles and extra packages (for display), and
+/// the optional post-install script and its hash.
+struct BuildRecipe<'a> {
+    profiles: &'a [ProfileDef],
+    extra_packages: &'a [String],
+    script: &'a str,
+    script_hash: Sha256Hash,
+    post_install_content: Option<&'a str>,
+    post_install_hash: Option<Sha256Hash>,
+}
+
 fn build_template(
     cfg: &CoopConfig,
     opts: &SetupOptions,
     image: &ImageName,
-    profiles: &[ProfileDef],
-    extra_packages: &[String],
-    recipe: &str,
-    script_hash: Sha256Hash,
-    post_install_content: Option<&str>,
-    post_install_hash: Option<Sha256Hash>,
+    recipe: &BuildRecipe,
+    template_config: &TemplateConfig,
     output_path: &Path,
 ) -> Result<()> {
     step("Building template rootfs");
@@ -440,8 +442,8 @@ fn build_template(
 
     eprintln!("  Found rootfs: {rootfs_name}");
     eprintln!("  URL: {rootfs_url}");
-    if !profiles.is_empty() {
-        eprintln!("  Profiles: {}", profile_names(profiles).join(", "));
+    if !recipe.profiles.is_empty() {
+        eprintln!("  Profiles: {}", profile_names(recipe.profiles).join(", "));
     }
     if !opts.oci_features.is_empty() {
         let features = opts
@@ -452,10 +454,10 @@ fn build_template(
             .join(", ");
         eprintln!("  Devcontainer OCI features: {features}");
     }
-    if !extra_packages.is_empty() {
-        eprintln!("  Extra packages: {}", extra_packages.join(", "));
+    if !recipe.extra_packages.is_empty() {
+        eprintln!("  Extra packages: {}", recipe.extra_packages.join(", "));
     }
-    if post_install_content.is_some() {
+    if recipe.post_install_content.is_some() {
         eprintln!("  Post-install script: yes");
     }
     eprintln!();
@@ -483,22 +485,11 @@ fn build_template(
     create_ext4_image(cfg, output_path)?;
     crate::signal::check_shutdown()?;
 
-    // Compose and execute install script
-    let marker_config = TemplateConfig {
-        version: TEMPLATE_VERSION,
-        created: utc_timestamp(),
-        install_script_hash: script_hash,
-        profiles: profile_names(profiles),
-        extra_packages: extra_packages.to_vec(),
-        post_install_hash,
-        marketplaces: Vec::new(),
-        plugins: Vec::new(),
-        guest_user: opts.guest_user.clone(),
-        oci_features: installed_features(&opts.oci_features),
-    };
-    let marker_json = serde_json::to_string_pretty(&marker_config)
+    // Compose and execute install script. The in-guest version marker is
+    // the same `TemplateConfig` we persist on the host after the swap.
+    let marker_json = serde_json::to_string_pretty(template_config)
         .context("Failed to serialize version marker")?;
-    let full_script = compose_full_script(recipe, &marker_json, post_install_content);
+    let full_script = compose_full_script(recipe.script, &marker_json, recipe.post_install_content);
     install_guest_packages(cfg, output_path, &full_script, &opts.guest_user)?;
 
     // Clean up intermediate files
@@ -760,7 +751,7 @@ fn has_kvm_access(kvm: &Path) -> bool {
 
 fn fix_kvm_access(skip_confirm: bool) -> Result<()> {
     // Prefer setfacl (immediate, no re-login needed)
-    if which("setfacl").is_some() {
+    if command_exists("setfacl") {
         let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
         let cmd = format!("sudo setfacl -m u:{user}:rw /dev/kvm");
         if !confirm(&cmd, skip_confirm)? {
@@ -799,22 +790,22 @@ fn fix_kvm_access(skip_confirm: bool) -> Result<()> {
 fn install_system_packages(skip_confirm: bool) -> Result<()> {
     let mut missing = Vec::new();
 
-    if which("setfacl").is_none() {
+    if !command_exists("setfacl") {
         missing.push("acl");
     }
-    if which("debootstrap").is_none() {
+    if !command_exists("debootstrap") {
         missing.push("debootstrap");
     }
-    if which("unsquashfs").is_none() {
+    if !command_exists("unsquashfs") {
         missing.push("squashfs-tools");
     }
-    if which("mkfs.ext4").is_none() {
+    if !command_exists("mkfs.ext4") {
         missing.push("e2fsprogs");
     }
-    if which("ssh").is_none() {
+    if !command_exists("ssh") {
         missing.push("openssh-client");
     }
-    if which("rsync").is_none() {
+    if !command_exists("rsync") {
         missing.push("rsync");
     }
 
@@ -1182,29 +1173,12 @@ fn install_guest_packages(
 /// host filesystem where the target doesn't exist. A symlink being
 /// present is sufficient — it will resolve correctly inside the guest.
 fn verify_chroot_binaries(mount_str: &str, guest_user: &GuestUser) -> Result<()> {
-    use crate::guest::required_guest_binaries;
-
-    eprintln!("  Verifying installed binaries...");
-    let mut missing: Vec<String> = Vec::new();
-
-    for path in required_guest_binaries(guest_user) {
-        let full_path = format!("{mount_str}{path}");
-        let exists = std::fs::symlink_metadata(&full_path).is_ok();
-        if !exists {
-            missing.push(path.to_string());
-        }
-    }
-
-    if !missing.is_empty() {
-        bail!(
-            "Golden image is missing required binaries: {}\n\
-             The install script completed but these tools were \
-             not installed correctly.",
-            missing.join(", "),
-        );
-    }
-
-    Ok(())
+    crate::guest::verify_required_binaries(
+        guest_user,
+        "install script",
+        |path| std::fs::symlink_metadata(format!("{mount_str}{path}")).is_ok(),
+        String::new,
+    )
 }
 
 fn mount_chroot(rootfs: &str, mount_str: &str) -> Result<()> {
@@ -1389,17 +1363,8 @@ impl fmt::Display for Architecture {
     }
 }
 
-fn which(program: &str) -> Option<PathBuf> {
-    Command::new("which")
-        .arg(program)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| PathBuf::from(String::from_utf8_lossy(&o.stdout).trim().to_string()))
-}
-
 fn require_command(name: &str, purpose: &str) -> Result<()> {
-    if which(name).is_some() {
+    if command_exists(name) {
         eprintln!("  {name}: OK");
         Ok(())
     } else {

--- a/src/update.rs
+++ b/src/update.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, Result, bail, ensure};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use crate::cmd::Cmd;
+use crate::cmd::{Cmd, command_exists};
 use crate::fs_util::atomic_write_json;
 use crate::prompt::confirm;
 use crate::sha256_hash::Sha256Hash;
@@ -235,7 +235,7 @@ fn select_auth_strategy(
 
 fn select_auth_strategy_from_env() -> AuthStrategy {
     let overridden = api_base_overridden();
-    let has_gh = !overridden && has_command("gh");
+    let has_gh = !overridden && command_exists("gh");
     let gh_authed = has_gh && gh_authenticated();
     let token = env::var("GITHUB_TOKEN").ok();
     select_auth_strategy(overridden, has_gh, gh_authed, token.as_deref())
@@ -370,13 +370,6 @@ fn verify_sha256(file: &Path, expected: &Sha256Hash) -> Result<()> {
 
 // ── Attestation verification (best-effort) ───────────────────────────────────
 
-fn has_command(prog: &str) -> bool {
-    Cmd::new("sh")
-        .arg("-c")
-        .arg(format!("command -v {prog} >/dev/null 2>&1"))
-        .status_ok()
-}
-
 fn verify_attestation(tarball: &Path) -> Result<()> {
     // Skip when the API base is overridden — the local test fixture serves
     // synthetic artifacts that have no provenance in GitHub's attestation
@@ -385,7 +378,7 @@ fn verify_attestation(tarball: &Path) -> Result<()> {
     if api_base_overridden() {
         return Ok(());
     }
-    if !has_command("gh") {
+    if !command_exists("gh") {
         tracing::info!(
             "Note: `gh` not installed — skipped cryptographic attestation verification. \
              The download was verified against the published `SHA256SUMS` checksum, which \


### PR DESCRIPTION
Closes #273.

Collapses several near-identical function pairs into single shared implementations so they can no longer drift apart silently.

## Changes

- **`backend.rs`** — `copy_claude_config` and `copy_codex_config` shared ~30 lines (staging-dir check, `mkdir`, per-entry scp loop). Extracted `copy_staged_to_guest(target, staged, guest_subdir, label)`.
- **`github_pat.rs`** — `probe_user` and `main.rs`'s `probe_pat_token` both did `GET /user` with an auth header. Extracted `probe_user_login(token) -> Result<String>`; `probe_user` calls it, and `cmd_validate` calls it directly. `probe_pat_token` is removed. The validate path now reports the HTTP status on failure instead of a generic curl error, and no longer prints `?` when a 200 response lacks a `login` field.
- **`cmd.rs`** — added `command_exists(program) -> bool` (via `command -v`), replacing `setup.rs::which` and `update.rs::has_command`. Every `which` caller only tested presence, so the returned `PathBuf` is dropped.
- **`guest.rs`** — `verify_chroot_binaries` and `verify_builder_binaries` shared the collect-missing/format logic with different probe mechanisms. Extracted `verify_required_binaries`, parameterized by a probe closure and a `diagnostics` closure (the Lima log tail) evaluated lazily only when a binary is missing.
- **`devcontainer_oci.rs`** — `installed_features` was byte-identical in `setup.rs` and `lima.rs`; moved to one shared function.
- **`setup.rs`** — `build_template` took ten positional arguments (with `too_many_arguments` suppressed). Six recipe inputs are now a `BuildRecipe` struct and the suppression is gone. `TemplateConfig` is built once in `build_or_check_template` and passed in, so the in-guest version marker and the persisted config share a single `created` timestamp instead of two separate `utc_timestamp()` calls.

## Tests

Added unit tests pinning `verify_required_binaries` (missing-binary listing, source label, lazy diagnostics evaluation) and `command_exists`. `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (740 pass), and `cargo fmt --check` are clean.

Integration tests (`tests/run-integration.sh`) were not run — they require Firecracker/Lima hosts unavailable in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)