### PR TITLE
Pin surviving secret_store.rs file-backend mutants with unit tests

### DIFF
--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -747,6 +747,36 @@ mod tests {
     }
 
     #[test]
+    fn file_backend_appends_single_trailing_newline() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let acc = account("trailofbits/coop");
+        // A token without a trailing newline gets exactly one appended.
+        store_file(SERVICE, &acc, "tok", tmp.path()).unwrap();
+        let path = file_backend_path(tmp.path(), &acc);
+        assert_eq!(std::fs::read(&path).unwrap(), b"tok\n");
+    }
+
+    #[test]
+    fn file_backend_does_not_double_newline() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let acc = account("trailofbits/coop");
+        // A token already newline-terminated is stored verbatim, not doubled.
+        store_file(SERVICE, &acc, "tok\n", tmp.path()).unwrap();
+        let path = file_backend_path(tmp.path(), &acc);
+        assert_eq!(std::fs::read(&path).unwrap(), b"tok\n");
+    }
+
+    #[test]
+    fn file_backend_dir_mode_is_0700() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let acc = account("trailofbits/coop");
+        store_file(SERVICE, &acc, "tok", tmp.path()).unwrap();
+        let dir = tmp.path().join(PAT_DIR);
+        let meta = std::fs::metadata(&dir).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o700);
+    }
+
+    #[test]
     fn file_backend_delete_removes_file() {
         let tmp = tempfile::TempDir::new().unwrap();
         let acc = account("x/y");


### PR DESCRIPTION
Closes #326.

Pins the two real surviving mutants from the `cargo mutants` sweep in `src/secret_store.rs`, both in the file backend's on-disk format and permissions.

## Tests added

- `file_backend_appends_single_trailing_newline` / `file_backend_does_not_double_newline` — assert raw file bytes equal exactly `"tok\n"` for both a token without a trailing newline and one that already has it. The existing `file_backend_round_trip` only checked `content.trim()`, which passes whether or not the `!` in `if !token.ends_with('\n')` is deleted; the new tests assert exact bytes, killing that mutant in both directions.
- `file_backend_dir_mode_is_0700` — stats `state_dir/github-pat` after `store_file` and asserts `mode & 0o777 == 0o700`, catching replacement of `set_dir_mode`'s body with `Ok(())` (which would leave the directory at the umask default).

## Verification

`cargo mutants -f src/secret_store.rs -- --lib`: both targeted mutants are now caught. The 7 remaining survivors are the ones the issue lists as equivalent/untestable — `Backend::label` (`&'static str` not asserted), `Backend::is_available`/`tool_on_path` (`$PATH` probes), and the macOS-`cfg`-gated keychain code (`from_words` arm, `store_keychain`) that the Linux mutation host compiles out.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --lib secret_store` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)