### PR TITLE
Add local-model support via `coop model`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -66,6 +66,18 @@
 # # Header values also accept the "cmd:" prefix:
 # # headers = { Authorization = "cmd:op read op://Private/Sentry/token" }
 
+# [claude.local_model]              # Route Claude Code at a host-side model.
+#                                   # Enable per VM with `coop model <vm> local`
+#                                   # (disable with `coop model <vm> remote`).
+#                                   # host_url is as seen on the *host*; a
+#                                   # localhost host is rewritten to the guest's
+#                                   # view of the host automatically.
+# host_url = "http://localhost:11434"  # Must serve the Anthropic Messages API
+#                                      # (vLLM / LM Studio native; Ollama needs a
+#                                      # proxy). Prompt caching is lost locally.
+# model = "qwen2.5-coder:32b"
+# auth_token = "sk-..."             # Optional; permissive servers ignore it.
+
 # [codex]
 # config_dir = "~/.codex"  # path to copy AGENTS.md, prompts/, config.toml, auth.json from (false to disable)
 # env_forward = ["CUSTOM_TOKEN"]  # Extra env vars to forward to guest
@@ -78,6 +90,15 @@
 # command = "npx"
 # args = ["-y", "@openai/some-mcp-server"]
 # env = { API_KEY = "MY_HOST_ENV_VAR" }
+
+# [codex.local_model]               # Route Codex at a host-side model.
+#                                   # Toggled per VM with `coop model <vm>
+#                                   # local|remote`, same as claude.local_model.
+# host_url = "http://localhost:11434/v1/"  # Must serve the Responses API
+#                                          # (Ollama / vLLM / LM Studio; ~64K
+#                                          # context floor).
+# model = "gpt-oss:120b"
+# auth_token = "sk-..."             # Optional; permissive servers ignore it.
 
 # [profiles.my-tools]
 # apt_packages = ["ripgrep", "fd-find", "jq"]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 #[cfg(target_os = "macos")]
 use std::fs;
 use std::num::NonZeroU16;
@@ -11,8 +12,10 @@ use toml::Value as TomlValue;
 
 use crate::cmd::Cmd;
 use crate::config::{
-    ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, McpServerDef, Validated,
+    ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, LocalModel, McpServerDef,
+    NetworkConfig, Validated,
 };
+use crate::model_state::ModelState;
 use crate::paths::{GuestPath, HostPath};
 use crate::remote_command::RemoteCommand;
 use crate::setup::SetupOptions;
