### PR TITLE
Allow changing memory and vCPUs on an existing instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 - **Codex integration**: API key forwarding, `~/.codex` config sync, MCP server configuration, dedicated `coop codex` launcher
 - **VS Code remote SSH**: `coop vscode` opens VS Code connected to the guest
 - **Multi-instance**: run multiple VMs side by side, each with its own name and disk
-- **Disk resize**: grow a stopped instance's disk with `coop resize --size +20`
+- **Reconfigure in place**: change a stopped instance's disk, memory, or vCPUs with `coop resize` (e.g. `coop resize --size +20 --mem 8192 --vcpus 4`) — no destroy/recreate
 - **Commit and restore**: save a stopped instance's filesystem as a reusable image with `coop commit`, and roll an instance back to it in place with `coop restore` — a `docker container commit`-style checkpoint for risky agent runs
 - **Config optional**: works with sensible defaults; customize via `~/.coop/config.toml` when needed
 
@@ -82,7 +82,7 @@ That gives you a Claude Code or Codex session running inside an isolated VM with
 | `ssh-config` | Install a `coop-<name>` SSH alias for ad-hoc ssh/scp/rsync |
 | `images` | List or delete template images |
 | `profiles` | List or inspect available profiles |
-| `resize` | Grow a stopped instance's disk |
+| `resize` | Change a stopped instance's disk, memory, or vCPUs |
 | `commit` | Save a stopped instance's filesystem as a reusable image |
 | `restore` | Roll a stopped instance back to an image's filesystem in place |
 | `init` | Generate a starter config file at ~/.coop/config.toml |

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -41,9 +41,11 @@ The Lima template configures:
 - `mountType: "virtiofs"` with no host mounts (empty `mounts: []`). When `coop up --mount` is used, Lima adds virtiofs mount entries for the specified host directories, providing live mounts where changes are visible immediately on both sides.
 - Lima's built-in containerd disabled (Docker is installed in the guest instead)
 
-### Disk resize
+### Resize (disk, memory, vCPUs)
 
-Resizing a stopped instance truncates the Lima disk to the new size. Cloud-init's `growpart` module expands the partition and filesystem on next boot. Shrinking is not supported.
+Resizing a stopped instance's disk truncates the Lima disk to the new size. Cloud-init's `growpart` module expands the partition and filesystem on next boot. Shrinking is not supported.
+
+Memory and vCPU changes rewrite the `cpus`/`memory` fields in the instance's `lima.yaml`, which Lima re-reads on `limactl start`. The edit is written atomically, then coop starts the instance to validate and apply the new spec — if `limactl` rejects it (e.g. a spec larger than the host), the previous `lima.yaml` is restored. Without `--start` the instance is stopped again after the validating boot. The `lima.yaml` is authoritative: the global `[vm]` `cpus`/`memory` settings only seed *new* instances.
 
 ### Resource ownership
 
@@ -113,9 +115,11 @@ The `network` section in `config.toml` controls Firecracker networking:
 
 These settings are ignored on macOS. Lima handles its own networking.
 
-### Disk resize
+### Resize (disk, memory, vCPUs)
 
-Resizing a stopped Firecracker instance runs `truncate` to extend the rootfs image, then `e2fsck -fy` and `resize2fs` to grow the filesystem in place. Shrinking is not supported.
+Resizing a stopped Firecracker instance's disk runs `truncate` to extend the rootfs image, then `e2fsck -fy` and `resize2fs` to grow the filesystem in place. Shrinking is not supported.
+
+Memory and vCPU changes edit the `machine-config` block of the instance's per-instance JSON (`vm_config.json`), written atomically so a crash mid-write leaves the prior values intact. This JSON is authoritative: on every restart `configure()` regenerates the infra fields (kernel path, boot args, drive, network) from the global config so they roll forward, but preserves the on-disk `mem_size_mib`/`vcpu_count` rather than resetting them to the global `[vm]` defaults. Those defaults therefore only seed *new* instances. Firecracker does not boot the VM to apply the change; it takes effect on the next `coop start` (or immediately with `--start`).
 
 ### Resource ownership
 
@@ -148,7 +152,7 @@ Both backends support the same CLI commands and guest capabilities:
 | `coop status` | Queries `limactl list --json` | Reads PID file, queries guest via SSH |
 | `coop logs` | Reads Lima's `serial.log` | Reads Firecracker log file |
 | `coop shell` | SSH to localhost on Lima-assigned port | SSH to guest IP on configured port |
-| `coop resize` | Truncates Lima disk | Truncates + resize2fs on rootfs |
+| `coop resize` | Disk: truncates Lima disk. Mem/vCPU: edits `lima.yaml`, validated via start | Disk: truncates + resize2fs on rootfs. Mem/vCPU: edits per-instance JSON |
 | Resource monitoring | SSH query to guest | SSH query to guest |
 | Docker in guest | Works (full kernel) | Works (with iptables-legacy workaround) |
 | `--mount` host mounts | Live virtiofs (changes visible immediately) | One-time rsync sync (use `push`/`pull` to re-sync) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -662,22 +662,45 @@ Absence is modelled honestly: `profiles` is `[]` (not `"none"`), `created` is
 
 ### `resize`
 
-Resize a stopped instance's disk. The VM must be stopped first.
+Change a stopped instance's disk size, memory, or vCPU count. The VM must
+be stopped first. At least one of `--size`, `--mem`, or `--vcpus` is required;
+they can be combined in a single command.
 
 ```
-coop resize [NAME] --size <SIZE>
+coop resize [NAME] [--size <SIZE>] [--mem <MIB>] [--vcpus <N>] [--start]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `NAME` | Instance name (required if multiple instances exist) |
-| `--size <size>` | New size (required). Absolute: `150` or `150G`. Relative: `+20` or `+20G`. |
+| `--size <size>` | New disk size. Absolute: `150` or `150G`. Relative: `+20` or `+20G`. |
+| `--mem <mib>` | New memory in MiB (minimum 128). |
+| `--vcpus <n>` | New vCPU count (> 0). |
+| `--start` | Start the instance after applying the change instead of leaving it stopped. |
 
-Absolute values set the disk to that exact size. A `+` prefix adds to the current size.
+Absolute disk values set the disk to that exact size; a `+` prefix adds to the
+current size. Memory and vCPU changes are written to the instance's backend
+config (the Firecracker per-instance JSON or the Lima `lima.yaml`), which is
+authoritative — the value survives restarts and is reported by `coop status`.
+The global `[vm]` settings in `config.toml` only seed these values for *new*
+instances.
+
+By default the instance is left stopped and the change takes effect on the next
+`coop start`. Pass `--start` to boot it immediately. On Firecracker, if a
+`--start` boot fails (e.g. more memory than the host has), the previous mem/vcpu
+is restored so a plain `coop start` still works; on Lima the `lima.yaml` is
+likewise restored.
+
+Combining `--size` with `--mem`/`--vcpus` applies the disk change first, then the
+machine-resource change; the two are separate artifacts and are not applied
+transactionally, so if the second step fails the disk change has already taken
+effect.
 
 ```
 coop resize my-project --size 150G
 coop resize --size +20
