### PR TITLE
Assert prefix-cache-buster env keys in local-model integration test

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3576,11 +3576,26 @@ CFGEOF
         fail "model local exits 0" "exit: $? stderr: $HARNESS_ERR"
     fi
 
-    # Claude settings.json carries the env block with a rewritten host.
+    # The VM is running, so the change applies live: assert the no-restart
+    # fast-path report line rather than the "applies on next start" message.
+    if echo "$HARNESS_OUT" | grep -qi "no restart needed"; then
+        pass "model local reports no-restart fast path"
+    else
+        fail "model local reports no-restart fast path" "out: $HARNESS_OUT"
+    fi
+
+    # Claude settings.json carries the env block with a rewritten host. The
+    # two cache-buster keys (CLAUDE_CODE_ATTRIBUTION_HEADER,
+    # CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS) disable the per-request prompt
+    # mutators that would otherwise re-prefill a local backend's KV cache on
+    # every tool call; they exist only in the local env block, so assert they
+    # reach the guest — the unit test pins only the in-process map shape.
     local settings
     if settings=$(lm_exec cat ./.claude/settings.json); then
         if echo "$settings" | grep -q "$claude_model" \
             && echo "$settings" | grep -q "ANTHROPIC_BASE_URL" \
+            && echo "$settings" | grep -q "CLAUDE_CODE_ATTRIBUTION_HEADER" \
+            && echo "$settings" | grep -q "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS" \
             && ! echo "$settings" | grep -q "localhost"; then
             pass "claude settings.json has rewritten local env block"
         else


### PR DESCRIPTION
## What

Adds guest-side assertions to the `test_local_model` phase in `tests/integration.sh` (runs under `--full`):

- Greps `CLAUDE_CODE_ATTRIBUTION_HEADER` and `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` in the existing `~/.claude/settings.json` check, alongside the current `ANTHROPIC_BASE_URL` and model-name greps.
- Asserts the "no restart needed" report line emitted by `coop model <vm> local`, covering the live-apply fast path.

## Why

The two keys disable the per-request prompt mutators (the attribution/billing fingerprint and the `git status` snapshot) that would otherwise force a full re-prefill of a local backend's KV cache on every tool call. They are written only in the local env block.

Before this change the phase only checked `ANTHROPIC_BASE_URL` and the model name, so a regression dropping either cache-buster key would still pass CI while silently restoring the re-prefill latency. The unit test `claude_env_block_disables_prefix_cache_busters` pins only the in-process `BTreeMap`; nothing pinned the guest-side result.

## Testing

Ran the `test_local_model` phase locally on macOS/Lima against the existing golden image: 11 passed, 0 failed, including both new assertions.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)