### PR TITLE
Parse repo slugs, disk size, and devcontainer paths at the clap boundary

### DIFF
--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -38,7 +38,7 @@ const PAT_NEW_URL: &str = "https://github.com/settings/personal-access-tokens/ne
 
 /// Options resolved by clap for `coop github setup-pat`.
 pub struct SetupOpts<'a> {
-    pub repo: Option<&'a str>,
+    pub repo: Option<RepoSlug>,
     pub config_path: &'a Path,
 }
 
@@ -47,7 +47,7 @@ pub struct SetupOpts<'a> {
 /// On success, the on-disk config has a fresh `[github.pat."owner/repo"]`
 /// entry and any matching skip-marker is removed.
 pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
-    let repo = resolve_target_repo(opts.repo)?;
+    let repo = resolve_target_repo(opts.repo.as_ref())?;
 
     let prediscovered = prefetch_submodules(&repo);
     print_form_instructions(&repo, prediscovered.as_ref());
@@ -83,7 +83,7 @@ pub fn run_setup_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
 /// `coop github rotate-pat` — same wizard, but messaging hints that
 /// we're replacing an existing entry.
 pub fn run_rotate_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
-    let repo = resolve_target_repo(opts.repo)?;
+    let repo = resolve_target_repo(opts.repo.as_ref())?;
     if cfg
         .github
         .as_ref()
@@ -184,9 +184,9 @@ pub fn run_forget_pat(cfg: &CoopConfig, repo: &RepoSlug, config_path: &Path) -> 
 
 /// Resolve the target repo from explicit `--repo`, fall back to a
 /// best-effort scan of the current working directory.