+coop resize my-project --mem 8192 --vcpus 4
+coop resize my-project --mem 4096 --start
 ```
 
 ### `commit`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,8 +123,8 @@ VM resource allocation and boot configuration.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `vcpu_count` | integer | `2` | Number of vCPUs. Must be > 0. Overridable with `--vcpus` on `setup` and `up`. |
-| `mem_size_mib` | integer | `4096` | Memory in MiB. Must be >= 128. Overridable with `--mem` on `setup` and `up`. |
+| `vcpu_count` | integer | `2` | Number of vCPUs for **new** instances. Must be > 0. Overridable with `--vcpus` on `setup` and `up`. Change an existing instance with `coop resize --vcpus`. |
+| `mem_size_mib` | integer | `4096` | Memory in MiB for **new** instances. Must be >= 128. Overridable with `--mem` on `setup` and `up`. Change an existing instance with `coop resize --mem`. |
 | `template_size_gib` | integer | `8` | Template rootfs disk size in GiB. Must be > 0. Overridable with `--template-size` on `setup`. |
 | `kernel_path` | string (path) | `~/.coop/vmlinux` | Path to the vmlinux kernel image. Linux/Firecracker only. |
 | `boot_args` | string | `console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw` | Kernel boot arguments. Linux/Firecracker only. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -344,6 +344,7 @@ coop images --delete python-dev
 | `coop ssh-config` | Install a `coop-<name>` SSH alias for ad-hoc `ssh`/`scp`/`rsync` |
 | `coop resize --size +20` | Grow a stopped instance's disk by 20 GiB |
 | `coop resize --size 100` | Set a stopped instance's disk to 100 GiB |
+| `coop resize --mem 8192 --vcpus 4` | Change a stopped instance's memory and vCPUs |
 
 ## Further reading
 

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -108,18 +108,24 @@ The instance disk grows from the template size when the requested size is larger
 
 ### After creation
 
-`coop resize` changes the disk size of a stopped instance:
+`coop resize` changes the disk size, memory, or vCPU count of a stopped instance:
 
 ```
-# Absolute size
+# Absolute disk size
 coop resize --size 150
 coop resize my-project --size 150
 
-# Relative size (grow by 20 GiB)
+# Relative disk size (grow by 20 GiB)
 coop resize my-project --size +20
