### PR TITLE
Add license field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "coop"
 version = "0.5.2"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
+license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
The Apache-2.0 `LICENSE` file was present at the repo root, but the package metadata did not declare a license. crates.io requires a `license` (or `license-file`) field to publish, and license tooling (`cargo deny`, dependency scanners) reads the SPDX identifier from metadata rather than the file.

This adds `license = "Apache-2.0"` to `[package]` in `Cargo.toml`, matching the existing LICENSE file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)