### PR TITLE
Add `coop ssh-config` to install the SSH alias standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- **`coop ssh-config` — install a `coop-<name>` SSH alias** (#294) —
+  Writes the same `~/.ssh/config` block `coop vscode` produces, but
+  without launching an editor, so plain `ssh`, `scp`, and `rsync` reach
+  the guest by alias. `--clean` removes the block. The alias now
+  survives `coop stop` and is refreshed on `coop start` (the Lima SSH
+  port changes per boot), so it stays valid across restarts;
+  `coop destroy` and `--clean` remove it.
+
 ## v0.5.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 | `status` | Show instance status and resource usage |
 | `logs` | Stream VM serial console output |
 | `vscode` | Open VS Code connected to the guest |
+| `ssh-config` | Install a `coop-<name>` SSH alias for ad-hoc ssh/scp/rsync |
 | `images` | List or delete template images |
 | `resize` | Grow a stopped instance's disk |
 | `validate` | Check config and prerequisites |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -507,6 +507,46 @@ coop vscode my-project --editor code
 coop vscode my-project --clean
 ```
 
+### `ssh-config`
+
+Install a `coop-<name>` alias into `~/.ssh/config` so plain `ssh`, `scp`, and
+`rsync` reach the guest without remembering its host, port, user, or key. This
+is the same SSH config block `coop vscode` writes, but without launching an
+editor.
+
+```
+coop ssh-config [NAME] [--clean]
+```
+
+| Flag | Description |
+|------|-------------|
+| `NAME` | Instance name (required if multiple instances exist) |
+| `--clean` | Remove the SSH config entry for this instance and exit |
+
+```
+coop ssh-config
+coop ssh-config my-project
+ssh coop-my-project
+scp ./file coop-my-project:/workspace/
+rsync -az ./dir/ coop-my-project:/workspace/dir/
+coop ssh-config my-project --clean
+```
+
+The alias is created only when you run `coop ssh-config` (or `coop vscode`).
+The lifecycle keeps it tidy: `coop stop` and `coop destroy` remove the block,
+and `coop start` refreshes an already-installed block so it stays valid across
+a restart. On macOS/Lima the forwarded SSH port changes on each start; the
+refresh keeps the alias current without you re-running the command. On
+Linux/Firecracker the host and port are stable, so the refresh is a no-op.
+
+The block sets `StrictHostKeyChecking no` and `UserKnownHostsFile /dev/null`,
+so `ssh coop-*` connections skip host-key verification. This is intentional —
+these VMs regenerate their host keys, so pinning them would only produce
+spurious mismatch warnings.
+
+Use `ssh-config` for ad-hoc copies of arbitrary paths. To sync the tracked
+workspace directory in bulk, use [`push`](#push) / [`pull`](#pull) instead.
+
 ### `images`
 
 List or delete golden images. Without flags, prints every image with its profiles, creation date, and size.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -341,6 +341,7 @@ coop images --delete python-dev
 | `coop validate` | Check config and prerequisites without changing anything |
 | `coop logs` | Stream VM serial console logs (`-f` to follow) |
 | `coop vscode` | Open VS Code connected to the guest via SSH |
+| `coop ssh-config` | Install a `coop-<name>` SSH alias for ad-hoc `ssh`/`scp`/`rsync` |
 | `coop resize --size +20` | Grow a stopped instance's disk by 20 GiB |
 | `coop resize --size 100` | Set a stopped instance's disk to 100 GiB |
 

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -57,14 +57,14 @@ Host coop-my-instance
 # coop END
 ```
 
-Each run of `coop vscode` replaces the existing block for that instance, or creates one if none exists.
+Each run of `coop vscode` replaces the existing block for that instance, or creates one if none exists. To install the same block without launching an editor — for plain `ssh`/`scp`/`rsync` — use [`coop ssh-config`](commands.md#ssh-config).
 
 ### Cleanup
 
-- **`coop vscode NAME --clean`** removes the SSH config entry for the specified instance and exits. This cleans up the config without destroying the instance.
+- **`coop vscode NAME --clean`** (or **`coop ssh-config NAME --clean`**) removes the SSH config entry for the specified instance and exits. This cleans up the config without destroying the instance.
 - **`coop destroy`** removes the SSH config block for the destroyed instance.
 - **`coop destroy --all`** removes all coop SSH config blocks.
-- **`coop stop`** leaves the SSH config block in place. A stale entry has no effect when the VM is not running, and keeping it avoids churn on restart.
+- **`coop stop`** leaves the SSH config block in place. A stale entry has no effect when the VM is not running, and `coop start` refreshes it on the next boot (the Lima SSH port changes per start).
 
 ## Other editors
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,6 +454,18 @@ enum Commands {
         #[arg(long)]
         clean: bool,
     },
+    /// Install a `coop-<name>` SSH alias for ad-hoc ssh/scp/rsync
+    SshConfig {
+        /// Instance name (required if multiple instances exist)
+        #[arg(
+            value_parser = config::InstanceName::new,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
+        /// Remove the SSH config entry for this instance and exit
+        #[arg(long)]
+        clean: bool,
+    },
     /// List or manage golden images
     Images {
         /// Delete a named image
@@ -1044,6 +1056,16 @@ fn main() -> Result<()> {
             }
             let running = resolve_running(&be, &cfg, name.as_ref())?;
             workspace::vscode(&running, Some(&project), editor.as_deref())
+        }
+        Commands::SshConfig { name, clean } => {
+            if clean {
+                let inst = cfg.resolve_instance(name.as_ref())?;
+                workspace::remove_ssh_config(&inst)?;
+                tracing::info!("Removed SSH config for '{}'", inst.name);
+                return Ok(());
+            }
+            let running = resolve_running(&be, &cfg, name.as_ref())?;
+            workspace::write_ssh_config(&running)
         }
         Commands::Images { delete } => cmd_images(&be, &cfg, delete.as_ref()),
         Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_ref(), size),
@@ -2953,6 +2975,13 @@ fn restart_instance(
 
     signal::check_shutdown()?;
 
+    // Keep an already-installed `coop-<name>` alias current. On Lima the
+    // forwarded port changes across stop/start; this is a no-op rewrite on
+    // Firecracker. Never installs a block the user didn't ask for.
+    if let Err(e) = workspace::refresh_ssh_config_if_present(&target, inst) {
+        tracing::warn!("Failed to refresh SSH config for '{}': {e}", inst.name);
+    }
+
     port_forward::ForwardsState {
         forwards: forwards.clone(),
     }
@@ -3359,9 +3388,10 @@ fn cmd_stop(
             port_forward::teardown_ssh_forwards(inst, &target);
         }
     }
-    if let Err(e) = workspace::remove_ssh_config(inst) {
-        tracing::debug!("SSH config cleanup failed (non-fatal): {e}");
-    }
+    // The `coop-<name>` SSH alias is left in place across stop: a stale
+    // entry has no effect while the VM is down, and `coop start` refreshes
+    // it (the Lima port changes per boot). `destroy`/`ssh-config --clean`
+    // remove it.
     tracing::info!("Instance '{}' stopped", inst.name);
     Ok(())
 }
