### PR TITLE
Scope shell-out and cfg(kani) code out of cargo-mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,134 @@
+# cargo-mutants configuration — see https://mutants.rs/
+#
+# Scopes shell-out / integration-only code and cfg(kani) proofs OUT of the
+# mutation sweep so the `missed` list means "real unit-test gap" rather than
+# "code a `--lib` unit test structurally cannot reach". The behaviors excluded
+# here are covered by `tests/integration.sh` (external processes, SSH, IO) or
+# by `cargo kani` (the proofs), neither of which a `cargo test` unit test can
+# stand in for. See issue #329 and the mutation-testing section of CLAUDE.md.
+#
+# What is NOT excluded: the pure-logic helpers the #321–#327 triage produced.
+# Those fixes EXTRACTED the testable logic out of shell-out/IO functions into
+# pure helpers, which stay in scope so a survivor on one reads as a genuine
+# coverage regression: parse_curl_status_body, parse_user_login (split from
+# probe_user_login), render_status (split from run_status), pick_backend,
+# doc_contains_literal_token, the SSH-config marker-block helpers
+# (remove_marker_blocks / remove_named_marker_block / remove_*_ssh_config_at,
+# split from remove_all_ssh_config / remove_ssh_config), CmdToken::from_words's
+# Linux/op arms, atomic_write_with_mode, and vscode_strategies. The thin
+# external-process / IO wrappers those helpers were carved out of ARE excluded
+# below — a `--lib` unit test cannot reach a wrapper without a real $HOME or
+# network, so its surviving body-replacement mutant is noise, not a gap.
+
+# Whole modules that only shell out, drive SSH, or talk to external services.
+# (CLAUDE.md "Don't bother with" list.) Unit tests cannot observe their effects.
+exclude_globs = [
+    "src/backend.rs",
+    "src/lima.rs",
+    "src/setup.rs",
+    "src/update.rs",
+    "src/shell.rs",
+    "src/port_forward.rs",
+    "src/cmd.rs",
+    "src/ssh.rs",
+    "src/vm.rs",
+]
+
+# Individual functions in otherwise-logic-bearing modules. Patterns match
+# against the full mutant name (`<file>:<line>:<col>: <description>`), so a
+# `\b`-anchored function name excludes both the whole-body replacement and the
+# operator/value mutants inside that function, without catching longer names
+# that share a prefix (e.g. \bprobe_user\b leaves probe_user_login alone).
+exclude_re = [
+    # cfg(kani) proofs (config.rs `mod proofs`): never compiled in a normal
+    # build, so every mutation is a silent no-op and always "missed". The
+    # proofs are exercised by `cargo kani`, not by mutation testing.
+    "proofs::",
+
+    # github_pat.rs — external process (curl/gh/git), browser, terminal echo.
+    "\\brun_setup_pat\\b",
+    "\\brun_rotate_pat\\b",
+    "\\brun_forget_pat\\b",
+    "\\bprobe_user\\b",
+    "\\bprobe_repo\\b",
+    "\\bcurl_with_token\\b",
+    "\\bcurl_with_accept\\b",
+    "\\bcurl_anonymous\\b",
+    "\\bcurl_anonymous_with_accept\\b",
+    "\\bis_public_repo_anonymous\\b",
+    "\\bdiscover_submodule_repos\\b",
+    "\\bprobe_same_owner_coverage\\b",
+    "\\bread_token_no_echo\\b",
+    "\\bopen_browser_best_effort\\b",
+    "\\bprint_form_instructions\\b",
+    "\\bprint_widen_instructions\\b",
+    "\\bwarn_token_format\\b",
+    "impl Drop for EchoGuard",
+    # PAT-wizard submodule orchestration: curl prefetch, then terminal prompts
+    # (read_token_no_echo) and eprintln advice gated on the discovery result.
+    # The classification logic (classify_urls / extract_urls / drop_public) is
+    # factored out and stays in scope.
+    "\\bprefetch_submodules\\b",
+    "\\bhandle_submodules\\b",
+    "\\bdiscover_from_pasted_token\\b",
+    # gh_auth_token is a pure `gh auth token` shell-out that delegates trimming
+    # to parse_gh_token (#322, kept). Exclude only its whole-body replacement;
+    # this module-agnostic pattern also covers the identical gh_auth_token in
+    # git_repo_devcontainer.rs (whose logic lives in normalize_token, kept).
+    "replace gh_auth_token ->",
+    # Thin wrappers whose logic was extracted in #322: run_status just prints
+    # render_status(...) (kept); probe_user_login just curls then delegates to
+    # parse_user_login (kept). \b leaves render_status / parse_user_login alone.
+    "\\brun_status\\b",
+    "\\bprobe_user_login\\b",
+
+    # workspace.rs — tar/rsync pipes, SSH-config IO, editor launch.
+    "\\btar_pipe_transfer\\b",
+    "\\btar_pipe_transfer_to\\b",
+    "\\btar_pipe_pull\\b",
+    "\\bjoin_drainer\\b",
+    "\\bsync_mounts\\b",
+    "\\bsync_mount_contents\\b",
+    "\\bvscode\\b",
+    "\\blaunch_editor\\b",
+    "\\brsync_push\\b",
+    "\\brsync_pull\\b",
+    "\\bcheck_guest_dirty\\b",
+    "\\bcheck_local_dirty\\b",
+    "\\batomic_write\\b",
+    "\\bwrite_ssh_config\\b",
+    "\\brefresh_ssh_config_if_present\\b",
+    "\\bupdate_ssh_config\\b",
+    # The bare `push`/`pull` free functions live in workspace.rs; anchor on the
+    # file so Report::push in devcontainer.rs (testable report logic) is kept.
+    "src/workspace\\.rs:.*\\bpush\\b",
+    "src/workspace\\.rs:.*\\bpull\\b",
+    # WorkspaceState persistence IO (same treatment as DevcontainerState).
+    "WorkspaceState::save",
+    "WorkspaceState::try_load",
+    # $HOME-resolving wrappers split out in #324; the read/clean/gated-write
+    # logic lives in remove_all_ssh_config_at / remove_ssh_config_at (kept by
+    # the `_at` suffix defeating the `\b` boundary) and remove_named_marker_block.
+    "\\bremove_all_ssh_config\\b",
+    "\\bremove_ssh_config\\b",
+
+    # devcontainer.rs — persistence IO and NotFound guards; tracing-only warn.
+    "DevcontainerPreferences::load",
+    "ParsedDevcontainer::load",
+    "AppliedDevcontainer::current_hash",
+    "DevcontainerState::save",
+    "DevcontainerState::try_load",
+    "\\bwarn_if_applied_devcontainer_changed\\b",
+
+    # secret_store.rs — $PATH probes and the macOS keychain write. The macOS
+    # `find-generic-password` arm of CmdToken::from_words is compiled out on the
+    # Linux sweep host (so its mutant is a no-op there) and pinned on macOS by
+    # parse_recognises_macos_keychain; its Linux/op arms stay as real gaps.
+    "Backend::is_available",
+    "\\btool_on_path\\b",
+    "\\bstore_keychain\\b",
+    "find-generic-password",
+
+    # fs_util.rs — flock syscall wrapper; callers always target existing dirs.
+    "\\block_sibling\\b",
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,15 @@ cargo install cargo-mutants --locked
 - `src/github_repo.rs`, `src/github_pat.rs`, `src/secret_store.rs` — slug parsing, secret routing
 - `src/fs_util.rs` — path manipulation helpers
 
-**Don't bother with:** `backend.rs`, `lima.rs`, `setup.rs`, `update.rs`, `shell.rs`, `port_forward.rs`, `cmd.rs`, `ssh.rs`, `vm.rs`. These mostly shell out, run SSH, or talk to external services — unit tests can't catch behavioral changes there. `tests/integration.sh` does that job.
+**Don't bother with:** `backend.rs`, `lima.rs`, `setup.rs`, `update.rs`, `shell.rs`, `port_forward.rs`, `cmd.rs`, `ssh.rs`, `vm.rs`. These mostly shell out, run SSH, or talk to external services — unit tests can't catch behavioral changes there. `tests/integration.sh` does that job. This list is enforced (not just advised) by `.cargo/mutants.toml` — see **Scoping** below.
+
+**Scoping (`.cargo/mutants.toml`).** The mutation surface is curated in `.cargo/mutants.toml` so the `missed` list means "real unit-test gap," not "code a `--lib` test structurally cannot reach." cargo-mutants reads this file automatically on every run (`--list` included). It scopes out three things:
+
+- **The "Don't bother with" modules above**, via `exclude_globs` — they only shell out, drive SSH, or hit external services.
+- **`cfg(kani)` proofs** (`config.rs mod proofs`), via `exclude_re = ["proofs::"]` — never compiled in a normal build, so every mutation is a silent no-op that always reports `missed`. They are exercised by `cargo kani`, not mutation testing.
+- **Individual shell-out / IO / terminal functions inside otherwise-logic-bearing modules** (`github_pat.rs`, `workspace.rs`, `devcontainer.rs`, `secret_store.rs`, `fs_util.rs`), via `exclude_re`. Each pattern is `\b`-anchored to a function name (or qualified `Type::method`) so it scopes the whole function without catching longer names that share a prefix. The module-agnostic `replace gh_auth_token ->` pattern also covers the identical `gh_auth_token` shell-out in `git_repo_devcontainer.rs`.
+
+What is deliberately *kept* (a survivor here is a genuine coverage regression, not noise): the pure-logic helpers the #321–#327 fixes carved the shell-out/IO functions down to. Those fixes extracted the testable logic into separate functions, which stay in scope: `parse_curl_status_body`, `parse_user_login` (split from `probe_user_login`), `render_status` (split from `run_status`), `parse_gh_token` / `normalize_token` (split from the two `gh_auth_token`s), `pick_backend`, `doc_contains_literal_token`, the SSH-config marker-block helpers (`remove_marker_blocks` / `remove_named_marker_block` / `remove_all_ssh_config_at` / `remove_ssh_config_at`, split from `remove_all_ssh_config` / `remove_ssh_config`), `CmdToken::from_words`'s Linux/`op`/`cat` arms (only the macOS keychain arm is scoped, since it is compiled out on the Linux sweep host and pinned on macOS by `parse_recognises_macos_keychain`), `Report::push`, `atomic_write_with_mode`, and `vscode_strategies`. The thin wrappers those helpers were split out of (`probe_user_login`, `run_status`, `remove_*_ssh_config`, `gh_auth_token`) are excluded — a `--lib` test cannot reach them without a real `$HOME` or network. When adding a new shell-out or IO function to one of these modules, add a matching `exclude_re` line; when adding logic, leave it in scope.
 
 **Running it.** Always scope with `-f`; all logic lives in the library crate
 (`src/lib.rs`; `main.rs` is a thin `coop::run()` shim), and every unit test runs
@@ -118,7 +126,7 @@ A kill rate around 70–80% on viable mutants is healthy for this code. Aim to d
     ```
 3. **Dead code.** If the function is genuinely unused, delete it (per the global "replace, don't deprecate" rule). Surviving mutants on truly dead code are a useful smell.
 
-**Baseline result on `config.rs` (recorded 2026-05-20):** 117 caught / 42 missed / 38 unviable. Real gaps were concentrated in `CoopConfig::validate` (5 survivors), `Instance::is_running` (4), `is_firecracker_process` (2), and `MiB::as_gib_f64` arithmetic. The rest were `fmt::Display` impls and default-value getters. Use this as a reference point — if a future run is much worse on these modules, treat it as a regression in test coverage.
+**Baseline (recorded 2026-06-17, after the #329 scoping and #321–#327 fixes).** A sweep of the eight logic modules (`config.rs`, `workspace.rs`, `devcontainer.rs`, `guest_env_state.rs`, `github_repo.rs`, `github_pat.rs`, `secret_store.rs`, `fs_util.rs`) under `.cargo/mutants.toml` reports **0 missed that are real gaps**. The only surviving `missed` mutants are the two equivalent `||`→`&&` mutations in `github_repo::canonicalize`: that guard (`owner.is_empty() || repo.is_empty() || repo.contains('/')`) is redundant with `RepoSlug::new`, which rejects the same inputs one line later, so no input distinguishes the mutants. Everything else is either caught or scoped out by the config. Treat any *new* survivor outside that pair as a coverage regression — first confirm it isn't a shell-out/IO function that belongs in `.cargo/mutants.toml`, then add a test.
 
 ### Fuzzing
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2432,6 +2432,22 @@ mod tests {
         assert!(format!("{err}").contains("/data"));
     }
 
+    #[test]
+    fn validate_unique_guest_paths_accepts_distinct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        std::fs::create_dir(&a).unwrap();
+        std::fs::create_dir(&b).unwrap();
+        let mounts = vec![
+            Mount::parse(&format!("{}:/data", a.display())).unwrap(),
+            Mount::parse(&format!("{}:/other", b.display())).unwrap(),
+        ];
+        validate_unique_guest_paths(&mounts).unwrap();
+        // The empty set is trivially conflict-free.
+        validate_unique_guest_paths(&[]).unwrap();
+    }
+
     fn default_img() -> ImageName {
         ImageName::new(DEFAULT_IMAGE).unwrap()
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1187,6 +1187,19 @@ mod tests {
     }
 
     #[test]
+    fn vscode_strategies_first_is_code_cli() {
+        let path = GuestPath::new("/workspace");
+        let strategies = vscode_strategies("ssh-remote+coop-test", &path);
+        // The `code` CLI strategy is present on every platform (the macOS
+        // `open -a` fallback is appended after it).
+        let code = &strategies[0];
+        assert_eq!(code.name, "code CLI");
+        assert_eq!(code.cmd, "code");
+        let args: Vec<&str> = code.args.iter().map(String::as_str).collect();
+        assert_eq!(args, ["--remote", "ssh-remote+coop-test", "/workspace"]);
+    }
+
+    #[test]
     fn resolve_host_dir_prefers_explicit_over_state() {
         let state = WorkspaceState {
             guest_path: GuestPath::absolute("/workspace").unwrap(),


### PR DESCRIPTION
Closes #329.

Adds `.cargo/mutants.toml` so a mutation sweep's `missed` list means "real unit-test gap" rather than "code a `--lib` unit test structurally cannot reach." cargo-mutants reads that path automatically (a root `mutants.toml` is not auto-read).

## What the config does

- **`exclude_globs`** drops the nine shell-out / SSH / external-service modules already listed under CLAUDE.md's "Don't bother with" (`backend`, `lima`, `setup`, `update`, `shell`, `port_forward`, `cmd`, `ssh`, `vm`).
- **`exclude_re`** drops:
  - the `cfg(kani)` proofs (`config.rs mod proofs`) — never compiled in a normal build, so every mutation is a silent no-op that always reports `missed`;
  - the individual external-process / IO / terminal functions inside the otherwise-logic-bearing modules. Each pattern is `\b`-anchored (or qualified `Type::method`) so it scopes only the intended wrapper and leaves the pure-logic helpers the #321–#327 fixes extracted in scope (`render_status`, `parse_user_login`, `parse_gh_token`, `remove_*_ssh_config_at`, the marker-block helpers, `vscode_strategies`, …).

The issue's function list was not exhaustive — several of its named "keep" functions had since been refactored (#322/#324) into pure helpers, leaving thin `$HOME`-resolving / shell-out wrappers behind. The config excludes the wrappers and keeps the extracted helpers (which the sweep catches), which is what the issue's stated outcome ("`missed` → ~zero") requires.

## Tests added for two real gaps the sweep surfaced

- `config.rs` `validate_unique_guest_paths_accepts_distinct`: the existing test only asserted duplicates are rejected, which the `delete !` mutant also satisfies (it bails on the first mount). The new test asserts distinct paths are accepted.
- `workspace.rs` `vscode_strategies_first_is_code_cli`: asserts the first launch strategy's name/cmd/args, killing the `-> vec![]` mutant.

Both were confirmed to fail under their mutation and pass without it.

## Result

A confirmation sweep of the four files that previously had survivors (`config.rs`, `github_pat.rs`, `workspace.rs`, `github_repo.rs`) reports **2 missed, 281 caught, 98 unviable** — and the 2 missed are the equivalent `||`→`&&` mutants in `github_repo::canonicalize`, whose guard is redundant with `RepoSlug::new` (no input distinguishes them; a function-level `#[mutants::skip]` would wrongly hide that function's real, caught mutants). CLAUDE.md's "Scoping" subsection and baseline note are updated to document the config and this state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)