### PR TITLE
Add type-safe RemoteCommand builder for SSH commands

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,8 +14,8 @@ use crate::config::{
     ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, McpServerDef, Validated,
 };
 use crate::paths::{GuestPath, HostPath};
+use crate::remote_command::RemoteCommand;
 use crate::setup::SetupOptions;
-use crate::shell::shell_escape;
 
 // ── Operation modes ───────────────────────────────────────────
 
@@ -396,10 +396,11 @@ impl SshTarget {
     }
 
     /// Run a command on the guest via SSH.
-    pub fn exec(&self, cmd: &str) -> Result<()> {
+    pub fn exec(&self, command: RemoteCommand) -> Result<()> {
+        let cmd = command.into_string();
         let mut args = self.ssh_opts();
         args.push(self.addr());
-        args.push(cmd.to_string());
+        args.push(cmd.clone());
 
         let status = Command::new("ssh")
             .args(&args)
@@ -417,10 +418,11 @@ impl SshTarget {
     /// The bytes are written to ssh's stdin and forwarded to the remote shell.
     /// Use this when the command needs to consume secrets that must not appear
     /// on argv or in the SSH debug log — e.g. tokens read via `read -r VAR`.
-    pub fn exec_with_stdin(&self, cmd: &str, stdin: Vec<u8>) -> Result<()> {
+    pub fn exec_with_stdin(&self, command: RemoteCommand, stdin: Vec<u8>) -> Result<()> {
+        let cmd = command.into_string();
         let mut args = self.ssh_opts();
         args.push(self.addr());
-        args.push(cmd.to_string());
+        args.push(cmd.clone());
         Cmd::new("ssh")
             .args(args)
             .stdin_input(stdin)
@@ -429,10 +431,10 @@ impl SshTarget {
     }
 
     /// Check if a command succeeds on the guest.
-    pub fn exec_ok(&self, cmd: &str) -> bool {
+    pub fn exec_ok(&self, command: RemoteCommand) -> bool {
         let mut args = self.ssh_opts();
         args.push(self.addr());
-        args.push(cmd.to_string());
+        args.push(command.into_string());
 
         Command::new("ssh")
             .args(&args)
@@ -443,10 +445,10 @@ impl SshTarget {
     }
 
     /// Like `exec_ok` but uses connection multiplexing for fast retries.
-    fn probe_ok_mux(&self, cmd: &str) -> bool {
+    fn probe_ok_mux(&self, command: RemoteCommand) -> bool {
         let mut args = self.ssh_opts_mux();
         args.push(self.addr());
-        args.push(cmd.to_string());
+        args.push(command.into_string());
 
         Command::new("ssh")
             .args(&args)
@@ -472,7 +474,7 @@ impl SshTarget {
         tracing::info!("Probing SSH readiness (timeout: {timeout:?})");
 
         loop {
-            if self.probe_ok_mux("true") {
+            if self.probe_ok_mux(RemoteCommand::new().literal("true")) {
                 tracing::info!("SSH is ready");
                 self.close_mux();
                 return Ok(());
@@ -590,10 +592,11 @@ impl SshSession {
     }
 
     /// Run a command on the guest via SSH with env forwarding.
-    pub fn exec(&self, cmd: &str) -> Result<()> {
+    pub fn exec(&self, command: RemoteCommand) -> Result<()> {
+        let cmd = command.into_string();
         let mut args = self.ssh_opts();
         args.push(self.target.addr());
-        args.push(cmd.to_string());
+        args.push(cmd.clone());
 
         let status = Command::new("ssh")
             .args(&args)
@@ -1256,7 +1259,7 @@ pub fn run_post_start(session: &SshSession, command: &str) {
     tracing::info!("Running post_start hook in guest");
     tracing::debug!("post_start: {command}");
 
-    match session.exec(command) {
+    match session.exec(RemoteCommand::new().literal(command)) {
         Ok(()) => tracing::debug!("post_start hook completed"),
         Err(e) => tracing::warn!("post_start hook failed (continuing): {e}"),
     }
@@ -1309,7 +1312,11 @@ fn bootstrap_claude(
             || !claude.plugins.is_empty()
             || !claude.mcp_servers.is_empty();
 
-        if needs_claude_cli && !session.target.exec_ok(&format!("test -x {claude_bin}")) {
+        if needs_claude_cli
+            && !session
+                .target
+                .exec_ok(RemoteCommand::new().literal("test -x ").arg(&claude_bin))
+        {
             bail!(
                 "Claude Code CLI is not installed in the guest.\n\
                  The golden image may have been built before the \
@@ -1364,10 +1371,11 @@ fn bootstrap_codex(session: &SshSession, cfg: &CoopConfig, mode: BootMode) -> Re
         return Ok(());
     }
 
-    if !session
-        .target
-        .exec_ok(&format!("test -x {}", crate::guest::codex_bin()))
-    {
+    if !session.target.exec_ok(
+        RemoteCommand::new()
+            .literal("test -x ")
+            .arg(crate::guest::codex_bin()),
+    ) {
         bail!("{}", codex_missing_guest_cli_message());
     }
 
@@ -1504,7 +1512,7 @@ fn resolve_pat_token(
 
 fn setup_github_auth(session: &SshSession) -> Result<()> {
     session
-        .exec("gh auth setup-git")
+        .exec(RemoteCommand::new().literal("gh auth setup-git"))
         .context("Failed to configure git credential helper in guest")
 }
 
@@ -1546,7 +1554,7 @@ fn copy_staged_to_guest(
         return Ok(());
     }
 
-    target.exec(&format!("mkdir -p ~/{guest_subdir}"))?;
+    target.exec(RemoteCommand::new().literal(format!("mkdir -p ~/{guest_subdir}")))?;
 
     let guest_dir = GuestPath::new(format!("./{guest_subdir}"));
     for entry in std::fs::read_dir(staging_path).context("Failed to read staging directory")? {
@@ -1599,10 +1607,10 @@ fn managed_claude_settings_json() -> String {
 /// is small and owned by coop; users wanting per-VM customization should
 /// extend coop's config rather than editing the guest file in place.
 fn write_managed_claude_settings(target: &SshTarget) -> Result<()> {
-    target.exec("mkdir -p ~/.claude")?;
+    target.exec(RemoteCommand::new().literal("mkdir -p ~/.claude"))?;
     target
         .exec_with_stdin(
-            "cat > ~/.claude/settings.json",
+            RemoteCommand::new().literal("cat > ~/.claude/settings.json"),
             managed_claude_settings_json().into_bytes(),
         )
         .context("Failed to write managed ~/.claude/settings.json in guest")?;
@@ -1833,9 +1841,9 @@ pub(crate) fn install_marketplaces(
         let local_path = Path::new(source);
         let guest_source = if local_path.is_absolute() && local_path.is_dir() {
             if !has_local {
-                session
-                    .target
-                    .exec(&format!("mkdir -p {GUEST_MARKETPLACE_DIR}"))?;
+                session.target.exec(
+                    RemoteCommand::new().literal(format!("mkdir -p {GUEST_MARKETPLACE_DIR}")),
+                )?;
                 has_local = true;
             }
             let dir_name = local_path
@@ -1862,12 +1870,13 @@ pub(crate) fn install_marketplaces(
         };
 
         tracing::info!("Adding marketplace: {guest_source}");
-        let cmd = format!(
-            "{claude_bin} plugin marketplace add {} --scope user",
-            shell_escape(&guest_source),
-        );
+        let cmd = RemoteCommand::new()
+            .arg(claude_bin)
+            .literal(" plugin marketplace add ")
+            .arg(&guest_source)
+            .literal(" --scope user");
         session
-            .exec(&cmd)
+            .exec(cmd)
             .with_context(|| format!("Failed to add marketplace '{source}'"))?;
     }
     Ok(())
@@ -1880,12 +1889,13 @@ pub(crate) fn install_plugins(
 ) -> Result<()> {
     for plugin in plugins {
         tracing::info!("Installing plugin: {plugin}");
-        let cmd = format!(
-            "{claude_bin} plugin install {} -s user",
-            shell_escape(plugin),
-        );
+        let cmd = RemoteCommand::new()
+            .arg(claude_bin)
+            .literal(" plugin install ")
+            .arg(plugin)
+            .literal(" -s user");
         session
-            .exec(&cmd)
+            .exec(cmd)
             .with_context(|| format!("Failed to install plugin '{plugin}'"))?;
     }
     Ok(())
@@ -1904,13 +1914,14 @@ fn register_mcp_servers(
 
         let json = serde_json::to_string(&resolved)
             .context("Failed to serialize MCP server definition")?;
-        let cmd = format!(
-            "{claude_bin} mcp add-json -s user {} {}",
-            shell_escape(name),
-            shell_escape(&json),
-        );
+        let cmd = RemoteCommand::new()
+            .arg(claude_bin)
+            .literal(" mcp add-json -s user ")
+            .arg(name)
+            .literal(" ")
+            .arg(&json);
         session
-            .exec(&cmd)
+            .exec(cmd)
             .with_context(|| format!("Failed to register MCP server '{name}'"))?;
     }
     Ok(())
@@ -2007,21 +2018,25 @@ fn resolve_clone_token(strategy: Option<&GitHubAuth>, repo_url: &str) -> Result<
 }
 
 fn clone_without_auth(target: &SshTarget, repo_url: &str) -> Result<()> {
-    let cmd = format!(
-        "sudo mkdir -p /workspace && \
-         sudo chown $(whoami):$(whoami) /workspace && \
-         git clone {} /workspace && \
-         echo 'Repository cloned to /workspace'",
-        shell_escape(repo_url),
-    );
-    target.exec(&cmd)
+    let cmd = RemoteCommand::new()
+        .literal(
+            "sudo mkdir -p /workspace && \
+             sudo chown $(whoami):$(whoami) /workspace && \
+             git clone ",
+        )
+        .arg(repo_url)
+        .literal(
+            " /workspace && \
+             echo 'Repository cloned to /workspace'",
+        );
+    target.exec(cmd)
 }
 
 fn clone_with_token(target: &SshTarget, repo_url: &str, token: &str) -> Result<()> {
     let mut stdin = Vec::with_capacity(token.len() + 1);
     stdin.extend_from_slice(token.as_bytes());
     stdin.push(b'\n');
-    target.exec_with_stdin(&build_clone_with_token_script(repo_url), stdin)
+    target.exec_with_stdin(build_clone_with_token_script(repo_url), stdin)
 }
 
 /// Build the remote shell script that reads a GitHub token from stdin and
@@ -2029,22 +2044,26 @@ fn clone_with_token(target: &SshTarget, repo_url: &str, token: &str) -> Result<(
 ///
 /// Separated from `clone_with_token` so the script template can be
 /// unit-tested without spawning ssh.
-fn build_clone_with_token_script(repo_url: &str) -> String {
+fn build_clone_with_token_script(repo_url: &str) -> RemoteCommand {
     // The remote shell reads the token from stdin into GH_TOKEN, exports it
     // so the credential helper subshell inherits it, then clones with a
     // one-shot helper that returns the token to git. The single quotes
     // around the helper preserve `$GH_TOKEN` for expansion inside the
     // helper's subshell (not at script-parse time).
-    format!(
-        "set -eu\n\
-         IFS= read -r GH_TOKEN\n\
-         export GH_TOKEN\n\
-         sudo mkdir -p /workspace\n\
-         sudo chown \"$(whoami):$(whoami)\" /workspace\n\
-         git -c credential.helper='!f() {{ echo username=x-access-token; echo \"password=$GH_TOKEN\"; }}; f' clone {url} /workspace\n\
-         echo 'Repository cloned to /workspace'\n",
-        url = shell_escape(repo_url),
-    )
+    RemoteCommand::new()
+        .literal(
+            "set -eu\n\
+             IFS= read -r GH_TOKEN\n\
+             export GH_TOKEN\n\
+             sudo mkdir -p /workspace\n\
+             sudo chown \"$(whoami):$(whoami)\" /workspace\n\
+             git -c credential.helper='!f() { echo username=x-access-token; echo \"password=$GH_TOKEN\"; }; f' clone ",
+        )
+        .arg(repo_url)
+        .literal(
+            " /workspace\n\
+             echo 'Repository cloned to /workspace'\n",
+        )
 }
 
 /// Returns true when `url` is an `https://github.com/...` URL with no userinfo.
@@ -2521,7 +2540,8 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
 
     #[test]
     fn build_clone_with_token_script_contains_required_pieces() {
-        let script = build_clone_with_token_script("https://github.com/owner/repo.git");
+        let script =
+            build_clone_with_token_script("https://github.com/owner/repo.git").into_string();
         assert!(script.starts_with("set -eu\n"), "script: {script}");
         assert!(
             script.contains("IFS= read -r GH_TOKEN\n"),
@@ -2548,7 +2568,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
     fn build_clone_with_token_script_escapes_repo_url() {
         // A URL with a single quote would otherwise break out of the
         // surrounding `'...'` argument. `shell_escape` must apply.
-        let script = build_clone_with_token_script("https://github.com/o'wner/repo");
+        let script = build_clone_with_token_script("https://github.com/o'wner/repo").into_string();
         // Embedded quote must be escaped via the standard `'\''` trick.
         assert!(
             script.contains("'https://github.com/o'\\''wner/repo'"),

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -13,6 +13,7 @@ use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
     SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
 };
+use crate::remote_command::RemoteCommand;
 use crate::setup::{SetupOptions, TEMPLATE_VERSION, TemplateConfig, utc_timestamp};
 use crate::sha256_hash::Sha256Hash;
 
@@ -1448,7 +1449,7 @@ fn wait_for_lima_ssh(
             }
             return Ok(());
         }
-        if target.exec_ok("true") {
+        if target.exec_ok(RemoteCommand::new().literal("true")) {
             tracing::info!("SSH ready on port {port}");
             return Ok(());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod naming;
 mod pat_prompt;
 mod paths;
 mod port_forward;
+mod remote_command;
 mod secret_store;
 mod sha256_hash;
 // Lima is an interactive CLI workflow — stderr output is intentional user communication.
@@ -990,20 +991,17 @@ fn main() -> Result<()> {
                 args.insert(0, "--permission-mode".to_string());
             }
             let claude_bin = guest::GuestUser::new(sess.target.user.as_ref())?.claude_bin();
-            ssh::run_interactive(&sess, &prepend_binary(&claude_bin.to_string(), args))
+            ssh::run_interactive(&sess, &prepend_binary(claude_bin.as_ref(), args))
         }
         Commands::ClaudeAgents { name, mut args } => {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
             args.insert(0, "agents".to_string());
             let claude_bin = guest::GuestUser::new(sess.target.user.as_ref())?.claude_bin();
-            ssh::run_interactive(&sess, &prepend_binary(&claude_bin.to_string(), args))
+            ssh::run_interactive(&sess, &prepend_binary(claude_bin.as_ref(), args))
         }
         Commands::Codex { name, args } => {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
-            ssh::run_interactive(
-                &sess,
-                &prepend_binary(&guest::codex_bin().to_string(), args),
-            )
+            ssh::run_interactive(&sess, &prepend_binary(guest::codex_bin().as_ref(), args))
         }
         Commands::Stop { name } => {
             let inst = cfg.resolve_instance(name.as_ref())?;
@@ -1998,7 +1996,7 @@ fn cmd_quickstart(
 
     let sess = open_ssh_session(be, cfg, Some(&inst.name))?;
     let claude_bin = guest::GuestUser::new(sess.target.user.as_ref())?.claude_bin();
-    ssh::run_interactive(&sess, &prepend_binary(&claude_bin.to_string(), Vec::new()))
+    ssh::run_interactive(&sess, &prepend_binary(claude_bin.as_ref(), Vec::new()))
 }
 
 /// Drives a fresh start with `--workspace <ws>` defaults (no mounts, no

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -51,6 +51,12 @@ impl std::fmt::Display for GuestPath {
     }
 }
 
+impl AsRef<str> for GuestPath {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 // ── Host path ─────────────────────────────────────────────────
 
 /// Path on the host. Pairs with [`GuestPath`] so scp call sites

--- a/src/remote_command.rs
+++ b/src/remote_command.rs
@@ -1,0 +1,158 @@
+//! A typed builder for the shell command strings sent over SSH.
+//!
+//! Remote commands are concatenated with spaces by `ssh` and handed to the
+//! guest's shell, so any dynamic value spliced into one must be escaped or it
+//! becomes live shell syntax (the #301 bug class). [`RemoteCommand`] makes that
+//! escaping happen *by construction*: the only way to add an untrusted value is
+//! [`RemoteCommand::arg`], which runs [`crate::shell::shell_escape`] exactly
+//! once. Trusted shell text coop authors itself — control flow, fixed flags,
+//! pipelines — goes through [`RemoteCommand::literal`], the explicit and
+//! auditable escape hatch.
+//!
+//! Because [`SshTarget::exec`](crate::backend::SshTarget::exec) and its
+//! siblings take a `RemoteCommand` rather than a `&str`, a bare `format!`
+//! string no longer type-checks at the SSH boundary — so the two failure modes
+//! are unrepresentable rather than merely discouraged:
+//!
+//! 1. forgetting to escape an interpolated value, and
+//! 2. double-escaping a value that was already escaped.
+//!
+//! # Composition model
+//!
+//! Parts are concatenated verbatim — there is no implicit separator. A
+//! [`RemoteCommand`] reads like the `format!` string it replaces, with each
+//! `{shell_escape(x)}` becoming `.arg(x)` and the surrounding text becoming
+//! `.literal(...)`. The caller keeps whatever spacing the command needs, which
+//! is what lets a value glue directly onto adjacent text — e.g.
+//! `.arg(dir).literal("/.git")` renders `'<dir>'/.git`, a single shell word.
+//!
+//! ```ignore
+//! let cmd = RemoteCommand::new()
+//!     .literal("tar xf - -C ")
+//!     .arg(guest_path);            // escaped exactly once, by construction
+//! target.exec(cmd)?;
+//! ```
+
+use crate::shell::shell_escape;
+
+/// A remote shell command assembled from trusted literal fragments and
+/// untrusted values that are shell-escaped exactly once.
+///
+/// See the [module docs](self) for the composition model and rationale.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RemoteCommand {
+    rendered: String,
+}
+
+impl RemoteCommand {
+    /// An empty command. Build it up with [`literal`](Self::literal) and
+    /// [`arg`](Self::arg).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a trusted literal shell fragment authored by coop — control
+    /// flow, fixed flags, pipelines, redirections.
+    ///
+    /// Never pass a dynamic or user-supplied value here; that is what
+    /// [`arg`](Self::arg) is for. The fragment is appended verbatim, so it
+    /// carries its own spacing.
+    #[must_use]
+    pub fn literal(mut self, fragment: impl AsRef<str>) -> Self {
+        self.rendered.push_str(fragment.as_ref());
+        self
+    }
+
+    /// Append an untrusted value, shell-escaped exactly once so it reaches the
+    /// remote shell as a single literal word regardless of its contents.
+    ///
+    /// The value is appended verbatim after escaping — include any needed
+    /// separating space in the surrounding [`literal`](Self::literal) calls.
+    #[must_use]
+    pub fn arg(mut self, value: impl AsRef<str>) -> Self {
+        self.rendered.push_str(&shell_escape(value.as_ref()));
+        self
+    }
+
+    /// Consume the builder and return the assembled command string for the
+    /// `ssh` argument vector.
+    #[must_use]
+    pub fn into_string(self) -> String {
+        self.rendered
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_command_renders_empty() {
+        assert_eq!(RemoteCommand::new().into_string(), "");
+    }
+
+    #[test]
+    fn literal_is_passed_through_verbatim() {
+        let cmd = RemoteCommand::new().literal("gh auth setup-git");
+        assert_eq!(cmd.into_string(), "gh auth setup-git");
+    }
+
+    #[test]
+    fn literal_does_not_escape_shell_metacharacters() {
+        // Literals are trusted shell text — `~`, `&&`, `$()` must survive so
+        // the remote shell interprets them, not receive them quoted.
+        let cmd = RemoteCommand::new().literal("mkdir -p ~/.coop && echo $(whoami)");
+        assert_eq!(cmd.into_string(), "mkdir -p ~/.coop && echo $(whoami)");
+    }
+
+    #[test]
+    fn arg_single_quotes_the_value() {
+        let cmd = RemoteCommand::new()
+            .literal("test -x ")
+            .arg("/usr/local/bin/codex");
+        assert_eq!(cmd.into_string(), "test -x '/usr/local/bin/codex'");
+    }
+
+    #[test]
+    fn arg_neutralizes_injection() {
+        // A value carrying shell metacharacters must end up inside the quotes,
+        // never as live syntax.
+        let cmd = RemoteCommand::new()
+            .literal("git clone ")
+            .arg("/work; rm -rf / $(touch pwned)")
+            .literal(" /workspace");
+        assert_eq!(
+            cmd.into_string(),
+            "git clone '/work; rm -rf / $(touch pwned)' /workspace"
+        );
+    }
+
+    #[test]
+    fn arg_escapes_embedded_single_quote_once() {
+        // Exactly one round of escaping: the `'\''` trick, not double-wrapped.
+        let cmd = RemoteCommand::new().arg("o'wner");
+        assert_eq!(cmd.into_string(), "'o'\\''wner'");
+    }
+
+    #[test]
+    fn arg_glues_directly_onto_following_literal() {
+        // The `{guest_path}/.git` adjacency from `check_guest_dirty`: the
+        // escaped value and the trailing literal form one shell word.
+        let cmd = RemoteCommand::new()
+            .literal("[ -d ")
+            .arg("/my work")
+            .literal("/.git ]");
+        assert_eq!(cmd.into_string(), "[ -d '/my work'/.git ]");
+    }
+
+    #[test]
+    fn same_value_used_twice_escapes_each_occurrence() {
+        let cmd = RemoteCommand::new()
+            .literal("mkdir -p ")
+            .arg("/a b")
+            .literal(" && chown ubuntu ")
+            .arg("/a b");
+        assert_eq!(cmd.into_string(), "mkdir -p '/a b' && chown ubuntu '/a b'");
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::backend::{RunningInstance, SshTarget};
 use crate::config::Instance;
 use crate::paths::GuestPath;
+use crate::remote_command::RemoteCommand;
 
 const GUEST_WORKSPACE: &str = "/workspace";
 
@@ -81,14 +82,6 @@ where
     use serde::de::Error as _;
     let raw = String::deserialize(deserializer)?;
     GuestPath::absolute(raw).map_err(D::Error::custom)
-}
-
-/// Single-quote a guest path for safe interpolation into a remote shell
-/// command. The path can originate from a hand-edited `workspace.json`, so it
-/// must never be spliced into an `ssh` command line unquoted — absolute-path
-/// validation alone does not neutralize shell metacharacters.
-fn shell_quote_guest(guest_path: &GuestPath) -> String {
-    crate::shell::shell_escape(&guest_path.to_string())
 }
 
 impl WorkspaceState {
@@ -206,7 +199,7 @@ pub fn tar_pipe_transfer_to(
     let extract_cmd = tar_extract_cmd(guest_path);
     let mut ssh_args = target.ssh_opts();
     ssh_args.push(target.addr());
-    ssh_args.push(extract_cmd);
+    ssh_args.push(extract_cmd.into_string());
 
     let mut ssh_child = Command::new("ssh")
         .args(&ssh_args)
@@ -432,7 +425,7 @@ pub fn push(
         state.guest_path
     );
 
-    if target.exec_ok("which rsync") {
+    if target.exec_ok(RemoteCommand::new().literal("which rsync")) {
         rsync_push(target, &source_dir, &state.guest_path, exclude_git)?;
     } else {
         tracing::info!("rsync not available on guest, using tar-pipe");
@@ -471,7 +464,7 @@ pub fn pull(
         dest_dir.display()
     );
 
-    if target.exec_ok("which rsync") {
+    if target.exec_ok(RemoteCommand::new().literal("which rsync")) {
         rsync_pull(target, &state.guest_path, &dest_dir, exclude_git)?;
     } else {
         tracing::info!("rsync not available on guest, using tar-pipe");
@@ -504,14 +497,17 @@ pub fn sync_mount_contents(
 ) -> Result<()> {
     for m in mounts {
         let guest = &m.guest_path;
-        let guest_q = shell_quote_guest(guest);
-        target.exec(&format!(
-            "sudo mkdir -p {guest_q} && sudo chown ubuntu:ubuntu {guest_q}"
-        ))?;
+        target.exec(
+            RemoteCommand::new()
+                .literal("sudo mkdir -p ")
+                .arg(guest)
+                .literal(" && sudo chown ubuntu:ubuntu ")
+                .arg(guest),
+        )?;
 
         tracing::info!("Syncing {} -> guest:{guest}", m.host_path.display(),);
 
-        if target.exec_ok("which rsync") {
+        if target.exec_ok(RemoteCommand::new().literal("which rsync")) {
             rsync_push(target, &m.host_path, guest, exclude_git)?;
         } else {
             tracing::info!("rsync not available on guest, using tar-pipe");
@@ -725,18 +721,18 @@ fn rsync_pull(
 
 /// Remote command that extracts a streamed tar archive into `guest_path`.
 ///
-/// `guest_path` is shell-quoted so it is treated as a single, literal
-/// directory argument regardless of its contents.
-fn tar_extract_cmd(guest_path: &GuestPath) -> String {
-    format!("tar xf - -C {}", shell_quote_guest(guest_path))
+/// `guest_path` is shell-escaped (via [`RemoteCommand::arg`]) so it is treated
+/// as a single, literal directory argument regardless of its contents.
+fn tar_extract_cmd(guest_path: &GuestPath) -> RemoteCommand {
+    RemoteCommand::new().literal("tar xf - -C ").arg(guest_path)
 }
 
 /// Remote command that streams a tar archive of `guest_path` to stdout,
 /// applying the same exclusions as a push.
 ///
-/// `guest_path` is shell-quoted (see [`shell_quote_guest`]); the exclude
+/// `guest_path` is shell-escaped (via [`RemoteCommand::arg`]); the exclude
 /// patterns are fixed constants, not user input.
-fn tar_pull_cmd(guest_path: &GuestPath, exclude_git: bool) -> String {
+fn tar_pull_cmd(guest_path: &GuestPath, exclude_git: bool) -> RemoteCommand {
     let mut excludes: Vec<String> = DEFAULT_EXCLUDES
         .iter()
         .map(|exc| format!("--exclude={exc}"))
@@ -745,10 +741,10 @@ fn tar_pull_cmd(guest_path: &GuestPath, exclude_git: bool) -> String {
         excludes.push(format!("--exclude={GIT_EXCLUDE}"));
     }
     let exclude_str = excludes.join(" ");
-    format!(
-        "tar cf - -C {} {exclude_str} .",
-        shell_quote_guest(guest_path)
-    )
+    RemoteCommand::new()
+        .literal("tar cf - -C ")
+        .arg(guest_path)
+        .literal(format!(" {exclude_str} ."))
 }
 
 fn tar_pipe_pull(
@@ -757,7 +753,7 @@ fn tar_pipe_pull(
     dest: &Path,
     exclude_git: bool,
 ) -> Result<()> {
-    let remote_cmd = tar_pull_cmd(guest_path, exclude_git);
+    let remote_cmd = tar_pull_cmd(guest_path, exclude_git).into_string();
 
     let mut ssh_args = target.ssh_opts();
     ssh_args.push(target.addr());
@@ -878,23 +874,26 @@ fn check_guest_dirty(target: &SshTarget, guest_path: &GuestPath) -> Result<()> {
     // edits made inside the guest. Modified tracked files and unpushed
     // commits are the real signal that an agent has done work the host
     // doesn't yet know about.
-    let guest_path = shell_quote_guest(guest_path);
-    let check_cmd = format!(
-        "if [ -d {guest_path}/.git ]; then \
-            cd {guest_path} && \
-            git status --porcelain --untracked-files=no && \
-            if git rev-parse --abbrev-ref '@{{u}}' >/dev/null 2>&1; then \
-                ahead=$(git rev-list --count '@{{u}}..HEAD' 2>/dev/null); \
-                if [ \"${{ahead:-0}}\" -gt 0 ]; then \
-                    echo \"AHEAD $ahead\"; \
-                fi; \
-            fi; \
-         fi"
-    );
+    let check_cmd = RemoteCommand::new()
+        .literal("if [ -d ")
+        .arg(guest_path)
+        .literal("/.git ]; then cd ")
+        .arg(guest_path)
+        .literal(
+            " && \
+             git status --porcelain --untracked-files=no && \
+             if git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then \
+                 ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null); \
+                 if [ \"${ahead:-0}\" -gt 0 ]; then \
+                     echo \"AHEAD $ahead\"; \
+                 fi; \
+             fi; \
+          fi",
+        );
 
     let mut args = target.ssh_opts();
     args.push(target.addr());
-    args.push(check_cmd);
+    args.push(check_cmd.into_string());
 
     let output = Command::new("ssh")
         .args(&args)
@@ -1680,13 +1679,13 @@ Host coop-0\n\
         // inside the quoted argument, never as live shell syntax.
         let evil = GuestPath::absolute("/work; rm -rf / $(touch pwned)").expect("absolute");
 
-        let extract = tar_extract_cmd(&evil);
+        let extract = tar_extract_cmd(&evil).into_string();
         assert_eq!(
             extract, "tar xf - -C '/work; rm -rf / $(touch pwned)'",
             "extract command must single-quote the guest path"
         );
 
-        let pull = tar_pull_cmd(&evil, false);
+        let pull = tar_pull_cmd(&evil, false).into_string();
         assert!(
             pull.starts_with("tar cf - -C '/work; rm -rf / $(touch pwned)' "),
             "pull command must single-quote the guest path: {pull}"


### PR DESCRIPTION
## What

Introduces `RemoteCommand`, a typed builder for the shell command strings sent over SSH, so an un-escaped interpolated value can no longer reach the remote shell.

Previously `SshTarget::exec`/`exec_ok`/`exec_with_stdin` and `SshSession::exec` took `&str`, and commands were assembled with `format!`. Whether a dynamic value was escaped depended on the author calling `shell::shell_escape` — the footgun behind #301.

`RemoteCommand` distinguishes the two kinds of fragment:

- `.literal(...)` — trusted shell text coop authors itself (control flow, fixed flags, `~`, `&&`, `$()`), appended verbatim.
- `.arg(...)` — an untrusted value, shell-escaped exactly once.

Parts are concatenated verbatim (no implicit separator), so a value can glue directly onto adjacent text — e.g. `.arg(path).literal("/.git")` renders `'<path>'/.git`, one shell word. This is what lets the hand-written snippets like `check_guest_dirty` migrate without becoming harder to read.

The `exec*` methods now take `RemoteCommand` by value, so a bare `format!` string no longer type-checks at the SSH boundary. The two failure modes — forgetting to escape, and double-escaping — become unrepresentable.

## Scope

- New `src/remote_command.rs` with unit tests (escaping, literal pass-through, glue, injection neutralization, repeated values).
- Migrated every `exec`/`exec_ok`/`exec_with_stdin`/`probe_ok_mux` call site in `backend.rs`, `workspace.rs`, and `lima.rs`.
- Removed the now-redundant manual `shell_escape` wrapping at those sites and the `shell_quote_guest` helper in `workspace.rs`. `shell::shell_escape` stays as the underlying primitive.
- Added `impl AsRef<str> for GuestPath` so guest paths pass to `.arg()` directly; this let three `claude_bin.to_string()` / `codex_bin().to_string()` calls in `main.rs` drop the allocation via `.as_ref()`.

Refactor only — no behavior change for legitimate inputs (`'/workspace'` is equivalent to `/workspace` to the shell). Values previously interpolated raw (`claude_bin`, `codex_bin`) are now shell-escaped, which is safe since they are plain absolute paths.

The interactive `ssh.rs` path already escapes per token and is unchanged; rsync remote-path quoting remains a separate concern, as noted in the issue.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)