### PR TITLE
Add `coop commit` and `coop restore` commands (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### New features
+
+- **`coop commit` + `coop restore` — checkpoint and roll back an instance** (#289) —
+  `coop commit <name> --image <image>` saves a stopped instance's
+  filesystem as a reusable image, a `docker container commit`-style
+  backup (files, not live memory). The committed image is an ordinary
+  coop image: `coop images` lists it and `coop up --image` launches new
+  instances from it. `coop restore <name> --image <image>` rolls a
+  stopped instance back to an image's filesystem in place, keeping the
+  instance's name, index, IP, and workspace association. Both require a
+  stopped instance; `commit --force` overwrites an existing image name.
+
 ## v0.5.1
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 - **VS Code remote SSH**: `coop vscode` opens VS Code connected to the guest
 - **Multi-instance**: run multiple VMs side by side, each with its own name and disk
 - **Disk resize**: grow a stopped instance's disk with `coop resize --size +20`
+- **Commit and restore**: save a stopped instance's filesystem as a reusable image with `coop commit`, and roll an instance back to it in place with `coop restore` — a `docker container commit`-style checkpoint for risky agent runs
 - **Config optional**: works with sensible defaults; customize via `~/.coop/config.toml` when needed
 
 ## Commands
@@ -77,6 +78,8 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 | `ssh-config` | Install a `coop-<name>` SSH alias for ad-hoc ssh/scp/rsync |
 | `images` | List or delete template images |
 | `resize` | Grow a stopped instance's disk |
+| `commit` | Save a stopped instance's filesystem as a reusable image |
+| `restore` | Roll a stopped instance back to an image's filesystem in place |
 | `validate` | Check config and prerequisites |
 | `update` | Self-update coop to the latest GitHub release |
 | `uninstall` | Remove the coop binary and (optionally) its data directories |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -585,6 +585,53 @@ coop resize my-project --size 150G
 coop resize --size +20
 ```
 
+### `commit`
+
+Save a stopped instance's filesystem as a reusable image, like `docker container commit`. The committed image is an ordinary coop image: `coop images` lists it and `coop up --image <name>` launches new instances from it. The instance must be stopped first so the filesystem is consistent.
+
+```
+coop commit [NAME] --image <name> [FLAGS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `NAME` | Instance name (required if multiple instances exist) |
+| `--image <name>` | Name of the image to create (required) |
+| `--force` | Overwrite an existing image with the same name |
+
+```
+coop stop my-project
+coop commit my-project --image my-project-baseline
+coop up . --image my-project-baseline --name fork
+```
+
+### `restore`
+
+Roll a stopped instance back to an image's filesystem in place. The instance keeps its name, index, IP, and workspace association — only the disk is replaced and its recorded image is updated. Run `coop start` afterwards to bring it back up.
+
+This pairs with `commit` for a known-good checkpoint before a risky run:
+
+```
+coop stop my-project
+coop commit my-project --image safe-point   # checkpoint
+coop start my-project
+# ... a bypass-permissions agent run trashes the environment ...
+coop stop my-project
+coop restore my-project --image safe-point   # back to the checkpoint, same VM
+coop start my-project
+```
+
+```
+coop restore [NAME] --image <name>
+```
+
+| Flag | Description |
+|------|-------------|
+| `NAME` | Instance name (required if multiple instances exist) |
+| `--image <name>` | Name of the image to restore from (required) |
+
+Unlike `destroy` + `up --image`, `restore` keeps the same instance identity (name, index, IP) instead of allocating a new one. The disk is reset to the image's size, so restoring an image built before a `coop resize` returns the instance to the smaller size.
+
 ### `profiles`
 
 List or inspect available profiles. With no subcommand, lists every profile (builtin and custom).

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -154,6 +154,29 @@ Delete a named image:
 coop images --delete polyglot
 ```
 
+## Committing an instance to an image
+
+`coop commit` captures a stopped instance's filesystem as a new image, the inverse of the template-to-instance copy `coop up` performs. Like `docker container commit`, it saves files — not live memory.
+
+```bash
+coop stop my-project
+coop commit my-project --image my-project-baseline
+```
+
+The committed image is an ordinary coop image stored under `~/.coop/images/<name>/`: it carries over the source image's `template-config.json` (profiles, guest user, hashes) with a fresh creation timestamp, so `coop images` lists it and `coop up --image <name>` launches new instances from it. The instance must be stopped first for filesystem consistency. Committing onto an existing image name requires `--force`.
+
+`coop restore` rolls a stopped instance back to an image's filesystem in place:
+
+```bash
+coop commit my-project --image safe-point   # checkpoint
+# ... a risky run trashes the environment ...
+coop stop my-project
+coop restore my-project --image safe-point   # back to the checkpoint
+coop start my-project
+```
+
+Restore keeps the instance's name, index, IP, and workspace association — only the disk is replaced and the instance's recorded image is updated. That makes it the ergonomic choice over `destroy` + `up --image` for the destructive-undo loop, which would allocate a different instance.
+
 ## Template versioning and staleness
 
 coop records what went into each template in a `template-config.json` file alongside the image. This config contains:

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -768,6 +768,27 @@ pub trait VmBackend: std::fmt::Display {
         stopped: &StoppedInstance,
         new_size: crate::config::GiB,
     ) -> Result<()>;
+    /// Save a stopped instance's filesystem as image `image` (the
+    /// backend-specific disk artifacts only — the caller carries over
+    /// the shared `template-config.json`). Takes a [`StoppedInstance`]
+    /// proof so the "must be stopped" precondition (filesystem
+    /// consistency) is enforced by the type system. Overwriting an
+    /// existing image is the caller's decision, gated before this call.
+    fn commit_disk(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        image: &ImageName,
+    ) -> Result<()>;
+    /// Replace a stopped instance's disk with image `image`'s template,
+    /// leaving the instance otherwise intact. The dual of
+    /// [`Self::commit_disk`]; like it, gated on a [`StoppedInstance`].
+    fn restore_disk(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        image: &ImageName,
+    ) -> Result<()>;
     fn is_running(&self, inst: &Instance) -> bool;
     /// Probe the live state of `inst`, returning a `RunningInstance`
     /// when it is up. This is the single chokepoint for "is this VM
@@ -937,6 +958,24 @@ impl VmBackend for FirecrackerBackend {
         crate::setup::resize_rootfs(stopped.instance(), new_size)
     }
 
+    fn commit_disk(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        image: &ImageName,
+    ) -> Result<()> {
+        crate::setup::commit_instance_rootfs(cfg, stopped.instance(), image)
+    }
+
+    fn restore_disk(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        image: &ImageName,
+    ) -> Result<()> {
+        crate::setup::restore_instance_rootfs(cfg, stopped.instance(), image)
+    }
+
     fn is_running(&self, inst: &Instance) -> bool {
         inst.is_running()
     }
@@ -1083,6 +1122,24 @@ impl VmBackend for LimaBackend {
         new_size: crate::config::GiB,
     ) -> Result<()> {
         crate::lima::resize_disk(cfg, stopped.instance(), new_size)
+    }
+
+    fn commit_disk(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        image: &ImageName,
+    ) -> Result<()> {
+        crate::lima::commit_disk(cfg, stopped.instance(), image)
+    }
+
+    fn restore_disk(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        image: &ImageName,
+    ) -> Result<()> {
+        crate::lima::restore_disk(cfg, stopped.instance(), image)
     }
 
     fn is_running(&self, inst: &Instance) -> bool {

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1626,6 +1626,89 @@ pub(crate) fn cmd_resize(
     be.resize_disk(cfg, &stopped, new_size)
 }
 
+/// Save a stopped instance's filesystem as a reusable image.
+///
+/// The inverse of `coop up --image`: the committed image is an ordinary
+/// coop image (`coop images` lists it, `coop up --image` relaunches it).
+/// The instance must be stopped for filesystem consistency; overwriting
+/// an existing image name requires `force`.
+pub(crate) fn cmd_commit(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    name: Option<&config::InstanceName>,
+    image: &config::ImageName,
+    force: bool,
+) -> Result<()> {
+    let inst = cfg.resolve_instance(name)?;
+    let source_image = inst.image.clone();
+
+    // Refuse to clobber an existing image unless asked. Checked before
+    // gating on stopped state so a typo'd or already-taken name fails fast.
+    if be.image_is_built(cfg, image) && !force {
+        bail!("Image '{image}' already exists. Pass --force to overwrite it.");
+    }
+
+    let stopped = be.as_stopped(inst)?;
+
+    // Carry the source image's template config over to the new image with a
+    // fresh creation timestamp. This is the backend-agnostic half of the
+    // image (guest_user, profiles, hashes) that `coop up` reads back. Load it
+    // *before* writing any disk artifact so a missing or unreadable source
+    // config fails fast, leaving no half-written image behind.
+    let mut template_config =
+        setup::TemplateConfig::load_for(cfg, &source_image).with_context(|| {
+            format!("Failed to load template config for source image '{source_image}'")
+        })?;
+
+    be.commit_disk(cfg, &stopped, image)?;
+
+    template_config.created = setup::utc_timestamp();
+    template_config.save_for(cfg, image)?;
+
+    tracing::info!(
+        "Committed instance '{}' to image '{image}'. \
+         Relaunch with `coop up --image {image}`.",
+        stopped.instance().name,
+    );
+    Ok(())
+}
+
+/// Roll a stopped instance back to image `image`'s filesystem in place.
+///
+/// The instance keeps its name, index, IP, and workspace association —
+/// only the disk is replaced. Its recorded origin image is updated so the
+/// guest-user lookup and status lineage track the restored image. Run
+/// `coop start` afterwards to bring the instance back up.
+pub(crate) fn cmd_restore(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    name: Option<&config::InstanceName>,
+    image: &config::ImageName,
+) -> Result<()> {
+    let inst = cfg.resolve_instance(name)?;
+
+    if !be.image_is_built(cfg, image) {
+        bail!("No image '{image}' found. Run `coop images` to list available images.");
+    }
+
+    let stopped = be.as_stopped(inst)?;
+    be.restore_disk(cfg, &stopped, image)?;
+
+    // Persist the new lineage after the disk swap: if `restore_disk` fails,
+    // the recorded image still matches the (untouched) disk. The only
+    // residual window is a failed `instance.json` write after a successful
+    // swap, which re-running `restore` corrects.
+    let mut restored = stopped.instance().clone();
+    restored.set_image(image.clone())?;
+
+    tracing::info!(
+        "Restored instance '{name}' from image '{image}'. \
+         Run `coop start {name}` to bring it back up.",
+        name = restored.name,
+    );
+    Ok(())
+}
+
 fn current_disk_gib(be: &backend::PlatformBackend, inst: &config::Instance) -> Result<config::GiB> {
     let path = be.disk_path(inst)?;
     let bytes = std::fs::metadata(&path)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,9 +19,9 @@ pub(crate) use devcontainer::{
 pub(crate) use github::cmd_github;
 pub(crate) use lifecycle::{
     ProfileImageTarget, ProjectTransport, StartOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts,
-    apply_runtime_guest_env, apply_vm_overrides, cmd_destroy, cmd_exec, cmd_list, cmd_resize,
-    cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_up, open_ssh_session, preflight_start_target,
-    prepend_binary, resolve_running,
+    apply_runtime_guest_env, apply_vm_overrides, cmd_commit, cmd_destroy, cmd_exec, cmd_list,
+    cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_up, open_ssh_session,
+    preflight_start_target, prepend_binary, resolve_running,
 };
 pub(crate) use profiles::{cmd_images, cmd_profiles};
 pub(crate) use quickstart::{QuickstartOpts, cmd_quickstart};

--- a/src/config.rs
+++ b/src/config.rs
@@ -2200,6 +2200,16 @@ impl Instance {
         Ok(())
     }
 
+    /// Update the recorded origin image and persist `instance.json`.
+    ///
+    /// Used by `coop restore`: after the disk is replaced with image
+    /// `image`'s template, the instance's lineage (and the guest-user
+    /// lookup that keys off it) must track the restored image.
+    pub(crate) fn set_image(&mut self, image: ImageName) -> Result<()> {
+        self.image = image;
+        self.save()
+    }
+
     fn load(dir: &Path) -> Result<Self> {
         let meta_path = dir.join("instance.json");
         let content = fs::read_to_string(&meta_path)
@@ -2580,6 +2590,24 @@ mod tests {
         assert_eq!(loaded.index.as_u16(), 42);
         assert_eq!(loaded.dir, dir);
         assert_eq!(loaded.image.as_str(), DEFAULT_IMAGE);
+    }
+
+    #[test]
+    fn set_image_updates_field_and_persists() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("myinst");
+        let mut inst = test_inst("myinst", idx(7), dir.clone());
+        inst.save().unwrap();
+
+        let restored = ImageName::new("safe-point").unwrap();
+        inst.set_image(restored.clone()).unwrap();
+
+        // The in-memory instance reflects the new image …
+        assert_eq!(inst.image, restored);
+        // … and so does the persisted instance.json (so the guest-user
+        // lookup and `coop status` lineage survive a reload).
+        let loaded = Instance::load(&dir).unwrap();
+        assert_eq!(loaded.image.as_str(), "safe-point");
     }
 
     // ── Instance::is_running / is_firecracker_process ────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,9 @@ use backend::VmBackend as _;
 use commands::{
     DevcontainerInput, DevcontainerOpts, ProfileImageTarget, ProjectTransport, QuickstartOpts,
     StartOpts, UninstallOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts, apply_runtime_guest_env,
-    apply_vm_overrides, cmd_destroy, cmd_devcontainer, cmd_devcontainer_check, cmd_exec,
-    cmd_github, cmd_images, cmd_init, cmd_list, cmd_profiles, cmd_quickstart, cmd_resize,
-    cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_uninstall, cmd_up, cmd_validate,
+    apply_vm_overrides, cmd_commit, cmd_destroy, cmd_devcontainer, cmd_devcontainer_check,
+    cmd_exec, cmd_github, cmd_images, cmd_init, cmd_list, cmd_profiles, cmd_quickstart, cmd_resize,
+    cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_uninstall, cmd_up, cmd_validate,
     open_ssh_session, preflight_start_target, prepend_binary, resolve_devcontainer,
     resolve_running,
 };
@@ -510,6 +510,38 @@ enum Commands {
         /// New size: absolute GiB (e.g. 150, 150G) or relative (e.g. +20, +20G)
         #[arg(long, required = true, value_parser = config::DiskSize::parse)]
         size: config::DiskSize,
+    },
+    /// Save a stopped instance's filesystem as a reusable image
+    Commit {
+        /// Instance name (required if multiple instances exist)
+        #[arg(
+            value_parser = config::InstanceName::new,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
+        /// Name of the image to create
+        #[arg(long, required = true, value_parser = config::ImageName::new)]
+        image: config::ImageName,
+        /// Overwrite an existing image with the same name
+        #[arg(long)]
+        force: bool,
+    },
+    /// Roll a stopped instance back to an image's filesystem in place
+    Restore {
+        /// Instance name (required if multiple instances exist)
+        #[arg(
+            value_parser = config::InstanceName::new,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
+        /// Name of the image to restore from
+        #[arg(
+            long,
+            required = true,
+            value_parser = config::ImageName::new,
+            add = ArgValueCandidates::new(completions::image_candidates),
+        )]
+        image: config::ImageName,
     },
     /// List or inspect available profiles
     Profiles {
@@ -1098,6 +1130,10 @@ pub fn run() -> Result<()> {
         }
         Commands::Images { delete } => cmd_images(&be, &cfg, delete.as_ref()),
         Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_ref(), size),
+        Commands::Commit { name, image, force } => {
+            cmd_commit(&be, &cfg, name.as_ref(), &image, force)
+        }
+        Commands::Restore { name, image } => cmd_restore(&be, &cfg, name.as_ref(), &image),
         Commands::Profiles { action } => {
             cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
         }
@@ -1251,6 +1287,53 @@ mod tests {
             parse(&["ssh-config"]).command,
             super::Commands::SshConfig { .. }
         ));
+    }
+
+    #[test]
+    fn commit_parses_name_image_and_force() {
+        let cli = parse(&["commit", "myvm", "--image", "safe-point", "--force"]);
+        let super::Commands::Commit { name, image, force } = cli.command else {
+            panic!("expected Commit variant");
+        };
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
+        assert_eq!(image.as_str(), "safe-point");
+        assert!(force);
+    }
+
+    #[test]
+    fn commit_force_defaults_off_and_image_required() {
+        let cli = parse(&["commit", "--image", "snap"]);
+        let super::Commands::Commit { name, force, .. } = cli.command else {
+            panic!("expected Commit variant");
+        };
+        assert!(name.is_none());
+        assert!(!force);
+        // `--image` is mandatory.
+        assert!(
+            parse_err(&["commit", "myvm"]).kind()
+                == clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[test]
+    fn restore_parses_name_and_image() {
+        let cli = parse(&["restore", "myvm", "--image", "safe-point"]);
+        let super::Commands::Restore { name, image } = cli.command else {
+            panic!("expected Restore variant");
+        };
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
+        assert_eq!(image.as_str(), "safe-point");
+        // `--image` is mandatory; `restore` has no `--force`.
+        assert!(
+            parse_err(&["restore", "myvm"]).kind()
+                == clap::error::ErrorKind::MissingRequiredArgument
+        );
     }
 
     #[test]

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -322,6 +322,58 @@ pub fn resize_disk(_cfg: &CoopConfig, inst: &Instance, new_size: crate::config::
     Ok(())
 }
 
+/// Save a stopped instance's disk as image `image`'s base image.
+///
+/// The inverse of instance creation: copies the Lima instance disk to
+/// the image's `lima-base.img` and regenerates the fast-start template
+/// so it points at the new base. The caller has gated on the instance
+/// being stopped and decided whether overwriting is allowed.
+pub fn commit_disk(cfg: &CoopConfig, inst: &Instance, image: &ImageName) -> Result<()> {
+    let src = disk_path(inst)?;
+    if !src.exists() {
+        bail!(
+            "Lima disk not found at {}.\n\
+             Is instance '{}' created?",
+            src.display(),
+            inst.name,
+        );
+    }
+
+    let image_dir = cfg.image_dir(image);
+    fs::create_dir_all(&image_dir)
+        .with_context(|| format!("Failed to create image dir {}", image_dir.display()))?;
+
+    let base_img = cfg.lima_base_path(image);
+    tracing::info!("Committing instance '{}' to image '{image}'", inst.name);
+    fs::copy(&src, &base_img)
+        .with_context(|| format!("Failed to copy {} -> {}", src.display(), base_img.display()))?;
+
+    generate_start_template(cfg, image)
+}
+
+/// Replace a stopped instance's disk with image `image`'s base image.
+pub fn restore_disk(cfg: &CoopConfig, inst: &Instance, image: &ImageName) -> Result<()> {
+    let base_img = cfg.lima_base_path(image);
+    if !base_img.exists() {
+        bail!("No image '{image}' found at {}.", base_img.display());
+    }
+
+    let dst = disk_path(inst)?;
+    if !dst.exists() {
+        bail!(
+            "Lima disk not found at {}.\n\
+             Is instance '{}' created?",
+            dst.display(),
+            inst.name,
+        );
+    }
+
+    tracing::info!("Restoring instance '{}' from image '{image}'", inst.name);
+    fs::copy(&base_img, &dst)
+        .with_context(|| format!("Failed to copy {} -> {}", base_img.display(), dst.display()))?;
+    Ok(())
+}
+
 /// Path to the VM disk for a Lima instance.
 ///
 /// Lima v2.1.0 renamed `diffdisk` to `disk`. We try `disk` first

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -134,13 +134,7 @@ pub fn create_instance(
     }
 
     tracing::info!("Creating instance '{}' from template", inst.name);
-    Cmd::new("cp")
-        .arg("--reflink=auto")
-        .arg(&template)
-        .arg(&rootfs)
-        .sudo()
-        .run()
-        .context("Failed to copy template to instance")?;
+    reflink_copy(&template, &rootfs).context("Failed to copy template to instance")?;
 
     // Resize if requested and larger than template
     if let Some(requested) = disk_gib {
@@ -208,6 +202,69 @@ pub fn resize_rootfs(inst: &Instance, new_size: crate::config::GiB) -> Result<()
     Cmd::new("e2fsck").arg("-fy").arg(&rootfs).sudo().run()?;
     Cmd::new("resize2fs").arg(&rootfs).sudo().run()?;
     tracing::info!("Resize complete");
+    Ok(())
+}
+
+/// Reflink-friendly copy of a rootfs image (`CoW` where the filesystem
+/// supports it, full copy otherwise). Runs as root because instance and
+/// template rootfs files are root-owned on Firecracker.
+fn reflink_copy(src: &Path, dst: &Path) -> Result<()> {
+    Cmd::new("cp")
+        .arg("--reflink=auto")
+        .arg(src)
+        .arg(dst)
+        .sudo()
+        .run()
+        .with_context(|| format!("Failed to copy {} -> {}", src.display(), dst.display()))
+}
+
+/// Save a stopped instance's rootfs as image `image`'s template.
+///
+/// The inverse of [`create_instance`]: reflink-copies the instance
+/// `rootfs.ext4` to the image's `rootfs-template.ext4`. The caller has
+/// already gated on the instance being stopped (filesystem consistency)
+/// and decided whether overwriting an existing image is allowed.
+pub fn commit_instance_rootfs(cfg: &CoopConfig, inst: &Instance, image: &ImageName) -> Result<()> {
+    let rootfs = inst.rootfs_path();
+    if !rootfs.exists() {
+        bail!("Instance rootfs not found at {}", rootfs.display());
+    }
+
+    let image_dir = cfg.image_dir(image);
+    fs::create_dir_all(&image_dir)
+        .with_context(|| format!("Failed to create image dir {}", image_dir.display()))?;
+
+    let template = cfg.template_path_for(image);
+    // Remove an existing (root-owned) template so the copy is a clean
+    // overwrite rather than appending to or failing on the old file.
+    if template.exists() {
+        Cmd::new("rm").arg("-f").arg(&template).sudo().run()?;
+    }
+
+    tracing::info!("Committing instance '{}' to image '{image}'", inst.name);
+    reflink_copy(&rootfs, &template)
+}
+
+/// Replace a stopped instance's rootfs with image `image`'s template.
+///
+/// Mirrors [`create_instance`]'s copy + network-patch, but sources the
+/// rootfs from an arbitrary image rather than the instance's origin
+/// image. The network config is re-patched for this instance's IP,
+/// overwriting whatever address the template baked in at commit time.
+pub fn restore_instance_rootfs(cfg: &CoopConfig, inst: &Instance, image: &ImageName) -> Result<()> {
+    let template = cfg.template_path_for(image);
+    if !template.exists() {
+        bail!("No image '{image}' found at {}.", template.display(),);
+    }
+
+    let rootfs = inst.rootfs_path();
+    if rootfs.exists() {
+        Cmd::new("rm").arg("-f").arg(&rootfs).sudo().run()?;
+    }
+
+    tracing::info!("Restoring instance '{}' from image '{image}'", inst.name);
+    reflink_copy(&template, &rootfs)?;
+    patch_guest_network(inst)?;
     Ok(())
 }
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1519,6 +1519,125 @@ test_resize_status() {
     fi
 }
 
+test_commit_restore() {
+    echo ""
+    echo "=== Phase: commit + restore ==="
+
+    # The instance is stopped from earlier phases. commit/restore both
+    # require a stopped instance for filesystem consistency.
+    local snap="snap-$$"
+
+    # Commit the stopped instance's filesystem as a new image.
+    if coop commit "$INSTANCE" --image "$snap"; then
+        pass "commit exits 0"
+    else
+        fail "commit exits 0" "exit code: $?; stderr: $HARNESS_ERR"
+        return
+    fi
+
+    # The committed image is an ordinary image — `coop images` lists it.
+    if coop images && echo "$HARNESS_OUT" | grep -q "$snap"; then
+        pass "images lists committed image '$snap'"
+    else
+        fail "images lists committed image '$snap'" "output: $HARNESS_OUT"
+    fi
+
+    # Committing onto an existing name without --force is refused.
+    if moat_fails commit "$INSTANCE" --image "$snap"; then
+        pass "commit without --force refuses to overwrite"
+        if echo "$HARNESS_ERR" | grep -qi "already exists\|--force"; then
+            pass "overwrite error suggests --force"
+        else
+            fail "overwrite error suggests --force" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "commit without --force refuses to overwrite" "should have failed"
+    fi
+
+    # --force overwrites the existing image.
+    if coop commit "$INSTANCE" --image "$snap" --force; then
+        pass "commit --force overwrites existing image"
+    else
+        fail "commit --force overwrites existing image" "exit code: $?; stderr: $HARNESS_ERR"
+    fi
+
+    # Restore rolls the instance back to the committed image in place.
+    if coop restore "$INSTANCE" --image "$snap"; then
+        pass "restore exits 0"
+    else
+        fail "restore exits 0" "exit code: $?; stderr: $HARNESS_ERR"
+    fi
+
+    # Status lineage now tracks the restored image.
+    if coop status "$INSTANCE" 2>/dev/null && echo "$HARNESS_OUT" | grep -q "$snap"; then
+        pass "status shows restored image '$snap'"
+    else
+        fail "status shows restored image '$snap'" "output: $HARNESS_OUT"
+    fi
+
+    # Restoring a non-existent image fails with a clear message.
+    if moat_fails restore "$INSTANCE" --image "no-such-image-$$"; then
+        pass "restore rejects unknown image"
+    else
+        fail "restore rejects unknown image" "should have failed"
+    fi
+
+    # The central claim: a committed image is a usable image. Boot the
+    # instance from the just-restored committed disk and confirm the guest
+    # is reachable — this exercises the re-patched guest network and proves
+    # the committed rootfs actually boots, not merely that it's listed.
+    if coop start "$INSTANCE" --no-agents >/dev/null 2>&1; then
+        if coop status "$INSTANCE" && echo "$HARNESS_OUT" | grep -qi "running"; then
+            pass "instance boots from restored committed image"
+        else
+            fail "instance boots from restored committed image" "status: $HARNESS_OUT"
+        fi
+
+        GUEST_INSTANCE="$INSTANCE"
+        local snap_hostname
+        snap_hostname=$(guest_exec hostname) || snap_hostname=""
+        unset GUEST_INSTANCE
+        if [[ -n "$snap_hostname" ]]; then
+            pass "guest reachable after restore from committed image"
+        else
+            fail "guest reachable after restore from committed image" "no response"
+        fi
+
+        # commit/restore on a running instance must be refused.
+        if moat_fails commit "$INSTANCE" --image "$snap-live"; then
+            pass "commit refuses a running instance"
+            if echo "$HARNESS_ERR" | grep -qi "running\|stop"; then
+                pass "commit error tells the user to stop first"
+            else
+                fail "commit error tells the user to stop first" "stderr: $HARNESS_ERR"
+            fi
+        else
+            fail "commit refuses a running instance" "should have failed"
+            coop images --delete "$snap-live" 2>/dev/null || true
+        fi
+
+        coop stop "$INSTANCE" >/dev/null 2>&1 || true
+    else
+        skip "instance boots from restored committed image" "could not start instance"
+    fi
+
+    # Roll lineage back to the default image before deleting the snapshot,
+    # so the instance isn't left pointing at a deleted image for the
+    # restart/destroy phases that follow.
+    if coop restore "$INSTANCE" --image default; then
+        pass "restore back to default image exits 0"
+    else
+        fail "restore back to default image exits 0" "exit code: $?; stderr: $HARNESS_ERR"
+    fi
+
+    # Clean up the committed image.
+    if coop images --delete "$snap"; then
+        pass "delete committed image exits 0"
+    else
+        fail "delete committed image exits 0" "exit code: $?"
+    fi
+}
+
 test_restart_stopped() {
     echo ""
     echo "=== Phase: restart stopped instance ==="
@@ -4070,6 +4189,7 @@ main() {
     test_status_stopped
     test_list_stopped
     test_resize_status
+    test_commit_restore
     test_restart_stopped
     test_restart_rejects_ignored_flags
     test_destroy


### PR DESCRIPTION
Closes #289.

Adds two commands for checkpointing and rolling back an instance's filesystem, in the `docker container commit` model (files, not live memory).

## `coop commit <instance> --image <name>`

Saves a **stopped** instance's filesystem as a reusable image — the inverse of `coop up --image`. The committed image is an ordinary coop image: it carries over the source image's `template-config.json` (guest user, profiles, hashes) with a fresh `created` timestamp, so `coop images` lists it and `coop up --image <name>` launches new instances from it. `--force` overwrites an existing image name.

- **Firecracker:** reflink-copies the instance `rootfs.ext4` → `images/<name>/rootfs-template.ext4`.
- **Lima:** copies the instance qcow2 → `lima-base.img` and regenerates `lima-template.yaml`.

## `coop restore <instance> --image <name>`

Rolls a stopped instance back to an image's filesystem in place. The instance keeps its name, index, IP, and workspace association; only the disk is replaced and the instance's recorded origin image is updated (so the guest-user lookup and `coop status` lineage track the restored image). Run `coop start` afterwards. Unlike `destroy` + `up --image`, the same instance identity is preserved.

```
coop stop my-project
coop commit my-project --image safe-point
coop start my-project
# ... a risky bypass-permissions run trashes the environment ...
coop stop my-project
coop restore my-project --image safe-point
coop start my-project
```

## Implementation

- New `commit_disk` / `restore_disk` methods on the `VmBackend` trait, gated on the `StoppedInstance` proof (same pattern as `resize_disk`). Firecracker re-patches the guest network for the target instance's IP after the copy, overwriting whatever IP the template baked in at commit time.
- Backend-agnostic logic — the image-exists/`--force` guard, the source-config carry-over, and the `Instance::set_image` lineage update — lives in `cmd_commit` / `cmd_restore`. The source template-config is loaded before any disk artifact is written, so a missing source config fails fast with no half-written image.

## Tests

- Unit tests: clap parsing for both commands (`--image` required, `--force` default-off, `restore` has no `--force`); `Instance::set_image` field update + persistence round-trip.
- Integration phase `test_commit_restore`: commit → `images` lists it → overwrite-without-`--force` refused → `--force` overwrite → restore → status lineage → unknown-image rejected → **boots the instance from the restored committed disk and confirms the guest is reachable** (proves the committed image is usable, exercising the re-patched network) → commit-while-running refused → roll lineage back to `default` and delete the snapshot.

The full integration suite still needs to be run on both platforms (KVM-capable Linux for Firecracker, macOS for Lima) per CLAUDE.md — this host has no `/dev/kvm`, so only the unit/clippy/fmt gates ran here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)