### PR TITLE
Add env-composition property tests and jsonc fuzz target

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,5 +23,12 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "jsonc_to_json"
+path = "fuzz_targets/jsonc_to_json.rs"
+test = false
+doc = false
+bench = false
+
 # Detach from the parent package so `cargo fuzz` resolves this as its own root.
 [workspace]

--- a/fuzz/fuzz_targets/jsonc_to_json.rs
+++ b/fuzz/fuzz_targets/jsonc_to_json.rs
@@ -1,0 +1,25 @@
+#![no_main]
+
+//! Fuzz target for [`jsonc::jsonc_to_json`].
+//!
+//! The scanner is fed hand-authored `devcontainer.json` text — user-editable
+//! input that crosses a trust boundary, which is the parser class #278
+//! reserves a standing fuzz harness for. There is no correctness oracle for
+//! arbitrary input, so the only property is **never panics**: libFuzzer
+//! reports any panic, abort, hang, or OOM as a crash.
+//!
+//! `coop` is a binary-only crate (no lib target), so the function cannot be
+//! imported as a dependency. The `jsonc` module is self-contained (std only),
+//! so it is included by path. Its `#[cfg(test)]` block is inactive in a fuzz
+//! build, so only production code compiles.
+
+use libfuzzer_sys::fuzz_target;
+
+#[path = "../../src/jsonc.rs"]
+mod jsonc;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let _ = jsonc::jsonc_to_json(input);
+    }
+});

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -24,6 +24,7 @@ use crate::config::{self, CoopConfig, GiB, MiB, Mount, PortForward};
 use crate::devcontainer_oci::{FeatureRequest, ResolvedFeature};
 use crate::guest::{BuiltinProfile, GuestUser, builtin_for_feature};
 use crate::guest_env_state::EnvVarName;
+use crate::jsonc::jsonc_to_json;
 use crate::sha256_hash::Sha256Hash;
 
 /// Default relative path coop looks for inside a workspace or mount root.
@@ -141,94 +142,6 @@ fn canonicalize_deleted_project(project: &Path) -> PathBuf {
 }
 
 // ── Parsing ──────────────────────────────────────────────────
-
-/// Convert JSONC (`//`, `/* */`, trailing commas) to plain JSON.
-///
-/// Implements a single-pass byte scanner aware of string literals (with
-/// `\"` and `\\` escapes). Trailing commas are detected by buffering each
-/// `,` and dropping it if the next non-whitespace, non-comment token is
-/// `]` or `}`. Whitespace bytes are preserved so error offsets in
-/// downstream `serde_json` diagnostics roughly track the source.
-#[must_use]
-pub fn jsonc_to_json(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut i = 0;
-    let mut pending_comma = false;
-    let mut in_string = false;
-
-    while i < bytes.len() {
-        let c = bytes[i];
-        if in_string {
-            if pending_comma {
-                out.push(',');
-                pending_comma = false;
-            }
-            out.push(c as char);
-            if c == b'\\' && i + 1 < bytes.len() {
-                out.push(bytes[i + 1] as char);
-                i += 2;
-                continue;
-            }
-            if c == b'"' {
-                in_string = false;
-            }
-            i += 1;
-            continue;
-        }
-        match c {
-            b'"' => {
-                if pending_comma {
-                    out.push(',');
-                    pending_comma = false;
-                }
-                in_string = true;
-                out.push('"');
-                i += 1;
-            }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                if i + 1 < bytes.len() {
-                    i += 2;
-                }
-            }
-            b',' => {
-                pending_comma = true;
-                i += 1;
-            }
-            b']' | b'}' => {
-                pending_comma = false;
-                out.push(c as char);
-                i += 1;
-            }
-            b if b.is_ascii_whitespace() => {
-                out.push(b as char);
-                i += 1;
-            }
-            _ => {
-                if pending_comma {
-                    out.push(',');
-                    pending_comma = false;
-                }
-                out.push(c as char);
-                i += 1;
-            }
-        }
-    }
-    if pending_comma {
-        // Trailing comma at EOF without a closer; let serde report it.
-        out.push(',');
-    }
-    out
-}
 
 /// Raw deserialization shape — close to the spec.
 ///
