### PR TITLE
Add --json output to read/query commands

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -84,11 +84,19 @@ exclude_re = [
     # this module-agnostic pattern also covers the identical gh_auth_token in
     # git_repo_devcontainer.rs (whose logic lives in normalize_token, kept).
     "replace gh_auth_token ->",
-    # Thin wrappers whose logic was extracted in #322: run_status just prints
-    # render_status(...) (kept); probe_user_login just curls then delegates to
-    # parse_user_login (kept). \b leaves render_status / parse_user_login alone.
+    # Thin wrappers whose logic was extracted in #322: run_status just renders
+    # build_status(...) as JSON or text (kept helpers below); probe_user_login
+    # just curls then delegates to parse_user_login (kept). \b leaves
+    # parse_user_login alone.
     "\\brun_status\\b",
     "\\bprobe_user_login\\b",
+    # build_status (#385, `github status --json` view builder): its `--probe`
+    # branch shells out via resolve_cmd_value, so a `--lib` test cannot observe
+    # it. The pure projections it calls — GithubMode::of, ProbeStatus::from_resolved
+    # — and format_status stay in scope, each unit-tested (a survivor there is a
+    # real gap). GithubMode::label carries an in-source `#[mutants::skip]`
+    # (equivalent: human label; the serde token is the tested contract).
+    "\\bbuild_status\\b",
 
     # workspace.rs — tar/rsync pipes, SSH-config IO, editor launch.
     "\\btar_pipe_transfer\\b",
@@ -177,6 +185,20 @@ exclude_re = [
     # current_disk_gib stats the disk image; its `/ 1 GiB` arithmetic kernel
     # is extracted into bytes_to_gib (kept in scope, unit-tested).
     "\\bcurrent_disk_gib\\b",
+    # instance_status (#385) runs as_running + query_resource_usage (SSH) to
+    # assemble the `status --json` shape; emit_up_dry_run (#385) drives the
+    # devcontainer collector + persisted_guest_user and renders the dry-run
+    # plan. Their pure inputs — InstanceState::from_running, BackendKind::of,
+    # up_translator_inputs — stay in scope and are unit-tested.
+    "\\binstance_status\\b",
+    "\\bemit_up_dry_run\\b",
+
+    # ---- src/commands/json.rs (#385): --json output ----
+    # render_json is the single stdout JSON writer; a `--lib` test cannot
+    # observe its writes. Everything else in json.rs is pure view models and
+    # projections (InstanceState, BackendKind::of, the Serialize structs) kept
+    # in scope and pinned by the shape tests in that module.
+    "\\brender_json\\b",
 
     # commands/mod.rs — purges every instance + image (backend destroy calls).
     "\\bpurge_all_data\\b",
@@ -188,11 +210,13 @@ exclude_re = [
     "\\bwipe_data_dir\\b",
     "\\bremove_self_binary\\b",
 
-    # profiles.rs — `read_dir` size walk; its byte→GiB formatting kernel is
-    # extracted into format_dir_size (kept in scope, unit-tested). The summary
-    # builders (builtin_summary / format_custom_summary / script_summary) and
-    # the writeln!-based listers are pure/IO-thin and stay in scope.
-    "\\bdir_size_display\\b",
+    # profiles.rs — `read_dir` size walk (dir_size_bytes); its byte→GiB
+    # formatting kernel is extracted into format_dir_size (kept in scope,
+    # unit-tested). The summary builders (builtin_summary / format_custom_summary
+    # / script_summary), the JSON inventory builder (collect_profiles_list, #385),
+    # and the writeln!-based listers stay in scope. write_profiles_list /
+    # write_profile_show are IO writers and stay excluded.
+    "\\bdir_size_bytes\\b",
     "\\bwrite_profiles_list\\b",
     "\\bwrite_profile_show\\b",
 
@@ -200,7 +224,14 @@ exclude_re = [
     # The pure guard (discovered_local_devcontainer) and the assumed-guest-user
     # helper stay in scope. resolve_oci_feature_requests drives the OCI feature
     # resolver (network/registry) so its effects aren't `--lib`-observable.
+    # resolve_devcontainer (stderr wrapper) and resolve_devcontainer_collect
+    # (the quiet collector it delegates to, #385) both discover + prompt +
+    # drive the OCI resolver; \b leaves the pure discovered_local_devcontainer
+    # guard alone. check_render_json (#385) drives the collector and builds
+    # TranslatorInputs inline, so it carries an in-source `#[mutants::skip]`
+    # (see the TranslatorInputs note below), not an entry here.
     "\\bresolve_devcontainer\\b",
+    "\\bresolve_devcontainer_collect\\b",
     "\\bmaybe_skip_stored_devcontainer_opt_out\\b",
     "\\bmaybe_record_devcontainer_opt_out\\b",
     "\\bresolve_oci_feature_requests\\b",
@@ -259,10 +290,10 @@ exclude_re = [
     #   * up_translator_inputs (lifecycle.rs) — pure builder, KEPT in scope and
     #     unit-tested (up_translator_inputs_maps_opts), which kills its
     #     field-deletion mutants.
-    #   * run (lib.rs), cmd_devcontainer_check, quickstart_fresh_start — these
-    #     are dispatch/shell-out handlers whose assembled inputs only become
-    #     observable once the (excluded) translator + a real VM consume them, so
-    #     a `--lib` test cannot kill the field-deletions. Because exclude_re is
-    #     powerless here, those three carry an in-source `#[mutants::skip]` with
-    #     a back-reference to this note.
+    #   * run (lib.rs), cmd_devcontainer_check, check_render_json (#385),
+    #     quickstart_fresh_start — these are dispatch/shell-out handlers whose
+    #     assembled inputs only become observable once the (excluded) translator
+    #     + a real VM consume them, so a `--lib` test cannot kill the
+    #     field-deletions. Because exclude_re is powerless here, those carry an
+    #     in-source `#[mutants::skip]` with a back-reference to this note.
 ]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,6 +64,7 @@ Use `--git-repo <url>` instead of `DIR` to clone a remote repository into
 | `--devcontainer <path>` | Explicit path to a `devcontainer.json` to use (skips discovery and prompt) |
 | `--no-devcontainer` | Ignore any discovered `devcontainer.json` for this invocation |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work |
+| `--json` | With `--dry-run`, emit the resolved plan as JSON on stdout (`{ report, profiles, guest_user, vm }`) instead of the text report on stderr |
 
 ```
 coop up .
@@ -191,8 +192,11 @@ coop devcontainer check <path> [--stage setup|start|both]
 |------|-------------|
 | `<path>` | Path to the `devcontainer.json` file to inspect |
 | `--stage <stage>` | Which lifecycle translation to report: `setup`, `start`, or `both` (default: `both`) |
+| `--json` | Emit the report as JSON on stdout instead of the text table on stderr |
 
 Use `--stage setup` to inspect setup-time keys such as `features`, `hostRequirements.cpus`, `hostRequirements.memory`, and `remoteUser`. Use `--stage start` to inspect start-time keys such as `postStartCommand`, `containerEnv`, `forwardPorts`, `mounts`, and `hostRequirements.storage`.
+
+With `--json`, a single stage emits one report object (`{ entries, source_path, ignored_paths }`, or `null` when no file applied); `--stage both` emits `{ "setup": <report>, "start": <report> }`. Each entry is `{ key, status, source, value, note }`, with `status` one of `applied`/`overridden`/`unsupported`/`invalid` and `source` one of `cli`/`devcontainer`. CI can branch on the translation without scraping the table.
 
 ### `devcontainer ignore`
 
@@ -243,6 +247,7 @@ instances, pass the instance name.
 | `--devcontainer <path>` | Dry-run translation aid; normal restarts reject devcontainer creation options. |
 | `--no-devcontainer` | Ignore any discovered `devcontainer.json` for this invocation (escape hatch for CI). |
 | `--dry-run` | Translate `devcontainer.json` and print the report, then exit before any VM work. |
+| `--json` | With `--dry-run`, emit the resolved plan as JSON on stdout instead of the text report on stderr. |
 
 Normal `start` restarts an existing VM without re-reading or re-applying
 `devcontainer.json`. If the instance was created with a devcontainer file, coop
@@ -411,6 +416,10 @@ coop ls
 
 Alias: `ls`.
 
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit a JSON array (`[{ "name", "state" }, …]`) instead of the text table |
+
 ### `status`
 
 Print instance status. Without a name, lists every instance with its state, image, backend, and resource usage (for running instances). With a name, prints detailed status for that instance.
@@ -422,10 +431,30 @@ coop status [NAME]
 | Flag | Description |
 |------|-------------|
 | `NAME` | Instance name (shows all if omitted) |
+| `--json` | Emit machine-readable JSON instead of the text output |
 
 ```
 coop status
 coop status my-project
+```
+
+With `--json`, a bare `coop status` emits a JSON array and `coop status NAME`
+emits a single object. Each carries the common fields — `name`, `state`
+(`running`/`stopped`), `image`, `backend` (`firecracker`/`lima`), and `usage`
+(raw MiB / load, or `null` when stopped or the query fails). The rich
+single-instance text report (guest IP, PID, SSH port, …) is text-only. JSON goes
+to stdout; tracing stays on stderr, so `coop status --json | jq` stays clean.
+
+```
+$ coop status my-project --json
+{
+  "name": "my-project",
+  "state": "running",
+  "image": "default",
+  "backend": "firecracker",
+  "usage": { "load_1m": 0.12, "mem_used_mib": 512, "mem_total_mib": 2048,
+             "disk_used_mib": 8192, "disk_total_mib": 20480 }
+}
 ```
 
 ### `model`
@@ -619,11 +648,17 @@ coop images [FLAGS]
 | Flag | Description |
 |------|-------------|
 | `--delete <name>` | Delete a named image |
+| `--json` | Emit a JSON array instead of the text table |
 
 ```
 coop images
 coop images --delete old-image
 ```
+
+With `--json`, each element is `{ "name", "profiles", "created", "size_bytes" }`.
+Absence is modelled honestly: `profiles` is `[]` (not `"none"`), `created` is
+`null` (not `"unknown"`), and `size_bytes` is the raw byte count (the text path's
+`"8.0 GiB"` is presentation only).
 
 ### `resize`
 
@@ -708,10 +743,13 @@ coop profiles [SUBCOMMAND]
 ```
 coop profiles
 coop profiles list
+coop profiles list --json
 coop profiles show rust
 ```
 
 `list` groups builtin and custom profiles separately. `show` resolves the name against custom profiles first, then builtins, and prints `(custom)` or `(builtin)` next to the name.
+
+`coop profiles list --json` emits `{ "builtin": [...], "custom": [...] }`, each entry `{ "name", "summary" }`.
 
 ### `update`
 
@@ -798,16 +836,23 @@ coop github <subcommand>
 |------------|--------|
 | `setup-pat [--repo owner/name]` | Run the wizard end-to-end: open the GitHub PAT-creation form, validate the pasted token against `api.github.com`, store it in a chosen secret manager (Keychain / Secret Service / 1Password / file), and write a `[github.pat."owner/repo"]` entry. The repo is auto-detected from `git remote get-url origin` when `--repo` is omitted. |
 | `rotate-pat --repo owner/name` | Re-run the wizard for an existing entry (FGPATs expire — max 1 year). |
-| `status [--probe]` | List configured entries and their storage backend. By default the cmd-invocation is *not* resolved (so Keychain / 1Password prompts don't fire). Pass `--probe` to also resolve each entry and report whether the secret store still serves it. |
+| `status [--probe] [--json]` | List configured entries and their storage backend. By default the cmd-invocation is *not* resolved (so Keychain / 1Password prompts don't fire). Pass `--probe` to also resolve each entry and report whether the secret store still serves it. Pass `--json` for machine-readable output. |
 | `forget-pat --repo owner/name` | Delete the stored secret from its backend and drop the `[github.pat."owner/repo"]` entry. Does **not** add a skip marker — use the auto-prompt's `never` answer if you want coop to stop asking about this repo. Does **not** revoke the PAT on GitHub. |
 
 ```
 coop github setup-pat --repo trailofbits/coop
 coop github status
 coop github status --probe
+coop github status --json
 coop github rotate-pat --repo trailofbits/coop
 coop github forget-pat --repo trailofbits/coop
 ```
+
+`coop github status --json` emits `{ "mode", "entries", "skip" }`. `mode` is
+`off`/`auto`/`env`/`pat`; each entry is `{ "repo", "storage", "probe" }` with
+`storage` a stable token (`macos_keychain`/`linux_secret_service`/`one_password`/
+`file`, or `null` when unparseable) and `probe` (`ok`/`unexpected_format`/
+`resolve_failed`, or `null` unless `--probe`). The token value is never emitted.
 
 ### `validate`
 

--- a/docs/json-output-design.md
+++ b/docs/json-output-design.md
@@ -1,0 +1,548 @@
+# `--json` machine-readable output — design & implementation guide
+
+Tracking issue: [#385](https://github.com/trailofbits/coop/issues/385).
+
+This document is an implementation guide. It specifies a `--json` output mode
+for coop's read/query commands, the shared infrastructure that keeps human and
+JSON output from drifting, and the exact view models (typed against coop's
+existing newtypes) for every command in scope.
+
+## Goal
+
+coop has no machine-readable output. Every command prints human text; automation
+must scrape fixed-width tables or free-form strings. Add an opt-in `--json` flag
+so command output can be parsed reliably, starting with the highest-value read
+commands. The human output stays the default and is unchanged.
+
+`serde_json` (with `preserve_order`) is already a dependency; `serde::Serialize`
+is derived widely across `config.rs`. No new dependency is needed.
+
+## Design principles
+
+These are the rules that keep this from becoming a maintenance burden. Follow
+them for every command you add to the JSON surface.
+
+### 1. Collect once, render twice (single source of truth)
+
+The trap is `if json { build_json() } else { build_table() }` with two hand-built
+formatters that drift. Instead: the command builds **one** `Serialize` view
+model, and `--json` switches only the final render step. The human formatter and
+the JSON serializer read the *same* value, so they cannot disagree about the
+data — only about presentation.
+
+```rust
+let view = collect(...)?;                 // one value, both paths read it
+if json {
+    render_json(&view)?;                  // serde_json → stdout
+} else {
+    render_human(&view)?;                 // existing formatter, now reads `view`
+}
+```
+
+### 2. Carry newtypes, don't downgrade to `String`
+
+coop already parses untrusted input into strong newtypes at the CLI boundary
+(`InstanceName`, `ImageName`, `RepoSlug`, `GuestUser`, …). Every one of these
+**already implements `Serialize` and emits a bare JSON string**:
+
+- `InstanceName` — `config.rs:1611`, serializes `self.0`
+- `ImageName` — `config.rs:1683`
+- `RepoSlug` — `github_repo.rs:96`, `serialize_str(&self.0)`
+- `GuestUser` — `guest.rs:42`, `#[serde(into = "String")]`
+
+So a view field typed as the newtype produces **byte-identical JSON** to a
+`String` field — downgrading to `String` (via `.to_string()` / `.as_str()`) buys
+nothing and throws away the type safety the boundary already paid for. View
+models carry the newtype, **borrowed** from the data already in hand (`serde`
+implements `Serialize` for `&T`), so there is no clone and no downgrade.
+
+Only use `String` where the domain genuinely has no newtype (see per-command
+notes: profile names, `Report` free-text, timestamps, `ResourceUsage`
+primitives).
+
+### 3. Enums for every closed set, never a free string
+
+State, backend kind, report status/source, PAT storage, probe result — each is a
+fixed set of values. Model each as an enum with `#[serde(rename_all = "…")]` so
+serialization is **total** (no typo'd literal can escape) and the compiler forces
+exhaustive handling. Where the human path already has a `label()` method that
+emits the human text, keep it and derive the JSON token from the same enum — that
+is what stops the two representations drifting.
+
+### 4. `Option<T>` for genuine absence, not sentinel strings
+
+Where the human table prints `"unknown"` / `"none"` / omits a line, the JSON
+models it as `null` / `[]`. `usage`, `created`, `storage`, `probe`, `valid` are
+all `Option`.
+
+### 5. JSON goes to stdout; tracing/human decoration stays on stderr
+
+Per `CLAUDE.md`, tracing already goes to stderr, so `coop … --json | jq` stays
+clean. **Two commands (`devcontainer check`, `up/start --dry-run`) currently
+write their report to stderr** via `eprintln!` / `Report::render()`. For those,
+`--json` must move the payload to **stdout** — the flag selects
+`(stderr, human)` vs `(stdout, json)`, not just the format. The human path stays
+on stderr, unchanged.
+
+## The flag: per-command `--json`, not global
+
+Add `#[arg(long)] json: bool` to each subcommand that supports it — **not** a
+global flag on `Cli`. A global flag would appear on `coop up`, `coop shell`,
+etc., where it does nothing, forcing a runtime rejection and lying in `--help`.
+Per-command keeps clap's help honest and matches the repo's "no speculative
+features" rule.
+
+A bare `bool` is correct while there are two formats. If a third format ever
+lands (`--yaml`), promote to `#[derive(ValueEnum)] enum OutputFormat { Human,
+Json }` then — a mechanical change.
+
+## Shared infrastructure
+
+Put the cross-cutting pieces in a new module `src/commands/json.rs` (declare
+`mod json;` in `src/commands/mod.rs`). Command-specific view structs live next to
+their command handler.
+
+### Shared enums
+
+```rust
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum InstanceState { Running, Stopped }
+
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum BackendKind { Firecracker, Lima }
+```
+
+Provide the projection from the live backend enum (match on `PlatformBackend`'s
+variants):
+
+```rust
+impl BackendKind {
+    pub(crate) fn of(be: &backend::PlatformBackend) -> Self { /* match variants */ }
+}
+```
+
+### The JSON writer
+
+One helper, used by every command. It is the *only* place JSON hits stdout:
+
+```rust
+/// Serialize `value` as pretty JSON to stdout, with a trailing newline.
+pub(crate) fn render_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
+    let mut out = std::io::stdout();
+    serde_json::to_writer_pretty(&mut out, value)
+        .map_err(|e| anyhow::anyhow!("Failed to write JSON: {e}"))?;
+    writeln!(out).map_err(|e| anyhow::anyhow!("Failed to write JSON: {e}"))?;
+    Ok(())
+}
+```
+
+## Command classification
+
+| Command | `--json`? | Priority | Reason |
+|---|---|---|---|
+| `status` | yes | **P0** | Instance state — highest automation value. |
+| `list` / `ls` | yes | **P0** | Trivial subset of status; nearly free once the enum exists. |
+| `images` | yes | **P1** | Machine-readable image inventory; already structured. |
+| `devcontainer check` | yes | **P1** | `Report` already structured; CI branches on translation. |
+| `github status` | yes | **P1** | PAT entries + validation state; secrets excluded. |
+| `up --dry-run` / `start --dry-run` | yes | **P2** | Resolved plan/translation. Heaviest shape. |
+| `profiles list` | yes | **P2** | Profile inventory; low automation demand. |
+| `model` (no action) | status-only | **P3** | Only the readout; `local`/`remote` mutate and prompt. |
+| `devcontainer status` | yes | **P3** | Lists opt-outs; minor query. |
+| `validate` | maybe | **P3** | Its value *is* the human warnings; wrap only on demand. |
+| `logs` | no | — | A stream; NDJSON adds ~nothing over raw text. |
+| `profiles show`, `github show` | no | — | Single-item detail dumps; wrap only if a consumer appears. |
+| `up`/`start`/`setup`/`quickstart`/`resize`/`commit`/`restore`/`stop`/`destroy`/`push`/`pull` | no | — | Mutations. Output is side effect + tracing (stderr). |
+| `shell`/`claude`/`claude-agents`/`codex`/`exec`/`vscode` | no | — | Interactive / passthrough; stdout is the guest's. |
+| `ssh-config` | no | — | Emits SSH config text, not data. |
+| `model local`/`remote`, `github setup-pat`/`rotate-pat`/`forget-pat`, `devcontainer ignore`/`clear` | no | — | Mutations; several prompt on a TTY. |
+| `init`/`update`/`uninstall`/`completions` | no | — | Installer/meta actions. |
+
+**Rule for the "no" set:** everything ruled out is a mutation (its output is a
+side effect + tracing), an interactive passthrough (stdout belongs to the guest
+process), or a text emitter. A structured *result envelope* for mutations is a
+separate feature — do not conflate it with this issue.
+
+---
+
+## Per-command specifications
+
+### P0 — `status`
+
+- **Handler:** `cmd_status`, `src/commands/lifecycle.rs:1612`.
+- **Clap:** add `json: bool` to the `Status` variant (`src/lib.rs:394`); thread it
+  through the `Commands::Status { name, json }` arm (`src/lib.rs:1117`) into
+  `cmd_status`.
+- **Current output:** list mode = fixed-width table (name / state / image /
+  backend + usage summary); single-instance mode = rich multi-line `String` from
+  `Backend::status`.
+
+**View model** (in `src/commands/json.rs` or beside the handler):
+
+```rust
+#[derive(Serialize)]
+pub(crate) struct Usage {
+    pub load_1m: f64,
+    pub mem_used_mib: u64,
+    pub mem_total_mib: u64,
+    pub disk_used_mib: u64,
+    pub disk_total_mib: u64,
+}
+
+#[derive(Serialize)]
+pub(crate) struct InstanceStatus<'a> {
+    pub name: &'a config::InstanceName,
+    pub state: InstanceState,
+    pub image: &'a config::ImageName,
+    pub backend: BackendKind,
+    pub usage: Option<Usage>,   // None ⇔ stopped, or query failed on a running guest
+}
+```
+
+Build `Usage` from `backend::ResourceUsage` (add `#[derive(Serialize)]` to
+`ResourceUsage` at `src/backend.rs:620`, or map field-by-field — either is fine;
+the fields are public primitives). Emit the **raw MiB / load** values, not
+derived percentages — consumers compute their own ratios, and this matches what
+the type holds. The issue's `cpu_pct`/`mem_mib` example was illustrative.
+
+- **Behavior:** bare `--json` emits a JSON **array**; `--name X --json` emits a
+  single **object**, mirroring the human modes.
+- **Scope decision — rich single-instance fields stay human-only.** The rich
+  single-instance report (`Backend::status` in `vm.rs`/`lima.rs`) carries
+  backend-*specific* fields (Firecracker: PID, guest IP; Lima: arch, disk, SSH
+  port). Unifying those two differing shapes into one serializable struct is real
+  cross-platform work and is **out of scope**. JSON single-instance emits the
+  common `InstanceStatus` shape. The common fields (state/image/backend/usage)
+  are computed from the same sources in both paths, so they never disagree; the
+  human path just adds decoration. If rich JSON is wanted later, change
+  `Backend::status` to return a struct — a separate change with its own
+  cross-platform test cost. **Do not touch the `Backend` trait for this issue.**
+
+**JSON example:**
+
+```json
+[
+  { "name": "my-project", "state": "running", "image": "default",
+    "backend": "firecracker",
+    "usage": { "load_1m": 0.12, "mem_used_mib": 512, "mem_total_mib": 2048,
+               "disk_used_mib": 8192, "disk_total_mib": 20480 } },
+  { "name": "other", "state": "stopped", "image": "default",
+    "backend": "firecracker", "usage": null }
+]
+```
+
+### P0 — `list` / `ls`
+
+- **Handler:** `cmd_list`, `src/commands/lifecycle.rs:1589`.
+- **Clap:** add `json: bool` to the `List` variant (`src/lib.rs:392`, currently a
+  unit variant — becomes `List { json: bool }`); update the match arm at
+  `src/lib.rs:1116`.
+
+```rust
+#[derive(Serialize)]
+pub(crate) struct InstanceSummary<'a> {
+    pub name: &'a config::InstanceName,
+    pub state: InstanceState,
+}
+```
+
+Turning the unit variant `List` into `List { json: bool }` breaks two existing
+clap tests that assert `matches!(cli.command, Commands::List)` (`src/lib.rs:1670`
+and `:1676`) — update them to `Commands::List { .. }`.
+
+Deliberately **smaller** than `InstanceStatus`: `cmd_list` only calls
+`is_running` and does **not** run the per-instance usage SSH query that `status`
+runs. Keep `list` cheap — do not add usage here. Consumers who want usage call
+`status --json`. Reusing `InstanceState` keeps the two consistent where they
+overlap.
+
+```json
+[ { "name": "my-project", "state": "running" },
+  { "name": "other", "state": "stopped" } ]
+```
+
+### P1 — `images`
+
+- **Handler:** `cmd_images`, `src/commands/profiles.rs:166`.
+- **Clap:** add `json: bool` to the `Images` variant (`src/lib.rs:510`).
+
+```rust
+#[derive(Serialize)]
+pub(crate) struct ImageInfo<'a> {
+    pub name: &'a config::ImageName,
+    pub profiles: Vec<String>,     // String: profile names are plain String in the domain
+    pub created: Option<&'a str>,  // None where the human path prints "unknown"
+    pub size_bytes: u64,           // raw bytes; human path keeps format_dir_size ("8.0 GiB")
+}
+```
+
+The human path collapses three cases to strings (`"none"` / `"unknown"`); JSON
+models them honestly: `profiles: []` (not `"none"`), `created: null` (not
+`"unknown"`), and raw `size_bytes` instead of a formatted GiB string. `profiles`
+stays `Vec<String>` because profile names have no newtype (`config.rs:678`:
+`profiles: HashMap<String, CustomProfile>`).
+
+```json
+[ { "name": "default", "profiles": ["python", "node"],
+    "created": "2026-06-01T12:00:00Z", "size_bytes": 8589934592 } ]
+```
+
+### P1 — `devcontainer check`
+
+- **Handler:** report rendered at `src/commands/devcontainer.rs:230` (and the
+  both-stage path at `:309`); subcommand at `src/lib.rs:699`.
+- **Clap:** add `json: bool` to the `Check` variant.
+- **stderr → stdout:** the human report currently goes to **stderr**
+  (`eprintln!`, behind `#[expect(clippy::print_stderr)]`). With `--json`, write
+  to **stdout** via `render_json`. Human path unchanged.
+
+The `Report` types (`src/devcontainer.rs:349–427`) are already structured — add
+`Serialize` derives. Their existing `label()` methods already return exactly the
+strings `rename_all = "lowercase"` produces (`"applied"`, `"cli"`, …), so human
+and JSON labels cannot diverge:
+
+```rust
+#[derive(Serialize, /* existing derives */)]
+#[serde(rename_all = "lowercase")]
+pub enum ReportStatus { Applied, Overridden, Unsupported, Invalid }
+
+#[derive(Serialize, /* existing derives */)]
+#[serde(rename_all = "lowercase")]
+pub enum ReportSource { Cli, Devcontainer }
+
+#[derive(Serialize, /* existing derives */)]
+pub struct ReportEntry { pub key: String, pub status: ReportStatus,
+                         pub source: ReportSource, pub value: String, pub note: String }
+
+#[derive(Serialize, /* existing derives */)]
+pub struct Report { pub entries: Vec<ReportEntry>, pub source_path: Option<PathBuf>,
+                    pub ignored_paths: Vec<PathBuf> }
+```
+
+`key` / `value` / `note` stay `String` — they are free-form (a dotted
+devcontainer path, a rendered value, a human note), not a closed set. Keep the
+`label()` methods for the human table; the derive is purely additive.
+
+- **`--stage both`** emits `{ "setup": <Report>, "start": <Report> }`; a single
+  stage emits one `Report`. `PathBuf` serializes as a string via serde.
+
+### P1 — `github status`
+
+- **Handler:** `render_status`, `src/github_pat.rs:115` (already split from
+  `run_status` for testability); subcommand `GithubAction::Status`,
+  `src/lib.rs:682`.
+- **Clap:** add `json: bool` alongside the existing `probe: bool`.
+- **Never emit the token value.** Only repo, storage backend, and validation
+  state.
+
+Reuse the existing `secret_store::Backend` enum (`src/secret_store.rs:37`) for
+storage — add a `Serialize` derive with a **stable machine token**
+(`rename_all = "snake_case"`, distinct from its human `label()`). The enum is
+`#[cfg]`-gated per OS; that is fine, you only serialize variants that exist on
+the host. Turn the three `probe_status_label` strings into an enum (the
+gap this closes), and have the human `label()` derive from it so the two do not
+drift:
+
+```rust
+// secret_store.rs — additive derive on the existing enum:
+#[derive(Serialize, /* existing */)]
+#[serde(rename_all = "snake_case")]
+pub enum Backend { /* MacosKeychain | LinuxSecretService | OnePassword | File */ }
+// → "macos_keychain" | "linux_secret_service" | "one_password" | "file"
+
+// github_pat.rs — replace the &'static str returned by probe_status_label:
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProbeStatus { Ok, UnexpectedFormat, ResolveFailed }
+
+impl ProbeStatus {
+    fn label(self) -> &'static str {         // human strings, unchanged
+        match self {
+            Self::Ok => "resolves, format ok",
+            Self::UnexpectedFormat => "resolves but unexpected format",
+            Self::ResolveFailed => "FAILED to resolve",
+        }
+    }
+}
+```
+
+**View model:**
+
+```rust
+#[derive(Serialize)]
+pub(crate) struct GithubStatus<'a> {
+    pub mode: GithubMode,               // off | pat | other; see note
+    pub entries: Vec<PatEntry<'a>>,     // empty unless pat mode
+    pub skip: Vec<&'a github_repo::RepoSlug>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct PatEntry<'a> {
+    pub repo: &'a github_repo::RepoSlug,
+    pub storage: Option<secret_store::Backend>, // None where human prints "unknown"
+    pub probe: Option<ProbeStatus>,             // None unless --probe
+}
+```
+
+`storage` is `Option` because `CmdToken::parse` returns `Option` — `None` is the
+"unknown" (unparseable `cmd:`) case. `probe` is `Option` because it is only
+resolved under `--probe`.
+
+- **`mode`:** the human path calls `GitHubAuth::mode_name()` and distinguishes
+  `off` (no `github` config) / `pat` / other modes. Model `GithubMode` as an enum
+  mirroring `GitHubAuth`'s discriminants plus `Off`. **Verify the exact variant
+  set** against `GitHubAuth` / `mode_name()` before finalizing; it is a closed
+  set, so it should be an enum, not a free string. Do **not** reuse the existing
+  `impl Serialize for GitHubAuth` (`config.rs:1100`) — that serializes the full
+  auth config, which may include secret material.
+
+```json
+{ "mode": "pat",
+  "entries": [ { "repo": "trailofbits/coop", "storage": "macos_keychain",
+                 "probe": "ok" } ],
+  "skip": [] }
+```
+
+### P2 — `up --dry-run` / `start --dry-run`
+
+- **Handlers:** dry-run early-returns in the `Up` and `Start` arms
+  (`src/lib.rs:970` and `:1032`). Today the dry-run runs `resolve_devcontainer`
+  (which renders the `Report` to stderr) and returns; there is no collected plan
+  object.
+- **Clap:** `--dry-run` already exists; add `json: bool` to `Up` and `Start`.
+- This is the **heaviest** shape — the plan's pieces (translation report,
+  resolved profiles, VM overrides, guest user) are computed but never assembled
+  into one struct. That assembly is the bulk of the work.
+
+```rust
+#[derive(Serialize)]
+pub(crate) struct DryRunPlan {
+    pub report: Option<devcontainer::Report>,   // reuse P1 Serialize derives
+    pub profiles: Vec<String>,                   // resolved profile names
+    pub guest_user: guest::GuestUser,            // newtype, serializes as string
+    pub vm: VmOverrides,
+}
+
+#[derive(Serialize)]
+pub(crate) struct VmOverrides {
+    pub vcpus: Option<u32>,
+    pub mem_mib: Option<u32>,
+    pub disk: Option<String>,   // or the DiskSize newtype if it implements Serialize
+}
+```
+
+Same stderr → stdout move as `devcontainer check`. Do this **after** P1 so the
+`Report` derives already exist.
+
+### P2 — `profiles list`
+
+- **Handler:** `cmd_profiles`, `src/commands/profiles.rs:10`; subcommand
+  `ProfilesAction::List`, `src/lib.rs:658`.
+
+```rust
+#[derive(Serialize)]
+pub(crate) struct ProfilesList {
+    pub builtin: Vec<ProfileEntry>,
+    pub custom: Vec<ProfileEntry>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ProfileEntry {
+    pub name: String,        // no ProfileName newtype exists
+    pub summary: String,     // from builtin_summary / custom detail
+}
+```
+
+### P3 — `model` (readout only), `devcontainer status`, `validate`
+
+Lower demand; wrap only when reached. Shapes:
+
+- **`model`** (no action, `render_status` at `src/commands/model.rs:33`): only
+  the `None` action gets `--json` — `local`/`remote` mutate and prompt on a TTY.
+  Carry `&InstanceName` and `&GuestUser`; `mode` reuses/mirrors the `ModelMode`
+  enum (already `ValueEnum`); per-tool endpoints as `{ claude: …, codex: … }`.
+- **`devcontainer status`** (`src/lib.rs:712`): `[{ "project": …, "ignored_path":
+  … }]` — paths serialize as strings.
+- **`validate`** (`src/lib.rs:1184`): only if a consumer appears; its value is the
+  human warning text.
+
+---
+
+## Testing
+
+Follow `CLAUDE.md`'s testing and mutation-testing rules.
+
+### Unit tests — assert the serialized shape
+
+For each view model, add a test that serializes a known value and asserts the
+JSON (via `serde_json::to_value` and comparison, or `to_string`). This pins the
+contract — field names, enum tokens, `null` vs omitted, array vs object. Test the
+edges:
+
+- `status`: running-with-usage, running-with-`usage: null` (query failed),
+  stopped; array (list) vs object (single `--name`).
+- `github status`: `mode: off`, `pat` with entries, unparseable `storage: null`,
+  `probe` present vs absent.
+- `images`: `profiles: []`, `created: null`.
+- enum round-trips: each `rename_all` token is what you expect
+  (`"firecracker"`, `"macos_keychain"`, `"unexpected_format"`, …).
+
+Also test the pure projections you add — e.g. `BackendKind::of`,
+`From<probe result> for ProbeStatus`, `GithubMode` from `GitHubAuth`.
+
+### Mutation testing — keep `.cargo/mutants.toml` in sync **in the same PR**
+
+`CLAUDE.md` is emphatic about this (see the `coop model` #352 regression). When
+you add these functions:
+
+- **`render_json`** and any handler branch that writes JSON to stdout are **IO** —
+  add an `exclude_re` entry (they only write stdout; a `--lib` test cannot observe
+  them). Anchor patterns with `\b`.
+- **View builders and pure projections** (`BackendKind::of`, `ProbeStatus`
+  mapping, the struct-assembly helpers, `GithubMode` derivation) are **pure
+  logic** — leave them **in** scope and cover them with the shape tests above. A
+  survivor there is a real gap.
+- `#[serde(...)]` derives are not meaningfully mutated; the shape tests are what
+  guard them.
+
+Verify with `cargo mutants -f <touched files> -- --lib` (full-file sweep, not
+just `--in-diff`), per `CLAUDE.md`.
+
+### Integration test
+
+Consider one JSON assertion in `tests/integration.sh` for `status --json` piped
+through `jq` (e.g. `coop status --json | jq -e '.[0].state'`), exercising the
+real stdout/stderr split on both backends.
+
+## Suggested phasing
+
+1. **P0 (this issue #385):** `status` + `list/ls` together — they share
+   `InstanceState` and get the shared `json` module + `render_json` helper in
+   place. Barely more than `status` alone.
+2. **P1:** `images`, `devcontainer check`, `github status` — mostly
+   derive-and-branch on already-structured data; `check` also does the
+   stderr → stdout move.
+3. **P2:** `up/start --dry-run`, `profiles list` — real assembly / lower demand.
+4. **P3 (on demand only):** `model` readout, `devcontainer status`, `validate`.
+
+## Per-command implementation checklist
+
+For each command you add:
+
+- [ ] Add `json: bool` to the clap variant in `src/lib.rs`; thread it through the
+      match arm into the handler.
+- [ ] Define the view model with newtypes (borrowed) and enums; `String` only
+      where the domain has no newtype.
+- [ ] Extract a pure builder from the handler's IO so the assembly is unit-testable.
+- [ ] Branch the handler: `render_json(&view)?` vs the existing human formatter.
+- [ ] For `check` / `--dry-run`: move the JSON payload to stdout (human stays on
+      stderr).
+- [ ] Add shape tests (edges: `null`, `[]`, array vs object, enum tokens).
+- [ ] Update `.cargo/mutants.toml` (exclude IO/stdout writers; keep pure builders
+      in scope) **in the same PR**.
+- [ ] Run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`,
+      `cargo test`, and `cargo mutants -f <touched> -- --lib`.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -617,6 +617,7 @@ impl SshSession {
 // ── Resource usage ────────────────────────────────────────────
 
 /// Runtime resource usage gathered from a running guest VM.
+#[derive(serde::Serialize)]
 pub struct ResourceUsage {
     /// 1-minute load average.
     pub load_1m: f64,

--- a/src/commands/devcontainer.rs
+++ b/src/commands/devcontainer.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
+use crate::commands::json;
 use crate::{
     DevcontainerCheckStage, DevcontainerCommands, config, devcontainer, devcontainer_oci,
     git_repo_devcontainer, guest, prompt,
@@ -115,18 +116,39 @@ fn maybe_record_devcontainer_opt_out(opts: &DevcontainerOpts<'_>, project: &Path
 }
 
 /// Discover, prompt, and translate a `devcontainer.json` for the given
-/// lifecycle `stage`.
+/// lifecycle `stage`, rendering the human report to stderr.
 ///
 /// Returns `None` when the user opts out, no file is found, or stdin is
 /// not a TTY with no explicit flag (in which case an error is returned
 /// instead — the issue forbids silently choosing). The report is always
 /// emitted to stderr when a file is loaded, so the user sees every key
 /// that did and didn't take effect.
+///
+/// This is the human-output wrapper over [`resolve_devcontainer_collect`];
+/// `--json` callers use the collector directly and serialize the report
+/// to stdout instead.
 #[expect(
     clippy::print_stderr,
     reason = "devcontainer report is intentional user-facing CLI output"
 )]
 pub(crate) fn resolve_devcontainer(
+    opts: &DevcontainerOpts<'_>,
+    inputs: &devcontainer::TranslatorInputs,
+    stage: devcontainer::Stage,
+) -> Result<Option<devcontainer::Translation>> {
+    let translation = resolve_devcontainer_collect(opts, inputs, stage)?;
+    if let Some(t) = &translation {
+        eprintln!("{}", t.report.render());
+    }
+    Ok(translation)
+}
+
+/// Collect the devcontainer translation without emitting any report.
+///
+/// Identical resolution logic to [`resolve_devcontainer`], minus the
+/// stderr render — the returned `Translation` carries the `report`, so
+/// callers render it however they like (`--json` serializes it to stdout).
+pub(crate) fn resolve_devcontainer_collect(
     opts: &DevcontainerOpts<'_>,
     inputs: &devcontainer::TranslatorInputs,
     stage: devcontainer::Stage,
@@ -227,8 +249,6 @@ pub(crate) fn resolve_devcontainer(
     translation.report.ignored_paths = losers;
     resolve_oci_feature_requests(&mut translation);
 
-    eprintln!("{}", translation.report.render());
-
     Ok(Some(translation))
 }
 
@@ -281,7 +301,11 @@ fn resolve_oci_feature_requests(translation: &mut devcontainer::Translation) {
 #[mutants::skip]
 pub(crate) fn cmd_devcontainer_check(command: &DevcontainerCommands) -> Result<()> {
     match command {
-        DevcontainerCommands::Check { path, stage } => {
+        DevcontainerCommands::Check {
+            path,
+            stage,
+            json: json_out,
+        } => {
             let dc_input = DevcontainerInput::Explicit(path.clone());
             let opts = DevcontainerOpts {
                 input: &dc_input,
@@ -292,6 +316,9 @@ pub(crate) fn cmd_devcontainer_check(command: &DevcontainerCommands) -> Result<(
                 github_auth: None,
                 preference_path: None,
             };
+            if *json_out {
+                return check_render_json(&opts, *stage);
+            }
             let setup_inputs = devcontainer::TranslatorInputs::default();
 
             match stage {
@@ -326,6 +353,55 @@ pub(crate) fn cmd_devcontainer_check(command: &DevcontainerCommands) -> Result<(
         | DevcontainerCommands::Status { .. }
         | DevcontainerCommands::Clear { .. } => {
             unreachable!("devcontainer preference commands require config")
+        }
+    }
+}
+
+/// `--stage both` JSON payload: one report per lifecycle stage.
+#[derive(serde::Serialize)]
+struct BothReports<'a> {
+    setup: Option<&'a devcontainer::Report>,
+    start: Option<&'a devcontainer::Report>,
+}
+
+/// Emit `coop devcontainer check --json` to stdout. A single stage emits
+/// one `Report` (or `null` when no file applied); `--stage both` emits
+/// `{ "setup": <Report>, "start": <Report> }`.
+// Drives the IO collector and builds TranslatorInputs inline; the report
+// content it serializes comes from the separately-tested `translate`. Skipped
+// in-source (not exclude_re) because exclude_re cannot suppress the
+// `delete field … from TranslatorInputs` mutants — see the note in
+// .cargo/mutants.toml.
+#[mutants::skip]
+fn check_render_json(opts: &DevcontainerOpts<'_>, stage: DevcontainerCheckStage) -> Result<()> {
+    let setup_inputs = devcontainer::TranslatorInputs::default();
+    match stage {
+        DevcontainerCheckStage::Setup => {
+            let t = resolve_devcontainer_collect(opts, &setup_inputs, devcontainer::Stage::Setup)?;
+            json::render_json(&t.as_ref().map(|t| &t.report))
+        }
+        DevcontainerCheckStage::Start => {
+            let start_inputs = devcontainer::TranslatorInputs {
+                persisted_guest_user: Some(guest::GuestUser::default()),
+                ..devcontainer::TranslatorInputs::default()
+            };
+            let t = resolve_devcontainer_collect(opts, &start_inputs, devcontainer::Stage::Start)?;
+            json::render_json(&t.as_ref().map(|t| &t.report))
+        }
+        DevcontainerCheckStage::Both => {
+            let setup_t =
+                resolve_devcontainer_collect(opts, &setup_inputs, devcontainer::Stage::Setup)?;
+            let assumed_guest_user = devcontainer_check_assumed_guest_user(setup_t.as_ref());
+            let start_inputs = devcontainer::TranslatorInputs {
+                persisted_guest_user: Some(assumed_guest_user),
+                ..devcontainer::TranslatorInputs::default()
+            };
+            let start_t =
+                resolve_devcontainer_collect(opts, &start_inputs, devcontainer::Stage::Start)?;
+            json::render_json(&BothReports {
+                setup: setup_t.as_ref().map(|t| &t.report),
+                start: start_t.as_ref().map(|t| &t.report),
+            })
         }
     }
 }

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -23,10 +23,7 @@ pub(crate) fn cmd_github(
             };
             github_pat::run_rotate_pat(cfg, &opts)
         }
-        GithubAction::Status { probe } => {
-            github_pat::run_status(cfg, probe);
-            Ok(())
-        }
+        GithubAction::Status { probe, json } => github_pat::run_status(cfg, probe, json),
         GithubAction::ForgetPat { repo } => github_pat::run_forget_pat(cfg, &repo, config_path),
     }
 }

--- a/src/commands/json.rs
+++ b/src/commands/json.rs
@@ -1,0 +1,375 @@
+//! Machine-readable (`--json`) output shared across read/query commands.
+//!
+//! Every command that supports `--json` builds a single `Serialize` view
+//! model and hands it to [`render_json`]; the human formatter reads the
+//! same value, so the two representations cannot disagree about the data.
+//! See `docs/json-output-design.md` for the full design.
+
+use std::io::Write as _;
+
+use serde::Serialize;
+
+use crate::{backend, config, devcontainer, guest};
+
+/// Serialize `value` as pretty JSON to stdout, with a trailing newline.
+///
+/// This is the only place JSON output reaches stdout; tracing and human
+/// decoration stay on stderr so `coop … --json | jq` sees clean JSON.
+pub(crate) fn render_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
+    let mut out = std::io::stdout();
+    serde_json::to_writer_pretty(&mut out, value)
+        .map_err(|e| anyhow::anyhow!("Failed to write JSON: {e}"))?;
+    writeln!(out).map_err(|e| anyhow::anyhow!("Failed to write JSON: {e}"))?;
+    Ok(())
+}
+
+/// Instance run state — the closed set the human path prints as
+/// `"running"` / `"stopped"`.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum InstanceState {
+    Running,
+    Stopped,
+}
+
+impl InstanceState {
+    /// Project a backend `is_running` boolean into the enum.
+    pub(crate) fn from_running(running: bool) -> Self {
+        if running {
+            Self::Running
+        } else {
+            Self::Stopped
+        }
+    }
+
+    /// Human-readable label — the same tokens the text output prints.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+        }
+    }
+}
+
+/// Which VM backend is in use. Like [`backend::PlatformBackend`] and
+/// [`crate::secret_store::Backend`], the variants are `#[cfg]`-gated per
+/// OS — only the host's backend can ever be selected, so only its token
+/// (`"firecracker"` on Linux, `"lima"` on macOS) is ever serialized.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum BackendKind {
+    #[cfg(not(target_os = "macos"))]
+    Firecracker,
+    #[cfg(target_os = "macos")]
+    Lima,
+}
+
+impl BackendKind {
+    /// The backend kind for the current platform. `PlatformBackend` is a
+    /// compile-time type alias, so this is fixed per target OS.
+    pub(crate) fn of(_be: &backend::PlatformBackend) -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            Self::Lima
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Self::Firecracker
+        }
+    }
+}
+
+// ── status / list ────────────────────────────────────────────
+
+/// `coop status --json` single-instance / array element. `usage` is
+/// `None` for a stopped instance or when the SSH usage query failed on a
+/// running guest.
+#[derive(Serialize)]
+pub(crate) struct InstanceStatus<'a> {
+    pub name: &'a config::InstanceName,
+    pub state: InstanceState,
+    pub image: &'a config::ImageName,
+    pub backend: BackendKind,
+    pub usage: Option<backend::ResourceUsage>,
+}
+
+/// `coop list --json` array element — deliberately smaller than
+/// [`InstanceStatus`]: `list` never runs the per-instance usage query.
+#[derive(Serialize)]
+pub(crate) struct InstanceSummary<'a> {
+    pub name: &'a config::InstanceName,
+    pub state: InstanceState,
+}
+
+// ── images ───────────────────────────────────────────────────
+
+/// `coop images --json` array element. The human path collapses absence
+/// to `"none"` / `"unknown"`; JSON models it as `[]` / `null`, and emits
+/// the raw byte count instead of a formatted GiB string.
+#[derive(Serialize)]
+pub(crate) struct ImageInfo<'a> {
+    pub name: &'a config::ImageName,
+    pub profiles: &'a [String],
+    pub created: Option<&'a str>,
+    pub size_bytes: u64,
+}
+
+// ── profiles list ────────────────────────────────────────────
+
+/// `coop profiles --json`.
+#[derive(Serialize)]
+pub(crate) struct ProfilesList {
+    pub builtin: Vec<ProfileEntry>,
+    pub custom: Vec<ProfileEntry>,
+}
+
+/// One profile row. `name` is `String` because profile names have no
+/// newtype; `summary` is the same free-text the human path prints.
+#[derive(Serialize)]
+pub(crate) struct ProfileEntry {
+    pub name: String,
+    pub summary: String,
+}
+
+// ── up / start --dry-run ─────────────────────────────────────
+
+/// VM resource overrides resolved for a dry-run. Each is `None` when the
+/// flag was not given. The `MiB`/`GiB` newtypes serialize as bare numbers.
+#[derive(Serialize)]
+pub(crate) struct VmOverrides {
+    pub vcpus: Option<u8>,
+    pub mem_mib: Option<config::MiB>,
+    pub disk_gib: Option<config::GiB>,
+}
+
+/// `coop up --dry-run --json` / `coop start --dry-run --json`. `report`
+/// is `None` when no devcontainer.json applied.
+#[derive(Serialize)]
+pub(crate) struct DryRunPlan<'a> {
+    pub report: Option<&'a devcontainer::Report>,
+    pub profiles: &'a [String],
+    pub guest_user: &'a guest::GuestUser,
+    pub vm: VmOverrides,
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code — panics are assertions"
+)]
+mod tests {
+    use super::{
+        BackendKind, DryRunPlan, ImageInfo, InstanceState, InstanceStatus, InstanceSummary,
+        ProfileEntry, ProfilesList, VmOverrides,
+    };
+    use crate::{backend, config, devcontainer, guest};
+    use serde_json::{Value, json};
+
+    fn to_value<T: serde::Serialize>(v: &T) -> Value {
+        serde_json::to_value(v).expect("view model serializes")
+    }
+
+    #[test]
+    fn instance_state_tokens() {
+        assert_eq!(to_value(&InstanceState::Running), json!("running"));
+        assert_eq!(to_value(&InstanceState::Stopped), json!("stopped"));
+        assert_eq!(InstanceState::from_running(true), InstanceState::Running);
+        assert_eq!(InstanceState::from_running(false), InstanceState::Stopped);
+        assert_eq!(InstanceState::Running.label(), "running");
+        assert_eq!(InstanceState::Stopped.label(), "stopped");
+    }
+
+    /// The backend token for the host — the only variant that exists in
+    /// this build.
+    fn platform_backend_token() -> &'static str {
+        if cfg!(target_os = "macos") {
+            "lima"
+        } else {
+            "firecracker"
+        }
+    }
+
+    #[test]
+    fn backend_kind_token_matches_platform() {
+        let be = backend::PlatformBackend::new();
+        assert_eq!(
+            to_value(&BackendKind::of(&be)),
+            json!(platform_backend_token())
+        );
+    }
+
+    #[test]
+    fn instance_status_running_with_usage() {
+        let name = config::InstanceName::new("web").unwrap();
+        let image = config::default_image_name();
+        let view = InstanceStatus {
+            name: &name,
+            state: InstanceState::Running,
+            image: &image,
+            backend: BackendKind::of(&backend::PlatformBackend::new()),
+            usage: Some(backend::ResourceUsage {
+                load_1m: 0.12,
+                mem_used_mib: 512,
+                mem_total_mib: 2048,
+                disk_used_mib: 8192,
+                disk_total_mib: 20480,
+            }),
+        };
+        assert_eq!(
+            to_value(&view),
+            json!({
+                "name": "web",
+                "state": "running",
+                "image": "default",
+                "backend": platform_backend_token(),
+                "usage": {
+                    "load_1m": 0.12,
+                    "mem_used_mib": 512,
+                    "mem_total_mib": 2048,
+                    "disk_used_mib": 8192,
+                    "disk_total_mib": 20480
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn instance_status_stopped_has_null_usage() {
+        let name = config::InstanceName::new("db").unwrap();
+        let image = config::default_image_name();
+        let view = InstanceStatus {
+            name: &name,
+            state: InstanceState::Stopped,
+            image: &image,
+            backend: BackendKind::of(&backend::PlatformBackend::new()),
+            usage: None,
+        };
+        assert_eq!(to_value(&view)["usage"], Value::Null);
+        assert_eq!(to_value(&view)["state"], json!("stopped"));
+    }
+
+    #[test]
+    fn instance_summary_shape() {
+        let name = config::InstanceName::new("web").unwrap();
+        let view = InstanceSummary {
+            name: &name,
+            state: InstanceState::Running,
+        };
+        assert_eq!(
+            to_value(&view),
+            json!({ "name": "web", "state": "running" })
+        );
+    }
+
+    #[test]
+    fn image_info_empty_profiles_and_null_created() {
+        let name = config::default_image_name();
+        let view = ImageInfo {
+            name: &name,
+            profiles: &[],
+            created: None,
+            size_bytes: 0,
+        };
+        assert_eq!(
+            to_value(&view),
+            json!({ "name": "default", "profiles": [], "created": Value::Null, "size_bytes": 0 })
+        );
+    }
+
+    #[test]
+    fn image_info_with_profiles_and_created() {
+        let name = config::default_image_name();
+        let profiles = vec!["python".to_string(), "node".to_string()];
+        let view = ImageInfo {
+            name: &name,
+            profiles: &profiles,
+            created: Some("2026-06-01T12:00:00Z"),
+            size_bytes: 8_589_934_592,
+        };
+        assert_eq!(
+            to_value(&view),
+            json!({
+                "name": "default",
+                "profiles": ["python", "node"],
+                "created": "2026-06-01T12:00:00Z",
+                "size_bytes": 8_589_934_592u64
+            })
+        );
+    }
+
+    #[test]
+    fn profiles_list_shape() {
+        let view = ProfilesList {
+            builtin: vec![ProfileEntry {
+                name: "python".to_string(),
+                summary: "python3".to_string(),
+            }],
+            custom: Vec::new(),
+        };
+        assert_eq!(
+            to_value(&view),
+            json!({
+                "builtin": [{ "name": "python", "summary": "python3" }],
+                "custom": []
+            })
+        );
+    }
+
+    #[test]
+    fn dry_run_plan_null_report_and_number_overrides() {
+        let user = guest::GuestUser::default();
+        let profiles = vec!["node".to_string()];
+        let view = DryRunPlan {
+            report: None,
+            profiles: &profiles,
+            guest_user: &user,
+            vm: VmOverrides {
+                vcpus: Some(4),
+                mem_mib: config::MiB::new(2048),
+                disk_gib: config::GiB::new(50),
+            },
+        };
+        assert_eq!(
+            to_value(&view),
+            json!({
+                "report": Value::Null,
+                "profiles": ["node"],
+                "guest_user": "ubuntu",
+                "vm": { "vcpus": 4, "mem_mib": 2048, "disk_gib": 50 }
+            })
+        );
+    }
+
+    #[test]
+    fn dry_run_plan_with_report() {
+        use devcontainer::{Report, ReportSource, ReportStatus};
+        let mut report = Report::default();
+        report.push(
+            "hostRequirements.cpus",
+            ReportStatus::Applied,
+            ReportSource::Devcontainer,
+            "4",
+            "",
+        );
+        let user = guest::GuestUser::default();
+        let view = DryRunPlan {
+            report: Some(&report),
+            profiles: &[],
+            guest_user: &user,
+            vm: VmOverrides {
+                vcpus: None,
+                mem_mib: None,
+                disk_gib: None,
+            },
+        };
+        let v = to_value(&view);
+        assert_eq!(v["report"]["entries"][0]["status"], json!("applied"));
+        assert_eq!(v["report"]["entries"][0]["source"], json!("devcontainer"));
+        assert_eq!(
+            v["report"]["entries"][0]["key"],
+            json!("hostRequirements.cpus")
+        );
+        assert_eq!(v["vm"]["vcpus"], Value::Null);
+    }
+}

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
-use super::{DevcontainerInput, DevcontainerOpts, resolve_devcontainer};
+use super::json;
+use super::{
+    DevcontainerInput, DevcontainerOpts, resolve_devcontainer, resolve_devcontainer_collect,
+};
 use super::{merge_runtime_guest_env, purge_all_data};
 use crate::backend::VmBackend as _;
 use crate::{
@@ -55,6 +58,8 @@ pub(crate) struct UpRuntimeOpts {
 pub(crate) struct UpDevcontainerOpts {
     pub(crate) input: DevcontainerInput,
     pub(crate) dry_run: bool,
+    /// Emit the dry-run plan as JSON on stdout (only meaningful with `dry_run`).
+    pub(crate) json: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -119,8 +124,9 @@ pub(crate) fn cmd_up(
     };
 
     if opts.devcontainer.dry_run {
-        let inputs = up_translator_inputs(cfg, opts);
-        resolve_devcontainer(
+        return emit_up_dry_run(
+            cfg,
+            opts,
             &DevcontainerOpts {
                 input: &opts.devcontainer.input,
                 dry_run: true,
@@ -130,10 +136,7 @@ pub(crate) fn cmd_up(
                 github_auth: cfg.github.as_ref(),
                 preference_path: Some(&cfg.devcontainer_preferences_path()),
             },
-            &inputs,
-            devcontainer::Stage::Start,
-        )?;
-        return Ok(());
+        );
     }
 
     if let Some(inst) = find_workspace_instance(cfg, &project_dir)? {
@@ -178,8 +181,9 @@ fn cmd_up_git_repo(
     repo_url: &str,
 ) -> Result<()> {
     if opts.devcontainer.dry_run {
-        let inputs = up_translator_inputs(cfg, opts);
-        resolve_devcontainer(
+        return emit_up_dry_run(
+            cfg,
+            opts,
             &DevcontainerOpts {
                 input: &opts.devcontainer.input,
                 dry_run: true,
@@ -189,10 +193,7 @@ fn cmd_up_git_repo(
                 github_auth: cfg.github.as_ref(),
                 preference_path: Some(&cfg.devcontainer_preferences_path()),
             },
-            &inputs,
-            devcontainer::Stage::Start,
-        )?;
-        return Ok(());
+        );
     }
 
     if let Some(inst) = find_git_repo_instance(cfg, repo_url)? {
@@ -240,6 +241,41 @@ fn up_translator_inputs(
         cli_workspace_or_git_repo: true,
         ..devcontainer::TranslatorInputs::default()
     }
+}
+
+/// Run the shared up dry-run: resolve the devcontainer for `Stage::Start`,
+/// then either render the human report to stderr or emit the resolved
+/// [`json::DryRunPlan`] to stdout.
+fn emit_up_dry_run(
+    cfg: &config::CoopConfig,
+    opts: &UpOpts<'_>,
+    dc_opts: &DevcontainerOpts<'_>,
+) -> Result<()> {
+    let inputs = up_translator_inputs(cfg, opts);
+    if !opts.devcontainer.json {
+        resolve_devcontainer(dc_opts, &inputs, devcontainer::Stage::Start)?;
+        return Ok(());
+    }
+    let translation = resolve_devcontainer_collect(dc_opts, &inputs, devcontainer::Stage::Start)?;
+    // Features that map to profiles are baked into the image at `coop setup`
+    // time, not selected per-start, so a Start-stage translation contributes
+    // no profiles; the effective set is exactly the CLI `--profile` list.
+    let profiles = opts
+        .profile_target
+        .as_ref()
+        .map_or(&[][..], |t| t.profiles.as_slice());
+    let guest_user = backend::persisted_guest_user(cfg, &opts.effective_image());
+    let plan = json::DryRunPlan {
+        report: translation.as_ref().map(|t| &t.report),
+        profiles,
+        guest_user: &guest_user,
+        vm: json::VmOverrides {
+            vcpus: opts.vcpus,
+            mem_mib: opts.mem,
+            disk_gib: opts.disk,
+        },
+    };
+    json::render_json(&plan)
 }
 
 fn create_up_instance(
@@ -1586,36 +1622,78 @@ pub(crate) fn cmd_destroy(
     Ok(())
 }
 
-pub(crate) fn cmd_list(be: &backend::PlatformBackend, cfg: &config::CoopConfig) -> Result<()> {
+pub(crate) fn cmd_list(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    json_out: bool,
+) -> Result<()> {
     let mut instances = cfg.list_instances()?;
-    if instances.is_empty() {
+    instances.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+    let summaries: Vec<json::InstanceSummary<'_>> = instances
+        .iter()
+        .map(|inst| json::InstanceSummary {
+            name: &inst.name,
+            state: json::InstanceState::from_running(be.is_running(inst)),
+        })
+        .collect();
+
+    if json_out {
+        return json::render_json(&summaries);
+    }
+
+    if summaries.is_empty() {
         writeln!(std::io::stdout(), "No instances found")
             .map_err(|e| anyhow::anyhow!("Failed to write list: {e}"))?;
         return Ok(());
     }
-    instances.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
-
     writeln!(std::io::stdout(), "{:<16} STATE", "NAME")
         .map_err(|e| anyhow::anyhow!("Failed to write list: {e}"))?;
-    for inst in &instances {
-        let state = if be.is_running(inst) {
-            "running"
-        } else {
-            "stopped"
-        };
-        writeln!(std::io::stdout(), "{:<16} {state}", inst.name.as_str())
-            .map_err(|e| anyhow::anyhow!("Failed to write list: {e}"))?;
+    for summary in &summaries {
+        writeln!(
+            std::io::stdout(),
+            "{:<16} {}",
+            summary.name.as_str(),
+            summary.state.label()
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to write list: {e}"))?;
     }
     Ok(())
+}
+
+/// Assemble the common JSON status shape for one instance. Runs the same
+/// state/usage queries as the human path, so the shared fields agree.
+fn instance_status<'a>(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    inst: &'a config::Instance,
+) -> Result<json::InstanceStatus<'a>> {
+    let (state, usage) = match be.as_running(cfg, inst.clone())? {
+        Some(running) => (
+            json::InstanceState::Running,
+            backend::query_resource_usage(running.target()),
+        ),
+        None => (json::InstanceState::Stopped, None),
+    };
+    Ok(json::InstanceStatus {
+        name: &inst.name,
+        state,
+        image: &inst.image,
+        backend: json::BackendKind::of(be),
+        usage,
+    })
 }
 
 pub(crate) fn cmd_status(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
     name: Option<&config::InstanceName>,
+    json_out: bool,
 ) -> Result<()> {
     if let Some(name) = name {
         let inst = cfg.resolve_instance(Some(name))?;
+        if json_out {
+            return json::render_json(&instance_status(be, cfg, &inst)?);
+        }
         let report = match be.as_running(cfg, inst.clone())? {
             Some(running) => be.status(cfg, &running)?,
             None => format!(
@@ -1627,6 +1705,13 @@ pub(crate) fn cmd_status(
             .map_err(|e| anyhow::anyhow!("Failed to write status: {e}"))?;
     } else {
         let instances = cfg.list_instances()?;
+        if json_out {
+            let statuses = instances
+                .iter()
+                .map(|inst| instance_status(be, cfg, inst))
+                .collect::<Result<Vec<_>>>()?;
+            return json::render_json(&statuses);
+        }
         if instances.is_empty() {
             writeln!(std::io::stdout(), "No instances found")
                 .map_err(|e| anyhow::anyhow!("Failed to write status: {e}"))?;
@@ -1850,6 +1935,7 @@ mod tests {
             devcontainer: super::UpDevcontainerOpts {
                 input: super::DevcontainerInput::Disabled,
                 dry_run: false,
+                json: false,
             },
         }
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@
 mod admin;
 mod devcontainer;
 mod github;
+pub(crate) mod json;
 mod lifecycle;
 mod model;
 mod profiles;
@@ -15,7 +16,7 @@ mod quickstart;
 pub(crate) use admin::{UninstallOpts, cmd_init, cmd_uninstall, cmd_validate};
 pub(crate) use devcontainer::{
     DevcontainerInput, DevcontainerOpts, cmd_devcontainer, cmd_devcontainer_check,
-    resolve_devcontainer,
+    resolve_devcontainer, resolve_devcontainer_collect,
 };
 pub(crate) use github::cmd_github;
 pub(crate) use lifecycle::{

--- a/src/commands/profiles.rs
+++ b/src/commands/profiles.rs
@@ -5,18 +5,44 @@ use std::io::Write as _;
 use anyhow::{Context, Result};
 
 use crate::backend::VmBackend as _;
+use crate::commands::json;
 use crate::{ProfilesAction, backend, config, guest};
 
 pub(crate) fn cmd_profiles(cfg: &config::CoopConfig, action: &ProfilesAction) -> Result<()> {
-    let out = &mut std::io::stdout();
-    let write_result = match action {
-        ProfilesAction::List => write_profiles_list(out, cfg),
+    match action {
+        ProfilesAction::List { json: true } => json::render_json(&collect_profiles_list(cfg)),
+        ProfilesAction::List { json: false } => write_profiles_list(&mut std::io::stdout(), cfg)
+            .context("failed to write profile output"),
         ProfilesAction::Show { name } => {
             let def = guest::lookup_profile(name, &cfg.profiles)?;
-            write_profile_show(out, cfg, name, &def)
+            write_profile_show(&mut std::io::stdout(), cfg, name, &def)
+                .context("failed to write profile output")
         }
-    };
-    write_result.context("failed to write profile output")
+    }
+}
+
+/// Assemble the builtin + custom profile inventory, sorted the same way
+/// the human listing prints them.
+fn collect_profiles_list(cfg: &config::CoopConfig) -> json::ProfilesList {
+    let builtin = guest::BUILTIN_PROFILES
+        .iter()
+        .map(|bp| json::ProfileEntry {
+            name: bp.name.to_string(),
+            summary: builtin_summary(bp),
+        })
+        .collect();
+
+    let mut custom_names: Vec<&str> = cfg.profiles.keys().map(String::as_str).collect();
+    custom_names.sort_unstable();
+    let custom = custom_names
+        .into_iter()
+        .map(|name| json::ProfileEntry {
+            name: name.to_string(),
+            summary: format_custom_summary(&cfg.profiles[name]),
+        })
+        .collect();
+
+    json::ProfilesList { builtin, custom }
 }
 
 fn write_profiles_list(
@@ -167,12 +193,30 @@ pub(crate) fn cmd_images(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
     delete: Option<&config::ImageName>,
+    json_out: bool,
 ) -> Result<()> {
     if let Some(name) = delete {
         return be.destroy_image(cfg, name);
     }
 
     let images = cfg.list_images()?;
+
+    if json_out {
+        let infos: Vec<json::ImageInfo<'_>> = images
+            .iter()
+            .map(|img| json::ImageInfo {
+                name: &img.name,
+                profiles: img
+                    .config
+                    .as_ref()
+                    .map_or(&[][..], |c| c.profiles.as_slice()),
+                created: img.config.as_ref().map(|c| c.created.as_str()),
+                size_bytes: dir_size_bytes(&img.dir),
+            })
+            .collect();
+        return json::render_json(&infos);
+    }
+
     if images.is_empty() {
         writeln!(
             std::io::stdout(),
@@ -192,7 +236,7 @@ pub(crate) fn cmd_images(
             .config
             .as_ref()
             .map_or("unknown", |c| c.created.as_str());
-        let size = dir_size_display(&img.dir);
+        let size = format_dir_size(dir_size_bytes(&img.dir));
         writeln!(
             std::io::stdout(),
             "{:<20} profiles: {:<30} created: {:<24} size: {}",
@@ -206,7 +250,9 @@ pub(crate) fn cmd_images(
     Ok(())
 }
 
-fn dir_size_display(dir: &std::path::Path) -> String {
+/// Sum the byte sizes of the files directly under `dir`. Best-effort: an
+/// unreadable directory or entry contributes zero.
+fn dir_size_bytes(dir: &std::path::Path) -> u64 {
     let mut total: u64 = 0;
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
@@ -215,7 +261,7 @@ fn dir_size_display(dir: &std::path::Path) -> String {
             }
         }
     }
-    format_dir_size(total)
+    total
 }
 
 /// Render a byte count as one-decimal gibibytes (1 GiB = 1024³ bytes).
@@ -226,9 +272,13 @@ fn format_dir_size(total_bytes: u64) -> String {
 }
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code — panics are assertions")]
 mod tests {
-    use super::{builtin_summary, format_custom_summary, format_dir_size, script_summary};
-    use crate::config::CustomProfile;
+    use super::{
+        builtin_summary, collect_profiles_list, format_custom_summary, format_dir_size,
+        script_summary,
+    };
+    use crate::config::{CoopConfig, CustomProfile};
     use crate::guest::BuiltinProfile;
 
     #[test]
@@ -300,6 +350,33 @@ mod tests {
         // line as multi-line).
         let s = script_summary(Some("first\nsecond\nthird"));
         assert_eq!(s, "first ... (3 lines)");
+    }
+
+    #[test]
+    fn collect_profiles_list_includes_builtin_and_sorts_custom() {
+        let mut cfg = CoopConfig::default();
+        let empty = || CustomProfile {
+            apt_packages: Vec::new(),
+            pre_install: None,
+            post_install: None,
+            marketplaces: Vec::new(),
+            plugins: Vec::new(),
+        };
+        cfg.profiles.insert("zeta".to_string(), empty());
+        cfg.profiles.insert("alpha".to_string(), empty());
+
+        let list = collect_profiles_list(&cfg);
+        assert!(
+            !list.builtin.is_empty(),
+            "builtin profiles should be listed"
+        );
+        let custom_names: Vec<&str> = list.custom.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(custom_names, ["alpha", "zeta"], "custom names sorted");
+
+        let v = serde_json::to_value(&list).expect("serializes");
+        assert!(v["builtin"].is_array());
+        assert_eq!(v["custom"][0]["name"], serde_json::json!("alpha"));
+        assert_eq!(v["custom"][0]["summary"], serde_json::json!("(empty)"));
     }
 
     #[test]

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -345,7 +345,8 @@ pub fn warn_if_applied_devcontainer_changed(inst: &config::Instance) {
 // ── Reporting ────────────────────────────────────────────────
 
 /// Result of translating one key.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ReportStatus {
     /// Value from devcontainer.json took effect.
     Applied,
@@ -369,7 +370,8 @@ impl ReportStatus {
 }
 
 /// Origin of the effective value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ReportSource {
     Cli,
     Devcontainer,
@@ -387,7 +389,7 @@ impl ReportSource {
 /// One row in the report table. `key` is the dotted devcontainer.json path
 /// (e.g. `hostRequirements.cpus`); `value` is the effective value (after
 /// CLI/precedence) rendered as a short string; `note` is free-form context.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ReportEntry {
     pub key: String,
     pub status: ReportStatus,
@@ -398,7 +400,7 @@ pub struct ReportEntry {
 
 /// Loud per-key report rendered after translation. Implements `Display`
 /// for direct `writeln!` into stderr.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, serde::Serialize)]
 pub struct Report {
     pub entries: Vec<ReportEntry>,
     pub source_path: Option<PathBuf>,

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -23,11 +23,12 @@ use anyhow::{Context, Result, anyhow, bail};
 use thiserror::Error;
 
 use crate::cmd::Cmd;
+use crate::commands::json;
 use crate::config::{CoopConfig, GitHubAuth, resolve_cmd_value};
 use crate::github_repo::{RepoSlug, detect_workspace_repo};
 use crate::github_submodules::{SubmoduleDiscovery, classify_urls, extract_urls};
 use crate::secret_store::{
-    AccountName, CmdToken, SERVICE, available_backends, delete_secret, store_secret,
+    AccountName, Backend, CmdToken, SERVICE, available_backends, delete_secret, store_secret,
 };
 
 /// Prefix every fine-grained PAT starts with. Surfaced as `pub const` so
@@ -103,66 +104,160 @@ pub fn run_rotate_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
 /// printed. When `probe` is true, each `cmd:` invocation is resolved to
 /// confirm the secret store still serves it — this may trigger a
 /// Keychain dialog / `op` Touch-ID prompt per entry, so it is opt-in.
-pub fn run_status(cfg: &CoopConfig, probe: bool) {
-    print!("{}", render_status(cfg, probe));
+pub fn run_status(cfg: &CoopConfig, probe: bool, json_out: bool) -> Result<()> {
+    let view = build_status(cfg, probe);
+    if json_out {
+        return json::render_json(&view);
+    }
+    print!("{}", format_status(&view));
+    Ok(())
 }
 
-/// Render the `coop github status` report as a string.
-///
-/// Pure for the non-probe path; when `probe` is true, each entry's
-/// `cmd:` invocation is resolved (running the underlying command) to
-/// confirm the secret store still serves it.
-fn render_status(cfg: &CoopConfig, probe: bool) -> String {
+/// Configured `github` auth mode. Mirrors [`GitHubAuth`]'s discriminants;
+/// `None` config maps to [`GithubMode::Off`]. The `lowercase` serde token
+/// matches [`GitHubAuth::mode_name`], so human and JSON labels agree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum GithubMode {
+    Auto,
+    Env,
+    Off,
+    Pat,
+}
+
+impl GithubMode {
+    /// Project the configured auth (or its absence) into the mode enum.
+    pub(crate) fn of(auth: Option<&GitHubAuth>) -> Self {
+        match auth {
+            Some(GitHubAuth::Auto) => Self::Auto,
+            Some(GitHubAuth::Env) => Self::Env,
+            Some(GitHubAuth::Off) | None => Self::Off,
+            Some(GitHubAuth::Pat(_)) => Self::Pat,
+        }
+    }
+
+    #[mutants::skip] // equivalent: human label only; the serde token is the tested contract
+    fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Env => "env",
+            Self::Off => "off",
+            Self::Pat => "pat",
+        }
+    }
+}
+
+/// Outcome of resolving a PAT entry's `cmd:` invocation under `--probe`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProbeStatus {
+    Ok,
+    UnexpectedFormat,
+    ResolveFailed,
+}
+
+impl ProbeStatus {
+    /// Classify a resolved-token result.
+    pub(crate) fn from_resolved(resolved: &Result<String>) -> Self {
+        match resolved {
+            Ok(token) if token.starts_with(TOKEN_PREFIX) => Self::Ok,
+            Ok(_) => Self::UnexpectedFormat,
+            Err(_) => Self::ResolveFailed,
+        }
+    }
+
+    /// Human status line, unchanged from the original text output.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ok => "resolves, format ok",
+            Self::UnexpectedFormat => "resolves but unexpected format",
+            Self::ResolveFailed => "FAILED to resolve",
+        }
+    }
+}
+
+/// `coop github status` view model. Never carries a token value — only
+/// repo, storage backend, and (opt-in) probe result.
+#[derive(serde::Serialize)]
+pub(crate) struct GithubStatus<'a> {
+    pub mode: GithubMode,
+    pub entries: Vec<PatEntryView<'a>>,
+    pub skip: Vec<&'a RepoSlug>,
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct PatEntryView<'a> {
+    pub repo: &'a RepoSlug,
+    /// `None` when the `cmd:` invocation is unparseable (human: "unknown").
+    pub storage: Option<Backend>,
+    /// `None` unless `--probe` resolved the entry.
+    pub probe: Option<ProbeStatus>,
+}
+
+/// Assemble the status view. Pure for the non-probe path; when `probe` is
+/// true each entry's `cmd:` invocation is resolved (running the underlying
+/// command) to confirm the secret store still serves it.
+// The probe branch shells out via resolve_cmd_value, so this cannot be
+// fully lib-tested; excluded in .cargo/mutants.toml. The pure projections
+// (GithubMode::of, ProbeStatus::from_resolved) and the non-probe shape are
+// covered by tests.
+fn build_status(cfg: &CoopConfig, probe: bool) -> GithubStatus<'_> {
+    let mode = GithubMode::of(cfg.github.as_ref());
+    let (entries, skip) = match cfg.github.as_ref() {
+        Some(GitHubAuth::Pat(c)) => {
+            let entries = c
+                .entries
+                .iter()
+                .map(|(repo, entry)| PatEntryView {
+                    repo,
+                    storage: CmdToken::parse(entry.token.expose()).map(|t| t.backend()),
+                    probe: probe.then(|| {
+                        ProbeStatus::from_resolved(&resolve_cmd_value(entry.token.expose()))
+                    }),
+                })
+                .collect();
+            let skip = c.skip.iter().collect();
+            (entries, skip)
+        }
+        _ => (Vec::new(), Vec::new()),
+    };
+    GithubStatus {
+        mode,
+        entries,
+        skip,
+    }
+}
+
+/// Render the status view as the plain-text report (unchanged output).
+fn format_status(view: &GithubStatus<'_>) -> String {
     use std::fmt::Write as _;
     let mut s = String::new();
-    let pat = match cfg.github.as_ref() {
-        Some(GitHubAuth::Pat(c)) => c,
-        Some(other) => {
-            let _ = writeln!(s, "github mode: {} (no PAT entries)", other.mode_name());
-            return s;
-        }
-        None => {
-            let _ = writeln!(s, "github mode: off (no PAT entries)");
-            return s;
-        }
-    };
-
-    if pat.entries.is_empty() && pat.skip.is_empty() {
+    if view.mode != GithubMode::Pat {
+        let _ = writeln!(s, "github mode: {} (no PAT entries)", view.mode.label());
+        return s;
+    }
+    if view.entries.is_empty() && view.skip.is_empty() {
         let _ = writeln!(s, "github mode: pat (no entries)");
         return s;
     }
 
     let _ = writeln!(s, "github mode: pat");
-    let _ = writeln!(s, "entries ({}):", pat.entries.len());
-    for (repo, entry) in &pat.entries {
-        let backend_label = CmdToken::parse(entry.token.expose()).map_or_else(
-            || "unknown".to_string(),
-            |t| t.backend().label().to_string(),
-        );
-        let _ = writeln!(s, "  {repo}");
-        let _ = writeln!(s, "    storage: {backend_label}");
-        if probe {
-            let validity = probe_status_label(&resolve_cmd_value(entry.token.expose()));
-            let _ = writeln!(s, "    status:  {validity}");
+    let _ = writeln!(s, "entries ({}):", view.entries.len());
+    for entry in &view.entries {
+        let storage_label = entry.storage.map_or("unknown", Backend::label);
+        let _ = writeln!(s, "  {}", entry.repo);
+        let _ = writeln!(s, "    storage: {storage_label}");
+        if let Some(probe) = entry.probe {
+            let _ = writeln!(s, "    status:  {}", probe.label());
         }
     }
-    if !pat.skip.is_empty() {
-        let _ = writeln!(s, "skip ({}):", pat.skip.len());
-        for repo in &pat.skip {
+    if !view.skip.is_empty() {
+        let _ = writeln!(s, "skip ({}):", view.skip.len());
+        for repo in &view.skip {
             let _ = writeln!(s, "  {repo}");
         }
     }
     s
-}
-
-/// Classify a resolved-token result into the one-line status label
-/// printed by `coop github status --probe`.
-fn probe_status_label(resolved: &Result<String>) -> &'static str {
-    match resolved {
-        Ok(token) if token.starts_with(TOKEN_PREFIX) => "resolves, format ok",
-        Ok(_) => "resolves but unexpected format",
-        Err(_) => "FAILED to resolve",
-    }
 }
 
 /// `coop github forget-pat --repo owner/name` — remove the secret and
@@ -1418,36 +1513,72 @@ mod tests {
         assert!(!doc_contains_literal_token(&doc));
     }
 
-    // ── probe_status_label ──────────────────────────────────────
+    // ── ProbeStatus ─────────────────────────────────────────────
 
     #[test]
-    fn probe_status_label_ok_with_prefix_is_format_ok() {
+    fn probe_status_ok_with_prefix_is_format_ok() {
         let resolved: Result<String> = Ok(format!("{TOKEN_PREFIX}abc"));
-        assert_eq!(probe_status_label(&resolved), "resolves, format ok");
-    }
-
-    #[test]
-    fn probe_status_label_ok_without_prefix_is_unexpected() {
-        let resolved: Result<String> = Ok("ghp_classic".to_string());
+        let status = ProbeStatus::from_resolved(&resolved);
+        assert_eq!(status, ProbeStatus::Ok);
+        assert_eq!(status.label(), "resolves, format ok");
         assert_eq!(
-            probe_status_label(&resolved),
-            "resolves but unexpected format"
+            serde_json::to_value(status).unwrap(),
+            serde_json::json!("ok")
         );
     }
 
     #[test]
-    fn probe_status_label_err_is_failed() {
-        let resolved: Result<String> = Err(anyhow!("boom"));
-        assert_eq!(probe_status_label(&resolved), "FAILED to resolve");
+    fn probe_status_ok_without_prefix_is_unexpected() {
+        let resolved: Result<String> = Ok("ghp_classic".to_string());
+        let status = ProbeStatus::from_resolved(&resolved);
+        assert_eq!(status, ProbeStatus::UnexpectedFormat);
+        assert_eq!(status.label(), "resolves but unexpected format");
+        assert_eq!(
+            serde_json::to_value(status).unwrap(),
+            serde_json::json!("unexpected_format")
+        );
     }
 
-    // ── render_status ───────────────────────────────────────────
+    #[test]
+    fn probe_status_err_is_failed() {
+        let resolved: Result<String> = Err(anyhow!("boom"));
+        let status = ProbeStatus::from_resolved(&resolved);
+        assert_eq!(status, ProbeStatus::ResolveFailed);
+        assert_eq!(status.label(), "FAILED to resolve");
+        assert_eq!(
+            serde_json::to_value(status).unwrap(),
+            serde_json::json!("resolve_failed")
+        );
+    }
+
+    #[test]
+    fn github_mode_of_covers_all_discriminants() {
+        use crate::config::PatConfig;
+        assert_eq!(GithubMode::of(None), GithubMode::Off);
+        assert_eq!(GithubMode::of(Some(&GitHubAuth::Off)), GithubMode::Off);
+        assert_eq!(GithubMode::of(Some(&GitHubAuth::Auto)), GithubMode::Auto);
+        assert_eq!(GithubMode::of(Some(&GitHubAuth::Env)), GithubMode::Env);
+        assert_eq!(
+            GithubMode::of(Some(&GitHubAuth::Pat(PatConfig::default()))),
+            GithubMode::Pat
+        );
+        assert_eq!(
+            serde_json::to_value(GithubMode::Pat).unwrap(),
+            serde_json::json!("pat")
+        );
+    }
+
+    // ── status report ───────────────────────────────────────────
 
     fn config_from(s: &str) -> CoopConfig {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, s).unwrap();
         CoopConfig::load(&path).unwrap()
+    }
+
+    fn render_status(cfg: &CoopConfig, probe: bool) -> String {
+        format_status(&build_status(cfg, probe))
     }
 
     #[test]
@@ -1488,6 +1619,41 @@ mod tests {
         let cfg = config_from("github = \"off\"\n");
         let out = render_status(&cfg, false);
         assert!(out.contains("(no PAT entries)"));
+    }
+
+    #[test]
+    fn build_status_off_mode_json_shape() {
+        let cfg = config_from("github = \"off\"\n");
+        let view = build_status(&cfg, false);
+        let v = serde_json::to_value(&view).unwrap();
+        assert_eq!(v["mode"], serde_json::json!("off"));
+        assert_eq!(v["entries"], serde_json::json!([]));
+        assert_eq!(v["skip"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn build_status_pat_entry_json_carries_storage_and_no_probe() {
+        // `cmd:echo` is not a recognised secret-store invocation, so storage
+        // parses to `null` (the "unknown" case); probe is absent without
+        // `--probe`.
+        let cfg = config_from(
+            "[github]\nmode = \"pat\"\n\n[github.pat.\"a/b\"]\ntoken = \"cmd:echo x\"\n",
+        );
+        let view = build_status(&cfg, false);
+        let v = serde_json::to_value(&view).unwrap();
+        assert_eq!(v["mode"], serde_json::json!("pat"));
+        assert_eq!(v["entries"][0]["repo"], serde_json::json!("a/b"));
+        assert_eq!(v["entries"][0]["storage"], serde_json::Value::Null);
+        assert_eq!(v["entries"][0]["probe"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn build_status_skip_only_json_lists_repo() {
+        let cfg = config_from("[github]\nmode = \"pat\"\nskip = [\"a/b\"]\n");
+        let view = build_status(&cfg, false);
+        let v = serde_json::to_value(&view).unwrap();
+        assert_eq!(v["skip"], serde_json::json!(["a/b"]));
+        assert_eq!(v["entries"], serde_json::json!([]));
     }
 
     // ── parse_gh_token ──────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::engine::ArgValueCandidates;
 
 use backend::VmBackend as _;
+use commands::json;
 use commands::{
     DevcontainerInput, DevcontainerOpts, ProfileImageTarget, ProjectTransport, QuickstartOpts,
     StartOpts, UninstallOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts, apply_runtime_guest_env,
@@ -71,7 +72,7 @@ use commands::{
     cmd_exec, cmd_github, cmd_images, cmd_init, cmd_list, cmd_model, cmd_profiles, cmd_quickstart,
     cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_uninstall, cmd_up,
     cmd_validate, codex_launch_args, open_ssh_session, preflight_start_target, prepend_binary,
-    resolve_devcontainer, resolve_running,
+    resolve_devcontainer, resolve_devcontainer_collect, resolve_running,
 };
 
 #[derive(Parser)]
@@ -174,6 +175,9 @@ enum Commands {
         /// before any VM work.
         #[arg(long)]
         dry_run: bool,
+        /// With --dry-run, emit the resolved plan as JSON on stdout
+        #[arg(long, requires = "dry_run")]
+        json: bool,
     },
     /// One-shot: ensure default image, start an instance for cwd, launch Claude.
     ///
@@ -306,6 +310,9 @@ enum Commands {
         /// before doing any VM work.
         #[arg(long)]
         dry_run: bool,
+        /// With --dry-run, emit the resolved plan as JSON on stdout
+        #[arg(long, requires = "dry_run")]
+        json: bool,
     },
     /// Open an interactive shell in the VM (or run a command non-interactively)
     #[command(alias = "ssh")]
@@ -389,7 +396,11 @@ enum Commands {
     },
     /// List instances by name and state
     #[command(alias = "ls")]
-    List,
+    List {
+        /// Emit machine-readable JSON instead of the text table
+        #[arg(long)]
+        json: bool,
+    },
     /// Show VM status
     Status {
         /// Instance name (shows all if omitted)
@@ -398,6 +409,9 @@ enum Commands {
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
+        /// Emit machine-readable JSON instead of the text output
+        #[arg(long)]
+        json: bool,
     },
     /// Show or switch a VM's model backend (cloud vs. local)
     Model {
@@ -515,6 +529,9 @@ enum Commands {
             add = ArgValueCandidates::new(completions::image_candidates),
         )]
         delete: Option<config::ImageName>,
+        /// Emit machine-readable JSON instead of the text table
+        #[arg(long)]
+        json: bool,
     },
     /// Resize a stopped instance's disk
     Resize {
@@ -655,7 +672,11 @@ impl From<ModelAction> for model_state::ModelMode {
 #[derive(Subcommand)]
 enum ProfilesAction {
     /// List all available profiles (builtin and custom)
-    List,
+    List {
+        /// Emit machine-readable JSON instead of the text listing
+        #[arg(long)]
+        json: bool,
+    },
     /// Show the full definition of a profile
     Show {
         /// Profile name to inspect
@@ -684,6 +705,9 @@ enum GithubAction {
         /// 1Password prompts) to confirm the secret store still serves it.
         #[arg(long)]
         probe: bool,
+        /// Emit machine-readable JSON instead of the text report
+        #[arg(long)]
+        json: bool,
     },
     /// Remove a configured PAT entry and its stored secret
     ForgetPat {
@@ -702,6 +726,9 @@ enum DevcontainerCommands {
         /// Which lifecycle translation to report
         #[arg(long, value_enum, default_value_t = DevcontainerCheckStage::Both)]
         stage: DevcontainerCheckStage,
+        /// Emit machine-readable JSON on stdout instead of the text report on stderr
+        #[arg(long)]
+        json: bool,
     },
     /// Persistently ignore discovered devcontainer.json for a project.
     Ignore {
@@ -871,6 +898,7 @@ pub fn run() -> Result<()> {
             devcontainer,
             no_devcontainer,
             dry_run,
+            json,
         } => {
             let validated = cfg.validate_and_warn()?;
             let transport = match (copy, mount) {
@@ -911,6 +939,7 @@ pub fn run() -> Result<()> {
                 devcontainer: UpDevcontainerOpts {
                     input: DevcontainerInput::from_flags(devcontainer, no_devcontainer),
                     dry_run,
+                    json,
                 },
             };
             cmd_up(&be, &mut cfg, &validated, &cli.config, &opts)
@@ -1022,6 +1051,7 @@ pub fn run() -> Result<()> {
             devcontainer,
             no_devcontainer,
             dry_run,
+            json: json_out,
         } => {
             let validated = cfg.validate_and_warn()?;
             if raw_args_use_deprecated_no_claude(&raw_args) {
@@ -1032,29 +1062,45 @@ pub fn run() -> Result<()> {
             if dry_run {
                 let cli_env_keys = guest_env.iter().map(|(k, _)| k.clone()).collect();
                 let dry_run_image = config::default_image_name();
+                let dry_run_guest_user = backend::persisted_guest_user(&cfg, &dry_run_image);
                 let inputs = devcontainer::TranslatorInputs {
                     cli_post_start: post_start.clone(),
                     cli_guest_env_keys: cli_env_keys,
                     cli_forward_ports: forward_ports.clone(),
-                    persisted_guest_user: Some(backend::persisted_guest_user(&cfg, &dry_run_image)),
+                    persisted_guest_user: Some(dry_run_guest_user.clone()),
                     cli_workspace_or_git_repo: workspace.is_some(),
                     ..devcontainer::TranslatorInputs::default()
                 };
                 let ws_path = workspace.as_deref().map(Path::new);
                 let dc_input = DevcontainerInput::from_flags(devcontainer.clone(), no_devcontainer);
-                let _ = resolve_devcontainer(
-                    &DevcontainerOpts {
-                        input: &dc_input,
-                        dry_run,
-                        workspace: ws_path,
-                        mounts: &[],
-                        git_repo: None,
-                        github_auth: cfg.github.as_ref(),
-                        preference_path: Some(&cfg.devcontainer_preferences_path()),
-                    },
-                    &inputs,
-                    devcontainer::Stage::Start,
-                )?;
+                let dc_opts = DevcontainerOpts {
+                    input: &dc_input,
+                    dry_run,
+                    workspace: ws_path,
+                    mounts: &[],
+                    git_repo: None,
+                    github_auth: cfg.github.as_ref(),
+                    preference_path: Some(&cfg.devcontainer_preferences_path()),
+                };
+                if json_out {
+                    let translation = resolve_devcontainer_collect(
+                        &dc_opts,
+                        &inputs,
+                        devcontainer::Stage::Start,
+                    )?;
+                    let plan = json::DryRunPlan {
+                        report: translation.as_ref().map(|t| &t.report),
+                        profiles: &[],
+                        guest_user: &dry_run_guest_user,
+                        vm: json::VmOverrides {
+                            vcpus: None,
+                            mem_mib: None,
+                            disk_gib: None,
+                        },
+                    };
+                    return json::render_json(&plan);
+                }
+                resolve_devcontainer(&dc_opts, &inputs, devcontainer::Stage::Start)?;
                 return Ok(());
             }
 
@@ -1113,8 +1159,8 @@ pub fn run() -> Result<()> {
             let _guard = signal::install_handlers();
             cmd_destroy(&be, &cfg, name.as_ref(), all)
         }
-        Commands::List => cmd_list(&be, &cfg),
-        Commands::Status { name } => cmd_status(&be, &cfg, name.as_ref()),
+        Commands::List { json } => cmd_list(&be, &cfg, json),
+        Commands::Status { name, json } => cmd_status(&be, &cfg, name.as_ref(), json),
         Commands::Model { name, action } => {
             cmd_model(&be, &cfg, name.as_ref(), action.map(Into::into))
         }
@@ -1171,15 +1217,16 @@ pub fn run() -> Result<()> {
             let running = resolve_running(&be, &cfg, name.as_ref())?;
             workspace::write_ssh_config(&running)
         }
-        Commands::Images { delete } => cmd_images(&be, &cfg, delete.as_ref()),
+        Commands::Images { delete, json } => cmd_images(&be, &cfg, delete.as_ref(), json),
         Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_ref(), size),
         Commands::Commit { name, image, force } => {
             cmd_commit(&be, &cfg, name.as_ref(), &image, force)
         }
         Commands::Restore { name, image } => cmd_restore(&be, &cfg, name.as_ref(), &image),
-        Commands::Profiles { action } => {
-            cmd_profiles(&cfg, &action.unwrap_or(ProfilesAction::List))
-        }
+        Commands::Profiles { action } => cmd_profiles(
+            &cfg,
+            &action.unwrap_or(ProfilesAction::List { json: false }),
+        ),
         Commands::Github { action } => cmd_github(&cfg, &cli.config, action),
         Commands::Validate { probe } => cmd_validate(&cfg, &be, probe),
         Commands::Init
@@ -1667,13 +1714,28 @@ mod tests {
     #[test]
     fn list_subcommand_parses() {
         let cli = parse(&["list"]);
-        assert!(matches!(cli.command, super::Commands::List));
+        assert!(matches!(cli.command, super::Commands::List { json: false }));
+    }
+
+    #[test]
+    fn list_json_flag_parses() {
+        let cli = parse(&["list", "--json"]);
+        assert!(matches!(cli.command, super::Commands::List { json: true }));
     }
 
     #[test]
     fn ls_alias_parses_as_list() {
         let cli = parse(&["ls"]);
-        assert!(matches!(cli.command, super::Commands::List));
+        assert!(matches!(cli.command, super::Commands::List { .. }));
+    }
+
+    #[test]
+    fn status_json_flag_parses() {
+        let cli = parse(&["status", "--json"]);
+        let super::Commands::Status { json, .. } = cli.command else {
+            panic!("expected Status variant");
+        };
+        assert!(json);
     }
 
     #[test]
@@ -1682,7 +1744,22 @@ mod tests {
         let super::Commands::Profiles { action } = cli.command else {
             panic!("expected Profiles variant");
         };
-        assert!(matches!(action, Some(super::ProfilesAction::List)));
+        assert!(matches!(
+            action,
+            Some(super::ProfilesAction::List { json: false })
+        ));
+    }
+
+    #[test]
+    fn profiles_list_json_flag_parses() {
+        let cli = parse(&["profiles", "list", "--json"]);
+        let super::Commands::Profiles { action } = cli.command else {
+            panic!("expected Profiles variant");
+        };
+        assert!(matches!(
+            action,
+            Some(super::ProfilesAction::List { json: true })
+        ));
     }
 
     #[test]
@@ -1924,7 +2001,7 @@ mod tests {
         let super::Commands::Devcontainer { command } = cli.command else {
             panic!("expected Devcontainer variant");
         };
-        let super::DevcontainerCommands::Check { path, stage } = command else {
+        let super::DevcontainerCommands::Check { path, stage, json } = command else {
             panic!("expected devcontainer check variant");
         };
         assert_eq!(
@@ -1932,6 +2009,24 @@ mod tests {
             std::path::PathBuf::from(".devcontainer/devcontainer.json")
         );
         assert!(matches!(stage, super::DevcontainerCheckStage::Both));
+        assert!(!json);
+    }
+
+    #[test]
+    fn devcontainer_check_json_flag_parses() {
+        let cli = parse(&[
+            "devcontainer",
+            "check",
+            ".devcontainer/devcontainer.json",
+            "--json",
+        ]);
+        let super::Commands::Devcontainer { command } = cli.command else {
+            panic!("expected Devcontainer variant");
+        };
+        let super::DevcontainerCommands::Check { json, .. } = command else {
+            panic!("expected devcontainer check variant");
+        };
+        assert!(json);
     }
 
     #[test]

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -33,7 +33,12 @@ use crate::naming::validate_safe_chars;
 /// system keychain is meaningless on the other.
 ///
 /// `OnePassword` and `File` are cross-platform and always present.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// The `serde` token (`snake_case`, e.g. `"macos_keychain"`) is a stable
+/// machine identifier for `coop github status --json`, distinct from the
+/// human [`label`](Backend::label).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Backend {
     /// macOS Keychain via `/usr/bin/security`.
     #[cfg(target_os = "macos")]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -505,6 +505,39 @@ test_status_running() {
         fail "status shows valid disk" "used=$disk_used total=$disk_total from: $HARNESS_OUT"
     fi
 
+    # JSON output: HARNESS_OUT captures stdout only (tracing stays on stderr),
+    # so `coop status --json` must be clean, parseable JSON. This exercises the
+    # real stdout/stderr split on both backends.
+    if coop status "$INSTANCE" --json; then
+        if command -v jq >/dev/null 2>&1; then
+            if echo "$HARNESS_OUT" | jq -e '.state == "running"' >/dev/null; then
+                pass "status --json reports running state"
+            else
+                fail "status --json reports running state" "got: $HARNESS_OUT"
+            fi
+            if echo "$HARNESS_OUT" | jq -e '.usage.mem_total_mib > 0' >/dev/null; then
+                pass "status --json carries usage"
+            else
+                fail "status --json carries usage" "got: $HARNESS_OUT"
+            fi
+        elif echo "$HARNESS_OUT" | grep -q '"state": "running"'; then
+            pass "status --json reports running state (no jq)"
+        else
+            fail "status --json reports running state (no jq)" "got: $HARNESS_OUT"
+        fi
+    else
+        fail "status --json exits 0" "exit code: $?"
+    fi
+
+    # Bare `--json` (no name) emits a JSON array of the common shape.
+    if coop status --json && command -v jq >/dev/null 2>&1; then
+        if echo "$HARNESS_OUT" | jq -e 'type == "array" and (.[0].state | test("running|stopped"))' >/dev/null; then
+            pass "status --json (all) emits an array"
+        else
+            fail "status --json (all) emits an array" "got: $HARNESS_OUT"
+        fi
+    fi
+
     # Multi-instance list: compact summary with valid percentages
     # Format: "load=X.XX mem=NN% disk=NN%"
     if coop status; then
@@ -552,6 +585,24 @@ test_list_running() {
         fi
     else
         fail "ls alias exits 0" "exit code: $?"
+    fi
+
+    # JSON output: parseable array with the running instance.
+    if coop list --json; then
+        if command -v jq >/dev/null 2>&1; then
+            if echo "$HARNESS_OUT" | jq -e --arg n "$INSTANCE" \
+                'any(.[]; .name == $n and .state == "running")' >/dev/null; then
+                pass "list --json shows instance running"
+            else
+                fail "list --json shows instance running" "got: $HARNESS_OUT"
+            fi
+        elif echo "$HARNESS_OUT" | grep -q '"state": "running"'; then
+            pass "list --json shows running (no jq)"
+        else
+            fail "list --json shows running (no jq)" "got: $HARNESS_OUT"
+        fi
+    else
+        fail "list --json exits 0" "exit code: $?"
     fi
 }
 


### PR DESCRIPTION
Adds an opt-in `--json` flag to coop's read/query commands so their output can be parsed reliably by automation. Human output stays the default and is unchanged. Implements `docs/json-output-design.md` (issue #385).

## What's covered

| Command | JSON shape |
|---|---|
| `status` | Array (bare) or single object (`--name`): `{ name, state, image, backend, usage }` |
| `list` / `ls` | Array of `{ name, state }` |
| `images` | Array of `{ name, profiles, created, size_bytes }` |
| `devcontainer check` | One `Report`, or `{ setup, start }` for `--stage both` |
| `github status` | `{ mode, entries, skip }`; entries are `{ repo, storage, probe }` — token never emitted |
| `profiles list` | `{ builtin, custom }` of `{ name, summary }` |
| `up --dry-run` / `start --dry-run` | `{ report, profiles, guest_user, vm }` |

## How it works

Each command builds one `Serialize` view model; `--json` switches only the final render step, so the human formatter and the JSON serializer read the same value and cannot drift. View models carry coop's existing newtypes (`InstanceName`, `ImageName`, `RepoSlug`, `GuestUser`, `MiB`/`GiB`) borrowed rather than downgraded to `String`, and model closed sets (state, backend, report status/source, PAT storage, probe result) as enums. Genuine absence is `null` / `[]`, not a sentinel string.

Shared infrastructure lives in `src/commands/json.rs`: the single `render_json` stdout writer plus the `InstanceState` / `BackendKind` enums. JSON goes to stdout; tracing stays on stderr, so `coop … --json | jq` stays clean.

For `devcontainer check` and `up`/`start --dry-run` the report currently prints to stderr; under `--json` the payload moves to stdout while the human path stays on stderr. To do this without changing behavior for the ~9 other `resolve_devcontainer` callers, that function is split into a quiet collector (`resolve_devcontainer_collect`) and a thin stderr-rendering wrapper.

On `up`/`start` the `--json` flag is `requires = "dry_run"`, so it never appears to do nothing: `coop up --json` without `--dry-run` errors at parse time.

## Tests

- Shape tests for every view model pin field names, enum tokens, `null` vs `[]`, and array-vs-object — including edges (`usage: null`, empty `profiles`, `storage: null`, `probe` present only with `--probe`, `mode: off`).
- Pure projections (`BackendKind::of`, `GithubMode::of`, `ProbeStatus::from_resolved`, `collect_profiles_list`) are unit-tested.
- `tests/integration.sh` gains jq-guarded `status --json` / `list --json` assertions that exercise the real stdout/stderr split on both backends.
- `.cargo/mutants.toml` is updated in this PR per CLAUDE.md: the new stdout/IO writers are scoped out, the pure view builders stay in scope. Mutation sweeps of the touched files report **0 missed** (`json.rs`, `profiles.rs`, `devcontainer.rs`+`github_pat.rs`, `lifecycle.rs` in-diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)