### PR TITLE
Prepare docs and metadata for open-sourcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **Firecracker CI artifact listing fetched over HTTPS** (#401) — the S3
+  `ListObjectsV2` request that discovers kernel/rootfs versions during
+  setup used plain HTTP: the bucket name contains dots, which breaks TLS
+  certificate matching for the virtual-hosted URL. It now uses the same
+  path-style HTTPS endpoint as the downloads themselves, so a network
+  attacker can no longer steer version selection.
+
+### Documentation
+
+- **Docs describe the public repository** (#401) — removed the
+  transitional "while `trailofbits/coop` is private" wording from the
+  README and `docs/commands.md`. `coop update` and `install.sh` work
+  anonymously and use `gh`/`GITHUB_TOKEN` opportunistically when present.
+
+### Internal
+
+- **`repository` metadata added to Cargo.toml** (#401).
+
 ## v0.5.3
 
 ### New features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.5.3"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
 license = "Apache-2.0"
+repository = "https://github.com/trailofbits/coop"
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ Install:
 curl -fsSL https://raw.githubusercontent.com/trailofbits/coop/main/install.sh | bash
 ```
 
-For internal/private repos (requires [GitHub CLI](https://cli.github.com/)):
-
-```
-gh api repos/trailofbits/coop/contents/install.sh -H "Accept: application/vnd.github.raw" | bash
-```
-
 Or build from source (requires [Rust](https://rustup.rs/)):
 
 ```
@@ -104,10 +98,9 @@ host triple, verifies the SHA-256 against the release's `SHA256SUMS`, and
 (when `gh` is installed) verifies the GitHub build-provenance attestation
 before swapping the binary atomically.
 
-While `trailofbits/coop` is private, `coop update` requires either
-[`gh`](https://cli.github.com/) authenticated against `github.com` or
-`GITHUB_TOKEN` in the environment to reach the API and download release
-assets. Once the repository is public, no auth is needed.
+No authentication is required. When [`gh`](https://cli.github.com/) is
+authenticated against `github.com` or `GITHUB_TOKEN` is set, `coop update`
+uses it, which helps avoid GitHub API rate limits.
 
 ```sh
 coop update --check             # report whether a newer release exists

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -778,7 +778,7 @@ coop profiles show rust
 
 Replace the running coop binary with a release from `github.com/trailofbits/coop`. Downloads the tarball matching the current host triple, verifies its SHA-256 against the release's `SHA256SUMS`, and (when `gh` is installed) verifies the GitHub build-provenance attestation before swapping the binary atomically.
 
-While `trailofbits/coop` is private, `coop update` requires either [`gh`](https://cli.github.com/) authenticated against `github.com` or `GITHUB_TOKEN` in the environment to reach the API and download release assets. Once the repository is public, no auth is needed.
+No authentication is required. When [`gh`](https://cli.github.com/) is authenticated against `github.com` or `GITHUB_TOKEN` is set, `coop update` uses it, which helps avoid GitHub API rate limits.
 
 ```
 coop update [FLAGS]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -17,8 +17,9 @@ use crate::guest::{
 };
 use crate::sha256_hash::Sha256Hash;
 
+// Path-style URL: the bucket name contains dots, so virtual-hosted HTTPS
+// (`https://spec.ccfc.min.s3.amazonaws.com`) fails TLS wildcard-cert matching.
 const S3_BUCKET: &str = "https://s3.amazonaws.com/spec.ccfc.min";
-const S3_LIST: &str = "http://spec.ccfc.min.s3.amazonaws.com";
 const GH_RELEASES: &str = "https://github.com/firecracker-microvm/firecracker/releases";
 
 /// Monotonic version bumped when the base install script changes
@@ -1100,7 +1101,7 @@ const FC_CI_FALLBACK_MINORS: u16 = 4;
 /// XML response. An empty response (the prefix has no objects) returns
 /// an empty Vec rather than an error.
 fn s3_list_keys(prefix: &str) -> Result<Vec<String>> {
-    let list_url = format!("{S3_LIST}/?prefix={prefix}&list-type=2");
+    let list_url = format!("{S3_BUCKET}/?prefix={prefix}&list-type=2");
     let output = Command::new("curl")
         .args(["-sf", &list_url])
         .output()


### PR DESCRIPTION
Three fixes from the pre-open-source audit, ahead of flipping the repository public.

## Changes

- **Docs**: remove the transitional "while `trailofbits/coop` is private" wording from the README "Updating" section and `docs/commands.md`, replacing it with the actual behavior: no auth required; `coop update` uses `gh`/`GITHUB_TOKEN` opportunistically when present (avoids API rate limits). Also drop the private-repo install alternative from the quick start — `install.sh` is already visibility-agnostic.
- **HTTPS S3 listing**: `s3_list_keys` fetched the Firecracker CI bucket listing over plain HTTP, letting a network attacker steer kernel/rootfs version selection during setup. The bucket name (`spec.ccfc.min`) contains dots, so virtual-hosted HTTPS fails TLS wildcard-cert matching — the fix reuses the existing path-style HTTPS `S3_BUCKET` constant (verified live) and deletes the now-redundant `S3_LIST`.
- **Cargo.toml**: add the `repository` field. `keywords`/`categories` are left for the crates.io work tracked in #392.

## Testing

- prek hooks pass (fmt, clippy, test, taplo, whitespace).
- Local integration suite (`./tests/run-integration.sh`, macOS/Lima): 195 passed, 0 failed, 2 skipped (pre-existing skips).
- The changed S3 listing path only runs during Firecracker setup on Linux; the new URL was verified live with `curl` and the version-walk logic is unit-tested with injected `list_keys`. Remote Firecracker integration run skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)