@@ -1696,51 +1609,6 @@ mod tests {
     }
 
     #[test]
-    fn jsonc_strips_line_comments() {
-        let src = r#"{
-            // a comment
-            "name": "demo" // trailing
-        }"#;
-        let json = jsonc_to_json(src);
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["name"], "demo");
-    }
-
-    #[test]
-    fn jsonc_strips_block_comments() {
-        let src = r#"{ /* block */ "k": /* inline */ 1 }"#;
-        let json = jsonc_to_json(src);
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["k"], 1);
-    }
-
-    #[test]
-    fn jsonc_strips_trailing_commas() {
-        let src = r#"{ "a": 1, "b": [1, 2, 3,], }"#;
-        let json = jsonc_to_json(src);
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["a"], 1);
-        assert_eq!(v["b"][2], 3);
-    }
-
-    #[test]
-    fn jsonc_keeps_commas_inside_strings() {
-        let src = r#"{ "k": "a, b, c", }"#;
-        let json = jsonc_to_json(src);
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["k"], "a, b, c");
-    }
-
-    #[test]
-    fn jsonc_keeps_slashes_inside_strings() {
-        let src = r#"{ "k": "https://example.com/a", "j": "/* not a comment */" }"#;
-        let json = jsonc_to_json(src);
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["k"], "https://example.com/a");
-        assert_eq!(v["j"], "/* not a comment */");
-    }
-
-    #[test]
     fn parse_supported_subset() {
         let f = parse(
             r#"{
@@ -1759,44 +1627,38 @@ mod tests {
     }
 
     #[test]
-    fn translate_marks_overridden_when_cli_wins() {
+    fn translate_cli_wins_over_devcontainer_cpus_and_post_start() {
         let f = parse(r#"{ "hostRequirements": { "cpus": 4 }, "postStartCommand": "x" }"#);
+
+        // Without CLI flags the devcontainer values are the effective output.
+        let defaults = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        assert_eq!(defaults.vcpus, Some(4));
+        assert_eq!(defaults.post_start.as_deref(), Some("x"));
+
+        // With CLI flags set, the devcontainer values must not take effect: the
+        // CLI value wins, so the translator yields no override of its own and
+        // the resolved config keeps the CLI value.
         let inputs = TranslatorInputs {
             cli_vcpus: Some(8),
             cli_post_start: Some("y".to_string()),
             ..TranslatorInputs::default()
         };
-        let t = translate(&f, &inputs, Stage::Start);
-        let cpu = t
-            .report
-            .entries
-            .iter()
-            .find(|e| e.key == "hostRequirements.cpus")
-            .unwrap();
-        assert_eq!(cpu.status, ReportStatus::Overridden);
-        let cmd = t
-            .report
-            .entries
-            .iter()
-            .find(|e| e.key == "postStartCommand")
-            .unwrap();
-        assert_eq!(cmd.status, ReportStatus::Overridden);
-        assert!(t.vcpus.is_none());
-        assert!(t.post_start.is_none());
+        let overridden = translate(&f, &inputs, Stage::Start);
+        assert!(overridden.vcpus.is_none());
+        assert!(overridden.post_start.is_none());
     }
 
     #[test]
-    fn translate_setup_reports_storage_as_start_time_only() {
+    fn translate_storage_sizes_disk_only_at_start() {
         let f = parse(r#"{ "hostRequirements": { "storage": "16GiB" } }"#);
-        let t = translate(&f, &TranslatorInputs::default(), Stage::Setup);
-        let storage = t
-            .report
-            .entries
-            .iter()
-            .find(|e| e.key == "hostRequirements.storage")
-            .unwrap();
-        assert_eq!(storage.status, ReportStatus::Unsupported);
-        assert!(t.disk_gib.is_none());
+
+        // Disk sizing happens at `coop start`, never during setup.
+        let setup = translate(&f, &TranslatorInputs::default(), Stage::Setup);
+        assert!(setup.disk_gib.is_none());
+
+        // At start the devcontainer's storage becomes the effective disk size.
+        let start = translate(&f, &TranslatorInputs::default(), Stage::Start);
+        assert!(start.disk_gib.is_some());
     }
 
     #[test]
@@ -1863,15 +1725,9 @@ mod tests {
     fn translate_remote_user_setup_captures_into_translation() {
         let f = parse(r#"{ "remoteUser": "vscode" }"#);
         let t = translate(&f, &TranslatorInputs::default(), Stage::Setup);
+        // The observable effect of a setup-stage `remoteUser` is the guest user
+        // baked into the translation; the report row is incidental.
         assert_eq!(t.guest_user.as_ref().map(GuestUser::as_str), Some("vscode"));
-        let entry = t
-            .report
-            .entries
-            .iter()
-            .find(|e| e.key == "remoteUser")
-            .unwrap();
-        assert_eq!(entry.status, ReportStatus::Applied);
-        assert_eq!(entry.source, ReportSource::Devcontainer);
     }
 
     #[test]

--- a/src/guest_env_state.rs
+++ b/src/guest_env_state.rs
@@ -198,6 +198,8 @@ pub fn parse_cli_env_arg(entry: &str) -> Result<(EnvVarName, String)> {
 mod tests {
     use std::path::PathBuf;
 
+    use proptest::prelude::*;
+
     use super::*;
     use crate::config::{ImageName, Instance, InstanceIndex, InstanceName};
 
@@ -215,13 +217,6 @@ mod tests {
     }
 
     // ── EnvVarName ───────────────────────────────────────────
-
-    #[test]
-    fn env_var_name_accepts_valid_forms() {
-        for s in ["FOO", "_BAR", "foo", "FOO_BAR_123", "_", "_0"] {
-            assert!(EnvVarName::new(s).is_ok(), "expected '{s}' to be valid");
-        }
-    }
 
     #[test]
     fn env_var_name_rejects_invalid_forms() {
@@ -334,5 +329,73 @@ mod tests {
         let (k, v) = parse_cli_env_arg("URL=https://x?a=b&c=d").unwrap();
         assert_eq!(k, env("URL"));
         assert_eq!(v, "https://x?a=b&c=d");
+    }
+
+    // ── property tests ───────────────────────────────────────
+
+    /// Keys drawn from a deliberately small space so independently generated
+    /// maps overlap often, exercising the CLI-wins-on-collision path rather
+    /// than only disjoint unions.
+    fn small_env_map() -> impl Strategy<Value = BTreeMap<EnvVarName, String>> {
+        prop::collection::btree_map(
+            "[A-E]".prop_map(|s| EnvVarName::new(&s).unwrap()),
+            any::<String>(),
+            0..6,
+        )
+    }
+
+    proptest! {
+        /// Every string matching the documented `[a-zA-Z_][a-zA-Z0-9_]*`
+        /// grammar parses, and the parsed name preserves the input verbatim.
+        #[test]
+        fn env_var_name_accepts_all_valid_forms(s in "[a-zA-Z_][a-zA-Z0-9_]*") {
+            let name = EnvVarName::new(&s).unwrap();
+            prop_assert_eq!(name.as_str(), s.as_str());
+        }
+
+        /// `merge_persisted_entries` keeps every key from both tiers (totality)
+        /// and resolves collisions in the CLI's favour (precedence). It is
+        /// intentionally not idempotent or associative across overlapping
+        /// tiers, so only these two invariants are asserted.
+        #[test]
+        fn merge_persisted_entries_is_total_and_cli_wins(
+            dc in small_env_map(),
+            cli in small_env_map(),
+        ) {
+            let merged = merge_persisted_entries(&dc, &cli);
+
+            // Totality: the key set is exactly the union — nothing dropped or
+            // invented.
+            let union: std::collections::BTreeSet<_> =
+                dc.keys().chain(cli.keys()).cloned().collect();
+            let got: std::collections::BTreeSet<_> = merged.keys().cloned().collect();
+            prop_assert_eq!(got, union);
+
+            // Precedence: CLI wins on collision; devcontainer fills the rest.
+            for (k, v) in &merged {
+                let expected = cli.get(k).or_else(|| dc.get(k)).unwrap();
+                prop_assert_eq!(v, expected);
+            }
+        }
+
+        /// A `GuestEnvState` round-trips through disk unchanged: save → load
+        /// yields the same entries, and a second save → load is identical to
+        /// the first (deterministic `BTreeMap` ordering). An empty map is not
+        /// persisted (see `save`), so loading then yields `None`, which decodes
+        /// back to the empty snapshot it represents.
+        #[test]
+        fn guest_env_state_round_trips_through_disk(entries in small_env_map()) {
+            let tmp = tempfile::tempdir().unwrap();
+            let inst = fake_instance(tmp.path().to_path_buf());
+            let state = GuestEnvState { entries: entries.clone() };
+
+            state.save(&inst).unwrap();
+            let loaded = GuestEnvState::try_load(&inst).unwrap().unwrap_or_default();
+            prop_assert_eq!(&loaded.entries, &entries);
+
+            loaded.save(&inst).unwrap();
+            let reloaded = GuestEnvState::try_load(&inst).unwrap().unwrap_or_default();
+            prop_assert_eq!(reloaded.entries, entries);
+        }
     }
 }

--- a/src/jsonc.rs
+++ b/src/jsonc.rs
@@ -1,0 +1,182 @@
+//! JSONC (`//`, `/* */`, trailing commas) to plain JSON.
+//!
+//! `devcontainer.json` is hand-authored and crosses a trust boundary, so
+//! the scanner must tolerate any byte sequence without panicking. The
+//! conversion is intentionally permissive: it strips comments and trailing
+//! commas and leaves everything else for `serde_json` to validate, so
+//! malformed input surfaces as a parse error rather than a crash. A
+//! standing fuzz target (`fuzz/fuzz_targets/jsonc_to_json.rs`) pins the
+//! never-panics property.
+
+/// Convert JSONC (`//`, `/* */`, trailing commas) to plain JSON.
+///
+/// Implements a single-pass byte scanner aware of string literals (with
+/// `\"` and `\\` escapes). Trailing commas are detected by buffering each
+/// `,` and dropping it if the next non-whitespace, non-comment token is
+/// `]` or `}`. Whitespace bytes are preserved so error offsets in
+/// downstream `serde_json` diagnostics roughly track the source.
+#[must_use]
+pub fn jsonc_to_json(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut pending_comma = false;
+    let mut in_string = false;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            if pending_comma {
+                out.push(',');
+                pending_comma = false;
+            }
+            out.push(c as char);
+            if c == b'\\' && i + 1 < bytes.len() {
+                out.push(bytes[i + 1] as char);
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' => {
+                if pending_comma {
+                    out.push(',');
+                    pending_comma = false;
+                }
+                in_string = true;
+                out.push('"');
+                i += 1;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    i += 2;
+                }
+            }
+            b',' => {
+                pending_comma = true;
+                i += 1;
+            }
+            b']' | b'}' => {
+                pending_comma = false;
+                out.push(c as char);
+                i += 1;
+            }
+            b if b.is_ascii_whitespace() => {
+                out.push(b as char);
+                i += 1;
+            }
+            _ => {
+                if pending_comma {
+                    out.push(',');
+                    pending_comma = false;
+                }
+                out.push(c as char);
+                i += 1;
+            }
+        }
+    }
+    if pending_comma {
+        // Trailing comma at EOF without a closer; let serde report it.
+        out.push(',');
+    }
+    out
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests use unwrap for brevity")]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn jsonc_strips_line_comments() {
+        let src = r#"{
+            // a comment
+            "name": "demo" // trailing
+        }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["name"], "demo");
+    }
+
+    #[test]
+    fn jsonc_strips_block_comments() {
+        let src = r#"{ /* block */ "k": /* inline */ 1 }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["k"], 1);
+    }
+
+    #[test]
+    fn jsonc_strips_trailing_commas() {
+        let src = r#"{ "a": 1, "b": [1, 2, 3,], }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["a"], 1);
+        assert_eq!(v["b"][2], 3);
+    }
+
+    #[test]
+    fn jsonc_keeps_commas_inside_strings() {
+        let src = r#"{ "k": "a, b, c", }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["k"], "a, b, c");
+    }
+
+    #[test]
+    fn jsonc_keeps_slashes_inside_strings() {
+        let src = r#"{ "k": "https://example.com/a", "j": "/* not a comment */" }"#;
+        let json = jsonc_to_json(src);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["k"], "https://example.com/a");
+        assert_eq!(v["j"], "/* not a comment */");
+    }
+
+    proptest! {
+        /// The scanner must never panic on arbitrary input — `devcontainer.json`
+        /// is hand-edited and untrusted. This mirrors the standing fuzz target
+        /// inside the unit-test suite so regressions surface without a fuzz run.
+        #[test]
+        fn jsonc_to_json_never_panics(input in ".*") {
+            let _ = jsonc_to_json(&input);
+        }
+
+        /// Input with no comments and no commas is passed through verbatim:
+        /// the scanner only ever removes comment spans and trailing commas, so
+        /// text containing neither must be returned unchanged.
+        #[test]
+        fn jsonc_to_json_is_identity_without_comments_or_commas(
+            input in "[a-zA-Z0-9 \t\n{}:_]*",
+        ) {
+            prop_assert_eq!(jsonc_to_json(&input), input);
+        }
+
+        /// Quoted string contents survive intact: a JSON document whose only
+        /// string value is comma- and slash-bearing text round-trips through
+        /// the scanner and back out of `serde_json` unchanged. The character
+        /// class stays within printable, unescaped JSON string content (no
+        /// quote, backslash, or control characters).
+        #[test]
+        fn jsonc_to_json_preserves_string_values(value in "[a-zA-Z0-9 ,./:_-]*") {
+            let src = format!(r#"{{ "k": "{value}" }}"#);
+            let json = jsonc_to_json(&src);
+            let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(v["k"].as_str().unwrap(), value.as_str());
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod github_repo;
 mod github_submodules;
 mod guest;
 mod guest_env_state;
+mod jsonc;
 mod naming;
 mod pat_prompt;
 mod paths;
@@ -3951,6 +3952,7 @@ fn dir_size_display(dir: &std::path::Path) -> String {
 #[expect(clippy::expect_used, reason = "test code — panics are assertions")]
 mod tests {
     use clap::Parser;
+    use proptest::prelude::*;
 
     use super::Cli;
 
@@ -4335,6 +4337,74 @@ mod tests {
             cfg.guest_env.get(&env("ONLY_CFG")).map(String::as_str),
             Some("cfg")
         );
+    }
+
+    /// Guest-env maps keyed in a deliberately small space so the three tiers
+    /// overlap often, exercising the precedence path rather than only disjoint
+    /// unions.
+    fn small_env_map()
+    -> impl Strategy<Value = std::collections::BTreeMap<super::guest_env_state::EnvVarName, String>>
+    {
+        prop::collection::btree_map(
+            "[A-E]".prop_map(|s| {
+                super::guest_env_state::EnvVarName::new(&s)
+                    .expect("single uppercase letter is valid")
+            }),
+            any::<String>(),
+            0..6,
+        )
+    }
+
+    proptest! {
+        /// `merge_runtime_guest_env` resolves all three tiers with
+        /// CLI > devcontainer.json > config.toml precedence. The returned map
+        /// carries exactly the devcontainer ∪ CLI entries (config-only keys
+        /// stay in `cfg.guest_env` but are never re-added to the persisted
+        /// map), and `cfg.guest_env` reflects the full three-tier merge.
+        #[test]
+        fn merge_runtime_guest_env_precedence_holds(
+            cfg_env in small_env_map(),
+            dc in small_env_map(),
+            cli_map in small_env_map(),
+        ) {
+            use super::guest_env_state::EnvVarName;
+
+            let mut cfg = super::config::CoopConfig::default();
+            for (k, v) in &cfg_env {
+                cfg.guest_env.insert(k.clone(), v.clone());
+            }
+            let cli: Vec<(EnvVarName, String)> =
+                cli_map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+            let merged = super::merge_runtime_guest_env(&mut cfg, &cli, Some(&dc));
+
+            // Returned map = devcontainer ∪ CLI (CLI wins); no config-only keys.
+            let persisted_union: std::collections::BTreeSet<_> =
+                dc.keys().chain(cli_map.keys()).cloned().collect();
+            let got: std::collections::BTreeSet<_> = merged.keys().cloned().collect();
+            prop_assert_eq!(got, persisted_union);
+            for (k, v) in &merged {
+                let expected = cli_map.get(k).or_else(|| dc.get(k)).expect("key from a tier");
+                prop_assert_eq!(v, expected);
+            }
+
+            // cfg.guest_env now reflects the full three-tier precedence over
+            // every key seen in any tier.
+            let all_keys: std::collections::BTreeSet<_> = cfg_env
+                .keys()
+                .chain(dc.keys())
+                .chain(cli_map.keys())
+                .cloned()
+                .collect();
+            for k in &all_keys {
+                let expected = cli_map
+                    .get(k)
+                    .or_else(|| dc.get(k))
+                    .or_else(|| cfg_env.get(k))
+                    .expect("key from a tier");
+                prop_assert_eq!(cfg.guest_env.get(k).expect("merged key present"), expected);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #300 (sub-issue of #278).

Adds property and fuzz coverage for the env-composition path and re-targets implementation-coupled translator tests to observable behavior.

## `src/guest_env_state.rs`
- proptest: `merge_persisted_entries` keeps every key from both tiers (totality) and resolves collisions in the CLI's favour (precedence). Asserts only those two invariants — the merge is not idempotent or associative across overlapping tiers, by design.
- Replaced the example-list `env_var_name_accepts_valid_forms` test with a proptest over the `[a-zA-Z_][a-zA-Z0-9_]*` grammar that also checks the parsed name preserves its input. The rejection and serde-rejection tests are kept as the contract boundary.
- proptest: `GuestEnvState` save→load→save→load disk round-trip identity over arbitrary maps.

## `src/main.rs`
- proptest: three-tier `merge_runtime_guest_env` precedence (CLI > devcontainer.json > config.toml), verifying both the returned persisted map and the mutated `cfg.guest_env`. The existing hand-coded example tests remain.

## `src/devcontainer.rs`
- Re-targeted three `translate_*` tests from asserting on the `ReportStatus`/`ReportSource` enums to asserting the observable `Translation` fields (`vcpus`, `post_start`, `disk_gib`, `guest_user`), so a report-struct refactor no longer breaks them.

## `src/jsonc.rs` (new)
- Extracted the self-contained `jsonc_to_json` scanner from `devcontainer.rs` into its own std-only module so it can be fuzzed in isolation. Moved the five happy-path tests and added proptests for never-panics, identity on comment/comma-free input, and string-value preservation.

## `fuzz/`
- Added a `jsonc_to_json` fuzz target mirroring the existing `parse_repo_slug` pattern, plus its `[[bin]]` entry.

## Verification
- `cargo test --bin coop` — 763 passed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo check --manifest-path fuzz/Cargo.toml --bin jsonc_to_json` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)