### PR TITLE
Fix interactive stdin blocking surfaced by the release preflight

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -109,7 +109,8 @@ This is why the preflight matters: `release.yml` re-runs CI and then builds the
 three target binaries, and a failure in *either* burns the version. Run
 `./scripts/preflight-release.sh` before every tag — it mirrors the CI checks
 **and** builds the three release targets locally (for each rustup toolchain you
-have installed, offering to `rustup target add` any that are missing), so the
+have installed; pass `--install-targets` to `rustup target add` any that are
+missing — the cross-linker tools must already be installed), so the
 cross-compile matrix is exercised before the tag rather than after. Run it from
 a macOS/Lima box with `musl-cross` set up to cover all three targets at once.
 

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -27,6 +27,8 @@ set -euo pipefail
 #                        running interactively, you are prompted for it.
 #   --mutants            Run mutation testing on lines changed since the last tag.
 #   --fuzz               Build and briefly run every fuzz target (needs nightly).
+#   --install-targets    rustup target add any missing release targets (the
+#                        cross-linker tools must already be installed).
 #   --quick              Skip the slow gates: full integration, mutants, fuzz.
 #   -h, --help           Show this help.
 #
@@ -40,6 +42,7 @@ cd "$PROJECT_DIR"
 REMOTE=""
 RUN_MUTANTS=0
 RUN_FUZZ=0
+RUN_INSTALL_TARGETS=0
 QUICK=0
 
 usage() {
@@ -52,6 +55,7 @@ while [[ $# -gt 0 ]]; do
     --remote) REMOTE="$2"; shift 2 ;;
     --mutants) RUN_MUTANTS=1; shift ;;
     --fuzz) RUN_FUZZ=1; shift ;;
+    --install-targets) RUN_INSTALL_TARGETS=1; shift ;;
     --quick) QUICK=1; shift ;;
     -h | --help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
