### PR TITLE
Document signing in with /login when coop ca runs before sign-in

### DIFF
--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -32,6 +32,8 @@ coop ca
 
 This runs `claude agents` in the guest, which opens the agent view — an interactive TUI for monitoring background agent sessions. Background sessions are managed by Claude Code (not by coop), so closing the TUI and reconnecting later with `coop ca` keeps you in sync with whatever is still running.
 
+The agent view has no sign-in flow of its own. If you haven't signed Claude in yet with `coop claude` (and aren't forwarding an `ANTHROPIC_API_KEY`), run `/login` at the start of your `coop ca` session to authenticate before using the agent view.
+
 If the remote TUI appears stuck or stops responding, use OpenSSH's local escape: type Enter, then `~.` to disconnect. coop forces the interactive SSH escape character to `~`, so the escape path is available even if your user SSH config changes or disables `EscapeChar`. If your terminal remains in raw/no-echo mode after the disconnect, run:
 
 ```bash

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -32,7 +32,7 @@ coop ca
 
 This runs `claude agents` in the guest, which opens the agent view — an interactive TUI for monitoring background agent sessions. Background sessions are managed by Claude Code (not by coop), so closing the TUI and reconnecting later with `coop ca` keeps you in sync with whatever is still running.
 
-The agent view has no sign-in flow of its own. If you haven't signed Claude in yet with `coop claude` (and aren't forwarding an `ANTHROPIC_API_KEY`), run `/login` at the start of your `coop ca` session to authenticate before using the agent view.
+The agent view itself has no sign-in prompt, but it forwards a `/login` command to a new Claude Code session. If you haven't signed Claude in with `coop claude` (and aren't forwarding an `ANTHROPIC_API_KEY`), run `/login` at the start of your `coop ca` session to start the sign-in flow.
 
 If the remote TUI appears stuck or stops responding, use OpenSSH's local escape: type Enter, then `~.` to disconnect. coop forces the interactive SSH escape character to `~`, so the escape path is available even if your user SSH config changes or disables `EscapeChar`. If your terminal remains in raw/no-echo mode after the disconnect, run:
 


### PR DESCRIPTION
## What

`coop ca` (the Claude Code agent view, alias for `coop claude-agents`) has no sign-in flow of its own. Running it before `coop claude` drops the user into an unconfigured Claude Code TUI.

This documents the workaround: the agent view is a Claude Code TUI, so users who haven't signed in with `coop claude` (and aren't forwarding an `ANTHROPIC_API_KEY`) can run `/login` at the start of their `coop ca` session to authenticate.

## Changes

- `docs/claude-integration.md` — note recommending `/login` at the start of a `coop ca` session when Claude isn't already signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)