### PR TITLE
Add release preflight script and checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,17 +78,20 @@ cargo install cargo-mutants --locked
 
 **Don't bother with:** `backend.rs`, `lima.rs`, `setup.rs`, `update.rs`, `shell.rs`, `port_forward.rs`, `cmd.rs`, `ssh.rs`, `vm.rs`. These mostly shell out, run SSH, or talk to external services — unit tests can't catch behavioral changes there. `tests/integration.sh` does that job.
 
-**Running it.** Always scope with `-f`; the crate is a binary so pass `-- --bins`:
+**Running it.** Always scope with `-f`; all logic lives in the library crate
+(`src/lib.rs`; `main.rs` is a thin `coop::run()` shim), and every unit test runs
+in the lib target, so pass `-- --lib`. (`-- --bins` runs zero tests and reports
+every mutant as missed.)
 
 ```bash
 # One file
-cargo mutants -f src/config.rs -- --bins
+cargo mutants -f src/config.rs -- --lib
 
 # Several logic modules at once
-cargo mutants -f src/config.rs -f src/workspace.rs -f src/devcontainer.rs -- --bins
+cargo mutants -f src/config.rs -f src/workspace.rs -f src/devcontainer.rs -- --lib
 
 # PR-scoped: mutate only lines changed vs main
-cargo mutants --in-diff <(git diff origin/main -- 'src/*.rs') -- --bins
+cargo mutants --in-diff <(git diff origin/main -- 'src/*.rs') -- --lib
 
 # Estimate cost without running
 cargo mutants --list -f src/config.rs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -99,11 +99,23 @@ CI can't run the full VM integration suite or the extra-toolchain checks
 
 ## If the tag run fails
 
-`release.yml` re-runs CI before building, so a red tag run means a check the
-preflight would have caught was skipped (or the build matrix failed). Delete the
-tag, fix forward on `main`, and re-tag — don't move a published tag.
+**Immutable releases are enabled org-wide, so a version cannot be recovered.**
+Once `vX.Y.Z` is pushed, that version is spent: you cannot move or re-tag it and
+re-run the release. A red `release.yml` run means you **bump to the next patch
+version and cut a fresh release** — go back to step 2 with `vX.Y.(Z+1)`.
+
+This is why the preflight matters: `release.yml` re-runs CI and then builds the
+three target binaries, and a failure in *either* burns the version. Run
+`./scripts/preflight-release.sh` (which mirrors the CI checks) before every tag
+so the only thing left to fail on the tag is the cross-compile build matrix —
+and consider building the release targets locally first to catch even that:
 
 ```bash
-git push origin :refs/tags/vX.Y.Z   # delete remote tag
-git tag -d vX.Y.Z                    # delete local tag
+# from a macOS/Lima box with musl-cross set up, all three targets build locally
+cargo build --release --target aarch64-apple-darwin
+cargo build --release --target x86_64-unknown-linux-musl
+cargo build --release --target aarch64-unknown-linux-musl
 ```
+
+Do **not** attempt `git push origin :refs/tags/vX.Y.Z` to delete and reuse a
+tag — immutable releases reject it, and reusing a spent version is not allowed.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,7 @@ push succeeds and ships something correct.
 | `integration-update` / `-uninstall` | ✓ | ✓ | |
 | Version ↔ lock ↔ CHANGELOG ↔ tag agreement | | ✓ | |
 | Formal verification (`cargo kani`) | | ✓ (if installed) | |
-| Full VM integration, both platforms | | ✓ (over SSH) | decide hosts |
+| Full VM integration, both platforms | | ✓ (local + 1 remote) | pick remote host |
 | Mutation testing (`--mutants`) | | opt-in | when logic changed |
 | Fuzzing (`--fuzz`) | | opt-in | when a parser changed |
 
@@ -57,12 +57,13 @@ CI can't run the full VM integration suite or the extra-toolchain checks
    ./scripts/preflight-release.sh
    ```
 