@@ -195,24 +199,21 @@ run_fuzz() {
 # Release-build targets, matching the matrix in .github/workflows/release.yml.
 RELEASE_TARGETS=(aarch64-apple-darwin x86_64-unknown-linux-musl aarch64-unknown-linux-musl)
 
-# Offer to install missing rustup targets (interactively), and always explain
-# how. `rustup target add` installs only the std library — cross-LINKING also
-# needs platform tools, so spell that out too.
-offer_install_targets() {
+# Report missing rustup targets and always explain how to install them.
+# `rustup target add` installs only the std library — cross-LINKING also needs
+# platform tools, so spell that out too. With --install-targets, run the
+# install non-interactively; otherwise warn and continue (never block on stdin).
+handle_missing_targets() {
   local targets=("$@")
   printf '\nMissing rustup targets for the release build: %s\n' "${targets[*]}"
   printf 'Install the standard libraries with:\n'
   printf '  rustup target add %s\n' "${targets[*]}"
   printf 'Cross-LINKING also needs platform tools (musl-cross on macOS; musl-tools\n'
   printf '+ gcc-aarch64-linux-gnu on Linux) — see .github/workflows/release.yml.\n'
-  if [[ ! -t 0 ]]; then
-    return
-  fi
-  printf 'Run rustup target add for %s now? [y/N] ' "${targets[*]}"
-  local ans
-  read -r ans || true
-  if [[ "$ans" =~ ^[Yy] ]]; then
+  if [[ "$RUN_INSTALL_TARGETS" == 1 ]]; then
     rustup target add "${targets[@]}" || warn "rustup target add failed for: ${targets[*]}"
+  else
+    warn "missing release targets won't be built locally: ${targets[*]} — re-run with --install-targets (plus the cross-linker tools above) to cover them."
   fi
 }
 
@@ -230,7 +231,7 @@ build_release_targets() {
     grep -qx "$target" <<<"$installed" || missing+=("$target")
   done
   if ((${#missing[@]})); then
-    offer_install_targets "${missing[@]}"
+    handle_missing_targets "${missing[@]}"
     installed="$(rustup target list --installed 2>/dev/null || true)"
   fi
   for target in "${RELEASE_TARGETS[@]}"; do

--- a/src/commands/admin.rs
+++ b/src/commands/admin.rs
@@ -128,7 +128,7 @@ pub(crate) fn cmd_uninstall(
         return Ok(());
     }
 
-    let remove_data = decide_remove_data(cfg, opts)?;
+    let remove_data = decide_remove_data(cfg, opts, prompt::confirm)?;
 
     if remove_data {
         purge_all_data(be, cfg)?;
@@ -176,7 +176,16 @@ fn print_uninstall_summary(cfg: &config::CoopConfig, binary_path: &Path) {
     }
 }
 
-fn decide_remove_data(cfg: &config::CoopConfig, opts: &UninstallOpts) -> Result<bool> {
+/// Decide whether to wipe the data directory during uninstall.
+///
+/// `confirm` supplies the interactive answer when no flag forces the outcome —
+/// production passes [`prompt::confirm`]; tests pass a deterministic stub so the
+/// decision never depends on ambient TTY state or real stdin.
+fn decide_remove_data(
+    cfg: &config::CoopConfig,
+    opts: &UninstallOpts,
+    confirm: impl FnOnce(&str) -> Result<bool>,
+) -> Result<bool> {
     if opts.keep_data {
         return Ok(false);
     }
@@ -185,7 +194,7 @@ fn decide_remove_data(cfg: &config::CoopConfig, opts: &UninstallOpts) -> Result<
     }
     let instance_count = cfg.list_instances().map(|v| v.len()).unwrap_or(0);
     let image_count = cfg.list_images().map(|v| v.len()).unwrap_or(0);
-    prompt::confirm(&format!(
+    confirm(&format!(
         "Also remove data directory {} ({instance_count} instance(s), {image_count} image(s))?",
         cfg.data_dir.display()
     ))
@@ -309,36 +318,75 @@ mod tests {
         )));
     }
 
+    /// Runs `decide_remove_data` with a confirmer that records whether it was
+    /// invoked, then asserts it stayed untouched — proving the flag-driven
+    /// branches short-circuit before consulting the interactive prompt. Returns
+    /// the decision so callers can assert on it too.
+    fn decide_without_consulting_confirmer(
+        cfg: &super::config::CoopConfig,
+        opts: &super::UninstallOpts,
+    ) -> bool {
+        let consulted = std::cell::Cell::new(false);
+        let decision = super::decide_remove_data(cfg, opts, |_| {
+            consulted.set(true);
+            Ok(true)
+        })
+        .unwrap();
+        assert!(
+            !consulted.get(),
+            "confirm must not be called when a flag forces the outcome"
+        );
+        decision
+    }
+
     #[test]
     fn decide_remove_data_keeps_data_when_keep_data_set() {
         let tmp = tempfile::tempdir().unwrap();
         let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
-        assert!(!super::decide_remove_data(&cfg, &opts(true, true, false)).unwrap());
-        assert!(!super::decide_remove_data(&cfg, &opts(false, true, false)).unwrap());
+        assert!(!decide_without_consulting_confirmer(
+            &cfg,
+            &opts(true, true, false)
+        ));
+        assert!(!decide_without_consulting_confirmer(
+            &cfg,
+            &opts(false, true, false)
+        ));
     }
 
     #[test]
     fn decide_remove_data_removes_when_yes_set() {
         let tmp = tempfile::tempdir().unwrap();
         let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
-        assert!(super::decide_remove_data(&cfg, &opts(true, false, false)).unwrap());
+        assert!(decide_without_consulting_confirmer(
+            &cfg,
+            &opts(true, false, false)
+        ));
     }
 
     #[test]
     fn decide_remove_data_removes_when_purge_set() {
         let tmp = tempfile::tempdir().unwrap();
         let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
-        assert!(super::decide_remove_data(&cfg, &opts(false, false, true)).unwrap());
-        assert!(super::decide_remove_data(&cfg, &opts(true, false, true)).unwrap());
+        assert!(decide_without_consulting_confirmer(
+            &cfg,
+            &opts(false, false, true)
+        ));
+        assert!(decide_without_consulting_confirmer(
+            &cfg,
+            &opts(true, false, true)
+        ));
     }
 
     #[test]
-    fn decide_remove_data_interactive_returns_false_without_tty() {
-        // In `cargo test` stdin is not a TTY, so `prompt::confirm` returns
-        // `Ok(false)` — exercising the interactive branch deterministically.
+    fn decide_remove_data_interactive_returns_confirmer_value() {
+        // With no flag set, the decision comes straight from the injected
+        // confirmer — hermetic, never touching real stdin or TTY state.
         let tmp = tempfile::tempdir().unwrap();
         let cfg = cfg_with_data_dir(tmp.path().to_path_buf());
-        assert!(!super::decide_remove_data(&cfg, &opts(false, false, false)).unwrap());
+        assert!(
+            !super::decide_remove_data(&cfg, &opts(false, false, false), |_| Ok(false)).unwrap()
+        );
+        assert!(super::decide_remove_data(&cfg, &opts(false, false, false), |_| Ok(true)).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Running `scripts/preflight-release.sh` surfaced two places that block on a
blocking stdin read when the gate is launched from an interactive terminal.
Both are fixed here.

## `decide_remove_data` test hangs ~60s

`prompt::confirm` returns early only when stdin is not a TTY; otherwise it does
a blocking `read_line`. The test `decide_remove_data_interactive_returns_false_without_tty`
assumed `cargo test` never has a TTY, but the preflight runs `cargo test`
directly in the terminal, so the test actually blocked on `read_line`.

`decide_remove_data` now takes the confirmer as a parameter. Production passes
`prompt::confirm` (behavior unchanged); the test injects a stub and asserts the
interactive branch returns the confirmer's value for both `false` and `true`,
with no stdin or TTY dependency. The flag-driven tests assert the confirmer is
never consulted. All other `prompt::confirm` / `confirm_default_yes` callers
were checked; no other test had the same dependency.

## Preflight prompt blocks unattended

`offer_install_targets` prompted `[y/N]` via `read` with no timeout, so a gate
left running would hang forever waiting for a keystroke.

Replaced with a non-interactive `--install-targets` flag. `handle_missing_targets`
always prints the install instructions and the cross-linker note, then either
runs `rustup target add` (only with `--install-targets`) or warns and continues.
No path reads stdin. `RELEASING.md` documents the flag.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test`: 845 pass in 0.43s; the previously-hanging test completes instantly
- `shellcheck scripts/preflight-release.sh`: clean
- `./scripts/preflight-release.sh --help` lists `--install-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)