### PR TITLE
docs: fix duplicate getting-started heading and MCP transport count

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,7 +196,7 @@ Claude Code configuration injected into the guest VM at start time. Every field 
 
 ### MCP servers
 
-Each key in `mcp_servers` maps a server name to its definition. Two transport types are supported.
+Each key in `mcp_servers` maps a server name to its definition. Three transport types are supported.
 
 **Stdio server** (spawns a process):
 
@@ -213,6 +213,15 @@ env = { SERVER_API_KEY = "MY_HOST_ENV_VAR" }
 [claude.mcp_servers.remote-server]
 type = "http"
 url = "https://mcp.example.com/v1"
+headers = { Authorization = "Bearer token" }
+```
+
+**SSE server** (connects to a remote endpoint over Server-Sent Events):
+
+```toml
+[claude.mcp_servers.events-server]
+type = "sse"
+url = "https://mcp.example.com/sse"
 headers = { Authorization = "Bearer token" }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -287,7 +287,7 @@ coop push --dir ~/other-dir
 coop pull --dir ~/other-dir
 ```
 
-### 6. Tear down
+### 7. Tear down
 
 Stop an instance (preserves disk state):
 


### PR DESCRIPTION
Closes #360.

Two small cleanups:

- **`docs/getting-started.md`** — renumbers the second `### 6.` ("Tear down") to `### 7.` so the step sequence is monotonic.
- **`docs/configuration.md`** — corrects "Two transport types are supported" to "Three" (`stdio`, `http`, `sse`) and adds an `sse` example matching the existing `http` one.

Transport types verified against the `McpServerDef` enum in `src/config.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)