### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.5.1
+
 ### New features
 
 - **`coop ssh-config` — install a `coop-<name>` SSH alias** (#294) —
@@ -11,6 +13,11 @@
   survives `coop stop` and is refreshed on `coop start` (the Lima SSH
   port changes per boot), so it stays valid across restarts;
   `coop destroy` and `--clean` remove it.
+
+- **`coop setup --builder-timeout <duration>`** (#315) — bounds how long
+  setup waits for image-build commands before timing out. Accepts bare
+  seconds or an `s`/`m`/`h` suffix (e.g. `60m`, `2h`). Applies across
+  both backends.
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coop"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coop"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
 

--- a/tests/integration-uninstall.sh
+++ b/tests/integration-uninstall.sh
@@ -19,6 +19,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Detach from the controlling terminal's stdin. coop gates interactive prompts
+# (here, `uninstall`'s confirmation) on stdin being a TTY. The --yes calls skip
+# it and Test 3 pins its own stdin to /dev/null, so nothing blocks today, but a
+# future prompt-bearing case run from an interactive shell (the release
+# preflight) would read real keystrokes and block — under CI stdin is already
+# not a TTY, so it would never be caught there. Redirecting the whole script
+# makes every coop subprocess see a non-TTY stdin regardless of how the suite is
+# invoked. The script itself never reads stdin.
+exec </dev/null
+
 # ── Temp workspace ───────────────────────────────────────────────────────────
 
 TMPDIR="$(mktemp -d)"

--- a/tests/integration-update.sh
+++ b/tests/integration-update.sh
@@ -14,6 +14,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Detach from the controlling terminal's stdin. coop gates interactive prompts
+# (here, `update`'s confirmation) on stdin being a TTY. Every call below passes
+# --yes or --check so no prompt fires today, but a future prompt-bearing case
+# run from an interactive shell (the release preflight) would read real
+# keystrokes and block — under CI stdin is already not a TTY, so it would never
+# be caught there. Redirecting the whole script makes every coop subprocess see
+# a non-TTY stdin regardless of how the suite is invoked. The script itself
+# never reads stdin.
+exec </dev/null
+
 # ── Platform detection (matches install.sh / update::target_triple) ──────────
 
 detect_triple() {

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -61,6 +61,15 @@ if [[ -z "$BINARY" ]]; then
     exit 1
 fi
 
+# Detach from the controlling terminal's stdin. coop gates interactive prompts
+# (e.g. the discovered-devcontainer confirmation) on stdin being a TTY, falling
+# back to a non-TTY error that the suite asserts on. Under CI stdin is already
+# not a TTY, but when the suite runs from an interactive shell (the release
+# preflight) those prompts would read real keystrokes and block. Redirecting the
+# whole script makes every coop subprocess see a non-TTY stdin regardless of how
+# the suite is invoked. The script itself never reads stdin.
+exec </dev/null
+
 # ── Output helpers ────────────────────────────────────────────
 
 pass_count=0


### PR DESCRIPTION
Release v0.5.1.

Bumps `version` to `0.5.1` in `Cargo.toml`/`Cargo.lock`, promotes the
`## Unreleased` changelog section to `## v0.5.1`, and starts a fresh
`## Unreleased`. Also detaches the integration, update, and uninstall
test suites' stdin from the controlling terminal, which surfaced during
the release preflight.

Release content (`## v0.5.1`):

- **`coop ssh-config`** (#294) — installs a `coop-<name>` SSH alias without
  launching an editor; refreshed on `start`, removed on `destroy`/`--clean`.
- **`coop setup --builder-timeout <duration>`** (#315) — bounds how long setup
  waits for image-build commands.
- **Removed `scripts/build-rootfs.sh`** (#293) — image creation runs through
  `coop setup`.

After merge, tag the merge commit `v0.5.1` and push to trigger `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
