### PR TITLE
Add .editorconfig

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -23,23 +23,23 @@
 # Whole modules that only shell out, drive SSH, or talk to external services.
 # (CLAUDE.md "Don't bother with" list.) Unit tests cannot observe their effects.
 exclude_globs = [
-    "src/backend.rs",
-    "src/lima.rs",
-    "src/setup.rs",
-    "src/update.rs",
-    "src/shell.rs",
-    "src/port_forward.rs",
-    "src/cmd.rs",
-    "src/ssh.rs",
-    "src/vm.rs",
-    # Thin binary shim: `fn main() { coop::run() }`. All logic is in the lib.
-    "src/main.rs",
-    # Interactive y/N + free-form line prompts (confirm / confirm_default_yes /
-    # read_line). Every function short-circuits to Ok(false)/Ok(None) off a TTY
-    # and otherwise reads stdin; the trailing match on the reply is only
-    # reachable behind a real terminal, so a `--lib` test cannot observe any of
-    # it. Whole-module exclude (cf. read_line added for #352, issue #373).
-    "src/prompt.rs",
+  "src/backend.rs",
+  "src/lima.rs",
+  "src/setup.rs",
+  "src/update.rs",
+  "src/shell.rs",
+  "src/port_forward.rs",
+  "src/cmd.rs",
+  "src/ssh.rs",
+  "src/vm.rs",
+  # Thin binary shim: `fn main() { coop::run() }`. All logic is in the lib.
+  "src/main.rs",
+  # Interactive y/N + free-form line prompts (confirm / confirm_default_yes /
+  # read_line). Every function short-circuits to Ok(false)/Ok(None) off a TTY
+  # and otherwise reads stdin; the trailing match on the reply is only
+  # reachable behind a real terminal, so a `--lib` test cannot observe any of
+  # it. Whole-module exclude (cf. read_line added for #352, issue #373).
+  "src/prompt.rs",
 ]
 
 # Individual functions in otherwise-logic-bearing modules. Patterns match
