### PR TITLE
Pin surviving config.rs mutants with unit tests

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2836,8 +2836,8 @@ mod tests {
                 "expected rejection for {name:?}, got: {err}"
             );
             assert!(
-                !err.contains("--workspace"),
-                "did not expect workspace hint for {name:?}, got: {err}"
+                !err.contains("coop up <PATH>"),
+                "did not expect path hint for {name:?}, got: {err}"
             );
         }
     }
@@ -2951,6 +2951,38 @@ mod tests {
             msg.contains("No instances exist."),
             "missing hint in: {msg}"
         );
+    }
+
+    #[test]
+    fn resolve_ignores_stale_fast_path_dir() {
+        // The fast path reads `instances_dir/<name>/instance.json` and only
+        // returns it when the stored name matches the requested name. Here the
+        // directory `wanted` holds an instance whose stored name is `decoy`, so
+        // the fast path must reject it and the slow path must find the real
+        // `wanted` instance living under a differently-named directory.
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp);
+        let instances = tmp.path().join("instances");
+
+        let stale = Instance {
+            name: iname("decoy"),
+            index: idx(0),
+            dir: instances.join("wanted"),
+            image: default_img(),
+        };
+        stale.save().unwrap();
+
+        let real = Instance {
+            name: iname("wanted"),
+            index: idx(1),
+            dir: instances.join("elsewhere"),
+            image: default_img(),
+        };
+        real.save().unwrap();
+
+        let inst = cfg.resolve_instance(Some(&iname("wanted"))).unwrap();
+        assert_eq!(inst.name, *"wanted");
+        assert_eq!(inst.index.as_u16(), 1);
     }
 
     #[test]
@@ -3499,6 +3531,13 @@ skip = ["not-a-slug"]
         assert!(serde_json::from_str::<InstanceName>(json).is_err());
     }
 
+    #[test]
+    fn instance_name_compares_to_str() {
+        let name = InstanceName::new("foo").unwrap();
+        assert!(name == *"foo");
+        assert!(name != *"bar");
+    }
+
     // ── ImageName ─────────────────────────────────────────────
 
     #[test]
@@ -3544,6 +3583,13 @@ skip = ["not-a-slug"]
     fn image_name_rejects_overlong() {
         let too_long = "a".repeat(MAX_IMAGE_NAME_LEN + 1);
         assert!(ImageName::new(&too_long).is_err());
+    }
+
+    #[test]
+    fn image_name_compares_to_str() {
+        let name = ImageName::new("foo").unwrap();
+        assert!(name == *"foo");
+        assert!(name != *"bar");
     }
 
     #[test]


### PR DESCRIPTION
Closes #323.

A full `cargo mutants -- --lib` sweep left four real test-coverage gaps in `src/config.rs`. This adds/fixes unit tests so each surviving mutant is now killed.

- **`looks_like_path`** — the existing `validate_name_non_path_omits_workspace_hint` asserted `!err.contains("--workspace")`, a substring the validator never emits, so it stayed green even when `looks_like_path` was replaced with `true`. It now asserts `!err.contains("coop up <PATH>")` — the actual hint text — for non-path names. The positive case (hint present for path-like names) is already covered by `validate_name_path_like_suggests_workspace`.
- **`InstanceName` / `ImageName` `PartialEq<str>`** — these impls were only reached through `assert_eq!`, so `eq -> true`, `eq -> false`, and `== -> !=` all survived. New `instance_name_compares_to_str` / `image_name_compares_to_str` exercise `==` and `!=` directly.
- **`CoopConfig::resolve_instance` fast path** — `&inst.name == name` flipped to `!=` made the fast path return a mismatched on-disk instance. `resolve_ignores_stale_fast_path_dir` writes an instance directory whose stored name differs from the directory name, plus the real match under another directory, and asserts resolve returns the real one.

Verification: `cargo mutants -f src/config.rs --re "looks_like_path|PartialEq<str>|resolve_instance" -- --lib` → 14 mutants, 12 caught, 2 unviable, 0 missed. Full `cargo test --lib` passes (828 tests); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)