@@ -823,6 +826,12 @@ pub trait VmBackend: std::fmt::Display {
     -> Result<()>;
     fn ssh_target(&self, cfg: &CoopConfig, inst: &Instance) -> Result<SshTarget>;
     fn disk_path(&self, inst: &Instance) -> Result<PathBuf>;
+    /// The address the guest uses to reach a server running on the host,
+    /// for rewriting local-model endpoints (see
+    /// [`crate::network::rewrite_host_url`]). Firecracker guests route
+    /// through the TAP gateway (`network.host_ip`); Lima injects
+    /// `host.lima.internal`.
+    fn guest_host_address(&self, network: &NetworkConfig) -> String;
     /// Whether mounts use live filesystem sharing (Lima/virtiofs)
     /// vs one-time sync (Firecracker/rsync).
     fn mounts_are_live(&self) -> bool;
@@ -1029,6 +1038,11 @@ impl VmBackend for FirecrackerBackend {
         Ok(inst.rootfs_path())
     }
 
+    fn guest_host_address(&self, network: &NetworkConfig) -> String {
+        // The guest's default gateway is the bridge's host IP.
+        network.host_ip.to_string()
+    }
+
     fn mounts_are_live(&self) -> bool {
         false
     }
@@ -1187,6 +1201,11 @@ impl VmBackend for LimaBackend {
         crate::lima::disk_path(inst)
     }
 
+    fn guest_host_address(&self, _network: &NetworkConfig) -> String {
+        // Lima injects this hostname into the guest, resolving to the host.
+        crate::lima::HOST_GATEWAY.to_string()
+    }
+
     fn mounts_are_live(&self) -> bool {
         true
     }
@@ -1323,11 +1342,16 @@ pub fn run_post_start(session: &SshSession, command: &str) {
 }
 
 /// Bootstrap configured guest agents in the guest declaratively.
+///
+/// `guest_host` is the backend's guest-visible host address (from
+/// [`VmBackend::guest_host_address`]), used to rewrite any local-model
+/// endpoint so the guest can reach a server running on the host.
 pub fn bootstrap_agents(
     session: &SshSession,
     cfg: &CoopConfig,
     inst: &crate::config::Instance,
     mode: BootMode,
+    guest_host: &str,
 ) -> Result<()> {
     // GitHub auth is guest-global state. Refresh it once before either
     // agent bootstrap if a token is available.
@@ -1336,8 +1360,8 @@ pub fn bootstrap_agents(
         setup_github_auth(session)?;
     }
 
-    bootstrap_claude(session, cfg, inst, mode)?;
-    bootstrap_codex(session, cfg, mode)?;
+    bootstrap_claude(session, cfg, inst, mode, guest_host)?;
+    bootstrap_codex(session, cfg, inst, mode, guest_host)?;
 
     Ok(())
 }
@@ -1360,6 +1384,7 @@ fn bootstrap_claude(
     cfg: &CoopConfig,
     inst: &crate::config::Instance,
     mode: BootMode,
+    guest_host: &str,
 ) -> Result<()> {
     let claude = &cfg.claude;
     let claude_bin = persisted_guest_user(cfg, &inst.image).claude_bin();
@@ -1388,7 +1413,12 @@ fn bootstrap_claude(
 
     // Managed permissions: pre-accept bypass mode so `coop ca` and
     // `coop claude` skip prompts without an interactive acceptance step.
-    write_managed_claude_settings(&session.target)?;
+    // The same file carries the local-model `env` block when this VM is
+    // in local mode, so the routing is refreshed on every boot and
+    // survives stop/start.
+    let model_state = ModelState::load_or_default(inst)?;
+    let local_env = claude_local_env(&model_state, cfg, guest_host)?;
+    write_managed_claude_settings(&session.target, &local_env)?;
 
     // Marketplaces, plugins, MCP servers — persisted on guest disk,
     // only install on first boot
@@ -1419,10 +1449,27 @@ fn bootstrap_claude(
 /// Codex uses `~/.codex/config.toml` for MCP registration and related
 /// settings, so bootstrap writes allowlisted user config files and a
 /// managed MCP section there when configured.
-fn bootstrap_codex(session: &SshSession, cfg: &CoopConfig, mode: BootMode) -> Result<()> {
+fn bootstrap_codex(
+    session: &SshSession,
+    cfg: &CoopConfig,
+    inst: &crate::config::Instance,
+    mode: BootMode,
+    guest_host: &str,
+) -> Result<()> {
     let codex = &cfg.codex;
     let source_dir = resolve_config_source_dir(&codex.config_dir, ".codex", "codex.config_dir");
-    let needs_codex = codex_bootstrap_needed(source_dir.as_deref(), &codex.mcp_servers);
+    let model_state = ModelState::load_or_default(inst)?;
+    let local = codex_local_table(&model_state, cfg, guest_host)?;
+    // Once coop has materialized a Codex local block (endpoint resolves,
+    // or it was materialized on a prior `local` switch), coop owns the
+    // model/provider keys in config.toml regardless of mode: it writes the
+    // provider block in local mode and rewrites a clean file in remote
+    // mode, so switching back to cloud reliably drops the block — even if
+    // the configured endpoint has since been removed.
+    let manages_local =
+        model_state.resolved_codex(codex).is_some() || model_state.codex_materialized;
+    let needs_codex =
+        codex_bootstrap_needed(source_dir.as_deref(), &codex.mcp_servers) || manages_local;
 
     if !needs_codex {
         return Ok(());
@@ -1436,7 +1483,13 @@ fn bootstrap_codex(session: &SshSession, cfg: &CoopConfig, mode: BootMode) -> Re
         bail!("{}", codex_missing_guest_cli_message());
     }
 
-    copy_codex_config(&session.target, source_dir.as_deref(), codex)?;
+    copy_codex_config(
+        &session.target,
+        source_dir.as_deref(),
+        codex,
+        local.as_ref(),
+        manages_local,
+    )?;
 
     match mode {
         BootMode::Restart => tracing::info!("Codex bootstrap refreshed"),
@@ -1648,14 +1701,24 @@ fn copy_staged_to_guest(
 /// The setting must live in user scope (`~/.claude/settings.json`) — Claude
 /// Code ignores `skipDangerousModePermissionPrompt` from project settings
 /// to prevent untrusted repositories from auto-bypassing the prompt.
-fn managed_claude_settings_json() -> String {
-    serde_json::json!({
+///
+/// When `local_env` is non-empty (the VM is in local-model mode), its
+/// entries are written into the `env` block so Claude Code routes at the
+/// local endpoint. Writing them here — rather than via SSH `SendEnv` —
+/// makes the routing launch-independent: it applies to `claude` however
+/// it is started in the guest, including a shell the user opened
+/// themselves.
+fn managed_claude_settings_json(local_env: &BTreeMap<String, String>) -> String {
+    let mut settings = serde_json::json!({
         "permissions": {
             "defaultMode": "bypassPermissions",
             "skipDangerousModePermissionPrompt": true,
         }
-    })
-    .to_string()
+    });
+    if !local_env.is_empty() {
+        settings["env"] = serde_json::json!(local_env);
+    }
+    settings.to_string()
 }
 
 /// Write coop's managed `~/.claude/settings.json` to the guest.
@@ -1663,24 +1726,79 @@ fn managed_claude_settings_json() -> String {
 /// Runs every VM startup, overwriting any in-guest edits. The file
 /// is small and owned by coop; users wanting per-VM customization should
 /// extend coop's config rather than editing the guest file in place.
-fn write_managed_claude_settings(target: &SshTarget) -> Result<()> {
+fn write_managed_claude_settings(
+    target: &SshTarget,
+    local_env: &BTreeMap<String, String>,
+) -> Result<()> {
     target.exec(RemoteCommand::new().literal("mkdir -p ~/.claude"))?;
     target
         .exec_with_stdin(
             RemoteCommand::new().literal("cat > ~/.claude/settings.json"),
-            managed_claude_settings_json().into_bytes(),
+            managed_claude_settings_json(local_env).into_bytes(),
         )
         .context("Failed to write managed ~/.claude/settings.json in guest")?;
     tracing::debug!("Wrote managed ~/.claude/settings.json to guest");
     Ok(())
 }
 
+/// The `env` block for a Claude local endpoint, with its host URL
+/// rewritten to be reachable from inside the guest. Empty when the VM is
+/// not in local mode or no Claude endpoint resolves.
+fn claude_local_env(
+    state: &ModelState,
+    cfg: &CoopConfig,
+    guest_host: &str,
+) -> Result<BTreeMap<String, String>> {
+    let Some(ep) = local_endpoint(state, state.resolved_claude(&cfg.claude)) else {
+        return Ok(BTreeMap::new());
+    };
+    let base_url = crate::network::rewrite_host_url(ep.host_url(), guest_host)?;
+    Ok(crate::model_state::claude_env_block(
+        base_url.as_str(),
+        ep.model(),
+        &ep.auth_token_or_default(),
+    ))
+}
+
+/// The Codex `config.toml` local-provider keys, with the endpoint's host
+/// URL rewritten for the guest. `None` when not in local mode or no Codex
+/// endpoint resolves.
+fn codex_local_table(
+    state: &ModelState,
+    cfg: &CoopConfig,
+    guest_host: &str,
+) -> Result<Option<toml::Table>> {
+    let Some(ep) = local_endpoint(state, state.resolved_codex(&cfg.codex)) else {
+        return Ok(None);
+    };
+    let base_url = crate::network::rewrite_host_url(ep.host_url(), guest_host)?;
+    Ok(Some(crate::model_state::codex_local_config(
+        base_url.as_str(),
+        ep.model(),
+    )))
+}
+
+/// Gate an already-resolved endpoint on the VM being in local mode. In
+/// remote mode the materialization is intentionally empty so cloud
+/// defaults apply.
+fn local_endpoint<'a>(
+    state: &ModelState,
+    resolved: Option<&'a LocalModel>,
+) -> Option<&'a LocalModel> {
+    match state.mode {
+        crate::model_state::ModelMode::Local => resolved,
+        crate::model_state::ModelMode::Remote => None,
+    }
+}
+
 fn copy_codex_config(
     target: &SshTarget,
     source_dir: Option<&Path>,
     codex: &crate::config::CodexConfig,
+    local: Option<&toml::Table>,
+    manages_local: bool,
 ) -> Result<()> {
-    let staged = stage_codex_files(source_dir, &codex.mcp_servers)
+    let staged = stage_codex_files(source_dir, &codex.mcp_servers, local, manages_local)
         .context("Failed to stage Codex config files")?;
     copy_staged_to_guest(target, &staged, ".codex", "Codex")
 }
@@ -1776,6 +1894,8 @@ const CODEX_CONFIG_FILE: &str = "config.toml";
 fn stage_codex_files(
     source_dir: Option<&Path>,
     mcp_servers: &std::collections::HashMap<String, McpServerDef>,
+    local: Option<&toml::Table>,
+    manages_local: bool,
 ) -> Result<tempfile::TempDir> {
     let staging = tempfile::TempDir::new().context("Failed to create staging directory")?;
 
@@ -1819,8 +1939,24 @@ fn stage_codex_files(
         );
     }
 
+    if let Some(local) = local {
+        let TomlValue::Table(root) = &mut config else {
+            bail!("Codex {CODEX_CONFIG_FILE} must deserialize to a TOML table");
+        };
+        // Local-model routing overrides any model/provider the user's own
+        // config.toml set; switching back to remote drops these keys
+        // because the file is rebuilt from source each time.
+        for (key, value) in local {
+            root.insert(key.clone(), value.clone());
+        }
+    }
+
+    // `manages_local` forces a rewrite even with no other content so that
+    // switching back to remote drops a previously-written provider block.
     let should_write_config = source_dir.is_some_and(|path| path.join(CODEX_CONFIG_FILE).is_file())
-        || !mcp_servers.is_empty();
+        || !mcp_servers.is_empty()
+        || local.is_some()
+        || manages_local;
 
     if should_write_config {
         std::fs::write(
@@ -2394,7 +2530,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
 
     #[test]
     fn managed_claude_settings_json_has_required_keys() {
-        let body = managed_claude_settings_json();
+        let body = managed_claude_settings_json(&BTreeMap::new());
         let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
         let perms = parsed.get("permissions").unwrap();
         assert_eq!(
@@ -2407,6 +2543,42 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
                 .and_then(serde_json::Value::as_bool),
             Some(true),
         );
+    }
+
+    #[test]
+    fn managed_claude_settings_json_omits_env_block_when_remote() {
+        let body = managed_claude_settings_json(&BTreeMap::new());
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(
+            parsed.get("env").is_none(),
+            "no env block expected in remote mode"
+        );
+    }
+
+    #[test]
+    fn managed_claude_settings_json_includes_local_env_block() {
+        let env = crate::model_state::claude_env_block(
+            "http://172.16.0.1:11434",
+            "qwen2.5-coder",
+            "coop-local",
+        );
+        let body = managed_claude_settings_json(&env);
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let env_block = parsed.get("env").unwrap();
+        assert_eq!(
+            env_block
+                .get("ANTHROPIC_BASE_URL")
+                .and_then(serde_json::Value::as_str),
+            Some("http://172.16.0.1:11434"),
+        );
+        assert_eq!(
+            env_block
+                .get("ANTHROPIC_MODEL")
+                .and_then(serde_json::Value::as_str),
+            Some("qwen2.5-coder"),
+        );
+        // Permissions survive alongside the injected env.
+        assert!(parsed.get("permissions").is_some());
     }
 
     #[test]
@@ -2424,7 +2596,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             },
         );
 
-        let staging = stage_codex_files(Some(src.path()), &servers).unwrap();
+        let staging = stage_codex_files(Some(src.path()), &servers, None, false).unwrap();
         assert!(staging.path().join("AGENTS.md").is_file());
 
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -2454,7 +2626,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             },
         );
 
-        let staging = stage_codex_files(Some(src.path()), &servers).unwrap();
+        let staging = stage_codex_files(Some(src.path()), &servers, None, false).unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
 
         assert!(config.contains("model = \"gpt-5\""));
@@ -2470,11 +2642,66 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         let src = tempfile::TempDir::new().unwrap();
         std::fs::write(src.path().join("auth.json"), "{\"access_token\":\"test\"}").unwrap();
 
-        let staging =
-            stage_codex_files(Some(src.path()), &std::collections::HashMap::new()).unwrap();
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &std::collections::HashMap::new(),
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             std::fs::read_to_string(staging.path().join("auth.json")).unwrap(),
             "{\"access_token\":\"test\"}"
+        );
+    }
+
+    #[test]
+    fn stage_codex_files_writes_local_provider_block() {
+        // No source dir, no MCP servers: the local provider block alone
+        // must still produce a config.toml.
+        let local = crate::model_state::codex_local_config(
+            "http://host.lima.internal:11434/v1/",
+            "gpt-oss:120b",
+        );
+        let staging =
+            stage_codex_files(None, &std::collections::HashMap::new(), Some(&local), true).unwrap();
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert!(config.contains("model_provider = \"coop_local\""));
+        assert!(config.contains("wire_api = \"responses\""));
+        assert!(config.contains("http://host.lima.internal:11434/v1/"));
+    }
+
+    #[test]
+    fn stage_codex_files_local_overrides_source_model() {
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(src.path().join("config.toml"), "model = \"gpt-5\"\n").unwrap();
+        let local =
+            crate::model_state::codex_local_config("http://172.16.0.1:11434/v1/", "qwen-local");
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &std::collections::HashMap::new(),
+            Some(&local),
+            true,
+        )
+        .unwrap();
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert!(config.contains("model = \"qwen-local\""));
+        assert!(
+            !config.contains("gpt-5"),
+            "local model must override source"
+        );
+    }
+
+    #[test]
+    fn stage_codex_files_remote_revert_drops_provider() {
+        // Switching back to remote: no local table, but `manages_local`
+        // forces a clean rewrite that omits the provider block.
+        let staging =
+            stage_codex_files(None, &std::collections::HashMap::new(), None, true).unwrap();
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert!(
+            !config.contains("coop_local"),
+            "remote revert must drop the local provider; got: {config}"
         );
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1723,9 +1723,15 @@ fn managed_claude_settings_json(local_env: &BTreeMap<String, String>) -> String 
 
 /// Write coop's managed `~/.claude/settings.json` to the guest.
 ///
-/// Runs every VM startup, overwriting any in-guest edits. The file
-/// is small and owned by coop; users wanting per-VM customization should
-/// extend coop's config rather than editing the guest file in place.
+/// Runs every VM startup and on `coop model` switches, overwriting any
+/// in-guest edits. The file is small and owned by coop; users wanting
+/// per-VM customization should extend coop's config rather than editing
+/// the guest file in place.
+///
+/// The write is staged to a temp file and renamed into place so a
+/// `claude`/`coop ca` session reading the file concurrently (during a
+/// live `coop model` switch) never observes a truncated file. The rename
+/// is atomic because the temp file is in the same directory.
 fn write_managed_claude_settings(
     target: &SshTarget,
     local_env: &BTreeMap<String, String>,
@@ -1733,7 +1739,10 @@ fn write_managed_claude_settings(
     target.exec(RemoteCommand::new().literal("mkdir -p ~/.claude"))?;
     target
         .exec_with_stdin(
-            RemoteCommand::new().literal("cat > ~/.claude/settings.json"),
+            RemoteCommand::new().literal(
+                "t=\"$(mktemp ~/.claude/settings.json.XXXXXX)\" && \
+                 cat > \"$t\" && mv \"$t\" ~/.claude/settings.json",
+            ),
             managed_claude_settings_json(local_env).into_bytes(),
         )
         .context("Failed to write managed ~/.claude/settings.json in guest")?;

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -9,8 +9,8 @@ use super::{DevcontainerInput, DevcontainerOpts, resolve_devcontainer};
 use super::{merge_runtime_guest_env, purge_all_data};
 use crate::backend::VmBackend as _;
 use crate::{
-    backend, config, devcontainer, github_repo, guest, guest_env_state, pat_prompt, port_forward,
-    setup, signal, ssh, workspace,
+    backend, config, devcontainer, github_repo, guest, guest_env_state, model_state, pat_prompt,
+    port_forward, setup, signal, ssh, workspace,
 };
 
 pub(crate) struct UpOpts<'a> {
@@ -1115,20 +1115,15 @@ fn restart_instance(
     }
     .save(inst)?;
 
-    let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
-    if opts.no_agents && post_start.is_none() {
-        tracing::info!("Skipping guest agent bootstrap (--no-agents)");
-    } else {
-        let session = prepare_session_from_target(cfg, None, target.clone(), repo.as_ref())?;
-        if opts.no_agents {
-            tracing::info!("Skipping guest agent bootstrap (--no-agents)");
-        } else {
-            backend::bootstrap_agents(&session, cfg, inst, backend::BootMode::Restart)?;
-        }
-        if let Some(cmd) = post_start {
-            backend::run_post_start(&session, cmd);
-        }
-    }
+    bootstrap_and_post_start(
+        be,
+        cfg,
+        inst,
+        &target,
+        repo.as_ref(),
+        opts,
+        backend::BootMode::Restart,
+    )?;
 
     tracing::info!(
         "Instance '{}' restarted — SSH: {}:{}",
@@ -1222,20 +1217,15 @@ fn start_instance(
         .save(inst)?;
     }
 
-    let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
-    if opts.no_agents && post_start.is_none() {
-        tracing::info!("Skipping guest agent bootstrap (--no-agents)");
-    } else {
-        let session = prepare_session_from_target(cfg, None, target.clone(), repo.as_ref())?;
-        if opts.no_agents {
-            tracing::info!("Skipping guest agent bootstrap (--no-agents)");
-        } else {
-            backend::bootstrap_agents(&session, cfg, inst, backend::BootMode::FirstBoot)?;
-        }
-        if let Some(cmd) = post_start {
-            backend::run_post_start(&session, cmd);
-        }
-    }
+    bootstrap_and_post_start(
+        be,
+        cfg,
+        inst,
+        &target,
+        repo.as_ref(),
+        opts,
+        backend::BootMode::FirstBoot,
+    )?;
 
     signal::check_shutdown()?;
 
@@ -1487,18 +1477,57 @@ pub(crate) fn open_ssh_session(
 /// is already authoritative for that one process; restart and every
 /// post-start command pass `Some` because the on-disk snapshot is
 /// the only place the original `--env` set still lives.
-fn prepare_session_from_target(
+/// Open a session and run the post-boot agent bootstrap plus any
+/// `postStartCommand`, honoring `--no-agents`. Shared by fresh start and
+/// restart, which differ only in the [`backend::BootMode`].
+fn bootstrap_and_post_start(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    inst: &config::Instance,
+    target: &backend::SshTarget,
+    repo: Option<&github_repo::RepoSlug>,
+    opts: &StartOpts<'_>,
+    mode: backend::BootMode,
+) -> Result<()> {
+    let post_start = opts.post_start_override.or(cfg.post_start.as_deref());
+    if opts.no_agents && post_start.is_none() {
+        tracing::info!("Skipping guest agent bootstrap (--no-agents)");
+        return Ok(());
+    }
+    let session = prepare_session_from_target(cfg, None, target.clone(), repo)?;
+    if opts.no_agents {
+        tracing::info!("Skipping guest agent bootstrap (--no-agents)");
+    } else {
+        let guest_host = be.guest_host_address(&cfg.network);
+        backend::bootstrap_agents(&session, cfg, inst, mode, &guest_host)?;
+    }
+    if let Some(cmd) = post_start {
+        backend::run_post_start(&session, cmd);
+    }
+    Ok(())
+}
+
+pub(crate) fn prepare_session_from_target(
     cfg: &config::CoopConfig,
     inst: Option<&config::Instance>,
     target: backend::SshTarget,
     repo: Option<&github_repo::RepoSlug>,
 ) -> Result<backend::SshSession> {
     let mut env = backend::prepare_env_forwarding(cfg, repo)?;
-    if let Some(inst) = inst
-        && let Some(state) = guest_env_state::GuestEnvState::try_load(inst)?
-    {
-        for (name, value) in &state.entries {
-            env.set(name.as_str(), value.as_str());
+    if let Some(inst) = inst {
+        if let Some(state) = guest_env_state::GuestEnvState::try_load(inst)? {
+            for (name, value) in &state.entries {
+                env.set(name.as_str(), value.as_str());
+            }
+        }
+        // In local-model mode, Codex reads its API key from the env var
+        // named by the provider's `env_key`. Claude's token rides in
+        // settings.json instead, so it needs no forwarding here.
+        let model = model_state::ModelState::load_or_default(inst)?;
+        if model.mode == model_state::ModelMode::Local
+            && let Some(ep) = model.resolved_codex(&cfg.codex)
+        {
+            env.set(model_state::CODEX_LOCAL_ENV_KEY, ep.auth_token_or_default());
         }
     }
     Ok(backend::SshSession { target, env })

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod admin;
 mod devcontainer;
 mod github;
 mod lifecycle;
+mod model;
 mod profiles;
 mod quickstart;
 
@@ -21,8 +22,10 @@ pub(crate) use lifecycle::{
     ProfileImageTarget, ProjectTransport, StartOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts,
     apply_runtime_guest_env, apply_vm_overrides, cmd_commit, cmd_destroy, cmd_exec, cmd_list,
     cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_up, codex_launch_args,
-    open_ssh_session, preflight_start_target, prepend_binary, resolve_running,
+    open_ssh_session, preflight_start_target, prepare_session_from_target, prepend_binary,
+    resolve_running,
 };
+pub(crate) use model::cmd_model;
 pub(crate) use profiles::{cmd_images, cmd_profiles};
 pub(crate) use quickstart::{QuickstartOpts, cmd_quickstart};
 

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -1,0 +1,186 @@
+//! `coop model` — switch a VM between cloud and local model backends.
+//!
+//! The selection is persisted per-VM ([`crate::model_state`]) and
+//! materialized as guest config files (Claude `settings.json` env block,
+//! Codex `config.toml` provider block) so every launch path picks it up.
+//! Switching is a cheap SSH file write against the running VM — no
+//! rebuild — and the persisted state is re-applied on the next start.
+
+use std::io::Write;
+
+use anyhow::{Result, bail};
+
+use crate::backend::VmBackend as _;
+use crate::config::{LocalModel, Secret};
+use crate::model_state::{ModelMode, ModelState};
+use crate::{backend, config, network, prompt};
+
+pub(crate) fn cmd_model(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    name: Option<&config::InstanceName>,
+    action: Option<ModelMode>,
+) -> Result<()> {
+    let inst = cfg.resolve_instance(name)?;
+    match action {
+        None => render_status(be, cfg, &inst),
+        Some(ModelMode::Local) => set_local(be, cfg, &inst),
+        Some(ModelMode::Remote) => set_remote(be, cfg, &inst),
+    }
+}
+
+/// Print the per-tool mode and the endpoint each tool resolves to.
+fn render_status(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    inst: &config::Instance,
+) -> Result<()> {
+    let state = ModelState::load_or_default(inst)?;
+    let guest_host = be.guest_host_address(&cfg.network);
+    let out = &mut std::io::stdout();
+    writeln!(out, "Instance: {}", inst.name)?;
+    writeln!(out, "Mode:     {}", state.mode.as_str())?;
+    write_tool_line(
+        out,
+        "Claude",
+        state.mode,
+        state.resolved_claude(&cfg.claude),
+        &guest_host,
+    )?;
+    write_tool_line(
+        out,
+        "Codex",
+        state.mode,
+        state.resolved_codex(&cfg.codex),
+        &guest_host,
+    )?;
+    Ok(())
+}
+
+fn write_tool_line(
+    out: &mut impl Write,
+    label: &str,
+    mode: ModelMode,
+    endpoint: Option<&LocalModel>,
+    guest_host: &str,
+) -> Result<()> {
+    match (mode, endpoint) {
+        (ModelMode::Local, Some(ep)) => {
+            let url = network::rewrite_host_url(ep.host_url(), guest_host)?;
+            writeln!(out, "{label:<9} local — {} @ {}", ep.model(), url)?;
+        }
+        (ModelMode::Local, None) => {
+            writeln!(out, "{label:<9} cloud (no local endpoint configured)")?;
+        }
+        (ModelMode::Remote, _) => writeln!(out, "{label:<9} cloud")?,
+    }
+    Ok(())
+}
+
+fn set_local(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    inst: &config::Instance,
+) -> Result<()> {
+    let mut state = ModelState::load_or_default(inst)?;
+    state.mode = ModelMode::Local;
+
+    // Only prompt when nothing is configured anywhere — the "VM exists,
+    // no config yet" case. If at least one tool already resolves an
+    // endpoint (from config.toml or a previous prompt), switch those and
+    // leave the rest on cloud.
+    if state.resolved_claude(&cfg.claude).is_none() && state.resolved_codex(&cfg.codex).is_none() {
+        if let Some(ep) = prompt_endpoint("Claude")? {
+            state.claude_endpoint = Some(ep);
+        }
+        if let Some(ep) = prompt_endpoint("Codex")? {
+            state.codex_endpoint = Some(ep);
+        }
+    }
+
+    if state.resolved_claude(&cfg.claude).is_none() && state.resolved_codex(&cfg.codex).is_none() {
+        bail!(
+            "No local model endpoint configured for '{}'.\n\
+             Set [claude.local_model] or [codex.local_model] in config.toml, \
+             or run `coop model {} local` in an interactive terminal to enter one.",
+            inst.name,
+            inst.name,
+        );
+    }
+
+    // Remember that coop now owns Codex's config.toml model keys, so a
+    // later switch to remote rewrites a clean file even if the configured
+    // endpoint is later removed (Claude's settings.json is unconditional).
+    if state.resolved_codex(&cfg.codex).is_some() {
+        state.codex_materialized = true;
+    }
+
+    state.save(inst)?;
+    tracing::info!("Switched '{}' to local model mode", inst.name);
+    apply_to_running(be, cfg, inst)
+}
+
+fn set_remote(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    inst: &config::Instance,
+) -> Result<()> {
+    let mut state = ModelState::load_or_default(inst)?;
+    // Keep any saved endpoints so a later `local` doesn't re-prompt; only
+    // the mode flips, which drops the materialized guest config.
+    state.mode = ModelMode::Remote;
+    state.save(inst)?;
+    tracing::info!("Switched '{}' to remote (cloud) model mode", inst.name);
+    apply_to_running(be, cfg, inst)
+}
+
+/// Re-materialize guest config for the current model state on the running
+/// VM. When the VM is stopped, the persisted state is applied on its next
+/// start, so this is a no-op with an informational log.
+fn apply_to_running(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    inst: &config::Instance,
+) -> Result<()> {
+    let Some(running) = be.as_running(cfg, inst.clone())? else {
+        tracing::info!(
+            "'{}' is not running — the model setting applies on next start",
+            inst.name
+        );
+        return Ok(());
+    };
+    let repo = backend::detect_instance_repo(running.instance());
+    let (inst, target) = running.into_parts();
+    let session = super::prepare_session_from_target(cfg, Some(&inst), target, repo.as_ref())?;
+    let guest_host = be.guest_host_address(&cfg.network);
+    backend::bootstrap_agents(
+        &session,
+        cfg,
+        &inst,
+        backend::BootMode::Restart,
+        &guest_host,
+    )
+}
+
+/// Interactively collect a local endpoint for `tool`. Returns `None` when
+/// the user declines or stdin is not a TTY.
+fn prompt_endpoint(tool: &str) -> Result<Option<LocalModel>> {
+    if !prompt::confirm(&format!("Configure a local model for {tool}?"))? {
+        return Ok(None);
+    }
+    let Some(host_url) =
+        prompt::read_line(&format!("{tool} host URL (e.g. http://localhost:11434)"))?
+    else {
+        bail!("{tool} host URL is required");
+    };
+    let url = url::Url::parse(&host_url)
+        .map_err(|e| anyhow::anyhow!("invalid {tool} host URL '{host_url}': {e}"))?;
+    let Some(model) = prompt::read_line(&format!("{tool} model name"))? else {
+        bail!("{tool} model name is required");
+    };
+    let token = prompt::read_line(&format!(
+        "{tool} auth token (optional — press enter to skip)"
+    ))?;
+    let endpoint = LocalModel::new(url, model, token.map(Secret::new))?;
+    Ok(Some(endpoint))
+}

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -116,8 +116,8 @@ fn set_local(
     }
 
     state.save(inst)?;
-    tracing::info!("Switched '{}' to local model mode", inst.name);
-    apply_to_running(be, cfg, inst)
+    let applied = apply_to_running(be, cfg, inst)?;
+    report_switch(inst, ModelMode::Local, applied)
 }
 
 fn set_remote(
@@ -130,24 +130,46 @@ fn set_remote(
     // the mode flips, which drops the materialized guest config.
     state.mode = ModelMode::Remote;
     state.save(inst)?;
-    tracing::info!("Switched '{}' to remote (cloud) model mode", inst.name);
-    apply_to_running(be, cfg, inst)
+    let applied = apply_to_running(be, cfg, inst)?;
+    report_switch(inst, ModelMode::Remote, applied)
 }
 
-/// Re-materialize guest config for the current model state on the running
-/// VM. When the VM is stopped, the persisted state is applied on its next
-/// start, so this is a no-op with an informational log.
+/// Tell the user what changed and what (if anything) they need to do.
+///
+/// Switching never requires a VM restart — the guest config is rewritten
+/// live over SSH. An agent that is *already running* won't change
+/// mid-session (it reads the config at launch), so the only follow-up is
+/// to relaunch `claude`/`codex`.
+fn report_switch(inst: &config::Instance, mode: ModelMode, applied: bool) -> Result<()> {
+    let target = match mode {
+        ModelMode::Local => "a local model",
+        ModelMode::Remote => "cloud models",
+    };
+    let out = &mut std::io::stdout();
+    if applied {
+        writeln!(out, "'{}' now uses {target}.", inst.name)?;
+        writeln!(
+            out,
+            "Applied to the running VM — no restart needed; relaunch claude/codex \
+             (e.g. `coop claude {}`) to pick it up.",
+            inst.name
+        )?;
+    } else {
+        writeln!(out, "'{}' will use {target} on next start.", inst.name)?;
+    }
+    Ok(())
+}
+
+/// Re-materialize guest config for the current model state. Returns `true`
+/// when the VM was running and the change was applied live, `false` when
+/// the VM is stopped and the persisted state will apply on next start.
 fn apply_to_running(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
     inst: &config::Instance,
-) -> Result<()> {
+) -> Result<bool> {
     let Some(running) = be.as_running(cfg, inst.clone())? else {
-        tracing::info!(
-            "'{}' is not running — the model setting applies on next start",
-            inst.name
-        );
-        return Ok(());
+        return Ok(false);
     };
     let repo = backend::detect_instance_repo(running.instance());
     let (inst, target) = running.into_parts();
@@ -159,7 +181,8 @@ fn apply_to_running(
         &inst,
         backend::BootMode::Restart,
         &guest_host,
-    )
+    )?;
+    Ok(true)
 }
 
 /// Interactively collect a local endpoint for `tool`. Returns `None` when

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -85,17 +85,17 @@ fn set_local(
     let mut state = ModelState::load_or_default(inst)?;
     state.mode = ModelMode::Local;
 
-    // Only prompt when nothing is configured anywhere — the "VM exists,
-    // no config yet" case. If at least one tool already resolves an
-    // endpoint (from config.toml or a previous prompt), switch those and
-    // leave the rest on cloud.
-    if state.resolved_claude(&cfg.claude).is_none() && state.resolved_codex(&cfg.codex).is_none() {
-        if let Some(ep) = prompt_endpoint("Claude")? {
-            state.claude_endpoint = Some(ep);
-        }
-        if let Some(ep) = prompt_endpoint("Codex")? {
-            state.codex_endpoint = Some(ep);
-        }
+    // Offer to configure each tool that doesn't already resolve an
+    // endpoint. This covers both the fresh "nothing configured yet" case
+    // and the "one tool is local, the other is still on cloud" case —
+    // declining leaves that tool on cloud. Non-interactive stdin declines
+    // automatically.
+    let (prompt_claude, prompt_codex) = tools_needing_prompt(&state, &cfg.claude, &cfg.codex);
+    if prompt_claude && let Some(ep) = prompt_endpoint("Claude")? {
+        state.claude_endpoint = Some(ep);
+    }
+    if prompt_codex && let Some(ep) = prompt_endpoint("Codex")? {
+        state.codex_endpoint = Some(ep);
     }
 
     if state.resolved_claude(&cfg.claude).is_none() && state.resolved_codex(&cfg.codex).is_none() {
@@ -117,7 +117,7 @@ fn set_local(
 
     state.save(inst)?;
     let applied = apply_to_running(be, cfg, inst)?;
-    report_switch(inst, ModelMode::Local, applied)
+    report_switch(inst, cfg, &state, applied)
 }
 
 fn set_remote(
@@ -131,33 +131,104 @@ fn set_remote(
     state.mode = ModelMode::Remote;
     state.save(inst)?;
     let applied = apply_to_running(be, cfg, inst)?;
-    report_switch(inst, ModelMode::Remote, applied)
+    report_switch(inst, cfg, &state, applied)
+}
+
+/// Tools that still need an interactive endpoint prompt when switching to
+/// local — those that don't already resolve one (from
+/// `[claude.local_model]`/`[codex.local_model]` in config.toml or a saved
+/// prompt answer). Returned as `(claude, codex)`. The two are independent,
+/// so configuring one tool now and adding the other later both work.
+fn tools_needing_prompt(
+    state: &ModelState,
+    claude: &config::ClaudeConfig,
+    codex: &config::CodexConfig,
+) -> (bool, bool) {
+    (
+        state.resolved_claude(claude).is_none(),
+        state.resolved_codex(codex).is_none(),
+    )
 }
 
 /// Tell the user what changed and what (if anything) they need to do.
 ///
-/// Switching never requires a VM restart — the guest config is rewritten
-/// live over SSH. An agent that is *already running* won't change
-/// mid-session (it reads the config at launch), so the only follow-up is
-/// to relaunch `claude`/`codex`.
-fn report_switch(inst: &config::Instance, mode: ModelMode, applied: bool) -> Result<()> {
-    let target = match mode {
-        ModelMode::Local => "a local model",
-        ModelMode::Remote => "cloud models",
-    };
+/// Reports each tool independently, because a switch to local only routes
+/// the tools that resolve an endpoint — any tool left on cloud gets an
+/// explicit warning so "now uses a local model" never hides a half-applied
+/// switch. Switching never requires a VM restart (the guest config is
+/// rewritten live over SSH), but an already-running agent reads its config
+/// at launch, so the only follow-up is to relaunch `claude`/`codex`.
+fn report_switch(
+    inst: &config::Instance,
+    cfg: &config::CoopConfig,
+    state: &ModelState,
+    applied: bool,
+) -> Result<()> {
+    let local = state.mode == ModelMode::Local;
+    let claude_local = local && state.resolved_claude(&cfg.claude).is_some();
+    let codex_local = local && state.resolved_codex(&cfg.codex).is_some();
     let out = &mut std::io::stdout();
-    if applied {
-        writeln!(out, "'{}' now uses {target}.", inst.name)?;
-        writeln!(
-            out,
-            "Applied to the running VM — no restart needed; relaunch claude/codex \
-             (e.g. `coop claude {}`) to pick it up.",
-            inst.name
-        )?;
-    } else {
-        writeln!(out, "'{}' will use {target} on next start.", inst.name)?;
+    for line in switch_report_lines(
+        inst.name.as_str(),
+        state.mode,
+        claude_local,
+        codex_local,
+        applied,
+    ) {
+        writeln!(out, "{line}")?;
     }
     Ok(())
+}
+
+/// Build the lines printed after a model switch: a per-tool summary and,
+/// in local mode, a warning for any tool left on cloud. Pure so it can be
+/// unit-tested without a backend, TTY, or stdout. In local mode at least
+/// one tool is always local ([`set_local`] bails otherwise).
+fn switch_report_lines(
+    inst_name: &str,
+    mode: ModelMode,
+    claude_local: bool,
+    codex_local: bool,
+    applied: bool,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    match mode {
+        ModelMode::Remote => lines.push(format!(
+            "'{inst_name}' now uses cloud models for Claude and Codex."
+        )),
+        ModelMode::Local => {
+            let tools = [
+                ("Claude", "claude.local_model", claude_local),
+                ("Codex", "codex.local_model", codex_local),
+            ];
+            let local: Vec<&str> = tools
+                .iter()
+                .filter_map(|&(label, _, is_local)| is_local.then_some(label))
+                .collect();
+            lines.push(format!(
+                "'{inst_name}' now uses a local model for {}.",
+                local.join(" and ")
+            ));
+            for &(label, key, is_local) in &tools {
+                if !is_local {
+                    lines.push(format!(
+                        "  warning: {label} stays on cloud — no local endpoint configured; \
+                         set [{key}] in config.toml or re-run `coop model {inst_name} local` \
+                         in an interactive terminal."
+                    ));
+                }
+            }
+        }
+    }
+    lines.push(if applied {
+        format!(
+            "Applied to the running VM — no restart needed; relaunch claude/codex \
+             (e.g. `coop claude {inst_name}`) to pick it up."
+        )
+    } else {
+        "Saved — applies on next start.".to_string()
+    });
+    lines
 }
 
 /// Re-materialize guest config for the current model state. Returns `true`
@@ -206,4 +277,88 @@ fn prompt_endpoint(tool: &str) -> Result<Option<LocalModel>> {
     ))?;
     let endpoint = LocalModel::new(url, model, token.map(Secret::new))?;
     Ok(Some(endpoint))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+    use crate::config::{ClaudeConfig, CodexConfig};
+
+    fn endpoint(url: &str) -> LocalModel {
+        LocalModel::new(url::Url::parse(url).unwrap(), "m".to_string(), None).unwrap()
+    }
+
+    fn claude_with_local() -> ClaudeConfig {
+        ClaudeConfig {
+            local_model: Some(endpoint("http://localhost:1/")),
+            ..Default::default()
+        }
+    }
+
+    // ── gating: which tools get an interactive prompt ──────────
+
+    #[test]
+    fn prompts_both_tools_when_nothing_configured() {
+        let state = ModelState::default();
+        assert_eq!(
+            tools_needing_prompt(&state, &ClaudeConfig::default(), &CodexConfig::default()),
+            (true, true)
+        );
+    }
+
+    #[test]
+    fn prompts_only_claude_when_codex_already_configured() {
+        // The reported scenario: Codex was set up first (saved endpoint),
+        // so switching to local must still offer to configure Claude.
+        let state = ModelState {
+            codex_endpoint: Some(endpoint("http://localhost:2/")),
+            ..Default::default()
+        };
+        assert_eq!(
+            tools_needing_prompt(&state, &ClaudeConfig::default(), &CodexConfig::default()),
+            (true, false)
+        );
+    }
+
+    #[test]
+    fn prompts_neither_tool_when_both_resolve() {
+        let codex = CodexConfig {
+            local_model: Some(endpoint("http://localhost:3/")),
+            ..Default::default()
+        };
+        assert_eq!(
+            tools_needing_prompt(&ModelState::default(), &claude_with_local(), &codex),
+            (false, false)
+        );
+    }
+
+    // ── per-tool switch reporting ──────────────────────────────
+
+    #[test]
+    fn local_report_lists_both_tools_and_warns_about_none() {
+        let lines = switch_report_lines("dev", ModelMode::Local, true, true, true);
+        assert!(lines[0].contains("local model for Claude and Codex"));
+        assert!(!lines.iter().any(|l| l.contains("stays on cloud")));
+        assert!(lines.last().unwrap().contains("relaunch"));
+    }
+
+    #[test]
+    fn local_report_warns_about_the_tool_left_on_cloud() {
+        let lines = switch_report_lines("dev", ModelMode::Local, true, false, true);
+        assert!(lines[0].contains("local model for Claude."));
+        let warning = lines.iter().find(|l| l.contains("stays on cloud")).unwrap();
+        assert!(warning.contains("Codex"));
+        assert!(warning.contains("codex.local_model"));
+        // The tool that did switch must not be warned about.
+        assert!(!warning.contains("Claude"));
+    }
+
+    #[test]
+    fn remote_report_has_no_cloud_warnings() {
+        let lines = switch_report_lines("dev", ModelMode::Remote, false, false, false);
+        assert!(lines[0].contains("cloud models"));
+        assert!(!lines.iter().any(|l| l.contains("stays on cloud")));
+        assert!(lines.last().unwrap().contains("next start"));
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1337,6 +1337,12 @@ pub struct ClaudeConfig {
     /// Source directory for Claude config files (CLAUDE.md, rules/, commands/)
     #[serde(default)]
     pub config_dir: ConfigDir,
+
+    /// Local-model endpoint to route Claude Code at when this VM is
+    /// switched to local mode (see `coop model`). Takes precedence over
+    /// any endpoint prompted interactively and saved in instance state.
+    #[serde(default)]
+    pub local_model: Option<LocalModel>,
 }
 
 /// `[setup]` section: controls one-time UX behaviour at VM startup.
@@ -1378,7 +1384,97 @@ pub struct CodexConfig {
     /// Source directory for Codex config files (config.toml, AGENTS.md, prompts/)
     #[serde(default)]
     pub config_dir: ConfigDir,
+
+    /// Local-model endpoint to route Codex at when this VM is switched to
+    /// local mode (see `coop model`). Takes precedence over any endpoint
+    /// prompted interactively and saved in instance state.
+    #[serde(default)]
+    pub local_model: Option<LocalModel>,
 }
+
+/// A local (host-side) model endpoint that `coop model <vm> local`
+/// materializes into guest agent config.
+///
+/// `host_url` is the endpoint as seen **on the host** (where the model
+/// server runs — Ollama / LM Studio / vLLM / llama.cpp). A local model
+/// cannot run inside the headless guest, so coop rewrites a
+/// `localhost`/`127.0.0.1` host to the backend's guest-visible host
+/// address (Firecracker: the TAP gateway; Lima: `host.lima.internal`)
+/// and passes any other host through verbatim, so a LAN endpoint also
+/// works. See [`crate::network::rewrite_host_url`].
+///
+/// The fields are private and the only constructor ([`LocalModel::new`],
+/// which the validating [`Deserialize`] impl also routes through)
+/// enforces the invariants — an `http`/`https` URL with a host and a
+/// non-empty model — so every `LocalModel` in the program is valid by
+/// construction and no later validation pass is needed.
+#[derive(Debug, Clone, Serialize)]
+pub struct LocalModel {
+    host_url: url::Url,
+    model: String,
+    auth_token: Option<Secret<String>>,
+}
+
+impl LocalModel {
+    /// Construct an endpoint, enforcing the invariants. The single place
+    /// a `LocalModel` is validated; deserialization and the interactive
+    /// `coop model` prompt both route through here.
+    pub fn new(
+        host_url: url::Url,
+        model: String,
+        auth_token: Option<Secret<String>>,
+    ) -> Result<Self> {
+        if model.trim().is_empty() {
+            bail!("local model 'model' must not be empty");
+        }
+        if !matches!(host_url.scheme(), "http" | "https") {
+            bail!("local model host_url '{host_url}' must use http or https");
+        }
+        if host_url.host_str().is_none() {
+            bail!("local model host_url '{host_url}' has no host");
+        }
+        Ok(Self {
+            host_url,
+            model,
+            auth_token,
+        })
+    }
+
+    pub fn host_url(&self) -> &url::Url {
+        &self.host_url
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// The configured auth token, or the shared dummy fallback used for
+    /// permissive local servers that accept any value.
+    pub fn auth_token_or_default(&self) -> String {
+        self.auth_token.as_ref().map_or_else(
+            || LOCAL_MODEL_AUTH_FALLBACK.to_string(),
+            |s| s.expose().clone(),
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for LocalModel {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Raw {
+            host_url: url::Url,
+            model: String,
+            #[serde(default)]
+            auth_token: Option<Secret<String>>,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        LocalModel::new(raw.host_url, raw.model, raw.auth_token).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Dummy auth token written for local endpoints with no configured token.
+/// Permissive local servers (Ollama, LM Studio, vLLM) ignore the value.
+pub const LOCAL_MODEL_AUTH_FALLBACK: &str = "coop-local";
 
 const MAX_INSTANCE_NAME_LEN: usize = 64;
 
@@ -1771,6 +1867,11 @@ impl CoopConfig {
             }
         }
 
+        // `[claude.local_model]` / `[codex.local_model]` invariants
+        // (http(s) scheme, present host, non-empty model) are enforced by
+        // `LocalModel`'s deserializer, so an invalid endpoint fails at
+        // config-load time and never reaches here.
+
         // `[github.pat]` keys and `github.skip` entries are typed as
         // `RepoSlug`; invalid values are rejected at config load time, so
         // no per-key check is needed here.
@@ -2088,6 +2189,7 @@ impl Default for ClaudeConfig {
             plugins: Vec::new(),
             mcp_servers: HashMap::new(),
             config_dir: ConfigDir::Default,
+            local_model: None,
         }
     }
 }
@@ -2099,6 +2201,7 @@ impl Default for CodexConfig {
             env_forward: Vec::new(),
             mcp_servers: HashMap::new(),
             config_dir: ConfigDir::Default,
+            local_model: None,
         }
     }
 }
@@ -2173,6 +2276,10 @@ impl Instance {
 
     pub fn guest_env_state_path(&self) -> PathBuf {
         self.dir.join("guest_env.json")
+    }
+
+    pub fn model_state_path(&self) -> PathBuf {
+        self.dir.join("model.json")
     }
 
     #[mutants::skip] // equivalent: default-path getter; no caller asserts the returned PathBuf
@@ -3151,6 +3258,66 @@ mod tests {
         assert!(cfg.env_forward.is_empty());
         assert!(cfg.mcp_servers.is_empty());
         assert_eq!(cfg.config_dir, ConfigDir::Default);
+        assert!(cfg.local_model.is_none());
+    }
+
+    // ── LocalModel ───────────────────────────────────────────
+
+    #[test]
+    fn local_model_deserializes_full_form() {
+        let toml_str = r#"
+host_url = "http://localhost:11434"
+model = "qwen2.5-coder:32b"
+auth_token = "secret-token"
+"#;
+        let lm: LocalModel = toml::from_str(toml_str).unwrap();
+        assert_eq!(lm.host_url().as_str(), "http://localhost:11434/");
+        assert_eq!(lm.model(), "qwen2.5-coder:32b");
+        assert_eq!(lm.auth_token_or_default(), "secret-token");
+    }
+
+    #[test]
+    fn local_model_auth_token_defaults_when_absent() {
+        let lm: LocalModel =
+            toml::from_str("host_url = \"http://localhost:1234\"\nmodel = \"m\"\n").unwrap();
+        assert_eq!(lm.auth_token_or_default(), LOCAL_MODEL_AUTH_FALLBACK);
+    }
+
+    #[test]
+    fn local_model_rejects_empty_model() {
+        let err = toml::from_str::<LocalModel>("host_url = \"http://localhost\"\nmodel = \"\"\n")
+            .unwrap_err();
+        assert!(err.to_string().contains("must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn local_model_rejects_non_http_scheme() {
+        let err = toml::from_str::<LocalModel>("host_url = \"ftp://localhost\"\nmodel = \"m\"\n")
+            .unwrap_err();
+        assert!(err.to_string().contains("http or https"), "{err}");
+    }
+
+    #[test]
+    fn local_model_embeds_in_claude_config() {
+        let toml_str = r#"
+[local_model]
+host_url = "http://localhost:11434"
+model = "qwen"
+"#;
+        let cfg: ClaudeConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.local_model.unwrap().model(), "qwen");
+    }
+
+    #[test]
+    fn local_model_invalid_endpoint_fails_config_load() {
+        // The invariant is enforced at deserialization, so a bad endpoint
+        // never produces a `CoopConfig` to validate later.
+        let toml_str = r#"
+[codex.local_model]
+host_url = "http://localhost:1234"
+model = ""
+"#;
+        assert!(toml::from_str::<CoopConfig>(toml_str).is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod github_submodules;
 mod guest;
 mod guest_env_state;
 pub mod jsonc;
+mod model_state;
 mod naming;
 mod pat_prompt;
 mod paths;
@@ -67,9 +68,9 @@ use commands::{
     DevcontainerInput, DevcontainerOpts, ProfileImageTarget, ProjectTransport, QuickstartOpts,
     StartOpts, UninstallOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts, apply_runtime_guest_env,
     apply_vm_overrides, cmd_commit, cmd_destroy, cmd_devcontainer, cmd_devcontainer_check,
-    cmd_exec, cmd_github, cmd_images, cmd_init, cmd_list, cmd_profiles, cmd_quickstart, cmd_resize,
-    cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_uninstall, cmd_up, cmd_validate,
-    codex_launch_args, open_ssh_session, preflight_start_target, prepend_binary,
+    cmd_exec, cmd_github, cmd_images, cmd_init, cmd_list, cmd_model, cmd_profiles, cmd_quickstart,
+    cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_uninstall, cmd_up,
+    cmd_validate, codex_launch_args, open_ssh_session, preflight_start_target, prepend_binary,
     resolve_devcontainer, resolve_running,
 };
 
@@ -398,6 +399,19 @@ enum Commands {
         )]
         name: Option<config::InstanceName>,
     },
+    /// Show or switch a VM's model backend (cloud vs. local)
+    Model {
+        /// Instance name (required if multiple instances exist)
+        #[arg(
+            value_parser = config::InstanceName::new,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
+        /// `local` to route at a host-side model, `remote` for cloud
+        /// defaults; omit to show the current selection
+        #[command(subcommand)]
+        action: Option<ModelAction>,
+    },
     /// Stream VM serial console logs
     Logs {
         /// Instance name (required if multiple instances exist)
@@ -620,6 +634,23 @@ extra line in your shell rc:
   zsh:   source <(COMPLETE=zsh coop)
   fish:  source (COMPLETE=fish coop | psub)
 ";
+
+#[derive(Subcommand, Clone, Copy)]
+enum ModelAction {
+    /// Route this VM's agents at a host-side local model server
+    Local,
+    /// Restore cloud defaults (Anthropic / `OpenAI`)
+    Remote,
+}
+
+impl From<ModelAction> for model_state::ModelMode {
+    fn from(action: ModelAction) -> Self {
+        match action {
+            ModelAction::Local => model_state::ModelMode::Local,
+            ModelAction::Remote => model_state::ModelMode::Remote,
+        }
+    }
+}
 
 #[derive(Subcommand)]
 enum ProfilesAction {
@@ -1084,6 +1115,9 @@ pub fn run() -> Result<()> {
         }
         Commands::List => cmd_list(&be, &cfg),
         Commands::Status { name } => cmd_status(&be, &cfg, name.as_ref()),
+        Commands::Model { name, action } => {
+            cmd_model(&be, &cfg, name.as_ref(), action.map(Into::into))
+        }
         Commands::Logs { name, follow } => {
             let running = resolve_running(&be, &cfg, name.as_ref())?;
             let mode = if follow {

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -20,6 +20,11 @@ use crate::sha256_hash::Sha256Hash;
 const LIMA_PREFIX: &str = "coop-";
 const BUILDER_NAME: &str = "coop-builder";
 
+/// Hostname Lima injects into the guest that resolves to the host machine.
+/// Used to rewrite local-model endpoints so the guest can reach a server
+/// running on the host.
+pub const HOST_GATEWAY: &str = "host.lima.internal";
+
 // ── Public API ────────────────────────────────────────────────
 
 /// Run first-time setup for Lima backend.

--- a/src/model_state.rs
+++ b/src/model_state.rs
@@ -161,10 +161,29 @@ impl ModelState {
 /// [`crate::network::rewrite_host_url`]). Every model tier is pinned to
 /// the same local model so requests for any tier route locally. A
 /// `BTreeMap` gives deterministic JSON for stable diffs and tests.
+///
+/// Two keys exist purely to keep a local inference server's KV cache
+/// warm. Local backends (llama.cpp, vLLM) reuse the prompt cache only on
+/// an exact prefix match, so anything Claude Code mutates per request
+/// forces a full re-prefill of the 20K+ token system prompt — seconds of
+/// latency on every tool call. We disable the two known mutators:
+/// `CLAUDE_CODE_ATTRIBUTION_HEADER` (a per-request billing/version
+/// fingerprint) and `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` (the `git
+/// status` snapshot, which changes every time a file is touched). Both
+/// only matter against a self-hosted endpoint, and this block is written
+/// only in local mode, so they are correctly scoped.
 pub fn claude_env_block(base_url: &str, model: &str, auth_token: &str) -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
     env.insert("ANTHROPIC_BASE_URL".to_string(), base_url.to_string());
     env.insert("ANTHROPIC_AUTH_TOKEN".to_string(), auth_token.to_string());
+    env.insert(
+        "CLAUDE_CODE_ATTRIBUTION_HEADER".to_string(),
+        "0".to_string(),
+    );
+    env.insert(
+        "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS".to_string(),
+        "1".to_string(),
+    );
     for tier in [
         "ANTHROPIC_MODEL",
         "ANTHROPIC_SMALL_FAST_MODEL",
@@ -416,6 +435,17 @@ mod tests {
         ] {
             assert_eq!(env[tier], "qwen2.5-coder", "tier {tier} not pinned");
         }
+    }
+
+    #[test]
+    fn claude_env_block_disables_prefix_cache_busters() {
+        // Both keys keep a local KV cache warm by stopping Claude Code
+        // from mutating the system prompt per request (see the doc on
+        // `claude_env_block`). A regression here silently restores the
+        // ~60s-per-tool-call latency on local backends.
+        let env = claude_env_block("http://172.16.0.1:11434", "qwen2.5-coder", "tok");
+        assert_eq!(env["CLAUDE_CODE_ATTRIBUTION_HEADER"], "0");
+        assert_eq!(env["CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS"], "1");
     }
 
     #[test]

--- a/src/model_state.rs
+++ b/src/model_state.rs
@@ -1,0 +1,439 @@
+//! Per-instance local-vs-remote model selection.
+//!
+//! A coop VM routes its agents (Claude Code, Codex) at Anthropic's /
+//! `OpenAI`'s cloud by default. `coop model <vm> local` flips the VM to a
+//! host-side local model server (Ollama / LM Studio / vLLM / llama.cpp);
+//! `coop model <vm> remote` flips it back. The choice is a per-VM
+//! persisted setting rather than a per-launch flag, because coop cannot
+//! inject env into a tool the user launches themselves inside a shell —
+//! so the selection is materialized as guest config files that every
+//! launch path (`coop shell`, `coop claude`, `coop codex`, VS Code)
+//! reads.
+//!
+//! Persistence layout: one JSON file at `<inst.dir>/model.json`. The
+//! default state (remote, no saved endpoints) is not written — a missing
+//! file means "cloud defaults," matching the boot-time behaviour.
+//!
+//! Endpoint resolution per tool (see [`ModelState::resolved_claude`] /
+//! [`ModelState::resolved_codex`]):
+//!
+//! 1. `[claude.local_model]` / `[codex.local_model]` in `config.toml`.
+//! 2. Else the per-instance endpoint saved here (e.g. one prompted
+//!    interactively when no config existed).
+//! 3. Else none — the tool stays on the cloud default.
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::ErrorKind;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::config::{ClaudeConfig, CodexConfig, Instance, LocalModel};
+
+/// Codex `model_provider` id written into `~/.codex/config.toml`.
+pub const CODEX_LOCAL_PROVIDER: &str = "coop_local";
+
+/// Env var Codex reads the local provider's API key from (`env_key`).
+/// Forwarded to the guest with the configured (or dummy) token whenever
+/// the VM is in local mode.
+pub const CODEX_LOCAL_ENV_KEY: &str = "COOP_LOCAL_API_KEY";
+
+/// Whether a VM's agents target the cloud or a host-side local server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ModelMode {
+    /// Cloud defaults (Anthropic / `OpenAI`). The shipped default.
+    #[default]
+    Remote,
+    /// A host-side local model server.
+    Local,
+}
+
+impl ModelMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ModelMode::Remote => "remote",
+            ModelMode::Local => "local",
+        }
+    }
+}
+
+/// Persisted per-instance model selection and any interactively-prompted
+/// endpoints. Endpoints from `config.toml` take precedence over the saved
+/// ones, so saving here only matters when `config.toml` has no entry.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ModelState {
+    #[serde(default)]
+    pub mode: ModelMode,
+
+    /// Endpoint for Claude saved from an interactive prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_endpoint: Option<LocalModel>,
+
+    /// Endpoint for Codex saved from an interactive prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_endpoint: Option<LocalModel>,
+
+    /// Set once coop has materialized a Codex local-provider block in the
+    /// guest. Unlike Claude's `settings.json` (rewritten unconditionally
+    /// every boot), Codex's `config.toml` is only rewritten when coop has
+    /// something to manage; this flag keeps that true after a switch to
+    /// local, so a later switch to remote still rewrites a clean file even
+    /// if the configured endpoint has since been removed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub codex_materialized: bool,
+}
+
+impl ModelState {
+    /// `true` when nothing needs persisting: remote mode, no saved
+    /// endpoints, and nothing materialized. Equivalent to "no `model.json`
+    /// on disk."
+    fn is_default(&self) -> bool {
+        self.mode == ModelMode::Remote
+            && self.claude_endpoint.is_none()
+            && self.codex_endpoint.is_none()
+            && !self.codex_materialized
+    }
+
+    pub fn save(&self, inst: &Instance) -> Result<()> {
+        let path = inst.model_state_path();
+        if self.is_default() {
+            // A missing file already encodes the default; don't leave a
+            // stale snapshot behind.
+            if path.exists()
+                && let Err(e) = fs::remove_file(&path)
+            {
+                tracing::debug!(
+                    "Failed to remove default model state {} (non-fatal): {e}",
+                    path.display()
+                );
+            }
+            return Ok(());
+        }
+        let json = serde_json::to_string_pretty(self).context("Failed to serialize model state")?;
+        // 0o600: an interactively-prompted `auth_token` is serialized here.
+        crate::fs_util::atomic_write_with_mode(&path, &json, 0o600)
+            .context("Failed to write model.json")?;
+        tracing::debug!("Wrote model state to {}", path.display());
+        Ok(())
+    }
+
+    pub fn try_load(inst: &Instance) -> Result<Option<Self>> {
+        let path = inst.model_state_path();
+        match fs::read_to_string(&path) {
+            Ok(content) => {
+                let state = serde_json::from_str(&content).context("Failed to parse model.json")?;
+                Ok(Some(state))
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+            Err(e) => {
+                Err(anyhow::Error::new(e).context(format!("Failed to read {}", path.display())))
+            }
+        }
+    }
+
+    /// Load the saved state, or the default (remote) when none exists.
+    pub fn load_or_default(inst: &Instance) -> Result<Self> {
+        Ok(Self::try_load(inst)?.unwrap_or_default())
+    }
+
+    /// The endpoint Claude should use, applying config-over-saved
+    /// precedence. Independent of [`Self::mode`] — callers gate on the
+    /// mode separately so they can show "would use" in status output.
+    pub fn resolved_claude<'a>(&'a self, claude: &'a ClaudeConfig) -> Option<&'a LocalModel> {
+        claude
+            .local_model
+            .as_ref()
+            .or(self.claude_endpoint.as_ref())
+    }
+
+    /// The endpoint Codex should use, applying config-over-saved
+    /// precedence. See [`Self::resolved_claude`].
+    pub fn resolved_codex<'a>(&'a self, codex: &'a CodexConfig) -> Option<&'a LocalModel> {
+        codex.local_model.as_ref().or(self.codex_endpoint.as_ref())
+    }
+}
+
+/// The `env` block coop writes into the managed `~/.claude/settings.json`
+/// to point Claude Code at a local endpoint.
+///
+/// `base_url` must already be rewritten to a guest-visible host (see
+/// [`crate::network::rewrite_host_url`]). Every model tier is pinned to
+/// the same local model so requests for any tier route locally. A
+/// `BTreeMap` gives deterministic JSON for stable diffs and tests.
+pub fn claude_env_block(base_url: &str, model: &str, auth_token: &str) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    env.insert("ANTHROPIC_BASE_URL".to_string(), base_url.to_string());
+    env.insert("ANTHROPIC_AUTH_TOKEN".to_string(), auth_token.to_string());
+    for tier in [
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    ] {
+        env.insert(tier.to_string(), model.to_string());
+    }
+    env
+}
+
+/// The top-level keys coop merges into `~/.codex/config.toml` to route
+/// Codex at a local endpoint: `model`, `model_provider`, and a
+/// `[model_providers.coop_local]` block using the Responses API (the
+/// only wire API current Codex supports).
+///
+/// `base_url` must already be rewritten to a guest-visible host.
+pub fn codex_local_config(base_url: &str, model: &str) -> toml::Table {
+    let mut provider = toml::Table::new();
+    provider.insert(
+        "name".to_string(),
+        toml::Value::String("coop local model".to_string()),
+    );
+    provider.insert(
+        "base_url".to_string(),
+        toml::Value::String(base_url.to_string()),
+    );
+    provider.insert(
+        "wire_api".to_string(),
+        toml::Value::String("responses".to_string()),
+    );
+    provider.insert(
+        "env_key".to_string(),
+        toml::Value::String(CODEX_LOCAL_ENV_KEY.to_string()),
+    );
+
+    let mut providers = toml::Table::new();
+    providers.insert(
+        CODEX_LOCAL_PROVIDER.to_string(),
+        toml::Value::Table(provider),
+    );
+
+    let mut root = toml::Table::new();
+    root.insert("model".to_string(), toml::Value::String(model.to_string()));
+    root.insert(
+        "model_provider".to_string(),
+        toml::Value::String(CODEX_LOCAL_PROVIDER.to_string()),
+    );
+    root.insert("model_providers".to_string(), toml::Value::Table(providers));
+    root
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::config::{
+        ClaudeConfig, CodexConfig, ImageName, Instance, InstanceIndex, InstanceName, Secret,
+    };
+
+    fn fake_instance(dir: PathBuf) -> Instance {
+        Instance {
+            name: InstanceName::new("test").unwrap(),
+            index: InstanceIndex::new(0).unwrap(),
+            dir,
+            image: ImageName::new("test.img").unwrap(),
+        }
+    }
+
+    fn endpoint(url: &str, model: &str, token: Option<&str>) -> LocalModel {
+        LocalModel::new(
+            url::Url::parse(url).unwrap(),
+            model.to_string(),
+            token.map(|t| Secret::new(t.to_string())),
+        )
+        .unwrap()
+    }
+
+    // ── ModelState persistence ───────────────────────────────
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        let state = ModelState {
+            mode: ModelMode::Local,
+            claude_endpoint: Some(endpoint("http://localhost:11434", "qwen", None)),
+            codex_endpoint: None,
+            codex_materialized: false,
+        };
+        state.save(&inst).unwrap();
+
+        let loaded = ModelState::try_load(&inst).unwrap().unwrap();
+        assert_eq!(loaded.mode, ModelMode::Local);
+        assert_eq!(loaded.claude_endpoint.as_ref().unwrap().model(), "qwen");
+        assert!(loaded.codex_endpoint.is_none());
+    }
+
+    #[test]
+    fn try_load_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        assert!(ModelState::try_load(&inst).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_or_default_is_remote_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        assert_eq!(
+            ModelState::load_or_default(&inst).unwrap().mode,
+            ModelMode::Remote
+        );
+    }
+
+    #[test]
+    fn default_state_is_not_persisted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        ModelState::default().save(&inst).unwrap();
+        assert!(!inst.model_state_path().exists());
+    }
+
+    #[test]
+    fn save_default_removes_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        ModelState {
+            mode: ModelMode::Local,
+            ..Default::default()
+        }
+        .save(&inst)
+        .unwrap();
+        assert!(inst.model_state_path().exists());
+
+        ModelState::default().save(&inst).unwrap();
+        assert!(!inst.model_state_path().exists());
+    }
+
+    #[test]
+    fn remote_with_saved_endpoint_is_persisted() {
+        // `coop model remote` must keep the prompted endpoint so the next
+        // `local` doesn't re-prompt.
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        ModelState {
+            mode: ModelMode::Remote,
+            claude_endpoint: Some(endpoint("http://localhost:1234", "m", None)),
+            codex_endpoint: None,
+            codex_materialized: false,
+        }
+        .save(&inst)
+        .unwrap();
+        let loaded = ModelState::try_load(&inst).unwrap().unwrap();
+        assert_eq!(loaded.mode, ModelMode::Remote);
+        assert!(loaded.claude_endpoint.is_some());
+    }
+
+    #[test]
+    fn remote_with_codex_materialized_is_persisted() {
+        // The materialized flag must survive a switch back to remote so the
+        // next boot still rewrites a clean Codex config.toml even when the
+        // configured endpoint has since been removed.
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        ModelState {
+            mode: ModelMode::Remote,
+            claude_endpoint: None,
+            codex_endpoint: None,
+            codex_materialized: true,
+        }
+        .save(&inst)
+        .unwrap();
+        assert!(inst.model_state_path().exists());
+        assert!(
+            ModelState::try_load(&inst)
+                .unwrap()
+                .unwrap()
+                .codex_materialized
+        );
+    }
+
+    #[test]
+    fn try_load_surfaces_non_not_found_read_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        fs::create_dir_all(inst.model_state_path()).unwrap();
+        assert!(ModelState::try_load(&inst).is_err());
+    }
+
+    // ── endpoint resolution ──────────────────────────────────
+
+    #[test]
+    fn config_endpoint_takes_precedence_over_saved() {
+        let claude = ClaudeConfig {
+            local_model: Some(endpoint("http://localhost:1/", "from-config", None)),
+            ..Default::default()
+        };
+        let state = ModelState {
+            mode: ModelMode::Local,
+            claude_endpoint: Some(endpoint("http://localhost:2/", "from-saved", None)),
+            codex_endpoint: None,
+            codex_materialized: false,
+        };
+        assert_eq!(
+            state.resolved_claude(&claude).unwrap().model(),
+            "from-config"
+        );
+    }
+
+    #[test]
+    fn saved_endpoint_used_when_config_absent() {
+        let claude = ClaudeConfig::default();
+        let state = ModelState {
+            mode: ModelMode::Local,
+            claude_endpoint: Some(endpoint("http://localhost:2/", "from-saved", None)),
+            codex_endpoint: None,
+            codex_materialized: false,
+        };
+        assert_eq!(
+            state.resolved_claude(&claude).unwrap().model(),
+            "from-saved"
+        );
+    }
+
+    #[test]
+    fn resolves_none_when_neither_config_nor_saved() {
+        let codex = CodexConfig::default();
+        let state = ModelState::default();
+        assert!(state.resolved_codex(&codex).is_none());
+    }
+
+    // ── env / provider materialization ───────────────────────
+
+    #[test]
+    fn claude_env_block_pins_every_tier_to_local_model() {
+        let env = claude_env_block("http://172.16.0.1:11434", "qwen2.5-coder", "tok");
+        assert_eq!(env["ANTHROPIC_BASE_URL"], "http://172.16.0.1:11434");
+        assert_eq!(env["ANTHROPIC_AUTH_TOKEN"], "tok");
+        for tier in [
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_SMALL_FAST_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        ] {
+            assert_eq!(env[tier], "qwen2.5-coder", "tier {tier} not pinned");
+        }
+    }
+
+    #[test]
+    fn codex_local_config_uses_responses_wire_api() {
+        let table = codex_local_config("http://host.lima.internal:11434/v1/", "gpt-oss:120b");
+        assert_eq!(table["model"].as_str().unwrap(), "gpt-oss:120b");
+        assert_eq!(
+            table["model_provider"].as_str().unwrap(),
+            CODEX_LOCAL_PROVIDER
+        );
+        let provider = table["model_providers"][CODEX_LOCAL_PROVIDER]
+            .as_table()
+            .unwrap();
+        assert_eq!(
+            provider["base_url"].as_str().unwrap(),
+            "http://host.lima.internal:11434/v1/"
+        );
+        assert_eq!(provider["wire_api"].as_str().unwrap(), "responses");
+        assert_eq!(provider["env_key"].as_str().unwrap(), CODEX_LOCAL_ENV_KEY);
+    }
+}

--- a/src/network.rs
+++ b/src/network.rs
@@ -7,6 +7,41 @@ use crate::config::{HostInterface, Instance, NetworkConfig};
 
 const BRIDGE_NAME: &str = "br0";
 
+/// Rewrite a host-visible endpoint URL into one reachable from inside the
+/// guest.
+///
+/// A local model server runs on the host; the guest reaches it through a
+/// backend-specific gateway address (`guest_host`): the TAP gateway on
+/// Firecracker, `host.lima.internal` on Lima. A `localhost`/loopback host
+/// in `url` is replaced with `guest_host`; any other host (a LAN IP or
+/// DNS name) is passed through verbatim so a non-loopback endpoint keeps
+/// working as-is.
+///
+/// Only the host is changed — scheme, port, path, query, and userinfo are
+/// preserved.
+pub fn rewrite_host_url(url: &url::Url, guest_host: &str) -> Result<url::Url> {
+    if !host_is_loopback(url.host().as_ref()) {
+        return Ok(url.clone());
+    }
+    let mut rewritten = url.clone();
+    rewritten
+        .set_host(Some(guest_host))
+        .with_context(|| format!("Invalid guest host address '{guest_host}'"))?;
+    Ok(rewritten)
+}
+
+/// Whether a URL host refers to the local machine: the literal
+/// `localhost`, or any IPv4/IPv6 loopback address. Uses url's typed host
+/// so bracketed IPv6 literals classify correctly.
+fn host_is_loopback(host: Option<&url::Host<&str>>) -> bool {
+    match host {
+        Some(url::Host::Domain(d)) => d.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    }
+}
+
 /// Ensure the bridge exists with the host IP, then create and attach the
 /// instance's tap device. Sets up NAT rules if this is the first instance.
 pub fn setup_tap(cfg: &NetworkConfig, inst: &Instance) -> Result<()> {
@@ -287,4 +322,81 @@ fn tap_exists(name: &str) -> bool {
         .stderr(std::process::Stdio::null())
         .status()
         .is_ok_and(|s| s.success())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    fn rewrite(url: &str, host: &str) -> String {
+        rewrite_host_url(&url::Url::parse(url).unwrap(), host)
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn rewrites_localhost_to_guest_host() {
+        assert_eq!(
+            rewrite("http://localhost:11434", "172.16.0.1"),
+            "http://172.16.0.1:11434/"
+        );
+    }
+
+    #[test]
+    fn rewrites_loopback_ipv4_to_guest_host() {
+        assert_eq!(
+            rewrite("http://127.0.0.1:11434/v1/", "host.lima.internal"),
+            "http://host.lima.internal:11434/v1/"
+        );
+    }
+
+    #[test]
+    fn rewrites_loopback_ipv6_to_guest_host() {
+        assert_eq!(
+            rewrite("http://[::1]:8080/", "172.16.0.1"),
+            "http://172.16.0.1:8080/"
+        );
+    }
+
+    #[test]
+    fn passes_lan_host_through_unchanged() {
+        // A non-loopback endpoint already reaches the host network; leave it.
+        assert_eq!(
+            rewrite("http://192.168.1.50:11434/", "172.16.0.1"),
+            "http://192.168.1.50:11434/"
+        );
+        assert_eq!(
+            rewrite("http://models.lan:11434/", "172.16.0.1"),
+            "http://models.lan:11434/"
+        );
+    }
+
+    #[test]
+    fn preserves_scheme_port_and_path() {
+        assert_eq!(
+            rewrite("https://localhost:9999/v1/chat?a=b", "10.0.0.1"),
+            "https://10.0.0.1:9999/v1/chat?a=b"
+        );
+    }
+
+    #[test]
+    fn host_is_loopback_classifies_correctly() {
+        let loopback = |h: &str| {
+            host_is_loopback(
+                url::Url::parse(&format!("http://{h}"))
+                    .unwrap()
+                    .host()
+                    .as_ref(),
+            )
+        };
+        assert!(loopback("localhost"));
+        assert!(loopback("LocalHost"));
+        assert!(loopback("127.0.0.1"));
+        assert!(loopback("127.5.5.5"));
+        assert!(loopback("[::1]"));
+        assert!(!loopback("192.168.0.1"));
+        assert!(!loopback("example.com"));
+        assert!(!host_is_loopback(None));
+    }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -48,3 +48,25 @@ pub fn confirm_default_yes(prompt: &str) -> Result<bool> {
         _ => Ok(false),
     }
 }
+
+/// Prompt for a free-form line of input. Returns the trimmed reply, or
+/// `None` when stdin is not a TTY or the reply is empty (so callers can
+/// treat empty as "skip"/"use default").
+pub fn read_line(prompt: &str) -> Result<Option<String>> {
+    if !std::io::stdin().is_terminal() {
+        return Ok(None);
+    }
+    let mut stderr = std::io::stderr();
+    write!(stderr, "{prompt}: ").context("Failed to write prompt")?;
+    stderr.flush().context("Failed to flush stderr")?;
+    let mut response = String::new();
+    std::io::stdin()
+        .read_line(&mut response)
+        .context("Failed to read input")?;
+    let trimmed = response.trim();
+    Ok(if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    })
+}

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3383,6 +3383,155 @@ CFGEOF
     rm -r "$ge_dir"
 }
 
+# ── coop model local/remote end-to-end (--full only) ──────────
+
+# Exercises `coop model <vm> local|remote`: the local-model wiring must
+# land in the guest's Claude settings.json (env block) and Codex
+# config.toml (provider block) with the host URL rewritten to the
+# backend's guest-visible address, and `remote` must drop both. No real
+# model server is needed — only the materialized config is asserted.
+test_local_model() {
+    echo ""
+    echo "=== Phase: coop model local/remote (--full) ==="
+
+    local inst_name="${INSTANCE}-model"
+    local lm_dir
+    lm_dir=$(mktemp -d)
+    local cfg_file="$lm_dir/config.toml"
+    local claude_model="coop-test-claude-model"
+    local codex_model="coop-test-codex-model"
+
+    cat > "$cfg_file" <<CFGEOF
+[claude]
+github = "off"
+
+[claude.local_model]
+host_url = "http://localhost:11434"
+model = "$claude_model"
+
+[codex.local_model]
+host_url = "http://localhost:11434/v1/"
+model = "$codex_model"
+CFGEOF
+
+    lm() {
+        local rc=0
+        HARNESS_OUT=$(env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY -u OPENAI_API_KEY \
+            "$BINARY" --config "$cfg_file" "$@" 2>"$tmpdir/stderr") || rc=$?
+        HARNESS_ERR=$(cat "$tmpdir/stderr")
+        return $rc
+    }
+    lm_exec() {
+        RUST_LOG=off env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY -u OPENAI_API_KEY \
+            "$BINARY" --config "$cfg_file" exec "$inst_name" -- "$@" \
+            2>"$tmpdir/guest_stderr"
+    }
+
+    local lm_ws="$tmpdir/${inst_name}-ws"
+    mkdir -p "$lm_ws"
+    if lm up "$lm_ws" --name "$inst_name" --no-agents --no-devcontainer; then
+        STARTED_INSTANCES+=("$inst_name")
+        pass "up for model test exits 0"
+    else
+        fail "up for model test exits 0" "exit: $? stderr: $HARNESS_ERR"
+        rm -r "$lm_dir"
+        return
+    fi
+
+    # Default (no model.json) must report remote.
+    if lm model "$inst_name" && echo "$HARNESS_OUT" | grep -qi "Mode:.*remote"; then
+        pass "model status defaults to remote"
+    else
+        fail "model status defaults to remote" "out: $HARNESS_OUT stderr: $HARNESS_ERR"
+    fi
+
+    # Switch to local — materializes guest config against the running VM.
+    if lm model "$inst_name" local; then
+        pass "model local exits 0"
+    else
+        fail "model local exits 0" "exit: $? stderr: $HARNESS_ERR"
+    fi
+
+    # Claude settings.json carries the env block with a rewritten host.
+    local settings
+    if settings=$(lm_exec cat ./.claude/settings.json); then
+        if echo "$settings" | grep -q "$claude_model" \
+            && echo "$settings" | grep -q "ANTHROPIC_BASE_URL" \
+            && ! echo "$settings" | grep -q "localhost"; then
+            pass "claude settings.json has rewritten local env block"
+        else
+            fail "claude settings.json has rewritten local env block" "got: $settings"
+        fi
+    else
+        fail "claude settings.json has rewritten local env block" \
+            "cat failed; stderr: $(guest_stderr)"
+    fi
+
+    # Codex config.toml carries the provider block with a rewritten host.
+    local codex_cfg
+    if codex_cfg=$(lm_exec cat ./.codex/config.toml); then
+        if echo "$codex_cfg" | grep -q "coop_local" \
+            && echo "$codex_cfg" | grep -q "responses" \
+            && echo "$codex_cfg" | grep -q "$codex_model" \
+            && ! echo "$codex_cfg" | grep -q "localhost"; then
+            pass "codex config.toml has rewritten local provider block"
+        else
+            fail "codex config.toml has rewritten local provider block" "got: $codex_cfg"
+        fi
+    else
+        fail "codex config.toml has rewritten local provider block" \
+            "cat failed; stderr: $(guest_stderr)"
+    fi
+
+    # Status now reports local with the model.
+    if lm model "$inst_name" && echo "$HARNESS_OUT" | grep -qi "Mode:.*local" \
+        && echo "$HARNESS_OUT" | grep -q "$claude_model"; then
+        pass "model status reports local with endpoint"
+    else
+        fail "model status reports local with endpoint" "out: $HARNESS_OUT"
+    fi
+
+    # The selection must survive a stop/start: boot-time bootstrap re-applies
+    # the persisted local mode.
+    lm stop "$inst_name" >/dev/null 2>&1 || true
+    if lm start "$inst_name" >/dev/null 2>&1; then
+        if settings=$(lm_exec cat ./.claude/settings.json) \
+            && echo "$settings" | grep -q "ANTHROPIC_BASE_URL"; then
+            pass "local mode persists across stop/start"
+        else
+            fail "local mode persists across stop/start" "got: $settings"
+        fi
+    else
+        fail "local mode persists across stop/start" "restart failed: $HARNESS_ERR"
+    fi
+
+    # Switch back to remote — both materializations must be dropped.
+    if lm model "$inst_name" remote; then
+        pass "model remote exits 0"
+    else
+        fail "model remote exits 0" "exit: $? stderr: $HARNESS_ERR"
+    fi
+
+    if settings=$(lm_exec cat ./.claude/settings.json) \
+        && ! echo "$settings" | grep -q "ANTHROPIC_BASE_URL"; then
+        pass "remote drops claude env block"
+    else
+        fail "remote drops claude env block" "got: $settings"
+    fi
+
+    if codex_cfg=$(lm_exec cat ./.codex/config.toml 2>/dev/null) \
+        && echo "$codex_cfg" | grep -q "coop_local"; then
+        fail "remote drops codex provider block" "stale provider: $codex_cfg"
+    else
+        pass "remote drops codex provider block"
+    fi
+
+    lm stop "$inst_name" 2>/dev/null || true
+    lm destroy "$inst_name" 2>/dev/null || true
+    untrack_instance "$inst_name"
+    rm -r "$lm_dir"
+}
+
 # ── Interrupted setup test (--full only) ──────────────────────
 
 test_interrupted_setup() {
@@ -4254,6 +4403,9 @@ main() {
 
         # [guest_env] config block + literal-over-forwarded precedence
         test_guest_env_config
+
+        # coop model local/remote: local-model wiring lands and reverts
+        test_local_model
 
         # Interrupted setup: SIGKILL mid-build, verify clean recovery
         test_interrupted_setup


### PR DESCRIPTION
Closes #343.

Lets a VM route Claude Code and Codex at a host-side local model server (Ollama / LM Studio / vLLM / llama.cpp) instead of the cloud, toggled per VM.

## Configuration

```toml
[claude.local_model]
host_url = "http://localhost:11434"     # Anthropic Messages API
model    = "qwen2.5-coder:32b"
# auth_token optional

[codex.local_model]
host_url = "http://localhost:11434/v1/" # Responses API
model    = "gpt-oss:120b"
```

`LocalModel` is a smart-constructor type with private fields and a validating `Deserialize`, so a non-`http(s)` URL, a hostless URL, or an empty model name is rejected at config load — illegal endpoints are unrepresentable rather than caught by a later validation pass.

## CLI

```
coop model <vm>            # status: per-tool mode + resolved endpoint
coop model <vm> local      # route this VM at the local model(s)
coop model <vm> remote     # restore cloud defaults (default)
```

The selection is a per-VM persisted setting, not a per-launch flag, so it applies to `coop shell`, `coop claude`, `coop codex`, and VS Code alike. Switching is an SSH file write against the running VM — no rebuild — and is re-applied on the next boot. When no endpoint is configured, `local` prompts interactively and remembers the answer.

## How it lands in the guest

- **Endpoint rewrite** (`network::rewrite_host_url`): a `localhost`/loopback host is rewritten to the backend's guest-visible host — the Firecracker TAP gateway (`network.host_ip`) or Lima's `host.lima.internal`. Any other host (LAN IP / DNS name) passes through.
- **Claude**: `ANTHROPIC_*` written into the `env` block of the managed `~/.claude/settings.json` (rewritten unconditionally every boot, so remote cleanly drops it).
- **Codex**: a `[model_providers.coop_local]` block (`wire_api = "responses"`) plus top-level `model`/`model_provider` in `~/.codex/config.toml`; the token is forwarded as `COOP_LOCAL_API_KEY`. A persisted `codex_materialized` flag ensures the block is rewritten clean on a switch back to remote even if the configured endpoint was later removed.

## State

`model_state.rs` persists the selection at `<inst.dir>/model.json` (mode `0o600`, since a prompted `auth_token` is serialized there). Endpoint resolution is config-over-saved per tool.

## Caveats (documented in `config.example.toml`)

Host server must bind the host interface / `0.0.0.0`; Claude needs an Anthropic-Messages endpoint, Codex a Responses-API endpoint; prompt caching is lost on local backends.

## Tests

- Unit tests for `LocalModel` validation, `ModelState` persistence/resolution, the URL rewrite (loopback v4/v6, `localhost`, LAN pass-through, scheme/port/path preservation), the Claude env block, and the Codex provider block (including remote-revert drop).
- Integration phase (`test_local_model`, `--full`) asserts the wiring lands in both guest files with the host rewritten, persists across stop/start, and reverts on `remote` — on both backends.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` are clean. A subagent code review ran against the diff; its findings (Codex revert orphan when the config source is removed, `model.json` permissions, and a documented-but-unimplemented `cmd:` token hint) are addressed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)