### PR TITLE
Add bounded no-panic proofs and exhaustive index-derivation test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ firecracker
 *.swo
 /mutants.out
 /mutants.out.old
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,29 @@ A crash is written to `fuzz/artifacts/<target>/`; reproduce it with `cargo +nigh
 - `jsonc_to_json` — `coop::jsonc::jsonc_to_json`, fed hand-authored `devcontainer.json` text. Property: never panics.
 - `config_load` — `toml::from_str` into `coop::config::CoopConfig` then `validate`, fed `config.toml` text. Exercises the custom `Deserialize`/`visit_map` impls (`SubnetMask`, `HostInterface`, `PortForward`). Property: never panics, only returns `Err`.
 
+### Formal verification (kani)
+
+[Kani](https://model-checking.github.io/kani/) is a bounded model checker that proves the *absence* of a property (here: arithmetic overflow / panics) over all inputs in a range, rather than sampling like proptest. It is a **narrow fit** in this crate — the type system already makes most illegal states unrepresentable, so kani earns its keep only on bounded integer/float arithmetic. Like mutation testing and fuzzing, it is a manual check, not a CI gate; it needs its own toolchain.
+
+Proofs live in a `#[cfg(kani)]` module so the normal `cargo build`/`test`/`fmt`/`clippy` never compile them. They run as one module in `src/config.rs`.
+
+**Install once:** `cargo install --locked kani-verifier && cargo kani setup`
+
+```bash
+cargo kani                                       # run every proof harness (~5s total)
+cargo kani --harness disk_relative_add_never_wraps   # one harness
+```
+
+**Current proofs (`src/config.rs`, `mod proofs`):**
+
+- `disk_relative_add_never_wraps` — the arithmetic kernel of `DiskSize::resolve`'s relative branch (`current.checked_add(delta)`): for any two non-zero `u32` sizes it yields `Some(current + delta)` exactly when the sum fits, and `None` otherwise — never wraps, never panics.
+- `mib_as_gib_f64_is_finite_and_positive` — `MiB::as_gib_f64` is finite and strictly positive across the whole non-zero range.
+- `instance_index_octet_stays_in_range` — the guest IP/MAC last octet (`index + 2`) stays in `2..=254` for every valid `InstanceIndex` (`0..=252`).
+
+A note on the disk proof: the harness verifies the `checked_add` kernel directly rather than calling `DiskSize::resolve`, because `resolve` wraps the overflow case with `anyhow`'s heap-allocating error construction, which CBMC cannot model tractably (it does not terminate). `resolve` adds only that infallible `.context()` on top of the kernel; its end-to-end behavior — including overflow → `Err` — is pinned by the deterministic unit tests `disk_size_resolve_relative` / `disk_size_resolve_relative_overflows`. This is the general rule for kani here: prove the arithmetic kernel, not code paths that route through `anyhow`/allocation.
+
+The `InstanceIndex` range is also pinned the cheaper way — by the exhaustive `0..=252` unit test `instance_network_derivations_over_full_range`, which the kani harness above demonstrates rather than replaces. `SubnetMask` was considered (#303) but carries no arithmetic: it is stored and rendered as `/N`, with the `0..=32` bound enforced by its constructor, so there is nothing for a model checker to prove.
+
 ## Known workarounds (revisit later)
 
 The Firecracker CI kernel (`vmlinux-6.1.155`) is minimal and missing several modules. Two workarounds are applied in the guest install script (`src/setup.rs`, `guest_install_script()`):

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,8 @@ similar_names = "allow"
 must_use_candidate = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
+
+[lints.rust]
+# `cfg(kani)` is set by `cargo kani` (the bounded-proof toolchain), never by a
+# normal build. Register it so the `proofs` module doesn't trip unexpected-cfgs.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2303,6 +2303,76 @@ fn default_firecracker_bin() -> PathBuf {
     default_data_dir().join("firecracker")
 }
 