@@ -48,252 +48,252 @@ exclude_globs = [
 # operator/value mutants inside that function, without catching longer names
 # that share a prefix (e.g. \bprobe_user\b leaves probe_user_login alone).
 exclude_re = [
-    # cfg(kani) proofs (config.rs `mod proofs`): never compiled in a normal
-    # build, so every mutation is a silent no-op and always "missed". The
-    # proofs are exercised by `cargo kani`, not by mutation testing.
-    "proofs::",
+  # cfg(kani) proofs (config.rs `mod proofs`): never compiled in a normal
+  # build, so every mutation is a silent no-op and always "missed". The
+  # proofs are exercised by `cargo kani`, not by mutation testing.
+  "proofs::",
 
-    # github_pat.rs — external process (curl/gh/git), browser, terminal echo.
-    "\\brun_setup_pat\\b",
-    "\\brun_rotate_pat\\b",
-    "\\brun_forget_pat\\b",
-    "\\bprobe_user\\b",
-    "\\bprobe_repo\\b",
-    "\\bcurl_with_token\\b",
-    "\\bcurl_with_accept\\b",
-    "\\bcurl_anonymous\\b",
-    "\\bcurl_anonymous_with_accept\\b",
-    "\\bis_public_repo_anonymous\\b",
-    "\\bdiscover_submodule_repos\\b",
-    "\\bprobe_same_owner_coverage\\b",
-    "\\bread_token_no_echo\\b",
-    "\\bopen_browser_best_effort\\b",
-    "\\bprint_form_instructions\\b",
-    "\\bprint_widen_instructions\\b",
-    "\\bwarn_token_format\\b",
-    "impl Drop for EchoGuard",
-    # PAT-wizard submodule orchestration: curl prefetch, then terminal prompts
-    # (read_token_no_echo) and eprintln advice gated on the discovery result.
-    # The classification logic (classify_urls / extract_urls / drop_public) is
-    # factored out and stays in scope.
-    "\\bprefetch_submodules\\b",
-    "\\bhandle_submodules\\b",
-    "\\bdiscover_from_pasted_token\\b",
-    # gh_auth_token is a pure `gh auth token` shell-out that delegates trimming
-    # to parse_gh_token (#322, kept). Exclude only its whole-body replacement;
-    # this module-agnostic pattern also covers the identical gh_auth_token in
-    # git_repo_devcontainer.rs (whose logic lives in normalize_token, kept).
-    "replace gh_auth_token ->",
-    # Thin wrappers whose logic was extracted in #322: run_status just renders
-    # build_status(...) as JSON or text (kept helpers below); probe_user_login
-    # just curls then delegates to parse_user_login (kept). \b leaves
-    # parse_user_login alone.
-    "\\brun_status\\b",
-    "\\bprobe_user_login\\b",
-    # build_status (#385, `github status --json` view builder): its `--probe`
-    # branch shells out via resolve_cmd_value, so a `--lib` test cannot observe
-    # it. The pure projections it calls — GithubMode::of, ProbeStatus::from_resolved
-    # — and format_status stay in scope, each unit-tested (a survivor there is a
-    # real gap). GithubMode::label carries an in-source `#[mutants::skip]`
-    # (equivalent: human label; the serde token is the tested contract).
-    "\\bbuild_status\\b",
+  # github_pat.rs — external process (curl/gh/git), browser, terminal echo.
+  "\\brun_setup_pat\\b",
+  "\\brun_rotate_pat\\b",
+  "\\brun_forget_pat\\b",
+  "\\bprobe_user\\b",
+  "\\bprobe_repo\\b",
+  "\\bcurl_with_token\\b",
+  "\\bcurl_with_accept\\b",
+  "\\bcurl_anonymous\\b",
+  "\\bcurl_anonymous_with_accept\\b",
+  "\\bis_public_repo_anonymous\\b",
+  "\\bdiscover_submodule_repos\\b",
+  "\\bprobe_same_owner_coverage\\b",
+  "\\bread_token_no_echo\\b",
+  "\\bopen_browser_best_effort\\b",
+  "\\bprint_form_instructions\\b",
+  "\\bprint_widen_instructions\\b",
+  "\\bwarn_token_format\\b",
+  "impl Drop for EchoGuard",
+  # PAT-wizard submodule orchestration: curl prefetch, then terminal prompts
+  # (read_token_no_echo) and eprintln advice gated on the discovery result.
+  # The classification logic (classify_urls / extract_urls / drop_public) is
+  # factored out and stays in scope.
+  "\\bprefetch_submodules\\b",
+  "\\bhandle_submodules\\b",
+  "\\bdiscover_from_pasted_token\\b",
+  # gh_auth_token is a pure `gh auth token` shell-out that delegates trimming
+  # to parse_gh_token (#322, kept). Exclude only its whole-body replacement;
+  # this module-agnostic pattern also covers the identical gh_auth_token in
+  # git_repo_devcontainer.rs (whose logic lives in normalize_token, kept).
+  "replace gh_auth_token ->",
+  # Thin wrappers whose logic was extracted in #322: run_status just renders
+  # build_status(...) as JSON or text (kept helpers below); probe_user_login
+  # just curls then delegates to parse_user_login (kept). \b leaves
+  # parse_user_login alone.
+  "\\brun_status\\b",
+  "\\bprobe_user_login\\b",
+  # build_status (#385, `github status --json` view builder): its `--probe`
+  # branch shells out via resolve_cmd_value, so a `--lib` test cannot observe
+  # it. The pure projections it calls — GithubMode::of, ProbeStatus::from_resolved
+  # — and format_status stay in scope, each unit-tested (a survivor there is a
+  # real gap). GithubMode::label carries an in-source `#[mutants::skip]`
+  # (equivalent: human label; the serde token is the tested contract).
+  "\\bbuild_status\\b",
 
-    # workspace.rs — tar/rsync pipes, SSH-config IO, editor launch.
-    "\\btar_pipe_transfer\\b",
-    "\\btar_pipe_transfer_to\\b",
-    "\\btar_pipe_pull\\b",
-    "\\bjoin_drainer\\b",
-    "\\bsync_mounts\\b",
-    "\\bsync_mount_contents\\b",
-    "\\bvscode\\b",
-    "\\blaunch_editor\\b",
-    "\\brsync_push\\b",
-    "\\brsync_pull\\b",
-    "\\bcheck_guest_dirty\\b",
-    "\\bcheck_local_dirty\\b",
-    "\\batomic_write\\b",
-    "\\bwrite_ssh_config\\b",
-    "\\brefresh_ssh_config_if_present\\b",
-    "\\bupdate_ssh_config\\b",
-    # The bare `push`/`pull` free functions live in workspace.rs; anchor on the
-    # file so Report::push in devcontainer.rs (testable report logic) is kept.
-    "src/workspace\\.rs:.*\\bpush\\b",
-    "src/workspace\\.rs:.*\\bpull\\b",
-    # WorkspaceState persistence IO (same treatment as DevcontainerState).
-    "WorkspaceState::save",
-    "WorkspaceState::try_load",
-    # $HOME-resolving wrappers split out in #324; the read/clean/gated-write
-    # logic lives in remove_all_ssh_config_at / remove_ssh_config_at (kept by
-    # the `_at` suffix defeating the `\b` boundary) and remove_named_marker_block.
-    "\\bremove_all_ssh_config\\b",
-    "\\bremove_ssh_config\\b",
+  # workspace.rs — tar/rsync pipes, SSH-config IO, editor launch.
+  "\\btar_pipe_transfer\\b",
+  "\\btar_pipe_transfer_to\\b",
+  "\\btar_pipe_pull\\b",
+  "\\bjoin_drainer\\b",
+  "\\bsync_mounts\\b",
+  "\\bsync_mount_contents\\b",
+  "\\bvscode\\b",
+  "\\blaunch_editor\\b",
+  "\\brsync_push\\b",
+  "\\brsync_pull\\b",
+  "\\bcheck_guest_dirty\\b",
+  "\\bcheck_local_dirty\\b",
+  "\\batomic_write\\b",
+  "\\bwrite_ssh_config\\b",
+  "\\brefresh_ssh_config_if_present\\b",
+  "\\bupdate_ssh_config\\b",
+  # The bare `push`/`pull` free functions live in workspace.rs; anchor on the
+  # file so Report::push in devcontainer.rs (testable report logic) is kept.
+  "src/workspace\\.rs:.*\\bpush\\b",
+  "src/workspace\\.rs:.*\\bpull\\b",
+  # WorkspaceState persistence IO (same treatment as DevcontainerState).
+  "WorkspaceState::save",
+  "WorkspaceState::try_load",
+  # $HOME-resolving wrappers split out in #324; the read/clean/gated-write
+  # logic lives in remove_all_ssh_config_at / remove_ssh_config_at (kept by
+  # the `_at` suffix defeating the `\b` boundary) and remove_named_marker_block.
+  "\\bremove_all_ssh_config\\b",
+  "\\bremove_ssh_config\\b",
 
-    # devcontainer.rs — persistence IO and NotFound guards; tracing-only warn.
-    "DevcontainerPreferences::load",
-    "ParsedDevcontainer::load",
-    "AppliedDevcontainer::current_hash",
-    "DevcontainerState::save",
-    "DevcontainerState::try_load",
-    "\\bwarn_if_applied_devcontainer_changed\\b",
+  # devcontainer.rs — persistence IO and NotFound guards; tracing-only warn.
+  "DevcontainerPreferences::load",
+  "ParsedDevcontainer::load",
+  "AppliedDevcontainer::current_hash",
+  "DevcontainerState::save",
+  "DevcontainerState::try_load",
+  "\\bwarn_if_applied_devcontainer_changed\\b",
 
-    # secret_store.rs — $PATH probes and the macOS keychain write. The macOS
-    # `find-generic-password` arm of CmdToken::from_words is compiled out on the
-    # Linux sweep host (so its mutant is a no-op there) and pinned on macOS by
-    # parse_recognises_macos_keychain; its Linux/op arms stay as real gaps.
-    "Backend::is_available",
-    "\\btool_on_path\\b",
-    "\\bstore_keychain\\b",
-    "find-generic-password",
+  # secret_store.rs — $PATH probes and the macOS keychain write. The macOS
+  # `find-generic-password` arm of CmdToken::from_words is compiled out on the
+  # Linux sweep host (so its mutant is a no-op there) and pinned on macOS by
+  # parse_recognises_macos_keychain; its Linux/op arms stay as real gaps.
+  "Backend::is_available",
+  "\\btool_on_path\\b",
+  "\\bstore_keychain\\b",
+  "find-generic-password",
 
-    # fs_util.rs — flock syscall wrapper; callers always target existing dirs.
-    "\\block_sibling\\b",
+  # fs_util.rs — flock syscall wrapper; callers always target existing dirs.
+  "\\block_sibling\\b",
 
-    # ---- src/commands/ and the lib.rs/main.rs shims ----
-    # The #321-#327 refactor split every command handler out of lib.rs into
-    # src/commands/. Apply the SAME surgical treatment the flat shell-out
-    # modules got: scope out the dispatch entrypoints and the handlers whose
-    # effects a `--lib` test cannot observe (they take `&PlatformBackend` and
-    # drive VM/SSH/IO, or open a TTY prompt). tests/integration.sh covers them.
-    # The pure-logic helpers they call stay in scope — a survivor on one of
-    # THOSE is a real coverage gap. NOT a blanket `src/commands/**` exclude.
+  # ---- src/commands/ and the lib.rs/main.rs shims ----
+  # The #321-#327 refactor split every command handler out of lib.rs into
+  # src/commands/. Apply the SAME surgical treatment the flat shell-out
+  # modules got: scope out the dispatch entrypoints and the handlers whose
+  # effects a `--lib` test cannot observe (they take `&PlatformBackend` and
+  # drive VM/SSH/IO, or open a TTY prompt). tests/integration.sh covers them.
+  # The pure-logic helpers they call stay in scope — a survivor on one of
+  # THOSE is a real coverage gap. NOT a blanket `src/commands/**` exclude.
 
-    # All `coop <subcommand>` dispatch entrypoints across the command modules
-    # (lifecycle.rs, admin.rs, github.rs, profiles.rs, quickstart.rs,
-    # commands/devcontainer.rs). Every `cmd_*` only parses the dispatch and
-    # shells out to a backend; whole-body `-> Ok(())` mutants are unobservable.
-    "\\bcmd_[a-z_]+\\b",
+  # All `coop <subcommand>` dispatch entrypoints across the command modules
+  # (lifecycle.rs, admin.rs, github.rs, profiles.rs, quickstart.rs,
+  # commands/devcontainer.rs). Every `cmd_*` only parses the dispatch and
+  # shells out to a backend; whole-body `-> Ok(())` mutants are unobservable.
+  "\\bcmd_[a-z_]+\\b",
 
-    # lifecycle.rs — handlers taking `&PlatformBackend` (VM boot, SSH, disk IO)
-    # or resolving the cwd. Their decision logic is extracted into the pure
-    # helpers kept in scope below (no_stopped_instance_message,
-    # creation_options_rejected_message, restart_has_ignored_creation_flags,
-    # bytes_to_gib, …) or pinned by tests/integration.sh.
-    "\\bcreate_up_instance\\b",
-    "\\bcreate_git_repo_instance\\b",
-    "\\bensure_profile_image\\b",
-    "\\bapply_runtime_guest_env\\b",
-    "\\bapply_vm_overrides\\b",
-    "\\bfind_stopped_instance\\b",
-    "\\brestart_instance\\b",
-    "\\bstart_instance\\b",
-    "\\bwarn_on_live_git_mounts\\b",
-    "\\bresolve_running\\b",
-    "\\ballocate_and_start\\b",
-    "\\bopen_ssh_session\\b",
-    "\\bpreflight_start_target\\b",
-    "\\bresolve_project_dir\\b",
-    # current_disk_gib stats the disk image; its `/ 1 GiB` arithmetic kernel
-    # is extracted into bytes_to_gib (kept in scope, unit-tested).
-    "\\bcurrent_disk_gib\\b",
-    # instance_status (#385) runs as_running + query_resource_usage (SSH) to
-    # assemble the `status --json` shape; emit_up_dry_run (#385) drives the
-    # devcontainer collector + persisted_guest_user and renders the dry-run
-    # plan. Their pure inputs — InstanceState::from_running, BackendKind::of,
-    # up_translator_inputs — stay in scope and are unit-tested.
-    "\\binstance_status\\b",
-    "\\bemit_up_dry_run\\b",
+  # lifecycle.rs — handlers taking `&PlatformBackend` (VM boot, SSH, disk IO)
+  # or resolving the cwd. Their decision logic is extracted into the pure
+  # helpers kept in scope below (no_stopped_instance_message,
+  # creation_options_rejected_message, restart_has_ignored_creation_flags,
+  # bytes_to_gib, …) or pinned by tests/integration.sh.
+  "\\bcreate_up_instance\\b",
+  "\\bcreate_git_repo_instance\\b",
+  "\\bensure_profile_image\\b",
+  "\\bapply_runtime_guest_env\\b",
+  "\\bapply_vm_overrides\\b",
+  "\\bfind_stopped_instance\\b",
+  "\\brestart_instance\\b",
+  "\\bstart_instance\\b",
+  "\\bwarn_on_live_git_mounts\\b",
+  "\\bresolve_running\\b",
+  "\\ballocate_and_start\\b",
+  "\\bopen_ssh_session\\b",
+  "\\bpreflight_start_target\\b",
+  "\\bresolve_project_dir\\b",
+  # current_disk_gib stats the disk image; its `/ 1 GiB` arithmetic kernel
+  # is extracted into bytes_to_gib (kept in scope, unit-tested).
+  "\\bcurrent_disk_gib\\b",
+  # instance_status (#385) runs as_running + query_resource_usage (SSH) to
+  # assemble the `status --json` shape; emit_up_dry_run (#385) drives the
+  # devcontainer collector + persisted_guest_user and renders the dry-run
+  # plan. Their pure inputs — InstanceState::from_running, BackendKind::of,
+  # up_translator_inputs — stay in scope and are unit-tested.
+  "\\binstance_status\\b",
+  "\\bemit_up_dry_run\\b",
 
-    # ---- src/commands/json.rs (#385): --json output ----
-    # render_json is the single stdout JSON writer; a `--lib` test cannot
-    # observe its writes. Everything else in json.rs is pure view models and
-    # projections (InstanceState, BackendKind::of, the Serialize structs) kept
-    # in scope and pinned by the shape tests in that module.
-    "\\brender_json\\b",
+  # ---- src/commands/json.rs (#385): --json output ----
+  # render_json is the single stdout JSON writer; a `--lib` test cannot
+  # observe its writes. Everything else in json.rs is pure view models and
+  # projections (InstanceState, BackendKind::of, the Serialize structs) kept
+  # in scope and pinned by the shape tests in that module.
+  "\\brender_json\\b",
 
-    # commands/mod.rs — purges every instance + image (backend destroy calls).
-    "\\bpurge_all_data\\b",
+  # commands/mod.rs — purges every instance + image (backend destroy calls).
+  "\\bpurge_all_data\\b",
 
-    # admin.rs — uninstall/init IO: terminal summary, recursive data-dir wipe,
-    # self-binary removal. The decide_remove_data / config_path_is_under_data_dir
-    # / is_dev_target_path predicates are pure and stay in scope (unit-tested).
-    "\\bprint_uninstall_summary\\b",
-    "\\bwipe_data_dir\\b",
-    "\\bremove_self_binary\\b",
+  # admin.rs — uninstall/init IO: terminal summary, recursive data-dir wipe,
+  # self-binary removal. The decide_remove_data / config_path_is_under_data_dir
+  # / is_dev_target_path predicates are pure and stay in scope (unit-tested).
+  "\\bprint_uninstall_summary\\b",
+  "\\bwipe_data_dir\\b",
+  "\\bremove_self_binary\\b",
 
-    # profiles.rs — `read_dir` size walk (dir_size_bytes); its byte→GiB
-    # formatting kernel is extracted into format_dir_size (kept in scope,
-    # unit-tested). The summary builders (builtin_summary / format_custom_summary
-    # / script_summary), the JSON inventory builder (collect_profiles_list, #385),
-    # and the writeln!-based listers stay in scope. write_profiles_list /
-    # write_profile_show are IO writers and stay excluded.
-    "\\bdir_size_bytes\\b",
-    "\\bwrite_profiles_list\\b",
-    "\\bwrite_profile_show\\b",
+  # profiles.rs — `read_dir` size walk (dir_size_bytes); its byte→GiB
+  # formatting kernel is extracted into format_dir_size (kept in scope,
+  # unit-tested). The summary builders (builtin_summary / format_custom_summary
+  # / script_summary), the JSON inventory builder (collect_profiles_list, #385),
+  # and the writeln!-based listers stay in scope. write_profiles_list /
+  # write_profile_show are IO writers and stay excluded.
+  "\\bdir_size_bytes\\b",
+  "\\bwrite_profiles_list\\b",
+  "\\bwrite_profile_show\\b",
 
-    # commands/devcontainer.rs — discovery + interactive prompt + stderr report.
-    # The pure guard (discovered_local_devcontainer) and the assumed-guest-user
-    # helper stay in scope. resolve_oci_feature_requests drives the OCI feature
-    # resolver (network/registry) so its effects aren't `--lib`-observable.
-    # resolve_devcontainer (stderr wrapper) and resolve_devcontainer_collect
-    # (the quiet collector it delegates to, #385) both discover + prompt +
-    # drive the OCI resolver; \b leaves the pure discovered_local_devcontainer
-    # guard alone. check_render_json (#385) drives the collector and builds
-    # TranslatorInputs inline, so it carries an in-source `#[mutants::skip]`
-    # (see the TranslatorInputs note below), not an entry here.
-    "\\bresolve_devcontainer\\b",
-    "\\bresolve_devcontainer_collect\\b",
-    "\\bmaybe_skip_stored_devcontainer_opt_out\\b",
-    "\\bmaybe_record_devcontainer_opt_out\\b",
-    "\\bresolve_oci_feature_requests\\b",
+  # commands/devcontainer.rs — discovery + interactive prompt + stderr report.
+  # The pure guard (discovered_local_devcontainer) and the assumed-guest-user
+  # helper stay in scope. resolve_oci_feature_requests drives the OCI feature
+  # resolver (network/registry) so its effects aren't `--lib`-observable.
+  # resolve_devcontainer (stderr wrapper) and resolve_devcontainer_collect
+  # (the quiet collector it delegates to, #385) both discover + prompt +
+  # drive the OCI resolver; \b leaves the pure discovered_local_devcontainer
+  # guard alone. check_render_json (#385) drives the collector and builds
+  # TranslatorInputs inline, so it carries an in-source `#[mutants::skip]`
+  # (see the TranslatorInputs note below), not an entry here.
+  "\\bresolve_devcontainer\\b",
+  "\\bresolve_devcontainer_collect\\b",
+  "\\bmaybe_skip_stored_devcontainer_opt_out\\b",
+  "\\bmaybe_record_devcontainer_opt_out\\b",
+  "\\bresolve_oci_feature_requests\\b",
 
-    # quickstart.rs — cwd/TTY prompt resolution. is_sensitive_workspace (pure)
-    # stays in scope and is tested. quickstart_fresh_start is scoped out via an
-    # in-source `#[mutants::skip]` (see the TranslatorInputs note below).
-    "\\bresolve_quickstart_workspace\\b",
+  # quickstart.rs — cwd/TTY prompt resolution. is_sensitive_workspace (pure)
+  # stays in scope and is tested. quickstart_fresh_start is scoped out via an
+  # in-source `#[mutants::skip]` (see the TranslatorInputs note below).
+  "\\bresolve_quickstart_workspace\\b",
 
-    # lib.rs shim — tracing-subscriber install. (The `run` dispatch is scoped
-    # out via an in-source `#[mutants::skip]`; see the TranslatorInputs note.)
-    "\\binit_tracing\\b",
+  # lib.rs shim — tracing-subscriber install. (The `run` dispatch is scoped
+  # out via an in-source `#[mutants::skip]`; see the TranslatorInputs note.)
+  "\\binit_tracing\\b",
 
-    # ---- coop model (#352): local/cloud model switch ----
-    # The pure logic is extracted and unit-tested in scope: tools_needing_prompt,
-    # switch_report_lines, resolved_claude / resolved_codex, ModelMode::as_str
-    # (pinned by mode_as_str_round_trips), and the From<ModelAction> mapping
-    # (pinned by model_action_maps_to_mode in lib.rs). What is excluded below
-    # writes stdout, drives the backend over SSH, or reads a TTY —
-    # tests/integration.sh covers those, a `--lib` test cannot.
+  # ---- coop model (#352): local/cloud model switch ----
+  # The pure logic is extracted and unit-tested in scope: tools_needing_prompt,
+  # switch_report_lines, resolved_claude / resolved_codex, ModelMode::as_str
+  # (pinned by mode_as_str_round_trips), and the From<ModelAction> mapping
+  # (pinned by model_action_maps_to_mode in lib.rs). What is excluded below
+  # writes stdout, drives the backend over SSH, or reads a TTY —
+  # tests/integration.sh covers those, a `--lib` test cannot.
 
-    # commands/model.rs — stdout writers, the state-save + SSH-apply
-    # orchestrators (set_local/set_remote, including set_local's `&&` endpoint
-    # guard), the thin stdout wrapper over switch_report_lines (report_switch),
-    # the `&PlatformBackend` handler (apply_to_running), and the TTY prompt.
-    # render_status is file-anchored because github_pat.rs has a *pure* (kept,
-    # tested) render_status; a bare \brender_status\b would wrongly scope it out.
-    "src/commands/model\\.rs:.*\\brender_status\\b",
-    "\\bwrite_tool_line\\b",
-    "\\bset_local\\b",
-    "\\bset_remote\\b",
-    "\\breport_switch\\b",
-    "\\bapply_to_running\\b",
-    "\\bprompt_endpoint\\b",
+  # commands/model.rs — stdout writers, the state-save + SSH-apply
+  # orchestrators (set_local/set_remote, including set_local's `&&` endpoint
+  # guard), the thin stdout wrapper over switch_report_lines (report_switch),
+  # the `&PlatformBackend` handler (apply_to_running), and the TTY prompt.
+  # render_status is file-anchored because github_pat.rs has a *pure* (kept,
+  # tested) render_status; a bare \brender_status\b would wrongly scope it out.
+  "src/commands/model\\.rs:.*\\brender_status\\b",
+  "\\bwrite_tool_line\\b",
+  "\\bset_local\\b",
+  "\\bset_remote\\b",
+  "\\breport_switch\\b",
+  "\\bapply_to_running\\b",
+  "\\bprompt_endpoint\\b",
 
-    # (model_state.rs's load_or_default stays IN scope: it is tempdir-testable,
-    # and load_or_default_returns_saved_state kills its `Ok(Default::default())`
-    # mutant — which load_or_default_is_remote_when_missing alone cannot, since
-    # the default IS Remote on the missing-file path.)
+  # (model_state.rs's load_or_default stays IN scope: it is tempdir-testable,
+  # and load_or_default_returns_saved_state kills its `Ok(Default::default())`
+  # mutant — which load_or_default_is_remote_when_missing alone cannot, since
+  # the default IS Remote on the missing-file path.)
 
-    # (prompt.rs — read_line and the other TTY prompts are scoped whole-module
-    # via exclude_globs above.)
+  # (prompt.rs — read_line and the other TTY prompts are scoped whole-module
+  # via exclude_globs above.)
 
-    # lifecycle.rs — backend-driving session/bootstrap helpers. Both open an SSH
-    # session and bootstrap guest agents (prepare_session_from_target also reads
-    # persisted guest-env / model state from disk); their effects are observable
-    # only against a real VM.
-    "\\bbootstrap_and_post_start\\b",
-    "\\bprepare_session_from_target\\b",
+  # lifecycle.rs — backend-driving session/bootstrap helpers. Both open an SSH
+  # session and bootstrap guest agents (prepare_session_from_target also reads
+  # persisted guest-env / model state from disk); their effects are observable
+  # only against a real VM.
+  "\\bbootstrap_and_post_start\\b",
+  "\\bprepare_session_from_target\\b",
 
-    # NOTE on `delete field … from struct …` mutants: cargo-mutants (27.x) does
-    # not honour exclude_re for these — the regex never matches their name (not
-    # by function, struct path, or even file:line). They are emitted only where
-    # a struct literal uses `..Default::default()`. In this crate that is
-    # `devcontainer::TranslatorInputs`, assembled in four places:
-    #   * up_translator_inputs (lifecycle.rs) — pure builder, KEPT in scope and
-    #     unit-tested (up_translator_inputs_maps_opts), which kills its
-    #     field-deletion mutants.
-    #   * run (lib.rs), cmd_devcontainer_check, check_render_json (#385),
-    #     quickstart_fresh_start — these are dispatch/shell-out handlers whose
-    #     assembled inputs only become observable once the (excluded) translator
-    #     + a real VM consume them, so a `--lib` test cannot kill the
-    #     field-deletions. Because exclude_re is powerless here, those carry an
-    #     in-source `#[mutants::skip]` with a back-reference to this note.
+  # NOTE on `delete field … from struct …` mutants: cargo-mutants (27.x) does
+  # not honour exclude_re for these — the regex never matches their name (not
+  # by function, struct path, or even file:line). They are emitted only where
+  # a struct literal uses `..Default::default()`. In this crate that is
+  # `devcontainer::TranslatorInputs`, assembled in four places:
+  #   * up_translator_inputs (lifecycle.rs) — pure builder, KEPT in scope and
+  #     unit-tested (up_translator_inputs_maps_opts), which kills its
+  #     field-deletion mutants.
+  #   * run (lib.rs), cmd_devcontainer_check, check_render_json (#385),
+  #     quickstart_fresh_start — these are dispatch/shell-out handlers whose
+  #     assembled inputs only become observable once the (excluded) translator
+  #     + a real VM consume them, so a `--lib` test cannot kill the
+  #     field-deletions. Because exclude_re is powerless here, those carry an
+  #     in-source `#[mutants::skip]` with a back-reference to this note.
 ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+# EditorConfig: https://editorconfig.org
+root = true
+
+# Defaults for every file. Mirrors the prek hooks (end-of-file-fixer,
+# trailing-whitespace) so the editor and the hooks never disagree.
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# Rust: 4-space indent, matching cargo fmt (rustfmt default).
+[*.rs]
+indent_size = 4
+
+# YAML: 2-space indent, matching .github/workflows and .pre-commit-config.yaml.
+[*.{yml,yaml}]
+indent_size = 2
+
+# TOML: 2-space indent, matching `taplo fmt` (the taplo prek hook enforces it).
+[*.toml]
+indent_size = 2
+
+# Markdown: 2-space indent for nested lists.
+[*.md]
+indent_size = 2
+
+# JSON: 2-space indent.
+[*.json]
+indent_size = 2
+
+# Shell: 4-space indent, matching the existing scripts.
+[*.sh]
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -31,6 +31,6 @@ indent_size = 2
 [*.json]
 indent_size = 2
 
-# Shell: 4-space indent, matching the existing scripts.
+# Shell: 4-space indent, matching most of the repo's scripts.
 [*.sh]
 indent_size = 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,32 +55,40 @@ jobs:
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@732870f031d2fb36309d0deaf36abcc704a7be65 # v1.20.1
 
+      # Pin to match CARGO_DENY_VERSION in scripts/install-dev-tools.sh so CI and
+      # local installs run the same version.
       - name: Install cargo-deny
-        run: cargo binstall --no-confirm cargo-deny
+        run: cargo binstall --no-confirm cargo-deny@0.19.9
 
       - name: Check advisories, licenses, bans, sources
         run: cargo deny check
 
   taplo:
     runs-on: ubuntu-latest
+    # Single version knob for this job; keep in sync with TAPLO_VERSION in
+    # scripts/install-dev-tools.sh. Used for both the cache key and the install,
+    # so the two can never drift (a bumped install with a stale key would
+    # silently keep checking with the cached old binary).
+    env:
+      TAPLO_VERSION: 0.10.0
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      # Cache the compiled binary keyed on the pinned version so only the first
-      # run (or a version bump) pays the compile cost. Keep the version here in
-      # sync with TAPLO_VERSION in scripts/install-dev-tools.sh.
+      # taplo has no cargo-binstall prebuilts, so compile from crates.io
+      # (checksum-verified source) and cache the binary keyed on the pinned
+      # version — only the first run or a version bump pays the compile cost.
       - name: Cache taplo
         id: cache-taplo
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/taplo
-          key: ${{ runner.os }}-taplo-cli-0.10.0
+          key: ${{ runner.os }}-taplo-cli-${{ env.TAPLO_VERSION }}
 
       - name: Install taplo
         if: steps.cache-taplo.outputs.cache-hit != 'true'
-        run: cargo install taplo-cli --version '=0.10.0' --locked
+        run: cargo install taplo-cli --version "=${TAPLO_VERSION}" --locked
 
       - name: Check TOML formatting
         run: taplo format --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,30 @@ jobs:
       - name: Check advisories, licenses, bans, sources
         run: cargo deny check
 
+  taplo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Cache the compiled binary keyed on the pinned version so only the first
+      # run (or a version bump) pays the compile cost. Keep the version here in
+      # sync with TAPLO_VERSION in scripts/install-dev-tools.sh.
+      - name: Cache taplo
+        id: cache-taplo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/taplo
+          key: ${{ runner.os }}-taplo-cli-0.10.0
+
+      - name: Install taplo
+        if: steps.cache-taplo.outputs.cache-hit != 'true'
+        run: cargo install taplo-cli --version '=0.10.0' --locked
+
+      - name: Check TOML formatting
+        run: taplo format --check
+
   zizmor:
     runs-on: ubuntu-latest
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: taplo-fmt
+        name: taplo fmt
+        entry: taplo format --check
+        language: system
+        types: [toml]
+
       - id: cargo-fmt
         name: cargo fmt
         entry: cargo fmt -- --check

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -3,5 +3,11 @@
 # deterministic regardless of any global taplo config, and documents the
 # convention .editorconfig declares for editors (taplo does not read
 # .editorconfig).
+
+# Keep the formatter off vendored/build trees so a bare `taplo format` (no file
+# args) only touches this repo's own TOML. revm-kani is a gitignored vendored
+# checkout used for the kani proofs; target is build output.
+exclude = ["revm-kani/**", "target/**"]
+
 [formatting]
 indent_string = "  "

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,7 @@
+# Taplo TOML formatter config (used by the `taplo fmt` prek hook).
+# 2-space indent is taplo's default; pinning it here keeps the hook
+# deterministic regardless of any global taplo config, and documents the
+# convention .editorconfig declares for editors (taplo does not read
+# .editorconfig).
+[formatting]
+indent_string = "  "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Backend abstraction in `src/backend.rs` provides `SshTarget` and `Backend` enum.
 
 ## Before committing
 
-Pre-commit hooks (prek) run automatically: cargo fmt, clippy, test, `taplo format --check` (TOML — also enforced by the `taplo` CI job), trailing whitespace, EOF fixer, large file check, merge conflict check. Install the hook runner and formatter at pinned versions with `./scripts/install-dev-tools.sh` (the single source of truth for dev-tool versions), then `prek install`. taplo's 2-space indent (its default, pinned in `.taplo.toml`, which also excludes `revm-kani/`/`target/`) is what `.editorconfig` declares for editors.
+Pre-commit hooks (prek) run automatically: cargo fmt, clippy, test, `taplo format --check` (TOML — also enforced by the `taplo` CI job), trailing whitespace, EOF fixer, large file check, merge conflict check. Install the hook runner and formatter at pinned versions with `./scripts/install-dev-tools.sh` (the pinned installer for local dev tools; CI pins its own taplo/cargo-deny in `.github/workflows/ci.yml`), then `prek install`. taplo's 2-space indent (its default, pinned in `.taplo.toml`, which also excludes `revm-kani/`/`target/`) is what `.editorconfig` declares for editors.
 
 After hooks pass, run integration tests on **both platforms** — these are too slow for hooks:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Backend abstraction in `src/backend.rs` provides `SshTarget` and `Backend` enum.
 
 ## Before committing
 
-Pre-commit hooks (prek) run automatically: fmt, clippy, test, trailing whitespace, EOF fixer, large file check, merge conflict check. If hooks aren't installed, run `prek install`.
+Pre-commit hooks (prek) run automatically: cargo fmt, clippy, test, `taplo format --check` (TOML), trailing whitespace, EOF fixer, large file check, merge conflict check. If hooks aren't installed, run `prek install`. The taplo hook needs the CLI on `PATH` — install once with `cargo install taplo-cli --locked`. Its 2-space indent (taplo's default, pinned in `.taplo.toml`) is what `.editorconfig` declares for editors.
 
 After hooks pass, run integration tests on **both platforms** — these are too slow for hooks:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Backend abstraction in `src/backend.rs` provides `SshTarget` and `Backend` enum.
 
 ## Before committing
 
-Pre-commit hooks (prek) run automatically: cargo fmt, clippy, test, `taplo format --check` (TOML), trailing whitespace, EOF fixer, large file check, merge conflict check. If hooks aren't installed, run `prek install`. The taplo hook needs the CLI on `PATH` — install once with `cargo install taplo-cli --locked`. Its 2-space indent (taplo's default, pinned in `.taplo.toml`) is what `.editorconfig` declares for editors.
+Pre-commit hooks (prek) run automatically: cargo fmt, clippy, test, `taplo format --check` (TOML — also enforced by the `taplo` CI job), trailing whitespace, EOF fixer, large file check, merge conflict check. Install the hook runner and formatter at pinned versions with `./scripts/install-dev-tools.sh` (the single source of truth for dev-tool versions), then `prek install`. taplo's 2-space indent (its default, pinned in `.taplo.toml`, which also excludes `revm-kani/`/`target/`) is what `.editorconfig` declares for editors.
 
 After hooks pass, run integration tests on **both platforms** — these are too slow for hooks:
 