+
+# Memory and/or vCPUs (combine with disk if you like)
+coop resize my-project --mem 8192 --vcpus 4
+
+# Apply and boot in one step
+coop resize my-project --mem 4096 --start
 ```
 
-The instance must be stopped first. coop rejects the resize and tells you to stop the instance if it is running.
+The instance must be stopped first. coop rejects the resize and tells you to stop the instance if it is running. Memory and vCPU changes persist in the instance's backend config (authoritative over the global `[vm]` defaults, which only apply to new instances) and take effect on the next `coop start`, or immediately with `--start`.
 
 ## Independent lifecycle
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 #[cfg(target_os = "macos")]
 use std::fs;
-use std::num::NonZeroU16;
+use std::num::{NonZeroU8, NonZeroU16};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -12,7 +12,7 @@ use toml::Value as TomlValue;
 
 use crate::cmd::Cmd;
 use crate::config::{
-    ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, LocalModel, McpServerDef,
+    ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, LocalModel, McpServerDef, MiB,
     NetworkConfig, Validated,
 };
 use crate::model_state::ModelState;
@@ -772,6 +772,26 @@ pub trait VmBackend: std::fmt::Display {
         stopped: &StoppedInstance,
         new_size: crate::config::GiB,
     ) -> Result<()>;
+    /// Change a stopped instance's memory and/or vCPU count. At least one
+    /// of `mem`/`vcpus` is `Some` (the caller enforces this). The new
+    /// value is written to the backend's authoritative artifact — the
+    /// per-instance Firecracker JSON or the Lima `lima.yaml` — so it
+    /// survives restarts rather than being reset from the global config.
+    ///
+    /// Firecracker writes the JSON atomically and does not boot the VM;
+    /// Lima must `limactl start` to validate and apply the new spec, and
+    /// restores the previous `lima.yaml` if that start fails. When
+    /// `start_after` is true the instance is left running; otherwise it
+    /// ends stopped (Lima stops it again after the validation boot).
+    /// Gated on a [`StoppedInstance`] like [`Self::resize_disk`].
+    fn set_machine_resources(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        mem: Option<MiB>,
+        vcpus: Option<NonZeroU8>,
+        start_after: bool,
+    ) -> Result<()>;
     /// Save a stopped instance's filesystem as image `image` (the
     /// backend-specific disk artifacts only — the caller carries over
     /// the shared `template-config.json`). Takes a [`StoppedInstance`]
@@ -968,6 +988,31 @@ impl VmBackend for FirecrackerBackend {
         crate::setup::resize_rootfs(stopped.instance(), new_size)
     }
 
+    fn set_machine_resources(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        mem: Option<MiB>,
+        vcpus: Option<NonZeroU8>,
+        start_after: bool,
+    ) -> Result<()> {
+        let inst = stopped.instance();
+        // Snapshot the prior spec so a failed validation boot can be rolled
+        // back — otherwise `configure()` would re-read the rejected value on
+        // every subsequent `coop start` and the instance would stay wedged.
+        let previous = crate::vm::machine_resources(inst)?;
+        crate::vm::set_machine_resources(inst, mem, vcpus)?;
+        if start_after && let Err(e) = self.start_existing(cfg, inst) {
+            if let Err(revert) =
+                crate::vm::set_machine_resources(inst, Some(previous.0), Some(previous.1))
+            {
+                tracing::error!("Failed to revert machine config after failed start: {revert}");
+            }
+            return Err(e.context("Failed to start after reconfigure — reverted machine config"));
+        }
+        Ok(())
+    }
+
     fn commit_disk(
         &self,
         cfg: &CoopConfig,
@@ -1137,6 +1182,17 @@ impl VmBackend for LimaBackend {
         new_size: crate::config::GiB,
     ) -> Result<()> {
         crate::lima::resize_disk(cfg, stopped.instance(), new_size)
+    }
+
+    fn set_machine_resources(
+        &self,
+        cfg: &CoopConfig,
+        stopped: &StoppedInstance,
+        mem: Option<MiB>,
+        vcpus: Option<NonZeroU8>,
+        start_after: bool,
+    ) -> Result<()> {
+        crate::lima::set_machine_resources(cfg, stopped.instance(), mem, vcpus, start_after)
     }
 
     fn commit_disk(

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1745,36 +1745,44 @@ pub(crate) fn cmd_status(
     Ok(())
 }
 
+/// Inputs to `coop resize`. At least one of `disk`/`mem`/`vcpus` is set;
+/// that invariant is enforced at the CLI boundary by the `resize_targets`
+/// arg group, so this is a plain data bundle (kept together to stay under
+/// the positional-parameter limit, like [`UpOpts`]/[`StartOpts`]).
+pub(crate) struct ResizeOpts<'a> {
+    pub(crate) name: Option<&'a config::InstanceName>,
+    pub(crate) disk: Option<config::DiskSize>,
+    pub(crate) mem: Option<config::MiB>,
+    pub(crate) vcpus: Option<std::num::NonZeroU8>,
+    pub(crate) start: bool,
+}
+
 pub(crate) fn cmd_resize(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    name: Option<&config::InstanceName>,
-    disk_size: Option<config::DiskSize>,
-    mem: Option<config::MiB>,
-    vcpus: Option<std::num::NonZeroU8>,
-    start: bool,
+    opts: &ResizeOpts<'_>,
 ) -> Result<()> {
     // Reject a below-minimum memory before touching any artifact, so a bad
     // value never leaves a half-applied instance (the CLI ArgGroup already
     // guarantees at least one of size/mem/vcpus is present).
-    if let Some(mem) = mem {
+    if let Some(mem) = opts.mem {
         config::validate_mem_size(mem)?;
     }
 
-    let inst = cfg.resolve_instance(name)?;
+    let inst = cfg.resolve_instance(opts.name)?;
     let stopped = be.as_stopped(inst)?;
 
-    if let Some(disk_size) = disk_size {
+    if let Some(disk_size) = opts.disk {
         let current = current_disk_gib(be, stopped.instance())?;
         let new_size = disk_size.resolve(current)?;
         be.resize_disk(cfg, &stopped, new_size)?;
     }
 
-    if mem.is_some() || vcpus.is_some() {
+    if opts.mem.is_some() || opts.vcpus.is_some() {
         // The backend applies mem/vcpu and, for `--start`, boots the
         // instance itself (Lima must boot to validate regardless).
-        be.set_machine_resources(cfg, &stopped, mem, vcpus, start)?;
-    } else if start {
+        be.set_machine_resources(cfg, &stopped, opts.mem, opts.vcpus, opts.start)?;
+    } else if opts.start {
         be.start_existing(cfg, stopped.instance())?;
     }
 

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -584,7 +584,9 @@ fn ensure_up_existing_inputs_are_compatible(
             "Instance '{}' already exists for this project. \
              --vcpus, --mem, --disk, --extra-mount, --exclude-git, and \
              --devcontainer only apply when creating a new instance.\n\
-             Use `coop destroy {}` first to recreate it with those options.",
+             To change memory, vCPUs, or disk on the existing instance, \
+             stop it and run `coop resize`. Otherwise `coop destroy {}` \
+             first to recreate it with those options.",
             inst.name,
             inst.name,
         );
@@ -661,7 +663,9 @@ fn ensure_up_existing_inputs_are_compatible_for_git_repo(
             "Instance '{}' already exists for this git repo. \
              --vcpus, --mem, --disk, --extra-mount, and --devcontainer only \
              apply when creating a new instance.\n\
-             Use `coop destroy {}` first to recreate it with those options.",
+             To change memory, vCPUs, or disk on the existing instance, \
+             stop it and run `coop resize`. Otherwise `coop destroy {}` \
+             first to recreate it with those options.",
             inst.name,
             inst.name,
         );
@@ -1745,15 +1749,36 @@ pub(crate) fn cmd_resize(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
     name: Option<&config::InstanceName>,
-    disk_size: config::DiskSize,
+    disk_size: Option<config::DiskSize>,
+    mem: Option<config::MiB>,
+    vcpus: Option<std::num::NonZeroU8>,
+    start: bool,
 ) -> Result<()> {
+    // Reject a below-minimum memory before touching any artifact, so a bad
+    // value never leaves a half-applied instance (the CLI ArgGroup already
+    // guarantees at least one of size/mem/vcpus is present).
+    if let Some(mem) = mem {
+        config::validate_mem_size(mem)?;
+    }
+
     let inst = cfg.resolve_instance(name)?;
-
     let stopped = be.as_stopped(inst)?;
-    let current = current_disk_gib(be, stopped.instance())?;
-    let new_size = disk_size.resolve(current)?;
 
-    be.resize_disk(cfg, &stopped, new_size)
+    if let Some(disk_size) = disk_size {
+        let current = current_disk_gib(be, stopped.instance())?;
+        let new_size = disk_size.resolve(current)?;
+        be.resize_disk(cfg, &stopped, new_size)?;
+    }
+
+    if mem.is_some() || vcpus.is_some() {
+        // The backend applies mem/vcpu and, for `--start`, boots the
+        // instance itself (Lima must boot to validate regardless).
+        be.set_machine_resources(cfg, &stopped, mem, vcpus, start)?;
+    } else if start {
+        be.start_existing(cfg, stopped.instance())?;
+    }
+
+    Ok(())
 }
 
 /// Save a stopped instance's filesystem as a reusable image.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,11 +20,11 @@ pub(crate) use devcontainer::{
 };
 pub(crate) use github::cmd_github;
 pub(crate) use lifecycle::{
-    ProfileImageTarget, ProjectTransport, StartOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts,
-    apply_runtime_guest_env, apply_vm_overrides, cmd_commit, cmd_destroy, cmd_exec, cmd_list,
-    cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_up, codex_launch_args,
-    open_ssh_session, preflight_start_target, prepare_session_from_target, prepend_binary,
-    resolve_running,
+    ProfileImageTarget, ProjectTransport, ResizeOpts, StartOpts, UpDevcontainerOpts, UpOpts,
+    UpRuntimeOpts, apply_runtime_guest_env, apply_vm_overrides, cmd_commit, cmd_destroy, cmd_exec,
+    cmd_list, cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_up,
+    codex_launch_args, open_ssh_session, preflight_start_target, prepare_session_from_target,
+    prepend_binary, resolve_running,
 };
 pub(crate) use model::cmd_model;
 pub(crate) use profiles::{cmd_images, cmd_profiles};

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,6 +227,22 @@ impl Quantity<MibUnit> {
     }
 }
 
+/// Smallest guest memory that boots reliably. Below this the kernel
+/// fails to come up, so it is rejected both when validating the global
+/// config and when reconfiguring an existing instance via `coop resize`.
+pub const MIN_MEM_MIB: MiB = MiB::from_nonzero(NonZeroU32::new(128).unwrap());
+
+/// Reject a requested memory size below [`MIN_MEM_MIB`].
+///
+/// Shared by `CoopConfig::validate` (global config) and `coop resize`
+/// (`--mem` on an existing instance) so both enforce the same floor.
+pub fn validate_mem_size(mem: MiB) -> Result<()> {
+    if mem < MIN_MEM_MIB {
+        bail!("mem_size_mib={mem} is too low (minimum {MIN_MEM_MIB})");
+    }
+    Ok(())
+}
+
 /// Disk size specification: absolute (`150`) or relative (`+20`), in GiB.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiskSize {
@@ -1842,19 +1858,14 @@ impl CoopConfig {
     /// Returns `Ok(warnings)` where warnings are non-fatal observations,
     /// or `Err` with all fatal validation errors joined.
     pub fn validate(&self) -> Result<Vec<String>> {
-        const MIN_MEM_MIB: MiB = MiB::from_nonzero(NonZeroU32::new(128).unwrap());
-
         let mut errors: Vec<String> = Vec::new();
         let mut warnings: Vec<String> = Vec::new();
 
         // VM config bounds
         // vcpu_count, mem_size_mib, template_size_gib, and ssh_port are
         // NonZero types — zero is rejected at deserialization time.
-        if self.vm.mem_size_mib < MIN_MEM_MIB {
-            errors.push(format!(
-                "vm.mem_size_mib={} is too low (minimum {MIN_MEM_MIB})",
-                self.vm.mem_size_mib,
-            ));
+        if let Err(e) = validate_mem_size(self.vm.mem_size_mib) {
+            errors.push(e.to_string());
         }
 
         // Path checks
@@ -4300,6 +4311,18 @@ skip = ["not-a-slug"]
         cfg.vm.mem_size_mib = MiB::new(64).unwrap();
         let err = cfg.validate().unwrap_err();
         assert!(err.to_string().contains("mem_size_mib=64 is too low"));
+    }
+
+    #[test]
+    fn validate_mem_size_rejects_below_minimum() {
+        let err = super::validate_mem_size(MiB::new(127).unwrap()).unwrap_err();
+        assert!(err.to_string().contains("mem_size_mib=127 is too low"));
+    }
+
+    #[test]
+    fn validate_mem_size_accepts_minimum_and_above() {
+        super::validate_mem_size(super::MIN_MEM_MIB).unwrap();
+        super::validate_mem_size(MiB::new(4096).unwrap()).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,12 +67,13 @@ use backend::VmBackend as _;
 use commands::json;
 use commands::{
     DevcontainerInput, DevcontainerOpts, ProfileImageTarget, ProjectTransport, QuickstartOpts,
-    StartOpts, UninstallOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts, apply_runtime_guest_env,
-    apply_vm_overrides, cmd_commit, cmd_destroy, cmd_devcontainer, cmd_devcontainer_check,
-    cmd_exec, cmd_github, cmd_images, cmd_init, cmd_list, cmd_model, cmd_profiles, cmd_quickstart,
-    cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_uninstall, cmd_up,
-    cmd_validate, codex_launch_args, open_ssh_session, preflight_start_target, prepend_binary,
-    resolve_devcontainer, resolve_devcontainer_collect, resolve_running,
+    ResizeOpts, StartOpts, UninstallOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts,
+    apply_runtime_guest_env, apply_vm_overrides, cmd_commit, cmd_destroy, cmd_devcontainer,
+    cmd_devcontainer_check, cmd_exec, cmd_github, cmd_images, cmd_init, cmd_list, cmd_model,
+    cmd_profiles, cmd_quickstart, cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status,
+    cmd_stop, cmd_uninstall, cmd_up, cmd_validate, codex_launch_args, open_ssh_session,
+    preflight_start_target, prepend_binary, resolve_devcontainer, resolve_devcontainer_collect,
+    resolve_running,
 };
 
 #[derive(Parser)]
@@ -1237,7 +1238,17 @@ pub fn run() -> Result<()> {
             mem,
             vcpus,
             start,
-        } => cmd_resize(&be, &cfg, name.as_ref(), size, mem, vcpus, start),
+        } => cmd_resize(
+            &be,
+            &cfg,
+            &ResizeOpts {
+                name: name.as_ref(),
+                disk: size,
+                mem,
+                vcpus,
+                start,
+            },
+        ),
         Commands::Commit { name, image, force } => {
             cmd_commit(&be, &cfg, name.as_ref(), &image, force)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,7 +533,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Resize a stopped instance's disk
+    /// Resize a stopped instance's disk, memory, or vCPU count
+    #[command(group(clap::ArgGroup::new("resize_targets")
+        .required(true)
+        .multiple(true)
+        .args(["size", "mem", "vcpus"])))]
     Resize {
         /// Instance name (required if multiple instances exist)
         #[arg(
@@ -541,9 +545,18 @@ enum Commands {
             add = ArgValueCandidates::new(completions::instance_candidates),
         )]
         name: Option<config::InstanceName>,
-        /// New size: absolute GiB (e.g. 150, 150G) or relative (e.g. +20, +20G)
-        #[arg(long, required = true, value_parser = config::DiskSize::parse)]
-        size: config::DiskSize,
+        /// New disk size: absolute GiB (e.g. 150, 150G) or relative (e.g. +20, +20G)
+        #[arg(long, value_parser = config::DiskSize::parse)]
+        size: Option<config::DiskSize>,
+        /// New memory in MiB (minimum 128)
+        #[arg(long, value_parser = config::MiB::parse_cli)]
+        mem: Option<config::MiB>,
+        /// New vCPU count
+        #[arg(long)]
+        vcpus: Option<std::num::NonZeroU8>,
+        /// Start the instance after applying the change instead of leaving it stopped
+        #[arg(long)]
+        start: bool,
     },
     /// Save a stopped instance's filesystem as a reusable image
     Commit {
@@ -1218,7 +1231,13 @@ pub fn run() -> Result<()> {
             workspace::write_ssh_config(&running)
         }
         Commands::Images { delete, json } => cmd_images(&be, &cfg, delete.as_ref(), json),
-        Commands::Resize { name, size } => cmd_resize(&be, &cfg, name.as_ref(), size),
+        Commands::Resize {
+            name,
+            size,
+            mem,
+            vcpus,
+            start,
+        } => cmd_resize(&be, &cfg, name.as_ref(), size, mem, vcpus, start),
         Commands::Commit { name, image, force } => {
             cmd_commit(&be, &cfg, name.as_ref(), &image, force)
         }

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::io::{BufRead, BufReader, Write as _};
+use std::num::NonZeroU8;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -7,7 +8,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 
 use crate::backend::{Hostname, LogMode, SshTarget, SshUser};
-use crate::config::{CoopConfig, GiB, ImageName, Instance, InstanceName};
+use crate::config::{CoopConfig, GiB, ImageName, Instance, InstanceName, MiB};
 use crate::devcontainer_oci::{ResolvedFeature, installed_features};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
@@ -325,6 +326,89 @@ pub fn resize_disk(_cfg: &CoopConfig, inst: &Instance, new_size: crate::config::
          (cloud-init growpart)."
     );
     Ok(())
+}
+
+/// Change a stopped Lima instance's cpus/memory by editing its
+/// `lima.yaml`, then validating the new spec with a start.
+///
+/// Lima re-reads `lima.yaml` on `limactl start`, so the edit is what
+/// applies the change. The edit is written atomically and the prior file
+/// restored if the start fails (limactl rejects a malformed or over-large
+/// spec). With `start_after` the instance is left running; otherwise it is
+/// stopped again after the validating boot so `coop resize` leaves it in
+/// the state it found it.
+pub fn set_machine_resources(
+    cfg: &CoopConfig,
+    inst: &Instance,
+    mem: Option<MiB>,
+    vcpus: Option<NonZeroU8>,
+    start_after: bool,
+) -> Result<()> {
+    let yaml_path = lima_home()?.join(lima_name(inst)).join("lima.yaml");
+    let original = fs::read_to_string(&yaml_path)
+        .with_context(|| format!("Failed to read {}", yaml_path.display()))?;
+
+    let mut edited = original.clone();
+    if let Some(vcpus) = vcpus {
+        edited = set_yaml_scalar(&edited, "cpus", &vcpus.to_string())
+            .with_context(|| format!("No top-level 'cpus' key in {}", yaml_path.display()))?;
+    }
+    if let Some(mem) = mem {
+        let value = format!("\"{}GiB\"", mem.as_gib_f64());
+        edited = set_yaml_scalar(&edited, "memory", &value)
+            .with_context(|| format!("No top-level 'memory' key in {}", yaml_path.display()))?;
+    }
+
+    crate::fs_util::atomic_write_with_mode(&yaml_path, &edited, 0o644)?;
+
+    // Lima applies cpus/memory only at start, so boot to validate + apply.
+    if let Err(e) = start_existing(cfg, inst) {
+        if let Err(restore) = crate::fs_util::atomic_write_with_mode(&yaml_path, &original, 0o644) {
+            tracing::error!(
+                "Failed to restore {} after a failed reconfigure: {restore}",
+                yaml_path.display()
+            );
+        }
+        return Err(e.context("Failed to apply new machine resources — reverted lima.yaml"));
+    }
+
+    if !start_after {
+        stop_running(inst)?;
+    }
+    Ok(())
+}
+
+/// Replace the value of a top-level scalar `key` in a YAML document,
+/// returning the edited document, or `None` if the key is absent.
+///
+/// Only an unindented `key:` line is matched, so nested keys of the same
+/// name are left untouched. coop always writes `cpus`/`memory` at the top
+/// level when creating an instance, so a `None` here means the file is not
+/// the expected shape and the caller should surface an error.
+fn set_yaml_scalar(yaml: &str, key: &str, value: &str) -> Option<String> {
+    let mut replaced = false;
+    let mut out = String::with_capacity(yaml.len() + value.len());
+    for line in yaml.lines() {
+        if !replaced && is_top_level_key(line, key) {
+            replaced = true;
+            out.push_str(key);
+            out.push_str(": ");
+            out.push_str(value);
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    replaced.then_some(out)
+}
+
+/// True if `line` is an unindented `key:` entry — the top-level scalar we
+/// rewrite — rather than a nested (indented) or differently-named key.
+fn is_top_level_key(line: &str, key: &str) -> bool {
+    match line.split_once(':') {
+        Some((name, _)) => name == key,
+        None => false,
+    }
 }
 
 /// Save a stopped instance's disk as image `image`'s base image.
@@ -1729,6 +1813,53 @@ mod tests {
     fn cloud_init_exit0_done_succeeds() {
         let result = check_cloud_init_output(Some(0), "status: done\n");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_yaml_scalar_replaces_top_level_cpus_and_memory() {
+        let yaml = "cpus: 2\nmemory: \"4GiB\"\ndisk: \"20GiB\"\n";
+        let edited = set_yaml_scalar(yaml, "cpus", "8").unwrap();
+        let edited = set_yaml_scalar(&edited, "memory", "\"16GiB\"").unwrap();
+        assert!(edited.contains("cpus: 8\n"), "cpus not updated: {edited}");
+        assert!(
+            edited.contains("memory: \"16GiB\"\n"),
+            "memory not updated: {edited}"
+        );
+        assert!(
+            edited.contains("disk: \"20GiB\"\n"),
+            "unrelated key changed: {edited}"
+        );
+    }
+
+    #[test]
+    fn set_yaml_scalar_returns_none_for_missing_key() {
+        assert!(set_yaml_scalar("cpus: 2\n", "memory", "\"4GiB\"").is_none());
+    }
+
+    #[test]
+    fn set_yaml_scalar_ignores_nested_keys() {
+        // A nested `cpus:` (indented) must not be mistaken for the
+        // top-level one; the top-level key is what limactl reads.
+        let yaml = "provision:\n  cpus: bogus\ncpus: 2\n";
+        let edited = set_yaml_scalar(yaml, "cpus", "8").unwrap();
+        assert!(
+            edited.contains("  cpus: bogus\n"),
+            "nested key edited: {edited}"
+        );
+        assert!(
+            edited.contains("cpus: 8\n"),
+            "top-level key not edited: {edited}"
+        );
+    }
+
+    #[test]
+    fn is_top_level_key_matches_only_unindented_exact_key() {
+        assert!(is_top_level_key("cpus: 2", "cpus"));
+        assert!(is_top_level_key("cpus: null", "cpus"));
+        assert!(!is_top_level_key("  cpus: 2", "cpus"));
+        assert!(!is_top_level_key("cpuset: 2", "cpus"));
+        assert!(!is_top_level_key("# cpus: 2", "cpus"));
+        assert!(!is_top_level_key("no colon here", "cpus"));
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3,15 +3,17 @@ use std::fs;
 use std::io::{BufRead, BufReader, Write as _};
 use std::marker::PhantomData;
 use std::net::TcpStream;
+use std::num::NonZeroU8;
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::backend::LogMode;
 use crate::cmd::Cmd;
-use crate::config::{CoopConfig, Instance};
+use crate::config::{CoopConfig, Instance, MiB};
 
 // ── Typestate markers ─────────────────────────────────────────
 
@@ -32,11 +34,10 @@ pub struct Running;
 pub struct FirecrackerVm<'a, S> {
     cfg: &'a CoopConfig,
     inst: &'a Instance,
-    fc_config: FirecrackerConfig,
     _state: PhantomData<S>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct FirecrackerConfig {
     #[serde(rename = "boot-source")]
     boot_source: BootSource,
@@ -48,13 +49,13 @@ struct FirecrackerConfig {
     vsock: Option<VsockConfig>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct BootSource {
     kernel_image_path: String,
     boot_args: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct Drive {
     #[serde(rename = "drive_id")]
     id: String,
@@ -63,20 +64,20 @@ struct Drive {
     is_read_only: bool,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Clone, Copy)]
 struct MachineConfig {
     vcpu_count: u8,
     mem_size_mib: u32,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct NetworkInterface {
     iface_id: String,
     guest_mac: String,
     host_dev_name: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct VsockConfig {
     guest_cid: u32,
     uds_path: String,
@@ -110,6 +111,79 @@ fn build_config(cfg: &CoopConfig, inst: &Instance) -> FirecrackerConfig {
     }
 }
 
+/// Read the persisted machine config (mem/vcpu) from an instance's JSON.
+///
+/// Returns `None` if the file is missing or unparsable, letting callers
+/// fall back to the global config for a not-yet-created instance.
+fn read_machine_config(path: &Path) -> Option<MachineConfig> {
+    let json = fs::read_to_string(path).ok()?;
+    let config: FirecrackerConfig = serde_json::from_str(&json).ok()?;
+    Some(config.machine_config)
+}
+
+/// The instance's currently persisted memory and vCPU count, as the typed
+/// values `set_machine_resources` accepts.
+///
+/// Used to snapshot the prior values before a reconfigure so the caller
+/// can roll them back if a subsequent boot fails, leaving the instance
+/// bootable at its previous spec rather than wedged at the rejected one.
+pub fn machine_resources(inst: &Instance) -> Result<(MiB, NonZeroU8)> {
+    let path = inst.vm_config_path();
+    let machine = read_machine_config(&path)
+        .with_context(|| format!("Failed to read machine config from {}", path.display()))?;
+    let mem = MiB::new(machine.mem_size_mib)
+        .with_context(|| format!("Corrupt mem_size_mib=0 in {}", path.display()))?;
+    let vcpus = NonZeroU8::new(machine.vcpu_count)
+        .with_context(|| format!("Corrupt vcpu_count=0 in {}", path.display()))?;
+    Ok((mem, vcpus))
+}
+
+/// Overwrite the memory and/or vCPU fields left `Some`, in place.
+///
+/// Split out from [`set_machine_resources`] so the field-selection logic
+/// is unit-testable without touching the filesystem.
+fn apply_machine_resources(
+    machine: &mut MachineConfig,
+    mem: Option<MiB>,
+    vcpus: Option<NonZeroU8>,
+) {
+    if let Some(mem) = mem {
+        machine.mem_size_mib = mem.as_u32();
+    }
+    if let Some(vcpus) = vcpus {
+        machine.vcpu_count = vcpus.get();
+    }
+}
+
+/// Update a stopped instance's persisted mem/vcpu, writing atomically so
+/// a crash mid-write leaves the prior values intact.
+///
+/// The change takes effect on the next `coop start` (Firecracker re-reads
+/// the JSON on boot); [`FirecrackerVm::configure`] preserves these fields
+/// rather than resetting them to the global default.
+pub fn set_machine_resources(
+    inst: &Instance,
+    mem: Option<MiB>,
+    vcpus: Option<NonZeroU8>,
+) -> Result<()> {
+    let path = inst.vm_config_path();
+    let json = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read VM config {}", path.display()))?;
+    let mut config: FirecrackerConfig = serde_json::from_str(&json)
+        .with_context(|| format!("Failed to parse VM config {}", path.display()))?;
+    apply_machine_resources(&mut config.machine_config, mem, vcpus);
+    let out =
+        serde_json::to_string_pretty(&config).context("Failed to serialize Firecracker config")?;
+    crate::fs_util::atomic_write_json(&path, &out)?;
+    tracing::info!(
+        "Updated machine config for instance '{}': {} vCPUs, {} MiB",
+        inst.name,
+        config.machine_config.vcpu_count,
+        config.machine_config.mem_size_mib,
+    );
+    Ok(())
+}
+
 // ── Configured state ──────────────────────────────────────────
 
 impl<'a> FirecrackerVm<'a, Configured> {
@@ -117,17 +191,29 @@ impl<'a> FirecrackerVm<'a, Configured> {
         Self {
             cfg,
             inst,
-            fc_config: build_config(cfg, inst),
             _state: PhantomData,
         }
     }
 
     /// Write the Firecracker JSON config.
+    ///
+    /// Infra fields (kernel path, boot args, drive, network, vsock) are
+    /// regenerated from the global config every time so they roll forward
+    /// on restart (e.g. after a kernel upgrade). Machine resources
+    /// (mem/vcpu) are the exception: once an instance's config exists on
+    /// disk it is authoritative for those two fields, so a value set via
+    /// `coop resize` survives a restart instead of being reset to the
+    /// global default. A fresh instance (no config yet) seeds them from
+    /// the global config.
     pub fn configure(&self) -> Result<()> {
         fs::create_dir_all(&self.inst.dir).context("Failed to create instance directory")?;
 
         let config_path = self.inst.vm_config_path();
-        let config_json = serde_json::to_string_pretty(&self.fc_config)
+        let mut fc_config = build_config(self.cfg, self.inst);
+        if let Some(existing) = read_machine_config(&config_path) {
+            fc_config.machine_config = existing;
+        }
+        let config_json = serde_json::to_string_pretty(&fc_config)
             .context("Failed to serialize Firecracker config")?;
         fs::write(&config_path, config_json).context("Failed to write Firecracker config")?;
 
@@ -198,7 +284,6 @@ impl<'a> FirecrackerVm<'a, Configured> {
         let running = FirecrackerVm {
             cfg: self.cfg,
             inst: self.inst,
-            fc_config: self.fc_config,
             _state: PhantomData,
         };
 
@@ -247,7 +332,6 @@ impl<'a> FirecrackerVm<'a, Running> {
         Self {
             cfg,
             inst,
-            fc_config: build_config(cfg, inst),
             _state: PhantomData,
         }
     }
@@ -366,13 +450,20 @@ impl<'a> FirecrackerVm<'a, Running> {
             fs::read_to_string(self.inst.pid_file_path()).context("Failed to read PID file")?;
         let pid = pid_str.trim();
 
+        // Report the mem/vcpu the VM actually booted with, read from the
+        // authoritative per-instance config, not the global default.
+        let machine = read_machine_config(&self.inst.vm_config_path()).unwrap_or(MachineConfig {
+            vcpu_count: self.cfg.vm.vcpu_count.get(),
+            mem_size_mib: self.cfg.vm.mem_size_mib.as_u32(),
+        });
+
         let mut out = format!(
             "Instance '{}' running (PID: {pid})\n  \
              vCPUs: {}\n  Memory: {} MiB\n  \
              Guest IP: {}\n  SSH: {}:{}",
             self.inst.name,
-            self.cfg.vm.vcpu_count,
-            self.cfg.vm.mem_size_mib,
+            machine.vcpu_count,
+            machine.mem_size_mib,
             self.inst.guest_ip(),
             self.inst.guest_ip(),
             self.cfg.ssh_port,
@@ -477,4 +568,80 @@ fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
         std::thread::sleep(Duration::from_millis(200));
     }
     false
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code — panics are assertions")]
+mod tests {
+    use super::{MachineConfig, MiB, NonZeroU8, apply_machine_resources, read_machine_config};
+
+    const SAMPLE_CONFIG_JSON: &str = r#"{
+        "boot-source": {"kernel_image_path": "/k", "boot_args": "console=ttyS0"},
+        "drives": [{"drive_id": "rootfs", "path_on_host": "/r",
+                    "is_root_device": true, "is_read_only": false}],
+        "machine-config": {"vcpu_count": 6, "mem_size_mib": 5120},
+        "network-interfaces": [{"iface_id": "eth0", "guest_mac": "06:00:AC:10:00:02",
+                                "host_dev_name": "tap0"}],
+        "vsock": {"guest_cid": 3, "uds_path": "/v"}
+    }"#;
+
+    #[test]
+    fn read_machine_config_parses_persisted_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm_config.json");
+        std::fs::write(&path, SAMPLE_CONFIG_JSON).unwrap();
+        let machine = read_machine_config(&path).unwrap();
+        assert_eq!(machine.vcpu_count, 6);
+        assert_eq!(machine.mem_size_mib, 5120);
+    }
+
+    #[test]
+    fn read_machine_config_returns_none_for_missing_or_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.json");
+        assert!(read_machine_config(&missing).is_none(), "missing file");
+
+        let malformed = dir.path().join("bad.json");
+        std::fs::write(&malformed, "{ not json").unwrap();
+        assert!(read_machine_config(&malformed).is_none(), "malformed file");
+    }
+
+    #[test]
+    fn apply_machine_resources_updates_only_provided_fields() {
+        let mut machine = MachineConfig {
+            vcpu_count: 2,
+            mem_size_mib: 2048,
+        };
+
+        apply_machine_resources(&mut machine, MiB::new(4096), None);
+        assert_eq!(machine.mem_size_mib, 4096);
+        assert_eq!(machine.vcpu_count, 2, "vcpu untouched when mem-only");
+
+        apply_machine_resources(&mut machine, None, NonZeroU8::new(8));
+        assert_eq!(machine.vcpu_count, 8);
+        assert_eq!(machine.mem_size_mib, 4096, "mem untouched when vcpu-only");
+    }
+
+    #[test]
+    fn apply_machine_resources_is_noop_when_both_none() {
+        let mut machine = MachineConfig {
+            vcpu_count: 2,
+            mem_size_mib: 2048,
+        };
+        apply_machine_resources(&mut machine, None, None);
+        assert_eq!(machine.vcpu_count, 2);
+        assert_eq!(machine.mem_size_mib, 2048);
+    }
+
+    #[test]
+    fn machine_config_round_trips_through_json() {
+        let machine = MachineConfig {
+            vcpu_count: 4,
+            mem_size_mib: 3072,
+        };
+        let json = serde_json::to_string(&machine).unwrap();
+        let back: MachineConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.vcpu_count, 4);
+        assert_eq!(back.mem_size_mib, 3072);
+    }
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1719,6 +1719,60 @@ test_resize_status() {
     fi
 }
 
+test_reconfigure() {
+    echo ""
+    echo "=== Phase: resize changes memory and vCPUs ==="
+
+    # The instance is stopped here. Apply new mem/vcpu and boot in one
+    # step (--start) so the result can be read back via `coop status`,
+    # which needs a running VM on Firecracker. Values are small and safe
+    # to boot on any host, and differ from the defaults so a no-op would
+    # be caught.
+    local want_vcpus=1
+    local want_mem=2048
+
+    if coop resize "$INSTANCE" --vcpus "$want_vcpus" --mem "$want_mem" --start; then
+        pass "resize --vcpus/--mem --start exits 0"
+    else
+        fail "resize --vcpus/--mem --start exits 0" "exit code: $?"
+        return
+    fi
+
+    # On Firecracker, `--start` routes through configure(), which must
+    # preserve the freshly-written mem/vcpu instead of resetting them to
+    # the global config — so this single check also exercises the
+    # preserve-on-restart behavior. On Lima the values come from the
+    # re-read lima.yaml via limactl.
+    if ! coop status "$INSTANCE" 2>/dev/null; then
+        fail "status after reconfigure" "status unavailable for running instance"
+        return
+    fi
+
+    local got_vcpus got_mem
+    got_vcpus=$(echo "$HARNESS_OUT" | sed -n 's/.*vCPUs: \([0-9][0-9]*\).*/\1/p' | head -1)
+    got_mem=$(echo "$HARNESS_OUT" | sed -n 's/.*Memory: \([0-9][0-9]*\) MiB.*/\1/p' | head -1)
+
+    if [[ "$got_vcpus" == "$want_vcpus" ]]; then
+        pass "status reflects reconfigured vCPUs (${got_vcpus})"
+    else
+        fail "status reflects reconfigured vCPUs" "expected ${want_vcpus}, got ${got_vcpus}"
+    fi
+
+    if [[ "$got_mem" == "$want_mem" ]]; then
+        pass "status reflects reconfigured memory (${got_mem} MiB)"
+    else
+        fail "status reflects reconfigured memory" "expected ${want_mem} MiB, got ${got_mem}"
+    fi
+
+    # Return the instance to a stopped state for the phases that follow
+    # (commit/restore/restart all expect it stopped).
+    if coop stop "$INSTANCE" >/dev/null 2>&1; then
+        pass "stop after reconfigure exits 0"
+    else
+        fail "stop after reconfigure exits 0" "exit code: $?"
+    fi
+}
+
 test_commit_restore() {
     echo ""
     echo "=== Phase: commit + restore ==="
@@ -4756,6 +4810,7 @@ main() {
     test_status_stopped
     test_list_stopped
     test_resize_status
+    test_reconfigure
     test_commit_restore
     test_restart_stopped
     test_restart_rejects_ignored_flags


### PR DESCRIPTION
Closes #396.

## What

Extends `coop resize` to change a stopped instance's **memory** and **vCPU count** in place, not just its disk:

```
coop resize [NAME] [--size <SIZE>] [--mem <MIB>] [--vcpus <N>] [--start]
```

At least one of `--size`/`--mem`/`--vcpus` is required (clap arg group). `--size` stays a flag (now optional). `--start` boots the instance after applying the change; by default it is left stopped and the change takes effect on the next `coop start`.

## The backend artifact is the source of truth

mem/vcpu now follow the same rule disk already did: once an instance exists, its **backend config artifact is authoritative**, and the global `[vm]` config only seeds *new* instances.

**Firecracker.** The per-instance `vm_config.json` is now read back (config structs gain `Deserialize`). `configure()` regenerates the infra fields (kernel path, boot args, drive, network, vsock) from the global config on every restart so they roll forward, but preserves the on-disk `mem_size_mib`/`vcpu_count`. This also fixes a latent drift bug: previously `configure()` rebuilt everything from global config on every boot, so changing `[vm].mem_size_mib` silently changed RAM for every existing instance. `resize` edits the JSON atomically; a failed `--start` boot rolls the values back so the instance stays bootable at its prior spec. `coop status` reports mem/vcpu from the JSON.

**Lima.** `cpus`/`memory` in `lima.yaml` are already authoritative and re-read on `limactl start`. `resize` rewrites those keys atomically, then starts the instance to validate and apply the new spec (limactl rejects a malformed/over-large spec), restoring the prior `lima.yaml` if the start fails. Without `--start` the instance is stopped again after the validating boot. Lima `status` already reads from `limactl`.

Memory is validated against the shared 128 MiB floor before any artifact is touched. The `coop up` guard still rejects `--mem`/`--vcpus`/`--disk` on an existing instance, now pointing users to `coop resize`.

## Tests

- Unit tests: `validate_mem_size` (config), `apply_machine_resources` + `read_machine_config` round-trip/fallback (vm), `set_yaml_scalar`/`is_top_level_key` (lima).
- Integration test: new `test_reconfigure` phase reconfigures mem/vcpu with `--start` and asserts `coop status` reports the new values on both backends, then returns the instance to stopped. The `--start` path routes Firecracker through `configure()`, so this also exercises the preserve-on-restart behavior.

`.cargo/mutants.toml` needs no change: the new IO/backend functions live in modules already whole-module-excluded (`vm.rs`, `lima.rs`, `backend.rs`), `cmd_resize` is covered by the `cmd_*` pattern, and the one new in-scope helper (`validate_mem_size`) is unit-tested (mutants: 0 missed).

## Not run here

This was implemented on a Linux host, so `tests/integration.sh` was not run on either backend. Please run it on both platforms per `CLAUDE.md` before merge:

    ./tests/run-integration.sh                       # macOS/Lima
    ./tests/run-integration.sh --remote user@host    # Linux/Firecracker