### PR TITLE
docs: document the coop model / local-model feature

### DIFF
--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -182,7 +182,7 @@ When `coop up` creates/restarts a project VM or `coop start` restarts a stopped 
 
 1. **GitHub auth**: If a `GITHUB_TOKEN` is available, run `gh auth setup-git` in the guest.
 2. **User content**: Copy the allowlisted entries (`CLAUDE.md`, `rules/`, `commands/`) from `config_dir` to `~/.claude/` in the guest.
-3. **Managed permissions**: Merge coop's managed permission keys (`permissions.defaultMode: bypassPermissions` and `permissions.skipDangerousModePermissionPrompt: true`) into the guest's `~/.claude/settings.json`, preserving any other keys it holds. The setting must live in user scope — Claude Code ignores `skipDangerousModePermissionPrompt` from project settings. Other keys Claude Code stores in this file (notably `enabledPlugins` and `extraKnownMarketplaces`) are left intact so plugin and marketplace state survives a stop/start cycle. The one exception is the `env` block, which coop owns for local-model routing (see `coop model`): it is set when the VM is in local-model mode and removed in remote mode, so any hand-authored `env` entries in this file are not preserved. A file that cannot be parsed is replaced with managed defaults.
+3. **Managed permissions**: Merge coop's managed permission keys (`permissions.defaultMode: bypassPermissions` and `permissions.skipDangerousModePermissionPrompt: true`) into the guest's `~/.claude/settings.json`, preserving any other keys it holds. The setting must live in user scope — Claude Code ignores `skipDangerousModePermissionPrompt` from project settings. Other keys Claude Code stores in this file (notably `enabledPlugins` and `extraKnownMarketplaces`) are left intact so plugin and marketplace state survives a stop/start cycle. The one exception is the `env` block, which coop owns for local-model routing (see [Local model support](#local-model-support)): it is set when the VM is in local-model mode and removed in remote mode, so any hand-authored `env` entries in this file are not preserved. A file that cannot be parsed is replaced with managed defaults.
 4. **Marketplaces**: Register each marketplace source (local directories are copied to the guest first). On first boot, coop compares the configured marketplaces against those already baked into the golden image (from `coop setup --profile`) and only installs the ones that are missing.
 5. **Plugins**: Install each plugin from the registered marketplaces. Like marketplaces, coop computes the delta against plugins already present in the golden image and skips those that are already installed.
 6. **MCP servers**: Register each MCP server definition.
@@ -199,3 +199,33 @@ coop start --no-agents
 ```
 
 This skips the entire bootstrap sequence. The VM boots normally but gets no API key, no GitHub token, no plugins, and no MCP servers. You can still run `coop claude` afterward, and that session forwards `ANTHROPIC_API_KEY` and any `env_forward` variables via SSH. Plugins and MCP servers won't be available unless you configure them manually inside the guest.
+
+## Local model support
+
+A VM can route Claude Code at a host-side local model server (Ollama / LM Studio
+/ vLLM / llama.cpp) instead of Anthropic's cloud. The endpoint must serve the
+Anthropic Messages API. Switch a VM with [`coop model <vm> local`](commands.md#model)
+and back with `coop model <vm> remote`; configure the endpoint under
+[`[claude.local_model]`](configuration.md#local-model-routing) or interactively
+at the `coop model … local` prompt.
+
+The selection is per VM and independent of Codex — Claude can run on a local
+model while Codex stays on cloud, or the reverse. The endpoint Claude resolves
+is the `[claude.local_model]` config block if present, otherwise an endpoint
+saved interactively for the instance, otherwise none (it stays on cloud).
+Config takes precedence over the saved endpoint.
+
+In local mode coop writes an `env` block into the managed
+`~/.claude/settings.json` (see step 3 of the [bootstrap sequence](#bootstrap-sequence))
+pointing `ANTHROPIC_BASE_URL` at the guest-visible endpoint, pinning every model
+tier to the configured model, and supplying `ANTHROPIC_AUTH_TOKEN`. coop owns
+this `env` block: it is set in local mode and removed in remote mode, so
+hand-authored `env` entries are not preserved. Two cache-stability keys
+(`CLAUDE_CODE_ATTRIBUTION_HEADER=0`, `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1`)
+are set in local mode. They stop Claude Code from mutating the system prompt
+per request, which keeps a local inference server's prompt cache warm.
+
+Switching takes effect without a VM restart: coop rewrites `settings.json` live
+over SSH on a running VM (or saves the selection to apply on the next start). A
+running `claude` reads its config at launch, so relaunch it (`coop claude <vm>`)
+to pick up the change.

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -101,7 +101,7 @@ type = "http"
 url = "https://mcp.sentry.dev/mcp"
 ```
 
-If `config_dir` also provides a `config.toml`, coop preserves its other settings but replaces the `mcp_servers` table with the one derived from `codex.mcp_servers`.
+If `config_dir` also provides a `config.toml`, coop preserves its other settings but replaces the `mcp_servers` table with the one derived from `codex.mcp_servers`. When the VM is in [local-model mode](#local-model-support), coop also owns the `model` and `model_provider` keys and a `[model_providers.coop_local]` block; these are written on a switch to local and removed on a switch back to remote, so they are not preserved across a mode change.
 
 ## Bootstrap sequence
 
@@ -123,3 +123,33 @@ coop start --no-agents
 ```
 
 This skips the guest bootstrap sequence entirely. The VM still includes both CLIs because they are baked into the image during `coop setup`.
+
+## Local model support
+
+A VM can route Codex at a host-side local model server (Ollama / LM Studio /
+vLLM / llama.cpp) instead of OpenAI's cloud. The endpoint must serve the
+Responses API — the only wire API Codex currently supports. Switch a VM with
+[`coop model <vm> local`](commands.md#model) and back with
+`coop model <vm> remote`; configure the endpoint under
+[`[codex.local_model]`](configuration.md#local-model-routing) or interactively
+at the `coop model … local` prompt.
+
+The selection is per VM and independent of Claude — Codex can run on a local
+model while Claude stays on cloud, or the reverse. The endpoint Codex resolves
+is the `[codex.local_model]` config block if present, otherwise an endpoint
+saved interactively for the instance, otherwise none (it stays on cloud).
+Config takes precedence over the saved endpoint.
+
+In local mode coop injects three coop-owned keys into `~/.codex/config.toml`:
+`model` (the configured model), `model_provider` (`coop_local`), and a
+`[model_providers.coop_local]` block pointing `base_url` at the guest-visible
+endpoint with `wire_api = "responses"`. The provider reads its API key from the
+`COOP_LOCAL_API_KEY` env var, which coop forwards with the configured (or dummy)
+token. These keys are coop-owned: they are written on a switch to local and
+removed on a switch back to remote, so they are not preserved across a mode
+change.
+
+Switching takes effect without a VM restart: coop rewrites `config.toml` live
+over SSH on a running VM (or saves the selection to apply on the next start). A
+running `codex` reads its config at launch, so relaunch it (`coop codex <vm>`)
+to pick up the change.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -428,6 +428,64 @@ coop status
 coop status my-project
 ```
 
+### `model`
+
+Show or switch a VM's model backend between cloud (Anthropic / OpenAI) and a
+host-side local model server. The selection is per-instance and persists across
+restarts. Switching rewrites the guest agent config; it never rebuilds or
+restarts the VM.
+
+```
+coop model [NAME] [local|remote]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `NAME` | Instance name (required if multiple instances exist) |
+| `local` | Route this VM's agents at a host-side local model server |
+| `remote` | Restore cloud defaults (Anthropic / OpenAI) |
+
+With no subcommand, `model` prints the current mode and the endpoint each tool
+(Claude, Codex) resolves to:
+
+```
+$ coop model my-project
+Instance: my-project
+Mode:     local
+Claude   local — qwen2.5-coder:32b @ http://172.16.0.1:11434
+Codex    cloud (no local endpoint configured)
+```
+
+`coop model NAME local` switches the VM to local mode. Each tool routes locally
+only if it resolves an endpoint — from `[claude.local_model]` /
+`[codex.local_model]` in `config.toml`, or from one saved earlier. For any tool
+that has neither, and only in an interactive terminal, coop prompts for a host
+URL, model name, and optional auth token, then saves that endpoint for the
+instance. (A non-interactive run declines the prompt.) If no tool ends up with
+an endpoint, the command fails. Claude and Codex are independent: you can put
+one on a local model and leave the other on cloud.
+
+`coop model NAME remote` switches back to cloud defaults for both tools. Saved
+endpoints are kept, so a later `local` does not re-prompt.
+
+Switching never requires a VM restart — coop rewrites the guest config live over
+SSH when the VM is running, or saves it to apply on the next start. An
+already-running `claude`/`codex` reads its config at launch, so relaunch the
+agent (for example `coop claude NAME`) to pick up the change.
+
+```
+coop model
+coop model my-project
+coop model my-project local
+coop model my-project remote
+```
+
+See the [`local_model`](configuration.md#local-model-routing) configuration
+reference and the local-model sections of
+[docs/claude-integration.md](claude-integration.md) and
+[docs/codex-integration.md](codex-integration.md) for the resolution and
+materialization details.
+
 ### `logs`
 
 Stream the VM serial console output.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,6 +192,7 @@ Claude Code configuration injected into the guest VM at start time. Every field 
 | `marketplaces` | array of strings | `[]` | Plugin marketplace sources. Each entry is a GitHub repo URL or an absolute local directory path. Local directories are copied into the guest before registration. |
 | `plugins` | array of strings | `[]` | Plugins to install from registered marketplaces. Format: `plugin-name@marketplace-name`. |
 | `mcp_servers` | table | `{}` | MCP servers to register in the guest. Keys are server names; values are server definitions. See [MCP servers](#mcp-servers). |
+| `local_model` | table | unset | Host-side model endpoint to route Claude Code at when the VM is in local mode (`coop model <vm> local`). See [Local-model routing](#local-model-routing). |
 
 ### MCP servers
 
@@ -238,8 +239,41 @@ Codex configuration injected into the guest VM at start time. Every field is opt
 | `config_dir` | string (path) or `false` | `~/.codex` | Source directory for Codex config files. Copies an allowlist of entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from this directory to `~/.codex/` in the guest on start. Set to `false` to disable. Supports `~` expansion. |
 | `env_forward` | array of strings | `[]` | Extra environment variable names to forward from host to guest via SSH `SendEnv`. `OPENAI_API_KEY` and `GITHUB_TOKEN` are forwarded automatically when set; list additional variables here. |
 | `mcp_servers` | table | `{}` | MCP servers to merge into the guest `~/.codex/config.toml`. Keys are server names; values are server definitions. See [MCP servers](#mcp-servers). |
+| `local_model` | table | unset | Host-side model endpoint to route Codex at when the VM is in local mode (`coop model <vm> local`). See [Local-model routing](#local-model-routing). |
 
 coop preserves any other settings already present in the staged `config.toml`, but the `mcp_servers` table is owned by coop when `codex.mcp_servers` is configured.
+
+## Local-model routing
+
+`[claude.local_model]` and `[codex.local_model]` declare a host-side model
+endpoint to route an agent at instead of the cloud. They are inert until the VM
+is switched to local mode with [`coop model <vm> local`](commands.md#model);
+`coop model <vm> remote` restores the cloud defaults. The two tools are
+independent — configure one, both, or neither.
+
+Each block takes the same fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host_url` | string (URL) | required | Endpoint as seen **on the host**, where the model server runs (Ollama / LM Studio / vLLM / llama.cpp). Must be an `http`/`https` URL with a host. A `localhost`/`127.0.0.1` host is rewritten to the guest's view of the host (Firecracker: the TAP gateway; Lima: `host.lima.internal`); any other host passes through verbatim, so a LAN endpoint also works. |
+| `model` | string | required | Model name to request. Must not be empty. For Claude, coop pins every model tier (opus/sonnet/haiku and the small-fast model) to this name so any tier routes locally. |
+| `auth_token` | string | unset | Auth token for the endpoint. Optional — permissive local servers (Ollama, LM Studio, vLLM) ignore it, and coop sends a dummy value when it is omitted. The value is used verbatim; unlike `api_key` it does not resolve a `cmd:` prefix. |
+
+```toml
+[claude.local_model]
+host_url = "http://localhost:11434"   # Anthropic Messages API
+model = "qwen2.5-coder:32b"
+
+[codex.local_model]
+host_url = "http://localhost:11434/v1/"   # Responses API
+model = "gpt-oss:120b"
+```
+
+An endpoint set here takes precedence over one entered interactively and saved
+in the instance's `model.json` by `coop model … local`. See the local-model
+sections of [docs/claude-integration.md](claude-integration.md) and
+[docs/codex-integration.md](codex-integration.md) for how each endpoint is
+materialized into guest config.
 
 ## `profiles` section
 

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -43,7 +43,7 @@ coop shell my-project
 coop shell another-project
 ```
 
-This applies to `shell`, `stop`, `destroy`, `status <name>`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`, `claude`, and `codex`.
+This applies to `shell`, `stop`, `destroy`, `status <name>`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`, `model`, `claude`, and `codex`.
 
 ## Checking status
 

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -79,6 +79,6 @@ Dynamic and static completion can coexist — static fills in subcommand and fla
 
 | Argument | Source |
 |----------|--------|
-| Instance name (`shell`, `claude`, `claude-agents`, `codex`, `stop`, `destroy`, `status`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`) | `~/.coop/instances/` |
+| Instance name (`shell`, `claude`, `claude-agents`, `codex`, `stop`, `destroy`, `status`, `logs`, `push`, `pull`, `exec`, `vscode`, `resize`, `model`) | `~/.coop/instances/` |
 | `--image` (`up`, `setup`, `start` compatibility flag), `images --delete` | `~/.coop/images/` |
 | `--profile` (`setup`, `up`), `profiles show <name>` | builtin profiles plus `[profiles.*]` from `~/.coop/config.toml` |


### PR DESCRIPTION
Closes #357.

Documents the `coop model` command and local-model routing, which shipped after v0.5.1 without doc updates.

- **`docs/commands.md`** — new `### model` section: `coop model [NAME] [local|remote]`, the no-subcommand status display, the per-tool endpoint resolution and interactive prompt, and that switching rewrites guest config live without a VM restart.
- **`docs/configuration.md`** — adds the `local_model` row to the `[claude]` and `[codex]` field tables and a `Local-model routing` subsection documenting `host_url` / `model` / `auth_token`, the localhost→guest-host rewrite, and config-over-saved precedence.
- **`docs/claude-integration.md`** / **`docs/codex-integration.md`** — `Local model support` sections covering per-tool independence, resolution precedence, the coop-owned `env` block (Claude) and the coop-owned `model` / `model_provider` / `[model_providers.coop_local]` keys (Codex), and the relaunch-agent / no-restart behavior. Resolves the dangling `(see coop model)` link.
- **`docs/multi-instance.md`** / **`docs/shell-completion.md`** — adds `model` to the instance-addressing and instance-name completion lists.

Every statement was verified against `src/commands/model.rs`, `src/model_state.rs`, `src/lib.rs`, `src/config.rs`, and `config.example.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)