@@ -60,7 +60,7 @@ When adding new features, consider whether they should be covered by the integra
 
 Mutation testing finds unit tests that pass even when the code is broken — i.e. real behavioral gaps. We use [`cargo-mutants`](https://mutants.rs/). It's a manual quality check, not a CI gate.
 
-**Install once:**
+**Install once** — via the pinned installer `./scripts/install-dev-tools.sh --all`, or directly:
 
 ```bash
 cargo install cargo-mutants --locked
@@ -148,7 +148,7 @@ Fuzzing is reserved for parsers of **untrusted or user-editable input** — it f
 
 Targets live in `fuzz/fuzz_targets/`. `coop` exposes a library target (`src/lib.rs`), so a target depends on the crate directly and imports the parser under test with `use coop::…` — no `#[path]` includes. `fuzz/Cargo.toml` is its own workspace, so the main `cargo build`/`test`/`fmt`/`clippy`/`deny` never touch it.
 
-**Install once:** `cargo install cargo-fuzz --locked`
+**Install once** (or `./scripts/install-dev-tools.sh --all`): `cargo install cargo-fuzz --locked`
 
 ```bash
 cargo +nightly fuzz build                                  # compile all targets
@@ -170,7 +170,7 @@ A crash is written to `fuzz/artifacts/<target>/`; reproduce it with `cargo +nigh
 
 Proofs live in a `#[cfg(kani)]` module so the normal `cargo build`/`test`/`fmt`/`clippy` never compile them. They run as one module in `src/config.rs`.
 
-**Install once:** `cargo install --locked kani-verifier && cargo kani setup`
+**Install once** (or `./scripts/install-dev-tools.sh --all`): `cargo install --locked kani-verifier && cargo kani setup`
 
 ```bash
 cargo kani                                       # run every proof harness (~5s total)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,17 @@ backend. The sections below note where that applies.
 
 - **Rust** via [rustup](https://rustup.rs/). The toolchain version is pinned in
   `rust-toolchain.toml` and installed automatically when you build.
-- **[prek](https://github.com/j178/prek)** for git hooks (`cargo install prek`
-  or see its install docs).
+- **Dev tools** at pinned versions — [prek](https://github.com/j178/prek) (git
+  hooks), [taplo](https://taplo.tamasfe.dev/) (TOML formatting), and cargo-deny
+  (supply-chain checks). Install them with:
+
+  ```bash
+  ./scripts/install-dev-tools.sh          # baseline
+  ./scripts/install-dev-tools.sh --all    # also cargo-mutants, cargo-fuzz, kani
+  ```
+
+  The script is the single source of truth for tool versions; bump a version
+  there rather than installing a floating `latest`.
 - To run the full integration suite you need a working backend:
   - **macOS**: Apple Silicon with [Lima](https://github.com/lima-vm/lima)
     (`limactl` on your PATH).
@@ -43,9 +52,9 @@ prek install
 ```
 
 The hooks run `cargo fmt -- --check`, `cargo clippy --all-targets --all-features
--- -D warnings`, `cargo test`, and a set of file checks (trailing whitespace,
-end-of-file, YAML, large files, merge conflicts). Run them by hand at any time
-with:
+-- -D warnings`, `cargo test`, `taplo format --check` (TOML formatting, also
+enforced by CI), and a set of file checks (trailing whitespace, end-of-file,
+YAML, large files, merge conflicts). Run them by hand at any time with:
 
 ```bash
 prek run --all-files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,9 @@ backend. The sections below note where that applies.
   ./scripts/install-dev-tools.sh --all    # also cargo-mutants, cargo-fuzz, kani
   ```
 
-  The script is the single source of truth for tool versions; bump a version
-  there rather than installing a floating `latest`.
+  The script pins the local dev-tool versions; bump a version there rather than
+  installing a floating `latest`. CI pins its own copies of taplo and cargo-deny
+  in `.github/workflows/ci.yml`, so keep those in sync when bumping.
 - To run the full integration suite you need a working backend:
   - **macOS**: Apple Silicon with [Lima](https://github.com/lima-vm/lima)
     (`limactl` on your PATH).

--- a/deny.toml
+++ b/deny.toml
@@ -2,12 +2,7 @@
 ignore = []
 
 [licenses]
-allow = [
-    "MIT",
-    "Apache-2.0",
-    "MPL-2.0",
-    "Unicode-3.0",
-]
+allow = ["MIT", "Apache-2.0", "MPL-2.0", "Unicode-3.0"]
 confidence-threshold = 0.8
 
 [licenses.private]

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install coop's development tools at pinned versions.
+#
+# This is the single source of truth for dev-tool versions. Bump a version
+# here, review the diff, and re-run — never install a floating "latest". The
+# `=<version>` requirement pins the tool exactly; `--locked` additionally pins
+# each tool's own transitive dependency tree to its published Cargo.lock, so an
+# install is reproducible and never silently picks up a freshly published (and
+# unreviewed) release.
+#
+# Usage:
+#   scripts/install-dev-tools.sh          # baseline: git hooks + supply-chain check
+#   scripts/install-dev-tools.sh --all    # also the heavy, occasional quality tools
+#
+# Requires a Rust toolchain (rustup); the version is pinned in rust-toolchain.toml.
+
+# --- Pinned versions ---------------------------------------------------------
+PREK_VERSION="0.4.8"           # git hook runner (prek install / prek run)
+TAPLO_VERSION="0.10.0"         # TOML formatter (taplo format --check hook + CI)
+CARGO_DENY_VERSION="0.19.9"    # supply-chain: advisories, licenses, bans, sources
+CARGO_MUTANTS_VERSION="27.1.0" # mutation testing (manual, opt-in)
+CARGO_FUZZ_VERSION="0.13.2"    # fuzzing (manual, opt-in; run targets on nightly)
+KANI_VERSION="0.67.0"          # formal verification (manual, opt-in)
+
+install_pinned() {
+  local crate="$1" version="$2"
+  echo ">> ${crate} =${version}"
+  cargo install "${crate}" --version "=${version}" --locked
+}
+
+extra=false
+case "${1:-}" in
+  "") ;;
+  --all) extra=true ;;
+  -h | --help)
+    sed -n '3,17p' "$0" | sed 's/^# \?//'
+    exit 0
+    ;;
+  *)
+    echo "unknown argument: $1" >&2
+    echo "usage: $0 [--all]" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo not found on PATH — install Rust via https://rustup.rs first" >&2
+  exit 1
+fi
+
+install_pinned prek "${PREK_VERSION}"
+install_pinned taplo-cli "${TAPLO_VERSION}"
+install_pinned cargo-deny "${CARGO_DENY_VERSION}"
+
+if [[ "${extra}" == true ]]; then
+  install_pinned cargo-mutants "${CARGO_MUTANTS_VERSION}"
+  install_pinned cargo-fuzz "${CARGO_FUZZ_VERSION}"
+  install_pinned kani-verifier "${KANI_VERSION}"
+  echo ">> cargo kani setup"
+  cargo kani setup
+fi
+
+echo "Done. Run 'prek install' once to enable the git hooks."

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install coop's development tools at pinned versions.
+# Install coop's development tools at pinned versions for local development.
 #
-# This is the single source of truth for dev-tool versions. Bump a version
-# here, review the diff, and re-run — never install a floating "latest". The
+# This installs the local dev tools at reviewed, pinned versions — bump a
+# version here, review the diff, and re-run, never a floating "latest". The
 # `=<version>` requirement pins the tool exactly; `--locked` additionally pins
-# each tool's own transitive dependency tree to its published Cargo.lock, so an
-# install is reproducible and never silently picks up a freshly published (and
-# unreviewed) release.
+# each tool's transitive dependency tree to its published Cargo.lock, so an
+# install is reproducible. CI pins its own taplo and cargo-deny versions in
+# .github/workflows/ci.yml — keep them in sync when bumping here.
 #
 # Usage:
 #   scripts/install-dev-tools.sh          # baseline: git hooks + supply-chain check
@@ -25,29 +25,29 @@ CARGO_FUZZ_VERSION="0.13.2"    # fuzzing (manual, opt-in; run targets on nightly
 KANI_VERSION="0.67.0"          # formal verification (manual, opt-in)
 
 install_pinned() {
-  local crate="$1" version="$2"
-  echo ">> ${crate} =${version}"
-  cargo install "${crate}" --version "=${version}" --locked
+    local crate="$1" version="$2"
+    echo ">> ${crate} =${version}"
+    cargo install "${crate}" --version "=${version}" --locked
 }
 
 extra=false
 case "${1:-}" in
-  "") ;;
-  --all) extra=true ;;
-  -h | --help)
-    sed -n '3,17p' "$0" | sed 's/^# \?//'
-    exit 0
-    ;;
-  *)
-    echo "unknown argument: $1" >&2
-    echo "usage: $0 [--all]" >&2
-    exit 2
-    ;;
+    "") ;;
+    --all) extra=true ;;
+    -h | --help)
+        sed -n '3,17p' "$0" | sed 's/^# \?//'
+        exit 0
+        ;;
+    *)
+        echo "unknown argument: $1" >&2
+        echo "usage: $0 [--all]" >&2
+        exit 2
+        ;;
 esac
 
 if ! command -v cargo >/dev/null 2>&1; then
-  echo "cargo not found on PATH — install Rust via https://rustup.rs first" >&2
-  exit 1
+    echo "cargo not found on PATH — install Rust via https://rustup.rs first" >&2
+    exit 1
 fi
 
 install_pinned prek "${PREK_VERSION}"
@@ -55,11 +55,11 @@ install_pinned taplo-cli "${TAPLO_VERSION}"
 install_pinned cargo-deny "${CARGO_DENY_VERSION}"
 
 if [[ "${extra}" == true ]]; then
-  install_pinned cargo-mutants "${CARGO_MUTANTS_VERSION}"
-  install_pinned cargo-fuzz "${CARGO_FUZZ_VERSION}"
-  install_pinned kani-verifier "${KANI_VERSION}"
-  echo ">> cargo kani setup"
-  cargo kani setup
+    install_pinned cargo-mutants "${CARGO_MUTANTS_VERSION}"
+    install_pinned cargo-fuzz "${CARGO_FUZZ_VERSION}"
+    install_pinned kani-verifier "${KANI_VERSION}"
+    echo ">> cargo kani setup"
+    cargo kani setup
 fi
 
 echo "Done. Run 'prek install' once to enable the git hooks."


### PR DESCRIPTION
Adds a `.editorconfig` and adopts [taplo](https://taplo.tamasfe.dev/) as the TOML formatter so editors and hooks agree on spacing automatically, cutting review noise. Recommended by the ToB open-source checklist.

## `.editorconfig`

- `root = true`; UTF-8, LF line endings, final newline, and trim trailing whitespace for all files. These match the prek `end-of-file-fixer` and `trailing-whitespace` hooks, so the editor and hooks never disagree (the trailing-whitespace hook has no markdown exception, so markdown is trimmed too).
- Indent widths: 4-space for Rust (cargo fmt) and shell; 2-space for YAML, TOML, Markdown, and JSON.

## TOML formatting

The issue suggested 2-space for TOML. TOML has no canonical formatter (`cargo fmt` does not touch it), so the repo's TOML files were hand-indented at 4-space. Rather than pick a number by convention, this adopts **taplo** — whose 2-space default is the de-facto ecosystem standard (it powers VS Code's "Even Better TOML") — and makes it enforceable:

- `.taplo.toml` pins the 2-space indent so the hook is deterministic regardless of any global taplo config.
- A `taplo format --check` prek hook checks staged TOML. It needs the CLI on `PATH` (`cargo install taplo-cli --locked`), consistent with the repo's other `language: system` hooks.
- `deny.toml` and `.cargo/mutants.toml` are reformatted to match — whitespace-only changes (plus taplo collapsing `deny.toml`'s short `allow` array onto one line). `.cargo/mutants.toml`'s diff is 100% indentation (`git diff -w` is empty).

`.editorconfig` declares 2-space for TOML; the taplo hook enforces it.

Closes #389
