### PR TITLE
Fix devcontainer opt-out test assertions to match message

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3397,7 +3397,7 @@ EOF
 
     if coop --config "$pref_cfg" up "$dcdir" --name "${INSTANCE}-dc-pref" \
         --dry-run --no-agents; then
-        if grep -q "stored opt-out" <<< "$HARNESS_ERR" \
+        if grep -q "stored devcontainer opt-out" <<< "$HARNESS_ERR" \
             && ! grep -q "devcontainer.json:" <<< "$HARNESS_ERR"; then
             pass "stored devcontainer opt-out skips discovery"
         else
@@ -3408,7 +3408,7 @@ EOF
     fi
 
     if coop --config "$pref_cfg" setup --workspace "$dcdir" --dry-run; then
-        if grep -q "stored opt-out" <<< "$HARNESS_ERR" \
+        if grep -q "stored devcontainer opt-out" <<< "$HARNESS_ERR" \
             && ! grep -q "setup-stage translation" <<< "$HARNESS_ERR"; then
             pass "stored devcontainer opt-out skips setup --workspace dry-run discovery"
         else
@@ -3419,7 +3419,7 @@ EOF
     fi
 
     if coop --config "$pref_cfg" start --workspace "$dcdir" --dry-run; then
-        if grep -q "stored opt-out" <<< "$HARNESS_ERR" \
+        if grep -q "stored devcontainer opt-out" <<< "$HARNESS_ERR" \
             && ! grep -q "start-stage translation" <<< "$HARNESS_ERR"; then
             pass "stored devcontainer opt-out skips start --workspace dry-run discovery"
         else


### PR DESCRIPTION
## What

Three integration-test assertions in `tests/integration.sh` grep the coop binary's stderr for the literal `"stored opt-out"`:

- `stored devcontainer opt-out skips discovery`
- `stored devcontainer opt-out skips setup --workspace dry-run discovery`
- `stored devcontainer opt-out skips start --workspace dry-run discovery`

The binary actually prints (`src/main.rs:2306`):

> Skipping … because a stored devcontainer **opt-out** is set for project …

The word `devcontainer` sits between `stored` and `opt-out`, so `"stored opt-out"` was never a substring of the real message. The grep failed unconditionally, so all three tests reported FAIL regardless of the binary's behavior.

This aligns the grep with the actual message. The negative assertions in the same blocks (`! grep -q "devcontainer.json:"`, `setup-stage translation`, `start-stage translation`) are unchanged and still match the discovery-report tokens the opt-out short-circuit suppresses.

## Verification

Ran `./tests/run-integration.sh` before and after on a Linux host. The three assertions go from FAIL to PASS (56→59 PASS). The remaining `setup exits 0` failure is environmental — this host has no `/dev/kvm`, so Firecracker can't boot — and is unrelated to this change.

These integration tests are run manually (not a CI gate per `CLAUDE.md`), which is how the drift reached `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)