-fn resolve_target_repo(repo_arg: Option<&str>) -> Result<RepoSlug> {
+fn resolve_target_repo(repo_arg: Option<&RepoSlug>) -> Result<RepoSlug> {
     if let Some(repo) = repo_arg {
-        return RepoSlug::new(repo.trim());
+        return Ok(repo.clone());
     }
     if let Ok(cwd) = std::env::current_dir()
         && let Some(slug) = detect_workspace_repo(&cwd)?

--- a/src/github_repo.rs
+++ b/src/github_repo.rs
@@ -46,6 +46,14 @@ impl RepoSlug {
         Ok(Self(s.to_string()))
     }
 
+    /// Parse a slug from a CLI argument, trimming surrounding whitespace first.
+    ///
+    /// Used as a clap `value_parser` so `--repo`/positional repo args become a
+    /// validated [`RepoSlug`] at the parse boundary instead of a raw `String`.
+    pub fn parse_cli(s: &str) -> Result<Self> {
+        Self::new(s.trim())
+    }
+
     /// Borrow the slug as `&str` (for formatting / passing to `&str` APIs).
     pub fn as_str(&self) -> &str {
         &self.0
@@ -372,6 +380,17 @@ mod tests {
     fn from_str_round_trips() {
         let s: RepoSlug = "trailofbits/coop".parse().unwrap();
         assert_eq!(s.as_str(), "trailofbits/coop");
+    }
+
+    #[test]
+    fn parse_cli_trims_surrounding_whitespace() {
+        let s = RepoSlug::parse_cli("  trailofbits/coop\n").unwrap();
+        assert_eq!(s.as_str(), "trailofbits/coop");
+    }
+
+    #[test]
+    fn parse_cli_rejects_invalid_slug() {
+        assert!(RepoSlug::parse_cli("not-a-slug").is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ enum Commands {
         guest_env: Vec<(guest_env_state::EnvVarName, String)>,
         /// Explicit path to a `devcontainer.json` to use (skips discovery).
         #[arg(long, value_name = "PATH", conflicts_with = "no_devcontainer")]
-        devcontainer: Option<String>,
+        devcontainer: Option<PathBuf>,
         /// Ignore any discovered `devcontainer.json` (escape hatch for CI).
         #[arg(long)]
         no_devcontainer: bool,
@@ -224,7 +224,7 @@ enum Commands {
         workspace: Option<String>,
         /// Explicit path to a `devcontainer.json` to use (skips discovery).
         #[arg(long, value_name = "PATH", conflicts_with = "no_devcontainer")]
-        devcontainer: Option<String>,
+        devcontainer: Option<PathBuf>,
         /// Ignore any discovered `devcontainer.json` (escape hatch for CI).
         #[arg(long)]
         no_devcontainer: bool,
@@ -274,7 +274,7 @@ enum Commands {
         guest_env: Vec<(guest_env_state::EnvVarName, String)>,
         /// Explicit path to a `devcontainer.json` to use (skips discovery).
         #[arg(long, value_name = "PATH", conflicts_with = "no_devcontainer")]
-        devcontainer: Option<String>,
+        devcontainer: Option<PathBuf>,
         /// Ignore any discovered `devcontainer.json` (escape hatch for CI).
         #[arg(long)]
         no_devcontainer: bool,
@@ -473,8 +473,8 @@ enum Commands {
         )]
         name: Option<config::InstanceName>,
         /// New size: absolute GiB (e.g. 150, 150G) or relative (e.g. +20, +20G)
-        #[arg(long, required = true)]
-        size: String,
+        #[arg(long, required = true, value_parser = config::DiskSize::parse)]
+        size: config::DiskSize,
     },
     /// List or inspect available profiles
     Profiles {
@@ -568,14 +568,14 @@ enum GithubAction {
     /// Run the fine-grained PAT wizard for a repo
     SetupPat {
         /// Repo slug to scope to (auto-detected if omitted)
-        #[arg(long)]
-        repo: Option<String>,
+        #[arg(long, value_parser = github_repo::RepoSlug::parse_cli)]
+        repo: Option<github_repo::RepoSlug>,
     },
     /// Re-run the wizard against an existing entry
     RotatePat {
         /// Repo slug to rotate
-        #[arg(long, required = true)]
-        repo: String,
+        #[arg(long, required = true, value_parser = github_repo::RepoSlug::parse_cli)]
+        repo: github_repo::RepoSlug,
     },
     /// Print configured PAT entries and their validation state
     Status {
@@ -587,8 +587,8 @@ enum GithubAction {
     /// Remove a configured PAT entry and its stored secret
     ForgetPat {
         /// Repo slug whose entry should be removed
-        #[arg(long, required = true)]
-        repo: String,
+        #[arg(long, required = true, value_parser = github_repo::RepoSlug::parse_cli)]
+        repo: github_repo::RepoSlug,
     },
 }
 
@@ -796,10 +796,7 @@ fn main() -> Result<()> {
                     guest_env,
                 },
                 devcontainer: UpDevcontainerOpts {
-                    input: DevcontainerInput::from_flags(
-                        devcontainer.map(PathBuf::from),
-                        no_devcontainer,
-                    ),
+                    input: DevcontainerInput::from_flags(devcontainer, no_devcontainer),
                     dry_run,
                 },
             };
@@ -842,8 +839,7 @@ fn main() -> Result<()> {
                 cli_guest_user: guest_user.clone(),
                 ..devcontainer::TranslatorInputs::default()
             };
-            let dc_input =
-                DevcontainerInput::from_flags(devcontainer.map(PathBuf::from), no_devcontainer);
+            let dc_input = DevcontainerInput::from_flags(devcontainer, no_devcontainer);
             let translation = resolve_devcontainer(
                 &DevcontainerOpts {
                     input: &dc_input,
@@ -930,10 +926,7 @@ fn main() -> Result<()> {
                     ..devcontainer::TranslatorInputs::default()
                 };
                 let ws_path = workspace.as_deref().map(Path::new);
-                let dc_input = DevcontainerInput::from_flags(
-                    devcontainer.clone().map(PathBuf::from),
-                    no_devcontainer,
-                );
+                let dc_input = DevcontainerInput::from_flags(devcontainer.clone(), no_devcontainer);
                 let _ = resolve_devcontainer(
                     &DevcontainerOpts {
                         input: &dc_input,
@@ -963,7 +956,7 @@ fn main() -> Result<()> {
                 config_path: &cli.config,
                 post_start_override: post_start.as_deref(),
                 persisted_guest_env: std::collections::BTreeMap::new(),
-                devcontainer_path: devcontainer.as_deref().map(Path::new),
+                devcontainer_path: devcontainer.as_deref(),
                 applied_devcontainer: None,
             };
             preflight_start_target(&be, &cfg, &start_opts)?;
@@ -1053,11 +1046,11 @@ fn main() -> Result<()> {
             workspace::vscode(&running, Some(&project), editor.as_deref())
         }
         Commands::Images { delete } => cmd_images(&be, &cfg, delete.as_ref()),
-        Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_ref(), &size),
+        Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_ref(), size),
         Commands::Profiles { action } => {
             cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
         }
-        Commands::Github { action } => cmd_github(&cfg, &cli.config, &action),
+        Commands::Github { action } => cmd_github(&cfg, &cli.config, action),
         Commands::Validate { probe } => cmd_validate(&cfg, &be, probe),
         Commands::Init
         | Commands::Update { .. }
@@ -1068,13 +1061,10 @@ fn main() -> Result<()> {
     }
 }
 
-fn cmd_github(cfg: &config::CoopConfig, config_path: &Path, action: &GithubAction) -> Result<()> {
+fn cmd_github(cfg: &config::CoopConfig, config_path: &Path, action: GithubAction) -> Result<()> {
     match action {
         GithubAction::SetupPat { repo } => {
-            let opts = github_pat::SetupOpts {
-                repo: repo.as_deref(),
-                config_path,
-            };
+            let opts = github_pat::SetupOpts { repo, config_path };
             github_pat::run_setup_pat(cfg, &opts)
         }
         GithubAction::RotatePat { repo } => {
@@ -1085,13 +1075,10 @@ fn cmd_github(cfg: &config::CoopConfig, config_path: &Path, action: &GithubActio
             github_pat::run_rotate_pat(cfg, &opts)
         }
         GithubAction::Status { probe } => {
-            github_pat::run_status(cfg, *probe);
+            github_pat::run_status(cfg, probe);
             Ok(())
         }
-        GithubAction::ForgetPat { repo } => {
-            let slug = github_repo::RepoSlug::new(repo)?;
-            github_pat::run_forget_pat(cfg, &slug, config_path)
-        }
+        GithubAction::ForgetPat { repo } => github_pat::run_forget_pat(cfg, &repo, config_path),
     }
 }
 
@@ -3693,10 +3680,9 @@ fn cmd_resize(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
     name: Option<&config::InstanceName>,
-    size: &str,
+    disk_size: config::DiskSize,
 ) -> Result<()> {
     let inst = cfg.resolve_instance(name)?;
-    let disk_size = config::DiskSize::parse(size)?;
 
     let stopped = be.as_stopped(inst)?;
     let current = current_disk_gib(be, stopped.instance())?;

--- a/src/pat_prompt.rs
+++ b/src/pat_prompt.rs
@@ -157,7 +157,7 @@ fn refresh_github_from_disk(cfg: &mut CoopConfig, config_path: &Path) -> Result<
 
 fn run_wizard_or_recover(cfg: &CoopConfig, config_path: &Path, repo: &RepoSlug) -> Result<()> {
     let opts = SetupOpts {
-        repo: Some(repo.as_str()),
+        repo: Some(repo.clone()),
         config_path,
     };
     match github_pat::run_setup_pat(cfg, &opts) {


### PR DESCRIPTION
Closes #268.

CLI argument parsing was inconsistent: some args parsed into strong types via `value_parser` at the clap boundary (`MiB`, `GiB`, `ImageName`, `InstanceName`), while repo slugs, the resize size, and the explicit devcontainer path carried raw `String`/`Option<String>` and were re-parsed deep in the dispatch body. This moves parsing to the clap layer so downstream code never re-checks what an earlier layer proved.

## Changes

- **Repo slugs.** `RepoSlug::parse_cli` is the `value_parser` for the `github setup-pat` / `rotate-pat` / `forget-pat` `--repo` args, so they parse to `RepoSlug` at the boundary. The `.trim()` previously done inside `resolve_target_repo` moves into `parse_cli`. `github_pat::SetupOpts::repo` becomes `Option<RepoSlug>` and `resolve_target_repo` takes `Option<&RepoSlug>`; the in-handler `RepoSlug::new` call in `cmd_github` is gone.
- **Disk size.** `coop resize --size` parses to `config::DiskSize` at the boundary via `value_parser = config::DiskSize::parse`; `cmd_resize` now takes the parsed `DiskSize` instead of `&str`.
- **Devcontainer path.** The three `--devcontainer` args (`up`, `setup`, `start`) become `Option<PathBuf>`, dropping the per-call-site `.map(PathBuf::from)` / `.map(Path::new)` conversions.

## Behavior note

Invalid `--repo` / `--size` input now fails at the clap layer (exit code 2, `error: invalid value ... try '--help'`) instead of an anyhow error (exit code 1). This is the standard clap UX and gives earlier, more consistent error messages. The validation message itself (e.g. `Repo slug must be 'owner/repo'`) is unchanged. Whitespace-trimming of `--repo` is preserved.

## Testing

- `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and `cargo test` (742 passing) all clean.
- Added unit tests for `RepoSlug::parse_cli` (trimming and invalid-slug rejection).
- Manually exercised the binary: `forget-pat --repo not-a-slug` and `resize --size abc` produce boundary errors; `forget-pat --repo "  owner/repo  "` trims and reaches the handler.

Integration tests (`tests/integration.sh`, both platforms) were not run in this environment; they exercise the VM lifecycle with valid inputs only and are unaffected by this boundary-parsing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)