+/// Bounded no-panic proofs (Kani), gated so normal `cargo build`/`test`/
+/// `clippy` never compile them. Run manually with `cargo kani`; see the
+/// "Formal verification" section in `CLAUDE.md`.
+///
+/// Kani is a narrow fit in a string-heavy CLI — the type system carries
+/// most invariants here. These proofs target the only genuine fit:
+/// bounded integer/float arithmetic where a wrap or overflow would panic.
+/// The `InstanceIndex` IP-derivation range is verified instead by the
+/// exhaustive `0..=252` unit test (`instance_network_derivations_over_full_range`),
+/// and `SubnetMask` carries no arithmetic to verify — it is stored and
+/// rendered as `/N`, with the `0..=32` bound enforced by its constructor.
+#[cfg(kani)]
+mod proofs {
+    use super::{GiB, InstanceIndex, MiB};
+
+    /// The arithmetic kernel of `DiskSize::resolve`'s relative branch:
+    /// `current.checked_add(delta)`. Over every pair of non-zero `u32`
+    /// sizes it yields `Some(current + delta)` exactly when the sum fits,
+    /// and `None` otherwise — it never wraps and never panics.
+    ///
+    /// This proves the kernel directly rather than through `resolve`,
+    /// because `resolve` wraps the `None` case with `anyhow`'s
+    /// heap-allocating error construction, which CBMC cannot model
+    /// tractably. `resolve` adds only that infallible `.context()` wrapper
+    /// on top of this kernel; its end-to-end behavior — including the
+    /// overflow → `Err` path — is pinned by the deterministic unit tests
+    /// `disk_size_resolve_relative` and `disk_size_resolve_relative_overflows`.
+    #[kani::proof]
+    fn disk_relative_add_never_wraps() {
+        let current_raw: u32 = kani::any();
+        let delta_raw: u32 = kani::any();
+        let (Some(current), Some(delta)) = (GiB::new(current_raw), GiB::new(delta_raw)) else {
+            return;
+        };
+        match current
+            .as_nonzero()
+            .checked_add(delta.as_u32())
+            .map(GiB::from_nonzero)
+        {
+            Some(sum) => assert_eq!(sum.as_u32(), current_raw + delta_raw),
+            None => assert!(current_raw.checked_add(delta_raw).is_none()),
+        }
+    }
+
+    /// `MiB::as_gib_f64` divides a non-zero `u32` by 1024.0, so the result
+    /// is always finite and strictly positive across the whole range.
+    #[kani::proof]
+    fn mib_as_gib_f64_is_finite_and_positive() {
+        let raw: u32 = kani::any();
+        let Some(mib) = MiB::new(raw) else { return };
+        let gib = mib.as_gib_f64();
+        assert!(gib.is_finite());
+        assert!(gib > 0.0);
+    }
+
+    /// The guest IP/MAC last octet is `index + 2`. For every valid index
+    /// (`0..=252`) that sum stays within `2..=254`, so it never overflows
+    /// `u32` and always fits the final IPv4/MAC octet (`u8`).
+    #[kani::proof]
+    fn instance_index_octet_stays_in_range() {
+        let raw: u16 = kani::any();
+        let Some(index) = InstanceIndex::new(raw) else {
+            return;
+        };
+        let octet = index.as_u32() + 2;
+        assert!((2..=254).contains(&octet));
+        assert!(u8::try_from(octet).is_ok());
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 #[expect(clippy::panic, reason = "tests use panic! for unreachable arms")]
@@ -2405,22 +2475,35 @@ mod tests {
 
     // ── Instance network derivation ──────────────────────────
 
-    /// Each derivation is index-driven; testing 0 and 252 covers the
-    /// arithmetic at both ends of the valid range, where overflow or
-    /// off-by-one bugs would land.
+    /// Every derivation is driven by the index. Exhaustively checking all
+    /// 253 valid indices (`0..=252`) pins the arithmetic across the full
+    /// range with no toolchain cost, so overflow, wrap, or off-by-one bugs
+    /// at any point — not just the endpoints — fail the test. This is the
+    /// zero-dependency guarantee preferred over a bounded model check for
+    /// `InstanceIndex` (see #303).
     #[test]
-    fn instance_network_derivations_at_boundaries() {
-        let lo = test_inst("test", idx(0), PathBuf::from("/tmp/fake"));
-        assert_eq!(lo.guest_ip(), std::net::Ipv4Addr::new(172, 16, 0, 2));
-        assert_eq!(lo.guest_mac(), "06:00:AC:10:00:02");
-        assert_eq!(lo.tap_device(), "tap0");
-        assert_eq!(lo.vsock_cid(), 3);
+    fn instance_network_derivations_over_full_range() {
+        for n in 0..=InstanceIndex::MAX {
+            let inst = test_inst("test", idx(n), PathBuf::from("/tmp/fake"));
+            let octet = u8::try_from(n + 2).unwrap();
 
-        let hi = test_inst("test", idx(InstanceIndex::MAX), PathBuf::from("/tmp/fake"));
-        assert_eq!(hi.guest_ip(), std::net::Ipv4Addr::new(172, 16, 0, 254));
-        assert_eq!(hi.guest_mac(), "06:00:AC:10:00:fe");
-        assert_eq!(hi.tap_device(), "tap252");
-        assert_eq!(hi.vsock_cid(), 255);
+            assert_eq!(
+                inst.guest_ip(),
+                std::net::Ipv4Addr::new(172, 16, 0, octet),
+                "guest_ip at index {n}"
+            );
+            assert_eq!(
+                inst.guest_mac(),
+                format!("06:00:AC:10:00:{octet:02x}"),
+                "guest_mac at index {n}"
+            );
+            assert_eq!(
+                inst.tap_device(),
+                format!("tap{n}"),
+                "tap_device at index {n}"
+            );
+            assert_eq!(inst.vsock_cid(), u32::from(n) + 3, "vsock_cid at index {n}");
+        }
     }
 
     // ── Instance save/load roundtrip ─────────────────────────
@@ -4474,6 +4557,13 @@ skip = ["not-a-slug"]
         let ds = DiskSize::Relative(GiB::new(20).unwrap());
         let resolved = ds.resolve(GiB::new(100).unwrap()).unwrap();
         assert_eq!(resolved, GiB::new(120).unwrap());
+    }
+
+    #[test]
+    fn disk_size_resolve_relative_overflows() {
+        let ds = DiskSize::Relative(GiB::new(u32::MAX).unwrap());
+        let err = ds.resolve(GiB::new(1).unwrap()).unwrap_err();
+        assert!(err.to_string().contains("overflow"), "{err}");
     }
 
     // ── Mount parsing ───────────────────────────────────────────


### PR DESCRIPTION
Closes #303 (sub-issue of #278).


## What's here

**Exhaustive `0..=252` unit test** (`instance_network_derivations_over_full_range`) for the `InstanceIndex`-driven derivations — `guest_ip`, `guest_mac`, `tap_device`, `vsock_cid`. Replaces the prior two-endpoint boundary test. This is the issue's own recommendation: 253 cases pin the arithmetic across the full range at zero toolchain cost.

**A `#[cfg(kani)]` proof module** in `src/config.rs`, run manually with `cargo kani` (not a CI gate). All three harnesses verify in ~5s under kani 0.67:

- `disk_relative_add_never_wraps` — the `checked_add` arithmetic kernel of `DiskSize::resolve`'s relative branch: `Some(current + delta)` exactly when the sum fits, `None` otherwise; never wraps, never panics.
- `mib_as_gib_f64_is_finite_and_positive` — `MiB::as_gib_f64` is finite and strictly positive across the non-zero range.
- `instance_index_octet_stays_in_range` — the guest IP/MAC last octet (`index + 2`) stays in `2..=254` for every valid index.

**`disk_size_resolve_relative_overflows` unit test** — pins `resolve`'s overflow → `Err` path.

**`cfg(kani)` registered** in `[lints.rust]` so normal builds don't warn on the gated module. **CLAUDE.md** gains a "Formal verification (kani)" subsection.

## Two findings from the issue's target list

- **`SubnetMask` has no arithmetic to verify.** The issue listed "`SubnetMask` (0..=32): bit-shift correctness", but `SubnetMask` is only stored and rendered as `/N`; there is no bit-shift or netmask-to-octet derivation anywhere in the crate. The `0..=32` bound is enforced by its constructor. Nothing for a model checker to prove — documented rather than faked.
- **The disk proof targets the kernel, not `resolve`.** Calling `DiskSize::resolve` under kani does not terminate (5+ min, killed): its overflow branch routes through `anyhow`'s heap-allocating error construction, which CBMC cannot model. The harness proves the `checked_add` kernel directly; `resolve`'s infallible `.context()` wrapper and its overflow → `Err` behavior are pinned by deterministic unit tests instead. CLAUDE.md records this as the general rule: prove the arithmetic kernel, not paths that route through `anyhow`/allocation.

## Verification

- `cargo kani` — 3 harnesses, all SUCCESSFUL (~5s)
- `cargo test --lib` — 777 passed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)