### PR TITLE
Add proptest properties and tighten CmdToken::File

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +185,7 @@ dependencies = [
  "indexmap",
  "libc",
  "mutants",
+ "proptest",
  "semver",
  "serde",
  "serde_json",
@@ -260,6 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,13 +315,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -552,6 +592,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +640,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +668,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,9 +703,53 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_users"
@@ -663,6 +790,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -948,6 +1087,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1134,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"
@@ -1258,6 +1412,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ hex = "0.4.3"
 mutants = "0.0.4"
 url = { version = "2", features = ["serde"] }
 
+[dev-dependencies]
+proptest = "1.11.0"
+
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 unwrap_used = "deny"

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -136,10 +136,21 @@ impl AccountName {
     }
 
     /// Validate `s` as an account name (non-empty, `[a-zA-Z0-9_.-]`) and wrap
-    /// it. This is the inverse boundary to [`from_repo`](Self::from_repo):
-    /// recovering a [`CmdToken::File`] from a stored `cmd:cat` path parses the
-    /// filename stem back into an `AccountName`, and only a stem in this
-    /// character class could have been produced by `from_repo`.
+    /// it. Used when recovering a [`CmdToken::File`] from a stored `cmd:cat`
+    /// path: the filename stem is parsed back into an `AccountName`.
+    ///
+    /// This accepts a *superset* of what [`from_repo`](Self::from_repo) emits
+    /// — `from_repo` always inserts a `-` separator, so a dash-free name like
+    /// `"abc"` passes here yet no repo slug could have produced it. That is
+    /// deliberate: the character class (not the exact `from_repo` image) is
+    /// the invariant that matters, because it keeps the value a safe filename
+    /// component and keeps [`CmdToken::parse`] an unambiguous inverse. A
+    /// recovered `File` token is only used to name the backend and to
+    /// round-trip through its `Display`; it never drives a filesystem write,
+    /// so a
+    /// stem coop would not itself have written is harmless to accept (and a
+    /// stem outside the class — spaces, quotes, a `/` — is still rejected,
+    /// falling through to `None` rather than being misattributed to `File`).
     pub fn new(s: &str) -> Result<Self> {
         if s.is_empty() {
             bail!("Account name is empty");

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -135,6 +135,19 @@ impl AccountName {
         Self(slug.as_str().replace('/', "-"))
     }
 
+    /// Validate `s` as an account name (non-empty, `[a-zA-Z0-9_.-]`) and wrap
+    /// it. This is the inverse boundary to [`from_repo`](Self::from_repo):
+    /// recovering a [`CmdToken::File`] from a stored `cmd:cat` path parses the
+    /// filename stem back into an `AccountName`, and only a stem in this
+    /// character class could have been produced by `from_repo`.
+    pub fn new(s: &str) -> Result<Self> {
+        if s.is_empty() {
+            bail!("Account name is empty");
+        }
+        validate_safe_chars(s, "Account name")?;
+        Ok(Self(s.to_string()))
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -274,8 +287,12 @@ pub enum CmdToken {
     SecretService { service: String, account: String },
     /// 1Password item read via `op item get`.
     OnePassword { title: String },
-    /// Plain-file read via `cat`, under `<state>/github-pat/<name>.txt`.
-    File { path: PathBuf },
+    /// Plain-file read via `cat`. Modelled by its varying parts — the state
+    /// directory and the [`AccountName`] — rather than a free `PathBuf`, so
+    /// the canonical `<dir>/github-pat/<account>.txt` layout holds by
+    /// construction and every representable value round-trips through
+    /// [`Display`](fmt::Display) / [`parse`](Self::parse).
+    File { dir: PathBuf, account: AccountName },
 }
 
 impl CmdToken {
@@ -350,9 +367,9 @@ impl CmdToken {
             ] => Some(Self::OnePassword {
                 title: (*title).to_string(),
             }),
-            ["cat", path] if is_pat_file(Path::new(path)) => Some(Self::File {
-                path: PathBuf::from(path),
-            }),
+            ["cat", path] => {
+                parse_pat_file(Path::new(path)).map(|(dir, account)| Self::File { dir, account })
+            }
             _ => None,
         }
     }
@@ -380,21 +397,32 @@ impl fmt::Display for CmdToken {
                 "cmd:op item get {} --fields password --reveal",
                 shell_quote(title),
             ),
-            Self::File { path } => {
+            Self::File { dir, account } => {
+                let path = file_backend_path(dir, account);
                 write!(f, "cmd:cat {}", shell_quote(&path.to_string_lossy()))
             }
         }
     }
 }
 
-/// Does `path` follow the canonical `…/github-pat/<name>.txt` layout coop
-/// writes for the file backend?
-fn is_pat_file(path: &Path) -> bool {
-    path.extension().is_some_and(|ext| ext == "txt")
-        && path
-            .parent()
-            .and_then(Path::file_name)
-            .is_some_and(|dir| dir == PAT_DIR)
+/// Decompose a `cat` path into the parts of a [`CmdToken::File`], or `None`
+/// if it does not follow the canonical `<dir>/github-pat/<account>.txt`
+/// layout coop writes for the file backend.
+///
+/// This is the exact inverse of joining those parts in
+/// [`file_backend_path`]: the `.txt` suffix and `github-pat` parent are
+/// stripped, and the filename stem must be a well-formed [`AccountName`].
+/// A path that fails any check is reported as `None` rather than being
+/// misattributed to the file backend.
+fn parse_pat_file(path: &Path) -> Option<(PathBuf, AccountName)> {
+    let stem = path.file_name()?.to_str()?.strip_suffix(".txt")?;
+    let parent = path.parent()?;
+    if parent.file_name()?.to_str()? != PAT_DIR {
+        return None;
+    }
+    let dir = parent.parent()?.to_path_buf();
+    let account = AccountName::new(stem).ok()?;
+    Some((dir, account))
 }
 
 /// Split a `cmd:` body into shell words, inverting [`shell_quote`].
@@ -545,7 +573,10 @@ fn store_file(
     }
     // Suppress unused-warning for `service` when the file backend ignores it.
     let _ = service;
-    Ok(CmdToken::File { path })
+    Ok(CmdToken::File {
+        dir: state_dir.to_path_buf(),
+        account: account.clone(),
+    })
 }
 
 fn file_backend_path(state_dir: &Path, account: &AccountName) -> PathBuf {
@@ -584,6 +615,7 @@ const PAT_DIR: &str = "github-pat";
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn file_backend_always_available() {
@@ -774,45 +806,6 @@ mod tests {
     }
 
     #[test]
-    fn cmd_token_round_trips_through_display_and_parse() {
-        // The whole point of CmdToken: Display and parse are exact inverses,
-        // so the stored string and the recognised backend cannot diverge.
-        // Titles and paths exercise shell-quoting (spaces, parens, quotes).
-        let tokens = vec![
-            #[cfg(target_os = "macos")]
-            CmdToken::Keychain {
-                service: "coop-github-pat".to_string(),
-                account: "trailofbits-coop".to_string(),
-            },
-            #[cfg(target_os = "linux")]
-            CmdToken::SecretService {
-                service: "coop-github-pat".to_string(),
-                account: "trailofbits-coop".to_string(),
-            },
-            CmdToken::OnePassword {
-                title: "coop-github-pat (trailofbits-coop)".to_string(),
-            },
-            CmdToken::OnePassword {
-                title: "weird 'quoted' title".to_string(),
-            },
-            CmdToken::File {
-                path: PathBuf::from("/home/u/.coop/state/github-pat/a-b.txt"),
-            },
-            CmdToken::File {
-                path: PathBuf::from("/tmp/space dir/github-pat/x.txt"),
-            },
-        ];
-        for token in tokens {
-            let rendered = token.to_string();
-            assert_eq!(
-                CmdToken::parse(&rendered),
-                Some(token.clone()),
-                "round-trip failed for {rendered}"
-            );
-        }
-    }
-
-    #[test]
     fn store_outputs_round_trip_through_parse() {
         // The cmd string a backend actually writes must parse back to the
         // backend that wrote it — this is the divergence the type prevents.
@@ -834,5 +827,106 @@ mod tests {
         assert_eq!(shell_split(r"'a'\''b'"), Some(vec!["a'b".into()]));
         // Unterminated single quote is rejected.
         assert_eq!(shell_split("'unterminated"), None);
+    }
+
+    // ── Property tests ─────────────────────────────────────────────
+    //
+    // `proptest!` blocks live alongside the example tests above (per the
+    // testing conventions), each pinning an invariant the examples only
+    // sample.
+
+    /// A well-formed account name — non-empty and in the `[a-zA-Z0-9_.-]`
+    /// class, exactly what [`AccountName::from_repo`] can produce.
+    fn arb_account_name() -> impl Strategy<Value = AccountName> {
+        "[a-zA-Z0-9_.-]{1,20}".prop_map(|s| AccountName::new(&s).unwrap())
+    }
+
+    /// A state directory. Mixes genuinely path-shaped values — multiple
+    /// segments, separators, empty/trailing components, and segments that
+    /// collide with the canonical layout (`github-pat`, a `*.txt` stem) —
+    /// with free text (spaces, quotes, unicode, the empty path) so the
+    /// round-trip is exercised on the inputs most likely to confuse the
+    /// `parse_pat_file` decomposition, not just random bytes. The NUL byte is
+    /// excluded; no real filesystem path carries it.
+    fn arb_dir() -> impl Strategy<Value = PathBuf> {
+        prop_oneof![
+            prop::collection::vec("(github-pat|[^\u{0}/]{0,8})", 0..4)
+                .prop_map(|segs| segs.iter().collect::<PathBuf>()),
+            "[^\u{0}]{0,40}".prop_map(PathBuf::from),
+        ]
+    }
+
+    /// A string field embedded into a `cmd:` invocation. Biased toward the
+    /// values that could collide with the surrounding literal/flag words —
+    /// the empty string, flag-shaped tokens (`-w`, `--fields`), and the
+    /// command words themselves — alongside arbitrary text. `shell_quote`
+    /// renders each as exactly one word, so a collision would have to defeat
+    /// the fixed-length slice match in `from_words`, not just look like a
+    /// flag.
+    fn arb_field() -> impl Strategy<Value = String> {
+        prop_oneof![
+            any::<String>(),
+            prop::sample::select(vec![
+                String::new(),
+                "-s".to_string(),
+                "-a".to_string(),
+                "-w".to_string(),
+                "--fields".to_string(),
+                "password".to_string(),
+                "--reveal".to_string(),
+                "cat".to_string(),
+                "lookup".to_string(),
+                "a b".to_string(),
+                "'".to_string(),
+            ]),
+        ]
+    }
+
+    #[cfg(target_os = "macos")]
+    fn arb_system_token() -> impl Strategy<Value = CmdToken> {
+        (arb_field(), arb_field())
+            .prop_map(|(service, account)| CmdToken::Keychain { service, account })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn arb_system_token() -> impl Strategy<Value = CmdToken> {
+        (arb_field(), arb_field())
+            .prop_map(|(service, account)| CmdToken::SecretService { service, account })
+    }
+
+    fn arb_cmd_token() -> impl Strategy<Value = CmdToken> {
+        prop_oneof![
+            arb_system_token(),
+            arb_field().prop_map(|title| CmdToken::OnePassword { title }),
+            (arb_dir(), arb_account_name())
+                .prop_map(|(dir, account)| CmdToken::File { dir, account }),
+        ]
+    }
+
+    proptest! {
+        /// `shell_quote` always produces exactly one shell word that splits
+        /// back to the original string — the "escaped string parses back as
+        /// exactly one literal argument" invariant the `cmd:` encoding rests
+        /// on.
+        #[test]
+        fn shell_quote_split_round_trips(s in any::<String>()) {
+            prop_assert_eq!(shell_split(&shell_quote(&s)), Some(vec![s]));
+        }
+
+        /// `Display` and `parse` are inverses (under `CmdToken`'s `PartialEq`)
+        /// for every representable token. For `File` this holds *by
+        /// construction* now that the variant is modelled by its varying parts
+        /// rather than a free path — the case the old hand-picked examples
+        /// could not exhaust, and which surfaced the empty-string quoting bug
+        /// in the #271/#277 review. `dir` round-trips up to `Path`'s
+        /// component-wise equality (a trailing or doubled separator
+        /// normalises away), which is exactly the equality the property
+        /// asserts and matches the normalised `state_dir` `store_file` feeds
+        /// in.
+        #[test]
+        fn cmd_token_round_trips(token in arb_cmd_token()) {
+            let rendered = token.to_string();
+            prop_assert_eq!(CmdToken::parse(&rendered), Some(token));
+        }
     }
 }

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -147,10 +147,10 @@ impl AccountName {
     /// component and keeps [`CmdToken::parse`] an unambiguous inverse. A
     /// recovered `File` token is only used to name the backend and to
     /// round-trip through its `Display`; it never drives a filesystem write,
-    /// so a
-    /// stem coop would not itself have written is harmless to accept (and a
-    /// stem outside the class — spaces, quotes, a `/` — is still rejected,
-    /// falling through to `None` rather than being misattributed to `File`).
+    /// so a stem coop would not itself have written is harmless to accept
+    /// (and a stem outside the class — spaces, quotes, a `/` — is still
+    /// rejected, falling through to `None` rather than being misattributed to
+    /// `File`).
     pub fn new(s: &str) -> Result<Self> {
         if s.is_empty() {
             bail!("Account name is empty");

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -640,6 +640,26 @@ mod tests {
     }
 
     #[test]
+    fn account_name_new_rejects_empty_and_slashes() {
+        // `new` is the parse-side smart constructor `parse_pat_file` relies
+        // on: a `/` (single, repeated, or leading) in the filename stem would
+        // make the path decomposition ambiguous, so it must be rejected here.
+        // This pins what keeps the `File` round-trip unambiguous, independent
+        // of `RepoSlug`'s own gating on the `from_repo` path.
+        assert!(AccountName::new("").is_err(), "empty must be rejected");
+        for bad in ["a/b", "/a", "a/", "a//b", "/"] {
+            assert!(
+                AccountName::new(bad).is_err(),
+                "slash-bearing '{bad}' must be rejected"
+            );
+        }
+        assert_eq!(
+            AccountName::new("trailofbits-coop").unwrap().as_str(),
+            "trailofbits-coop"
+        );
+    }
+
+    #[test]
     fn account_from_repo_uses_safe_chars_only() {
         // Constructor is infallible; result must consist only of the
         // [a-zA-Z0-9_.-] class so downstream filename / lookup-key use


### PR DESCRIPTION
Implements #298 — the first item of the property-testing track (#278).

## Foundation
- Adds `proptest = "1.11.0"` as the only new dev-dependency (current crates.io stable). `cargo-fuzz` / `kani` deferred per #278.
- `proptest!` blocks live in the existing `#[cfg(test)] mod tests`, next to the example tests.

## `CmdToken` round-trip
- `cmd_token_round_trips` asserts `CmdToken::parse(token.to_string()) == Some(token)` over arbitrary `service` / `account` / `title` / `dir` / account. The field strategy is biased toward the empty string and flag-shaped values (`-w`, `--fields`, …) that stress the fixed-length slice match in `from_words` — covering the empty-string quoting case from the #271/#277 review. This subsumes the hand-written `cmd_token_round_trips_through_display_and_parse` example, which is removed.
- `shell_quote_split_round_trips` asserts `shell_split(shell_quote(s)) == [s]` for arbitrary `s`, satisfying the "an escaped string parses back as exactly one literal argument" checklist item.

## `File`-variant tightening
- `CmdToken::File` now holds `dir: PathBuf` + `account: AccountName` instead of a free `PathBuf`. `Display` joins the canonical `<dir>/github-pat/<account>.txt` layout via `file_backend_path`, so the round-trip holds **by construction** rather than only for paths `store_file` happens to produce.
- `is_pat_file` (a boolean predicate) is replaced by `parse_pat_file`, the exact inverse of `file_backend_path`: it strips the `.txt` suffix and `github-pat` parent and parses the stem back into an `AccountName`. `AccountName::new` is the parse-side smart constructor that rejects non-canonical stems.
- `store_outputs_round_trip_through_parse` is kept as the concrete anchor.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (758 tests) all clean.
- Property tests pass at `PROPTEST_CASES=30000`; a separate exhaustive search over short paths found no `File` round-trip failures.
- New transitive deps all carry MIT/Apache-2.0-compatible licenses (within `deny.toml`'s allowlist).

The change was reviewed by a separate critical-review pass before opening this PR; its nits (strategy distribution, doc precision on `Path` component equality) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)