### PR TITLE
Set release title in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,4 +122,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
-        run: gh release create "$TAG" --notes-file RELEASE_NOTES.md coop-*.tar.gz SHA256SUMS
+        run: gh release create "$TAG" --title "$TAG" --notes-file RELEASE_NOTES.md coop-*.tar.gz SHA256SUMS


### PR DESCRIPTION
The Create GitHub release step called `gh release create "$TAG" --notes-file RELEASE_NOTES.md ...`. When the workflow switched from `--generate-notes` to `--notes-file` (to source notes from the CHANGELOG), it dropped the behavior that set the release title to the tag. `--generate-notes` set the title as a side effect; `--notes-file` does not. As a result, releases since v0.3.1 have an empty title and render with no heading.

This adds `--title "$TAG"` to the same command, restoring the tag as the release title. No other changes.

Already-published release titles have been backfilled separately; this only affects future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)