### PR TITLE
Bypass Codex sandbox by default for parity with coop claude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### New features
 
+- **`coop codex` bypasses Codex's sandbox by default** (#353) — `coop codex`
+  now launches Codex with `--dangerously-bypass-approvals-and-sandbox`, so it
+  runs unrestricted like `coop claude`. The VM is the isolation boundary, and
+  Codex's Linux sandbox does not work in the guest (no functioning bubblewrap),
+  which previously made every shell command Codex ran fail on sandbox setup.
+  Pass `coop codex --ask` to keep Codex's sandbox and approval prompts.
+
 - **`coop commit` + `coop restore` — checkpoint and roll back an instance** (#289) —
   `coop commit <name> --image <image>` saves a stopped instance's
   filesystem as a reusable image, a `docker container commit`-style

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -8,7 +8,15 @@ coop installs Codex into every guest image and gives you a dedicated `coop codex
 coop codex [instance-name] [-- extra-args...]
 ```
 
-This SSHes into the guest and runs the `codex` CLI.
+This SSHes into the guest and runs the `codex` CLI. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with how `coop claude` runs unrestricted. The VM is the isolation boundary, so Codex's own sandbox is redundant; it also does not work in the guest, which lacks a functioning bubblewrap, so leaving it enabled makes every shell command Codex runs fail.
+
+To keep Codex's sandbox and approval prompts for a single session, pass `--ask`. coop then launches `codex` with no bypass flag, so Codex applies its normal defaults:
+
+```bash
+coop codex --ask
+```
+
+Use `--ask` too if you want to supply your own sandbox or approval flags (`--sandbox`, `-a`) as trailing arguments — otherwise coop's bypass flag takes precedence.
 
 Trailing arguments go straight through to the `codex` CLI:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -327,7 +327,7 @@ coop ca my-project -- --cwd /workspace
 
 ### `codex`
 
-Launch Codex inside the VM.
+Launch Codex inside the VM. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with `coop claude`. The VM is the isolation boundary, and Codex's own Linux sandbox does not work in the guest (no functioning bubblewrap), so leaving it enabled makes every shell command Codex runs fail. Use `--ask` to keep Codex's sandbox and approval prompts for that session.
 
 ```
 coop codex [NAME] [FLAGS] [ARGS...]
@@ -336,10 +336,12 @@ coop codex [NAME] [FLAGS] [ARGS...]
 | Flag | Description |
 |------|-------------|
 | `NAME` | Instance name (required if multiple instances exist) |
+| `--ask` | Keep Codex's sandbox and approval prompts instead of bypassing them |
 | `ARGS...` | Extra arguments passed through to `codex` |
 
 ```
 coop codex
+coop codex my-project --ask
 coop codex my-project -- --model gpt-5
 ```
 

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1430,6 +1430,22 @@ pub(crate) fn prepend_binary(binary: &str, args: Vec<String>) -> Vec<String> {
     command
 }
 
+/// Codex's flag for running fully unrestricted (no sandbox, no approvals).
+const CODEX_BYPASS_FLAG: &str = "--dangerously-bypass-approvals-and-sandbox";
+
+/// Prepend Codex's sandbox-bypass flag unless the user opted into approvals.
+///
+/// The VM is the isolation boundary, so Codex's own sandbox is redundant — and
+/// broken in the guest, which lacks a working bubblewrap. Bypassing by default
+/// gives `coop codex` parity with `coop claude`'s `bypassPermissions`. `ask`
+/// (from `--ask`) keeps Codex's sandbox and approval prompts.
+pub(crate) fn codex_launch_args(ask: bool, mut args: Vec<String>) -> Vec<String> {
+    if !ask {
+        args.insert(0, CODEX_BYPASS_FLAG.to_string());
+    }
+    args
+}
+
 pub(crate) fn cmd_exec(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
@@ -1829,6 +1845,31 @@ mod tests {
     fn prepend_binary_with_no_args() {
         let cmd = super::prepend_binary("/usr/bin/codex", Vec::new());
         assert_eq!(cmd, vec!["/usr/bin/codex"]);
+    }
+
+    #[test]
+    fn codex_launch_args_bypasses_sandbox_by_default() {
+        let args = super::codex_launch_args(false, vec!["--model".into(), "gpt-5".into()]);
+        assert_eq!(
+            args,
+            vec![
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--model",
+                "gpt-5"
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_launch_args_with_ask_keeps_sandbox() {
+        let args = super::codex_launch_args(true, vec!["--model".into(), "gpt-5".into()]);
+        assert_eq!(args, vec!["--model", "gpt-5"]);
+    }
+
+    #[test]
+    fn codex_launch_args_bypass_flag_leads_empty_args() {
+        let args = super::codex_launch_args(false, Vec::new());
+        assert_eq!(args, vec!["--dangerously-bypass-approvals-and-sandbox"]);
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,8 +20,8 @@ pub(crate) use github::cmd_github;
 pub(crate) use lifecycle::{
     ProfileImageTarget, ProjectTransport, StartOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts,
     apply_runtime_guest_env, apply_vm_overrides, cmd_commit, cmd_destroy, cmd_exec, cmd_list,
-    cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_up, open_ssh_session,
-    preflight_start_target, prepend_binary, resolve_running,
+    cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_up, codex_launch_args,
+    open_ssh_session, preflight_start_target, prepend_binary, resolve_running,
 };
 pub(crate) use profiles::{cmd_images, cmd_profiles};
 pub(crate) use quickstart::{QuickstartOpts, cmd_quickstart};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,8 @@ use commands::{
     apply_vm_overrides, cmd_commit, cmd_destroy, cmd_devcontainer, cmd_devcontainer_check,
     cmd_exec, cmd_github, cmd_images, cmd_init, cmd_list, cmd_profiles, cmd_quickstart, cmd_resize,
     cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_uninstall, cmd_up, cmd_validate,
-    open_ssh_session, preflight_start_target, prepend_binary, resolve_devcontainer,
-    resolve_running,
+    codex_launch_args, open_ssh_session, preflight_start_target, prepend_binary,
+    resolve_devcontainer, resolve_running,
 };
 
 #[derive(Parser)]
@@ -350,7 +350,7 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Launch Codex inside the VM
+    /// Launch Codex inside the VM (bypasses the sandbox and approvals by default)
     Codex {
         /// Instance name (required if multiple instances exist)
         #[arg(
@@ -358,6 +358,9 @@ enum Commands {
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
+        /// Keep Codex's sandbox and approval prompts instead of bypassing them
+        #[arg(long)]
+        ask: bool,
         /// Extra arguments passed to `codex`
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -1066,8 +1069,9 @@ pub fn run() -> Result<()> {
             let claude_bin = guest::GuestUser::new(sess.target.user.as_ref())?.claude_bin();
             ssh::run_interactive(&sess, &prepend_binary(claude_bin.as_ref(), args))
         }
-        Commands::Codex { name, args } => {
+        Commands::Codex { name, ask, args } => {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
+            let args = codex_launch_args(ask, args);
             ssh::run_interactive(&sess, &prepend_binary(guest::codex_bin().as_ref(), args))
         }
         Commands::Stop { name } => {
@@ -1382,13 +1386,24 @@ mod tests {
     #[test]
     fn codex_name_and_trailing_args_parse() {
         let cli = parse(&["codex", "myvm", "--", "--model", "gpt-5"]);
-        let super::Commands::Codex { name, args, .. } = cli.command else {
+        let super::Commands::Codex { name, ask, args } = cli.command else {
             panic!("expected Codex variant");
         };
         assert_eq!(
             name.as_ref().map(super::config::InstanceName::as_str),
             Some("myvm")
         );
+        assert!(!ask, "ask defaults to false (sandbox bypassed)");
+        assert_eq!(args, vec!["--model", "gpt-5"]);
+    }
+
+    #[test]
+    fn codex_ask_flag_parses() {
+        let cli = parse(&["codex", "myvm", "--ask", "--", "--model", "gpt-5"]);
+        let super::Commands::Codex { ask, args, .. } = cli.command else {
+            panic!("expected Codex variant");
+        };
+        assert!(ask, "--ask keeps Codex's sandbox and approvals");
         assert_eq!(args, vec!["--model", "gpt-5"]);
     }
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -826,6 +826,31 @@ test_codex_bin_path() {
     fi
 }
 
+test_codex_sandbox_bypass() {
+    echo ""
+    echo "=== Phase: codex sandbox bypass (issue #353) ==="
+
+    # `coop codex` runs Codex unrestricted by prepending the global flag
+    # `--dangerously-bypass-approvals-and-sandbox` (as `codex <flag> <args>`),
+    # for parity with `coop claude`'s bypassPermissions. The VM is the isolation
+    # boundary and Codex's own Linux sandbox does not work in the guest, so every
+    # shell command Codex would otherwise run fails on sandbox setup.
+    #
+    # A full agentic run that actually spawns a sandboxed shell command needs model
+    # credentials the CI guest doesn't have (Codex only reaches sandbox setup after
+    # a model turn), so we can't drive a live tool call here. Instead we pin the
+    # coop<->Codex contract: the installed Codex must accept that exact flag in the
+    # global position coop uses. If a Codex release renames or moves it, this fails
+    # loudly rather than silently re-enabling the broken sandbox.
+    if moat_exec /usr/local/bin/codex --dangerously-bypass-approvals-and-sandbox \
+        exec --help >/dev/null; then
+        pass "codex accepts global --dangerously-bypass-approvals-and-sandbox flag"
+    else
+        fail "codex accepts global --dangerously-bypass-approvals-and-sandbox flag" \
+            "stderr: $(guest_stderr)"
+    fi
+}
+
 test_github_token_forwarding() {
     echo ""
     echo "=== Phase: github token forwarding ==="
@@ -4172,6 +4197,7 @@ main() {
     test_exec
     test_claude_bin_path
     test_codex_bin_path
+    test_codex_sandbox_bypass
     test_github_token_forwarding
     test_term_handling
     test_guest_environment


### PR DESCRIPTION
## Summary

`coop codex` launched Codex with no flags, so Codex's default Linux sandbox tried to set itself up via bubblewrap — which the guest doesn't ship. Codex fell back to its bundled bubblewrap, which can't initialize the sandbox, so **every shell command Codex ran failed**. Meanwhile `coop claude` runs unrestricted (managed `settings.json` sets `defaultMode: bypassPermissions`). This fixes the asymmetry.

The VM is already the isolation boundary, so Codex's own sandbox is both redundant and broken here.

## Changes

- `coop codex` now prepends `--dangerously-bypass-approvals-and-sandbox` (the same flag the in-guest `codex-yolo` shortcut uses), so Codex runs unrestricted by default — parity with `coop claude`.
- New `coop codex --ask` opts back into Codex's sandbox and approval prompts, mirroring `coop claude --ask`.
- The flag-assembly logic is a pure `codex_launch_args` helper (in `src/commands/lifecycle.rs`), unit-tested for the default-vs-`--ask` behavior.
- Integration suite gains a `test_codex_sandbox_bypass` phase.
- Docs (`commands.md`, `codex-integration.md`) and CHANGELOG updated.

## Testing

- `cargo test --lib` — 881 pass (5 new Codex tests).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `shellcheck tests/integration.sh` — no new warnings.
- A reviewing subagent ran `cargo mutants` on the new helper: 4 mutants, 4 caught (0 missed) — the tests catch a dropped flag and an inverted `--ask` check.

## Note on the integration test

The acceptance criterion asks the integration test to assert a Codex-driven shell command actually executes. A full agentic run that spawns a sandboxed shell command requires model credentials the CI guest doesn't have (Codex only reaches sandbox setup after a model turn), so a live tool call can't run in CI. The new phase instead pins the narrower, stable contract that's actually verifiable without credentials: the installed Codex accepts `--dangerously-bypass-approvals-and-sandbox` in the global position `coop codex` uses, so a Codex rename fails the suite loudly rather than silently re-enabling the broken sandbox. The unit tests pin coop's own flag-assembly behavior.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