@@ -3945,6 +3975,39 @@ mod tests {
     fn ssh_alias_parses_as_shell() {
         let cli = parse(&["ssh"]);
         assert!(matches!(cli.command, super::Commands::Shell { .. }));
+    }
+
+    #[test]
+    fn ssh_config_subcommand_parses() {
+        let cli = parse(&["ssh-config", "myvm"]);
+        let super::Commands::SshConfig { name, clean } = cli.command else {
+            panic!("expected SshConfig variant");
+        };
+        assert_eq!(name.expect("name").as_str(), "myvm");
+        assert!(!clean);
+    }
+
+    #[test]
+    fn ssh_config_clean_flag_parses() {
+        let cli = parse(&["ssh-config", "--clean"]);
+        let super::Commands::SshConfig { name, clean } = cli.command else {
+            panic!("expected SshConfig variant");
+        };
+        assert!(name.is_none());
+        assert!(clean);
+    }
+
+    #[test]
+    fn ssh_config_does_not_collide_with_ssh_shell_alias() {
+        // `ssh` is an alias for `shell`; `ssh-config` is its own command.
+        assert!(matches!(
+            parse(&["ssh"]).command,
+            super::Commands::Shell { .. }
+        ));
+        assert!(matches!(
+            parse(&["ssh-config"]).command,
+            super::Commands::SshConfig { .. }
+        ));
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -522,24 +522,74 @@ pub fn vscode(
     editor: Option<&str>,
 ) -> Result<()> {
     let inst = running.instance();
-    let target = running.target();
     let remote_path = match project {
         Some(p) => GuestPath::absolute(p)
             .with_context(|| format!("--project must be an absolute guest path: {p:?}"))?,
         None => default_workspace_path(),
     };
 
-    update_ssh_config(target, inst)?;
+    write_ssh_config(running)?;
     launch_editor(inst, &remote_path, editor)?;
+    Ok(())
+}
 
+/// Install (or refresh) the `coop-<name>` SSH alias and print it.
+///
+/// Writes the `Host coop-<name>` block to `~/.ssh/config` idempotently,
+/// then prints the block plus `ssh`/`scp`/`rsync` usage hints to stderr.
+/// Shared by `coop vscode` (which also launches an editor) and the
+/// standalone `coop ssh-config` command.
+///
+/// Takes a `RunningInstance` so the SSH target is proven live by the
+/// type — a stale alias is worse than none.
+pub fn write_ssh_config(running: &RunningInstance) -> Result<()> {
+    let inst = running.instance();
+    let target = running.target();
+
+    update_ssh_config(target, inst)?;
+
+    let host = ssh_config_host(inst);
     let block = ssh_config_block(target, inst);
     writeln!(
         std::io::stderr(),
-        "\nSSH config entry (for manual editor connections):\n\n{block}"
+        "\nSSH alias '{host}' is ready:\n\n{block}\n\n\
+         Use it with ssh/scp/rsync, e.g.:\n\
+         \x20   ssh {host}\n\
+         \x20   scp ./file {host}:/workspace/\n\
+         \x20   rsync -az ./dir/ {host}:/workspace/dir/\n\n\
+         These connections skip host-key verification \
+         (the VM's keys are ephemeral)."
     )
     .context("Failed to write SSH config info")?;
 
     Ok(())
+}
+
+/// Refresh an already-installed `coop-<name>` alias after a restart.
+///
+/// Only rewrites the block if one already exists for this instance, so a
+/// restart never installs SSH config for a user who never ran
+/// `coop ssh-config`. Keeps a Lima alias current across stop/start, where
+/// the forwarded port changes (Firecracker ports are stable, so this is a
+/// no-op rewrite there).
+pub fn refresh_ssh_config_if_present(target: &SshTarget, inst: &Instance) -> Result<()> {
+    let ssh_config = ssh_config_path()?;
+    if !ssh_config.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&ssh_config).context("Failed to read ~/.ssh/config")?;
+    if !marker_block_present(&content, &ssh_config_host(inst)) {
+        return Ok(());
+    }
+
+    update_ssh_config(target, inst)
+}
+
+/// Whether `~/.ssh/config` content already holds a coop block for `host`.
+fn marker_block_present(content: &str, host: &str) -> bool {
+    let marker = format!("{MARKER_PREFIX} {host}");
+    content.lines().any(|line| line.trim() == marker)
 }
 
 /// Remove SSH config blocks for all instances from ~/.ssh/config.
@@ -1318,6 +1368,62 @@ Host coop-b\n\
         let input = "Host something\n    HostName 1.2.3.4\n";
         let result = remove_named_marker_block(input, "coop-x");
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn marker_block_present_detects_matching_host() {
+        let input = "\
+# coop START coop-a\n\
+Host coop-a\n\
+    HostName 172.16.0.2\n\
+# coop END\n";
+        assert!(marker_block_present(input, "coop-a"));
+    }
+
+    #[test]
+    fn marker_block_present_false_for_other_host() {
+        let input = "\
+# coop START coop-a\n\
+Host coop-a\n\
+    HostName 172.16.0.2\n\
+# coop END\n";
+        // A different instance's block must not count as present, or
+        // restart would refresh an alias the user never installed.
+        assert!(!marker_block_present(input, "coop-b"));
+    }
+
+    #[test]
+    fn marker_block_present_false_for_empty_config() {
+        assert!(!marker_block_present("", "coop-a"));
+    }
+
+    #[test]
+    fn marker_block_present_ignores_host_substring() {
+        // `coop-a` is a prefix of `coop-app`; a substring match would
+        // wrongly report the block present.
+        let input = "\
+# coop START coop-app\n\
+Host coop-app\n\
+    HostName 172.16.0.2\n\
+# coop END\n";
+        assert!(!marker_block_present(input, "coop-a"));
+    }
+
+    #[test]
+    fn ssh_config_block_has_expected_fields() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inst = temp_instance(dir.path());
+        let block = ssh_config_block(&fake_ssh_target(), &inst);
+
+        assert!(block.starts_with("# coop START coop-test"));
+        assert!(block.trim_end().ends_with("# coop END"));
+        assert!(block.contains("Host coop-test"));
+        assert!(block.contains("HostName 127.0.0.1"));
+        assert!(block.contains("Port 2222"));
+        assert!(block.contains("User ubuntu"));
+        assert!(block.contains("IdentityFile /tmp/key"));
+        assert!(block.contains("StrictHostKeyChecking no"));
+        assert!(block.contains("UserKnownHostsFile /dev/null"));
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -624,6 +624,64 @@ test_ssh_alias() {
     fi
 }
 
+# Exercises `coop ssh-config`: it installs a `coop-<name>` alias into
+# ~/.ssh/config, the alias works with plain ssh, the block survives `stop`
+# and is refreshed on `start` (the Lima port changes per boot), and
+# `--clean` removes it. Self-contained: leaves the instance running.
+test_ssh_config() {
+    echo ""
+    echo "=== Phase: ssh-config alias ==="
+
+    local marker="# coop START coop-$INSTANCE"
+    local ssh_cfg="$HOME/.ssh/config"
+
+    if coop ssh-config "$INSTANCE"; then
+        pass "ssh-config exits 0"
+    else
+        fail "ssh-config exits 0" "stderr: $HARNESS_ERR"
+        return
+    fi
+
+    if grep -qF "$marker" "$ssh_cfg" 2>/dev/null; then
+        pass "ssh-config writes marker block"
+    else
+        fail "ssh-config writes marker block" "no marker in $ssh_cfg"
+    fi
+
+    if _timeout 30 ssh "coop-$INSTANCE" echo "ssh-config-ok" 2>/dev/null | grep -q "ssh-config-ok"; then
+        pass "plain ssh via coop-$INSTANCE alias connects"
+    else
+        fail "plain ssh via coop-$INSTANCE alias connects" "ssh through alias failed"
+    fi
+
+    coop stop "$INSTANCE" || true
+    if grep -qF "$marker" "$ssh_cfg" 2>/dev/null; then
+        pass "ssh-config block survives stop"
+    else
+        fail "ssh-config block survives stop" "marker removed by stop"
+    fi
+
+    if coop start "$INSTANCE" --no-agents; then
+        if _timeout 30 ssh "coop-$INSTANCE" echo "refreshed-ok" 2>/dev/null | grep -q "refreshed-ok"; then
+            pass "ssh alias works after restart (block refreshed)"
+        else
+            fail "ssh alias works after restart (block refreshed)" "alias stale after restart"
+        fi
+    else
+        fail "restart for ssh-config refresh exits 0" "stderr: $HARNESS_ERR"
+    fi
+
+    if coop ssh-config "$INSTANCE" --clean; then
+        if grep -qF "$marker" "$ssh_cfg" 2>/dev/null; then
+            fail "ssh-config --clean removes block" "marker still present"
+        else
+            pass "ssh-config --clean removes block"
+        fi
+    else
+        fail "ssh-config --clean exits 0" "stderr: $HARNESS_ERR"
+    fi
+}
+
 test_exec() {
     echo ""
     echo "=== Phase: exec ==="
@@ -3982,6 +4040,7 @@ main() {
     test_auto_resolve_running
     test_shell_connectivity
     test_ssh_alias
+    test_ssh_config
     test_exec
     test_claude_bin_path
     test_codex_bin_path


### PR DESCRIPTION
Closes #294.

## What this does

Adds `coop ssh-config [name] [--clean]`, which writes the `coop-<name>` block to `~/.ssh/config` so plain `ssh`, `scp`, and `rsync` reach the guest by alias — without launching VS Code. It writes the same block `coop vscode` already produces.

```
coop ssh-config my-project
ssh coop-my-project
scp ./file coop-my-project:/workspace/
rsync -az ./dir/ coop-my-project:/workspace/dir/
coop ssh-config my-project --clean
```

## Changes

- **New command.** `Commands::SshConfig` clap variant and dispatch in `src/main.rs`. `--clean` removes the block via the existing `remove_ssh_config`, mirroring `coop vscode --clean`.
- **Shared helper.** Extract `workspace::write_ssh_config(running)` (update config + print the block with ssh/scp/rsync hints). Both `coop vscode` and `coop ssh-config` call it, so they stay in lockstep.
- **Alias survives restart.** `coop start` refreshes an already-installed block via `refresh_ssh_config_if_present`, keeping the alias valid across stop/start. This matters on macOS/Lima, where the forwarded SSH port is reassigned each boot; on Firecracker the host/port are stable, so it is a no-op rewrite. The guard rewrites only a block that already exists (exact `# coop START coop-<name>` line match), so a restart never installs config for a user who did not run `coop ssh-config`.
- **Stop keeps the block.** `cmd_stop` no longer removes the SSH config block. This matches what `docs/vscode.md` already documented and is what makes refresh-on-start meaningful. `coop destroy`, `--clean`, and uninstall still remove it.

## Tests

- Unit tests for `marker_block_present` (match, non-match, empty, prefix-vs-substring), the `ssh-config` block fields, and clap parsing (`ssh-config`, `--clean`, no collision with the `ssh`→`shell` alias).
- New `test_ssh_config` integration phase: install → marker present → functional `ssh coop-<name>` → block survives `stop` → alias works after `start` (refreshed) → `--clean` removes the block.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (757 passing) are clean.

## Docs

`docs/commands.md` (new `ssh-config` section with a push/pull cross-reference and a host-key-verification note), `docs/vscode.md`, `docs/getting-started.md`, `README.md`, and `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)