### PR TITLE
Pin surviving guest_env_state.rs try_load mutant with a unit test

### DIFF
--- a/src/guest_env_state.rs
+++ b/src/guest_env_state.rs
@@ -271,6 +271,17 @@ mod tests {
     }
 
     #[test]
+    fn try_load_surfaces_non_not_found_read_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        // Put a directory where the JSON file is expected: reading it fails
+        // with a non-NotFound error kind, which must surface as Err rather
+        // than being swallowed as Ok(None).
+        fs::create_dir_all(inst.guest_env_state_path()).unwrap();
+        assert!(GuestEnvState::try_load(&inst).is_err());
+    }
+
+    #[test]
     fn save_empty_removes_existing_file() {
         let tmp = tempfile::tempdir().unwrap();
         let inst = fake_instance(tmp.path().to_path_buf());


### PR DESCRIPTION
## What

Adds a unit test pinning a surviving `cargo-mutants` mutant in `src/guest_env_state.rs`.

`GuestEnvState::try_load` returns `Ok(None)` only for a missing file (`ErrorKind::NotFound`) and surfaces every other read error as `Err`. No test exercised the non-NotFound path, so replacing the match guard `e.kind() == ErrorKind::NotFound` with `true` — which would swallow every IO error (permission denied, etc.) as `Ok(None)` — survived the mutation sweep.

The new test places a directory where `guest_env.json` is expected. Reading it fails with a non-NotFound kind (`IsADirectory` on Linux), so the test asserts `try_load` returns `Err`. It fails under the mutant and passes on the original.

After this change, `cargo mutants -f src/guest_env_state.rs -- --lib` reports 0 missed (9 caught, 8 unviable).

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)