-   It prompts for the `user@host` targets to run the cross-platform VM suite on
-   — give it both a **Linux/Firecracker** host and a **macOS/Lima** host. Or
-   pass them up front:
+   The full VM suite runs on **this machine** (one platform) plus **one remote
+   host** you give for the other platform — so run the preflight from a
+   macOS/Lima box and point `--remote` at a Linux/Firecracker box, or vice
+   versa. It prompts for the host, or pass it up front:
 
    ```bash
-   ./scripts/preflight-release.sh --remote you@linux-box --remote you@mac-box
+   ./scripts/preflight-release.sh --remote you@other-platform-box
    ```
 
 6. **Run the deep checks when the diff warrants it** (these are slow and not CI
@@ -73,7 +74,7 @@ CI can't run the full VM integration suite or the extra-toolchain checks
      (`parse_repo_slug`, `jsonc_to_json`, `config_load`).
 
    ```bash
-   ./scripts/preflight-release.sh --remote you@linux-box --remote you@mac-box --mutants --fuzz
+   ./scripts/preflight-release.sh --remote you@other-platform-box --mutants --fuzz
    ```
 
 7. **Open the bump PR** (`Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`), get it

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,108 @@
+# Releasing coop
+
+How a `coop` release is cut, and what to check before cutting one.
+
+## How the automation works
+
+- **`ci.yml`** runs on pushes to `main` and on every PR: `fmt --check`, `clippy -D warnings`,
+  `cargo test`, `integration-update.sh`, `integration-uninstall.sh`,
+  `cargo deny check`, and `zizmor`.
+- **`release.yml`** runs when a `v*` tag is pushed. It **re-runs all of CI as a
+  gate**, then cross-compiles the three target binaries
+  (`aarch64-apple-darwin`, `x86_64-unknown-linux-musl`,
+  `aarch64-unknown-linux-musl`), generates `SHA256SUMS`, attests build
+  provenance, extracts the `## vX.Y.Z` section from `CHANGELOG.md` as the
+  release notes, and publishes the GitHub release. **It fails if there is no
+  matching CHANGELOG section.**
+
+So pushing the tag is the release. Everything below is about making sure that
+push succeeds and ships something correct.
+
+## What runs where
+
+| Check | CI (on PR + on tag) | `preflight-release.sh` | Manual judgement |
+|-------|:---:|:---:|:---:|
+| fmt / clippy / unit tests | ✓ | ✓ | |
+| `cargo deny`, `zizmor` | ✓ | ✓ (if installed) | |
+| `integration-update` / `-uninstall` | ✓ | ✓ | |
+| Version ↔ lock ↔ CHANGELOG ↔ tag agreement | | ✓ | |
+| Formal verification (`cargo kani`) | | ✓ (if installed) | |
+| Full VM integration, both platforms | | ✓ (over SSH) | decide hosts |
+| Mutation testing (`--mutants`) | | opt-in | when logic changed |
+| Fuzzing (`--fuzz`) | | opt-in | when a parser changed |
+
+CI can't run the full VM integration suite or the extra-toolchain checks
+(kani/mutants/fuzz); those are the preflight's job.
+
+## Release checklist
+
+1. **Land all release content on `main`.** Open PRs merged, `main` green in CI.
+
+2. **Pick the version** (`X.Y.Z`, semver). Breaking changes → major; new
+   features → minor; fixes only → patch. Look at the `## Unreleased` section of
+   `CHANGELOG.md` to judge.
+
+3. **Bump the version.**
+   - Edit `version` in `Cargo.toml`.
+   - Run `cargo build` so `Cargo.lock` picks up the new `coop` version.
+
+4. **Promote the changelog.** Rename `## Unreleased` to `## vX.Y.Z` in
+   `CHANGELOG.md`. The text under it becomes the GitHub release notes verbatim,
+   so read it as release notes. Start a fresh empty `## Unreleased` above it.
+
+5. **Run the preflight.** It refuses to pass until the version sources agree and
+   the tag is free, then runs the full gate:
+
+   ```bash
+   ./scripts/preflight-release.sh
+   ```
+
+   It prompts for the `user@host` targets to run the cross-platform VM suite on
+   — give it both a **Linux/Firecracker** host and a **macOS/Lima** host. Or
+   pass them up front:
+
+   ```bash
+   ./scripts/preflight-release.sh --remote you@linux-box --remote you@mac-box
+   ```
+
+6. **Run the deep checks when the diff warrants it** (these are slow and not CI
+   gates — see `CLAUDE.md`):
+   - `--mutants` when this release changed logic-dense modules (config,
+     workspace, devcontainer, parsing, secret routing).
+   - `--fuzz` when it changed a parser of user-editable input
+     (`parse_repo_slug`, `jsonc_to_json`, `config_load`).
+
+   ```bash
+   ./scripts/preflight-release.sh --remote you@linux-box --remote you@mac-box --mutants --fuzz
+   ```
+
+7. **Open the bump PR** (`Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`), get it
+   reviewed, and merge to `main`. Never push the bump straight to `main`.
+
+8. **Tag the merge commit and push.**
+
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   This triggers `release.yml`.
+
+9. **Verify the published release.** On the GitHub release page confirm:
+   - three `coop-vX.Y.Z-<target>.tar.gz` artifacts plus `SHA256SUMS`,
+   - the build-provenance attestation is attached,
+   - the notes match the `## vX.Y.Z` CHANGELOG section.
+
+   Then smoke-test the install path (`install.sh`) against the new tag.
+
+## If the tag run fails
+
+`release.yml` re-runs CI before building, so a red tag run means a check the
+preflight would have caught was skipped (or the build matrix failed). Delete the
+tag, fix forward on `main`, and re-tag — don't move a published tag.
+
+```bash
+git push origin :refs/tags/vX.Y.Z   # delete remote tag
+git tag -d vX.Y.Z                    # delete local tag
+```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,6 +26,7 @@ push succeeds and ships something correct.
 | `cargo deny`, `zizmor` | ✓ | ✓ (if installed) | |
 | `integration-update` / `-uninstall` | ✓ | ✓ | |
 | Version ↔ lock ↔ CHANGELOG ↔ tag agreement | | ✓ | |
+| Release builds (3 targets) | native only | ✓ (per installed toolchain) | |
 | Formal verification (`cargo kani`) | | ✓ (if installed) | |
 | Full VM integration, both platforms | | ✓ (local + 1 remote) | pick remote host |
 | Mutation testing (`--mutants`) | | opt-in | when logic changed |
@@ -106,16 +107,11 @@ version and cut a fresh release** — go back to step 2 with `vX.Y.(Z+1)`.
 
 This is why the preflight matters: `release.yml` re-runs CI and then builds the
 three target binaries, and a failure in *either* burns the version. Run
-`./scripts/preflight-release.sh` (which mirrors the CI checks) before every tag
-so the only thing left to fail on the tag is the cross-compile build matrix —
-and consider building the release targets locally first to catch even that:
-
-```bash
-# from a macOS/Lima box with musl-cross set up, all three targets build locally
-cargo build --release --target aarch64-apple-darwin
-cargo build --release --target x86_64-unknown-linux-musl
-cargo build --release --target aarch64-unknown-linux-musl
-```
+`./scripts/preflight-release.sh` before every tag — it mirrors the CI checks
+**and** builds the three release targets locally (for each rustup toolchain you
+have installed, offering to `rustup target add` any that are missing), so the
+cross-compile matrix is exercised before the tag rather than after. Run it from
+a macOS/Lima box with `musl-cross` set up to cover all three targets at once.
 
 Do **not** attempt `git push origin :refs/tags/vX.Y.Z` to delete and reuse a
 tag — immutable releases reject it, and reusing a spent version is not allowed.

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release preflight for coop.
+#
+# Runs every check that gates a release from one machine, mirroring the CI
+# jobs (fmt, clippy, test, deny, the lightweight integration scripts) so a
+# doomed tag is never pushed, and adds the checks CI does not perform:
+#   - Cargo.toml / Cargo.lock / CHANGELOG / git-tag version agreement
+#   - formal verification (kani), and opt-in mutation testing and fuzzing
+#   - the cross-platform VM integration suite, driven over SSH the same way
+#     tests/run-integration.sh does (these need Firecracker/Lima hardware and
+#     cannot run in GitHub-hosted CI)
+#
+# Usage:
+#   ./scripts/preflight-release.sh [options]
+#
+# Options:
+#   --remote USER@HOST   Run the full integration suite on this host. Repeatable
+#                        (run once for a Linux/Firecracker host and once for a
+#                        macOS/Lima host). If omitted, you are prompted.
+#   --local-integration  Also run the full integration suite on this machine.
+#   --mutants            Run mutation testing on lines changed since the last tag.
+#   --fuzz               Build and briefly run every fuzz target (needs nightly).
+#   --quick              Skip the slow gates: full integration, mutants, fuzz.
+#   -h, --help           Show this help.
+#
+# Environment:
+#   FUZZ_SECONDS   Per-target fuzz budget when --fuzz is set (default 30).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+REMOTES=()
+LOCAL_INTEGRATION=0
+RUN_MUTANTS=0
+RUN_FUZZ=0
+QUICK=0
+
+usage() {
+  sed -n '3,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remote) REMOTES+=("$2"); shift 2 ;;
+    --local-integration) LOCAL_INTEGRATION=1; shift ;;
+    --mutants) RUN_MUTANTS=1; shift ;;
+    --fuzz) RUN_FUZZ=1; shift ;;
+    --quick) QUICK=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+FAILURES=()
+WARNINGS=()
+
+section() { printf '\n========== %s ==========\n' "$1"; }
+warn() {
+  printf 'WARN: %s\n' "$1"
+  WARNINGS+=("$1")
+}
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# step "Name" cmd args... — runs cmd, records a failure on non-zero exit but
+# keeps going so one preflight run reports every problem.
+step() {
+  local name="$1"
+  shift
+  section "$name"
+  if "$@"; then
+    printf 'PASS: %s\n' "$name"
+  else
+    printf 'FAIL: %s\n' "$name"
+    FAILURES+=("$name")
+  fi
+}
+
+cargo_toml_version() {
+  awk -F'"' '/^\[package\]/{p=1} p && /^version *=/{print $2; exit}' Cargo.toml
+}
+
+check_worktree() {
+  local dirty=0
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    printf 'Tracked changes are uncommitted:\n'
+    git status --short --untracked-files=no
+    dirty=1
+  fi
+  if [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
+    warn "Untracked files present — confirm they are not meant for the release"
+  fi
+  return "$dirty"
+}
+
+check_versions() {
+  local v tag lockv
+  v="$(cargo_toml_version)"
+  if [[ -z "$v" ]]; then
+    echo "Could not read version from Cargo.toml" >&2
+    return 1
+  fi
+  tag="v$v"
+  printf 'Cargo.toml version: %s  (release tag: %s)\n' "$v" "$tag"
+
+  lockv="$(awk '/^name = "coop"$/{getline; gsub(/version = "|"/, ""); print; exit}' Cargo.lock)"
+  if [[ "$lockv" != "$v" ]]; then
+    printf 'Cargo.lock coop version (%s) != Cargo.toml (%s) — run cargo build to refresh the lockfile\n' "$lockv" "$v"
+    return 1
+  fi
+
+  # release.yml extracts notes with an exact whole-line match ($0 == "## vX.Y.Z"),
+  # so the header must match exactly — a trailing date would pass a looser check
+  # here yet make the release run find no notes. Mirror that exact-match.
+  if ! grep -qxF "## $tag" CHANGELOG.md; then
+    printf 'CHANGELOG.md has no exact "## %s" header — promote "## Unreleased" (header must be exactly "## %s", no trailing text)\n' "$tag" "$tag"
+    return 1
+  fi
+
+  if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    printf 'Tag %s already exists — bump the version in Cargo.toml first\n' "$tag"
+    return 1
+  fi
+
+  printf 'Version sources agree; tag %s is free.\n' "$tag"
+}
+
+run_deny() {
+  if ! have cargo-deny; then
+    warn "cargo-deny not installed — supply-chain check skipped (CI still runs it; cargo install cargo-deny --locked)"
+    return 0
+  fi
+  cargo deny check
+}
+
+run_zizmor() {
+  if ! have zizmor; then
+    warn "zizmor not installed — workflow audit skipped (CI still runs it; pipx install zizmor)"
+    return 0
+  fi
+  zizmor .github/workflows/
+}
+
+run_kani() {
+  if ! have cargo-kani; then
+    warn "kani not installed — formal-verification proofs skipped (cargo install --locked kani-verifier && cargo kani setup)"
+    return 0
+  fi
+  cargo kani
+}
+
+run_mutants() {
+  if ! have cargo-mutants; then
+    warn "cargo-mutants not installed — mutation testing skipped (cargo install cargo-mutants --locked)"
+    return 0
+  fi
+  local lasttag
+  lasttag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+  if [[ -n "$lasttag" ]]; then
+    printf 'Mutating src/*.rs lines changed since %s\n' "$lasttag"
+    cargo mutants --in-diff <(git diff "$lasttag" -- 'src/*.rs') -- --lib
+  else
+    printf 'No prior tag found; mutating the logic-dense modules\n'
+    cargo mutants \
+      -f src/config.rs \
+      -f src/workspace.rs \
+      -f src/devcontainer.rs \
+      -f src/guest_env_state.rs \
+      -f src/github_repo.rs \
+      -f src/github_pat.rs \
+      -f src/secret_store.rs \
+      -f src/fs_util.rs \
+      -- --lib
+  fi
+}
+
+run_fuzz() {
+  if ! have cargo-fuzz; then
+    warn "cargo-fuzz not installed — fuzzing skipped (cargo install cargo-fuzz --locked)"
+    return 0
+  fi
+  cargo +nightly fuzz build
+  local target
+  for target in parse_repo_slug jsonc_to_json config_load; do
+    cargo +nightly fuzz run "$target" -- -max_total_time="${FUZZ_SECONDS:-30}"
+  done
+}
+
+prompt_for_hosts() {
+  if [[ ${#REMOTES[@]} -gt 0 || "$LOCAL_INTEGRATION" == 1 || "$QUICK" == 1 ]]; then
+    return
+  fi
+  if [[ ! -t 0 ]]; then
+    warn "No --remote host and not a TTY — cross-platform integration NOT run. Run ./tests/run-integration.sh --remote user@host on both a Linux and a macOS host."
+    return
+  fi
+  printf '\nThe full integration suite needs VM hardware (Firecracker on Linux, Lima on macOS).\n'
+  printf 'Enter user@host targets, space-separated (blank to skip): '
+  local line
+  read -r line || true
+  if [[ -n "$line" ]]; then
+    read -r -a REMOTES <<<"$line"
+  fi
+  printf 'Also run the full suite on THIS host? [y/N] '
+  local ans
+  read -r ans || true
+  [[ "$ans" =~ ^[Yy] ]] && LOCAL_INTEGRATION=1
+}
+
+# ── Run ──────────────────────────────────────────────────────────
+
+step "Working tree clean" check_worktree
+step "Version consistency" check_versions
+step "Format (cargo fmt --check)" cargo fmt -- --check
+step "Clippy" cargo clippy --all-targets --all-features -- -D warnings
+step "Unit tests" cargo test
+step "Supply chain (cargo deny)" run_deny
+step "Workflow audit (zizmor)" run_zizmor
+step "Integration — coop update" ./tests/integration-update.sh
+step "Integration — coop uninstall" ./tests/integration-uninstall.sh
+step "Formal verification (kani)" run_kani
+
+if [[ "$RUN_MUTANTS" == 1 ]]; then
+  step "Mutation testing" run_mutants
+elif [[ "$QUICK" != 1 ]]; then
+  warn "Mutation testing not run — pass --mutants if this release touches logic/parsing modules"
+fi
+
+if [[ "$RUN_FUZZ" == 1 ]]; then
+  step "Fuzzing" run_fuzz
+elif [[ "$QUICK" != 1 ]]; then
+  warn "Fuzzing not run — pass --fuzz if this release touches parsers of user-editable input"
+fi
+
+if [[ "$QUICK" == 1 ]]; then
+  warn "--quick: full cross-platform integration suite skipped"
+else
+  prompt_for_hosts
+  if [[ "$LOCAL_INTEGRATION" == 1 ]]; then
+    step "Full integration (local host)" ./tests/run-integration.sh
+  fi
+  if ((${#REMOTES[@]})); then
+    for host in "${REMOTES[@]}"; do
+      step "Full integration ($host)" ./tests/run-integration.sh --remote "$host"
+    done
+  fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────
+
+section "Summary"
+if [[ ${#WARNINGS[@]} -gt 0 ]]; then
+  printf 'Warnings (%d):\n' "${#WARNINGS[@]}"
+  printf '  - %s\n' "${WARNINGS[@]}"
+fi
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  printf '\nFailed checks (%d):\n' "${#FAILURES[@]}"
+  printf '  - %s\n' "${FAILURES[@]}"
+  printf '\nPreflight FAILED — do not tag the release.\n'
+  exit 1
+fi
+version="$(cargo_toml_version)"
+printf 'All required checks passed for v%s.\n' "$version"
+printf 'Next: tag v%s on the merge commit and push to trigger release.yml.\n' "$version"

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 # jobs (fmt, clippy, test, deny, the lightweight integration scripts) so a
 # doomed tag is never pushed, and adds the checks CI does not perform:
 #   - Cargo.toml / Cargo.lock / CHANGELOG / git-tag version agreement
+#   - release builds of all three target binaries (CI builds only the native
+#     target; a cross-compile break otherwise first surfaces on the tag, which
+#     burns the version under immutable releases)
 #   - formal verification (kani), and opt-in mutation testing and fuzzing
 #   - the cross-platform VM integration suite, driven over SSH the same way
 #     tests/run-integration.sh does (these need Firecracker/Lima hardware and
@@ -189,6 +192,62 @@ run_fuzz() {
   done
 }
 
+# Release-build targets, matching the matrix in .github/workflows/release.yml.
+RELEASE_TARGETS=(aarch64-apple-darwin x86_64-unknown-linux-musl aarch64-unknown-linux-musl)
+
+# Offer to install missing rustup targets (interactively), and always explain
+# how. `rustup target add` installs only the std library — cross-LINKING also
+# needs platform tools, so spell that out too.
+offer_install_targets() {
+  local targets=("$@")
+  printf '\nMissing rustup targets for the release build: %s\n' "${targets[*]}"
+  printf 'Install the standard libraries with:\n'
+  printf '  rustup target add %s\n' "${targets[*]}"
+  printf 'Cross-LINKING also needs platform tools (musl-cross on macOS; musl-tools\n'
+  printf '+ gcc-aarch64-linux-gnu on Linux) — see .github/workflows/release.yml.\n'
+  if [[ ! -t 0 ]]; then
+    return
+  fi
+  printf 'Run rustup target add for %s now? [y/N] ' "${targets[*]}"
+  local ans
+  read -r ans || true
+  if [[ "$ans" =~ ^[Yy] ]]; then
+    rustup target add "${targets[@]}" || warn "rustup target add failed for: ${targets[*]}"
+  fi
+}
+
+# Build each release target whose toolchain is installed. CI only builds the
+# native target, so a cross-compile break otherwise first surfaces on the tag —
+# which, with immutable releases, burns the version.
+build_release_targets() {
+  if ! have rustup; then
+    warn "rustup not found — release targets not built locally; release.yml builds them on the tag (a failure there burns the version)."
+    return 0
+  fi
+  local installed target built=0 missing=()
+  installed="$(rustup target list --installed 2>/dev/null || true)"
+  for target in "${RELEASE_TARGETS[@]}"; do
+    grep -qx "$target" <<<"$installed" || missing+=("$target")
+  done
+  if ((${#missing[@]})); then
+    offer_install_targets "${missing[@]}"
+    installed="$(rustup target list --installed 2>/dev/null || true)"
+  fi
+  for target in "${RELEASE_TARGETS[@]}"; do
+    if grep -qx "$target" <<<"$installed"; then
+      printf 'Building %s...\n' "$target"
+      cargo build --release --target "$target" || return 1
+      built=$((built + 1))
+    else
+      warn "release target $target not built locally (toolchain absent) — release.yml builds it on the tag, uncaught here."
+    fi
+  done
+  if [[ "$built" -eq 0 ]]; then
+    warn "no release targets built locally — cross-compile breakage won't surface until the tag is pushed. Run the preflight from a host that can cross-compile all three (macOS + musl-cross)."
+  fi
+  return 0
+}
+
 prompt_for_remote() {
   if [[ -n "$REMOTE" || "$QUICK" == 1 ]]; then
     return
@@ -211,6 +270,7 @@ step "Version consistency" check_versions
 step "Format (cargo fmt --check)" cargo fmt -- --check
 step "Clippy" cargo clippy --all-targets --all-features -- -D warnings
 step "Unit tests" cargo test
+step "Release target builds" build_release_targets
 step "Supply chain (cargo deny)" run_deny
 step "Workflow audit (zizmor)" run_zizmor
 step "Integration — coop update" ./tests/integration-update.sh

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -12,14 +12,16 @@ set -euo pipefail
 #     tests/run-integration.sh does (these need Firecracker/Lima hardware and
 #     cannot run in GitHub-hosted CI)
 #
+# The full integration suite runs on THIS machine (one platform) plus one
+# remote host you specify for the other platform.
+#
 # Usage:
 #   ./scripts/preflight-release.sh [options]
 #
 # Options:
-#   --remote USER@HOST   Run the full integration suite on this host. Repeatable
-#                        (run once for a Linux/Firecracker host and once for a
-#                        macOS/Lima host). If omitted, you are prompted.
-#   --local-integration  Also run the full integration suite on this machine.
+#   --remote USER@HOST   Run the full integration suite on this remote host (the
+#                        other platform). Local always runs too. If omitted and
+#                        running interactively, you are prompted for it.
 #   --mutants            Run mutation testing on lines changed since the last tag.
 #   --fuzz               Build and briefly run every fuzz target (needs nightly).
 #   --quick              Skip the slow gates: full integration, mutants, fuzz.
@@ -32,20 +34,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_DIR"
 
-REMOTES=()
-LOCAL_INTEGRATION=0
+REMOTE=""
 RUN_MUTANTS=0
 RUN_FUZZ=0
 QUICK=0
 
 usage() {
-  sed -n '3,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '/^# Release preflight/,/^# *FUZZ_SECONDS/p' "${BASH_SOURCE[0]}" |
+    sed 's/^# \{0,1\}//'
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --remote) REMOTES+=("$2"); shift 2 ;;
-    --local-integration) LOCAL_INTEGRATION=1; shift ;;
+    --remote) REMOTE="$2"; shift 2 ;;
     --mutants) RUN_MUTANTS=1; shift ;;
     --fuzz) RUN_FUZZ=1; shift ;;
     --quick) QUICK=1; shift ;;
@@ -188,25 +189,19 @@ run_fuzz() {
   done
 }
 
-prompt_for_hosts() {
-  if [[ ${#REMOTES[@]} -gt 0 || "$LOCAL_INTEGRATION" == 1 || "$QUICK" == 1 ]]; then
+prompt_for_remote() {
+  if [[ -n "$REMOTE" || "$QUICK" == 1 ]]; then
     return
   fi
   if [[ ! -t 0 ]]; then
-    warn "No --remote host and not a TTY — cross-platform integration NOT run. Run ./tests/run-integration.sh --remote user@host on both a Linux and a macOS host."
+    warn "No --remote host and not a TTY — the other platform's integration suite is NOT run. Pass --remote user@host, or run ./tests/run-integration.sh --remote user@host yourself."
     return
   fi
-  printf '\nThe full integration suite needs VM hardware (Firecracker on Linux, Lima on macOS).\n'
-  printf 'Enter user@host targets, space-separated (blank to skip): '
+  printf '\nThe full suite runs here (this platform). Enter a remote user@host for\n'
+  printf 'the other platform (Firecracker on Linux, Lima on macOS), blank to skip: '
   local line
   read -r line || true
-  if [[ -n "$line" ]]; then
-    read -r -a REMOTES <<<"$line"
-  fi
-  printf 'Also run the full suite on THIS host? [y/N] '
-  local ans
-  read -r ans || true
-  [[ "$ans" =~ ^[Yy] ]] && LOCAL_INTEGRATION=1
+  REMOTE="$line"
 }
 
 # ── Run ──────────────────────────────────────────────────────────
@@ -237,14 +232,12 @@ fi
 if [[ "$QUICK" == 1 ]]; then
   warn "--quick: full cross-platform integration suite skipped"
 else
-  prompt_for_hosts
-  if [[ "$LOCAL_INTEGRATION" == 1 ]]; then
-    step "Full integration (local host)" ./tests/run-integration.sh
-  fi
-  if ((${#REMOTES[@]})); then
-    for host in "${REMOTES[@]}"; do
-      step "Full integration ($host)" ./tests/run-integration.sh --remote "$host"
-    done
+  prompt_for_remote
+  step "Full integration (local host)" ./tests/run-integration.sh
+  if [[ -n "$REMOTE" ]]; then
+    step "Full integration ($REMOTE)" ./tests/run-integration.sh --remote "$REMOTE"
+  else
+    warn "No remote host given — only the local platform's integration suite ran; the other platform was not covered."
   fi
 fi
 


### PR DESCRIPTION
Adds tooling to run the full test gate before cutting a release.

## What's here

- **`scripts/preflight-release.sh`** — a one-machine release gate. It:
  - mirrors the CI jobs (`fmt --check`, `clippy -D warnings`, `cargo test`, `cargo deny`, `zizmor`, `integration-update.sh`, `integration-uninstall.sh`) so a failing tag is caught before it's pushed;
  - adds the checks CI doesn't do: `Cargo.toml` ↔ `Cargo.lock` ↔ `CHANGELOG.md` ↔ git-tag version agreement, clean-worktree, and formal verification (`cargo kani`);
  - runs the full integration suite on the local machine (one platform) plus one `--remote user@host` for the other platform, prompting for the remote when not passed;
  - gates the slow manual checks behind flags (`--mutants`, `--fuzz`), warning when they're skipped;
  - missing optional toolchains degrade to a warning, not a hard failure; the CHANGELOG check uses an exact whole-line match so it agrees with `release.yml`'s notes extractor.
- **`RELEASING.md`** — the ordered release flow (bump → promote changelog → preflight → PR → tag → verify) and a table of what runs in CI vs preflight vs manually.

## CLAUDE.md fix

After the lib split, all logic and unit tests live in the lib target, so the documented `cargo mutants -- --bins` runs **zero tests** and reports every mutant as missed. Switched the documented command (and the script's mutants step) to `-- --lib`.

## Verification

- `shellcheck` clean; `bash -n` clean.
- Version-parsing and exact CHANGELOG-match logic checked against the live `Cargo.toml`/`Cargo.lock`/`CHANGELOG.md`.
- Ran a full mutation sweep on the 8 logic modules with the corrected `--lib`: 370 caught / 206 missed / 134 unviable (64% kill rate on viable mutants). Missed mutants cluster in `github_pat.rs` (73), `workspace.rs` (55), and `devcontainer.rs` (39) — existing test-coverage gaps, tracked separately from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)