### PR TITLE
Pin surviving fs_util.rs mutants with unit tests

### DIFF
--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -72,6 +72,7 @@ pub struct FileLock {
 /// purpose is purely to serialize access to `target`. Releases on drop.
 /// Returns an error if the parent directory cannot be created or the
 /// lock cannot be acquired.
+#[mutants::skip] // low-payoff: flock helper; callers always target existing dirs, so the parent-dir guard is never exercised
 pub fn lock_sibling(target: &Path) -> Result<FileLock> {
     let parent = target.parent().unwrap_or_else(|| Path::new("."));
     if !parent.as_os_str().is_empty() {
@@ -258,6 +259,38 @@ mod tests {
         atomic_write_ssh(&path, "new").unwrap();
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o644);
+    }
+
+    #[test]
+    fn atomic_write_with_mode_never_relaxes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret");
+        fs::write(&path, "old").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+
+        // Requesting a more permissive mode must not widen the file.
+        atomic_write_with_mode(&path, "new", 0o644).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "existing 0o600 must not be relaxed to 0o644");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "new");
+    }
+
+    #[test]
+    fn atomic_write_with_mode_default_for_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new");
+        atomic_write_with_mode(&path, "content", 0o640).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o640, "new file must use the requested mode verbatim");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "content");
+    }
+
+    #[test]
+    fn atomic_write_with_mode_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub").join("dir").join("file");
+        atomic_write_with_mode(&path, "content", 0o600).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "content");
     }
 
     #[test]


### PR DESCRIPTION
Adds unit tests for the three surviving mutants in `src/fs_util.rs::atomic_write_with_mode`, which previously had no tests. Two of them sit on the permission-restriction bits, so an uncaught mutation there could ship a silent permission-widening.

## Changes

- `atomic_write_with_mode_never_relaxes` — pre-create a file at `0o600`, write with `mode=0o644`, assert the result stays `0o600`. Kills the `existing & mode` → `|`/`^` mutants.
- `atomic_write_with_mode_default_for_new_file` — new file with `mode=0o640` ends up `0o640`. Uses a non-default mode (not `0o644`) so the assertion confirms the requested mode flows through verbatim.
- `atomic_write_with_mode_creates_parent_dirs` — write into a missing `sub/dir/`, assert success and content. Kills the `!parent...is_empty()` guard mutant.
- Annotate `lock_sibling` with `#[mutants::skip]` — its parent-dir guard is a low-payoff flock helper whose callers always target existing dirs, matching the issue's stated rationale and the project's documented skip convention.

## Verification

- `cargo mutants -f src/fs_util.rs -- --lib`: 9 caught, 0 missed (was 1 missed before the skip annotation, 3 real gaps before the tests).
- `cargo test --lib`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`: all clean.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)