### PR TITLE
Add `coop agent update` to refresh in-guest agents

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -282,6 +282,25 @@ exclude_re = [
   "\\bbootstrap_and_post_start\\b",
   "\\bprepare_session_from_target\\b",
 
+  # ---- coop agent update (#402): in-guest agent refresh ----
+  # The pure logic is extracted and unit-tested in scope: AgentSelection
+  # (from_flags / agents), Agent (display / strategy), AgentVersion::parse
+  # (+ from_token), check_status, check_report / check_line, outcome_line,
+  # and selection_phrase. What is excluded below drives SSH into the guest,
+  # hits the GitHub release API, writes stdout, or resolves a guest binary
+  # path from a live session — none observable from a `--lib` test.
+  # (cmd_agent_update itself is covered by the module-wide `\bcmd_[a-z_]+\b`.)
+  # tests/integration.sh exercises the end-to-end update/check on both backends.
+  "\\brun_updates\\b",
+  "\\brun_check\\b",
+  "\\bupdate_one\\b",
+  "\\breinstall_as_root\\b",
+  "\\bself_update\\b",
+  "\\bcheck_row\\b",
+  "\\bcodex_latest\\b",
+  "\\bcapture_version\\b",
+  "\\bagent_binary\\b",
+
   # NOTE on `delete field … from struct …` mutants: cargo-mutants (27.x) does
   # not honour exclude_re for these — the regex never matches their name (not
   # by function, struct path, or even file:line). They are emitted only where

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -200,6 +200,18 @@ coop start --no-agents
 
 This skips the entire bootstrap sequence. The VM boots normally but gets no API key, no GitHub token, no plugins, and no MCP servers. You can still run `coop claude` afterward, and that session forwards `ANTHROPIC_API_KEY` and any `env_forward` variables via SSH. Plugins and MCP servers won't be available unless you configure them manually inside the guest.
 
+## Updating Claude Code
+
+Claude Code auto-updates in the background by default — it checks for a newer version on startup and periodically, and applies the update on the next launch. coop does not disable this and the guest has outbound network access, so Claude Code keeps itself current with no action from you.
+
+To force an update immediately rather than waiting for the background updater:
+
+```bash
+coop agent update --claude
+```
+
+This runs `claude update` synchronously inside the guest as the guest user. It is a convenience for when you want the newest version right now; for the recurring stale-agent problem, Codex is the one that needs attention (see [Updating Codex](codex-integration.md#updating-codex)). See [`agent update`](commands.md#agent-update).
+
 ## Local model support
 
 A VM can route Claude Code at a host-side local model server (Ollama / LM Studio

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -124,6 +124,17 @@ coop start --no-agents
 
 This skips the guest bootstrap sequence entirely. The VM still includes both CLIs because they are baked into the image during `coop setup`.
 
+## Updating Codex
+
+Codex is installed "latest at build time" during `coop setup` and has no background updater, so it stays at that version until the image is rebuilt. Unlike Claude Code, it does not refresh itself. To update Codex in a running VM without rebuilding the image:
+
+```bash
+coop agent update --codex          # update Codex to the latest release
+coop agent update --check          # report installed vs. latest, change nothing
+```
+
+This re-runs coop's own Codex installer inside the guest as root, overwriting `/usr/local/bin/codex` with the current release. To refresh the golden image so new VMs ship the latest Codex, rebuild it with `coop setup --rebuild`. See [`agent update`](commands.md#agent-update).
+
 ## Local model support
 
 A VM can route Codex at a host-side local model server (Ollama / LM Studio /

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -457,6 +457,51 @@ $ coop status my-project --json
 }
 ```
 
+### `agent update`
+
+Update the coding agents (Claude Code and Codex) installed inside a running VM
+to their latest versions, without rebuilding the golden image. Both agents are
+installed "latest at build time" during `coop setup`, so they can go stale in
+long-running VMs and in new VMs created from an old image. To refresh the image
+itself instead, rebuild it with `coop setup --rebuild`.
+
+```
+coop agent update [NAME] [--claude] [--codex] [--check] [-y]
+```
+
+| Argument / Flag | Description |
+|-----------------|-------------|
+| `NAME` | Instance name (required if multiple instances exist) |
+| `--claude` | Update Claude Code |
+| `--codex` | Update Codex |
+| `--check` | Only report installed vs. latest versions — change nothing |
+| `-y`, `--yes` | Skip the confirmation prompt |
+
+With no agent flag, both agents are updated; passing both `--claude` and
+`--codex` is the same as passing neither. The VM must be running.
+
+Codex has no background updater, so `coop agent update --codex` re-runs coop's
+own installer inside the guest as root, overwriting `/usr/local/bin/codex` with
+the current release. Claude Code already auto-updates in the background;
+`coop agent update --claude` runs `claude update` now, synchronously — a
+convenience rather than a fix.
+
+`--check` reports each agent's installed version and, for Codex, the latest
+release on GitHub, changing nothing:
+
+```
+$ coop agent update my-project --check
+Claude Code  1.2.3            up to date (auto-updates in background)
+Codex        0.4.1 → 0.5.0    update available — run: coop agent update --codex
+```
+
+```
+coop agent update                 # both agents, resolved instance
+coop agent update my-project      # both agents, instance "my-project"
+coop agent update --codex         # Codex only
+coop agent update --check         # report versions, change nothing
+```
+
 ### `model`
 
 Show or switch a VM's model backend between cloud (Anthropic / OpenAI) and a

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -28,6 +28,11 @@ Every template installs these packages regardless of profile selection.
 
 **Codex CLI:** installed as a standalone binary during the template build.
 
+Both agents are installed at whatever version was current when the template was built, and that version is not part of the staleness hash — a plain `coop setup` does not refresh them. There are two ways to get newer agents:
+
+- **A live instance:** `coop agent update [--claude] [--codex]` updates the binaries inside a running VM in place (see [`agent update`](commands.md#agent-update)). Claude Code also auto-updates itself in the background; Codex does not, so it is the one that typically needs this.
+- **The golden image:** `coop setup --rebuild` rebuilds the template from a fresh base, so every new instance ships the latest agents.
+
 ## Built-in profiles
 
 Profiles layer language-specific toolchains on top of the base install. Pass them to `--profile` during setup:

--- a/scripts/guest/codex.sh
+++ b/scripts/guest/codex.sh
@@ -3,7 +3,12 @@ set -euo pipefail
 # Using if/else (not early `exit 0`) because this file is concatenated
 # with claude-code.sh into a single shell invocation; an unconditional
 # exit would short-circuit anything appended after it.
-if [ -x /usr/local/bin/codex ]; then
+#
+# COOP_FORCE_INSTALL bypasses the "already installed" guard so `coop agent
+# update --codex` can re-run this same script to overwrite the root-owned
+# binary with the current release. Unset during normal setup, so the
+# skip-if-present behaviour is preserved there.
+if [ -z "${COOP_FORCE_INSTALL:-}" ] && [ -x /usr/local/bin/codex ]; then
     echo '  [guest] Codex CLI already installed, skipping.'
 else
     echo '  [guest] Installing Codex CLI...'

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -1,0 +1,684 @@
+//! `coop agent update` — refresh the coding-agent binaries inside a running VM.
+//!
+//! Both agents are installed "latest at build time" during `coop setup`, so
+//! they go stale in long-running VMs and in VMs created from an old image.
+//! This command updates them in place against a *running* instance, without
+//! rebuilding the golden image (`coop setup --rebuild` remains the path for
+//! refreshing the image itself).
+//!
+//! The two agents differ in how they update, and the difference is encoded in
+//! [`UpdateStrategy`] so no caller can run the wrong one:
+//!
+//! - **Codex** lives at root-owned `/usr/local/bin/codex` and has no
+//!   background updater. coop re-runs its own installer ([`guest::SCRIPT_CODEX`])
+//!   as root with `COOP_FORCE_INSTALL=1` to overwrite the binary with the
+//!   current release.
+//! - **Claude Code** lives in the guest user's `~/.local/bin` and already
+//!   auto-updates in the background. `coop agent update --claude` just runs
+//!   `claude update` synchronously as the guest user — a convenience, not a
+//!   fix.
+
+use std::io::Write as _;
+
+use anyhow::{Context, Result, bail};
+use semver::Version;
+
+use crate::backend::{self, SshSession};
+use crate::paths::GuestPath;
+use crate::remote_command::RemoteCommand;
+use crate::{config, guest, prompt, update};
+
+use super::{prepare_session_from_target, resolve_running};
+
+/// Options for `coop agent update`, parsed from the CLI flags.
+pub(crate) struct AgentUpdateOpts {
+    pub selection: AgentSelection,
+    pub check: bool,
+    pub yes: bool,
+}
+
+/// The `openai/codex` release feed coop compares the guest binary against.
+const CODEX_REPO: &str = "openai/codex";
+
+// ── Domain types ──────────────────────────────────────────────
+
+/// A coding agent coop can update inside the guest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Agent {
+    Claude,
+    Codex,
+}
+
+impl Agent {
+    /// Human-facing label used in prompts, reports, and errors.
+    fn display(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude Code",
+            Self::Codex => "Codex",
+        }
+    }
+
+    /// How this agent's binary is refreshed inside the guest. The
+    /// root-vs-user asymmetry lives here so a caller can't run Claude's
+    /// self-update as root or Codex's reinstall without sudo.
+    fn strategy(self) -> UpdateStrategy {
+        match self {
+            Self::Claude => UpdateStrategy::SelfUpdate,
+            Self::Codex => UpdateStrategy::ReinstallAsRoot {
+                script: guest::SCRIPT_CODEX,
+            },
+        }
+    }
+}
+
+/// How an agent's binary is refreshed in the guest.
+enum UpdateStrategy {
+    /// Re-run coop's own installer as root, forcing overwrite of the
+    /// root-owned binary. Carries the embedded installer script.
+    ReinstallAsRoot { script: &'static str },
+    /// Invoke the agent's own updater as the guest user (no sudo).
+    SelfUpdate,
+}
+
+/// Which agents a single `coop agent update` invocation targets. No variant
+/// can represent "update nothing", so [`agents`](Self::agents) is always
+/// non-empty.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AgentSelection {
+    Claude,
+    Codex,
+    Both,
+}
+
+impl AgentSelection {
+    /// Map the two CLI booleans to a selection. Selection is additive: no
+    /// flag, or both flags, means both agents.
+    pub(crate) fn from_flags(claude: bool, codex: bool) -> Self {
+        match (claude, codex) {
+            (true, false) => Self::Claude,
+            (false, true) => Self::Codex,
+            _ => Self::Both,
+        }
+    }
+
+    fn agents(self) -> &'static [Agent] {
+        match self {
+            Self::Claude => &[Agent::Claude],
+            Self::Codex => &[Agent::Codex],
+            Self::Both => &[Agent::Claude, Agent::Codex],
+        }
+    }
+}
+
+/// A parsed agent version. The constructor extracts the first semver-looking
+/// token from arbitrary `--version` / `tag_name` output, so callers compare
+/// with `<` rather than string-diffing.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct AgentVersion(Version);
+
+impl AgentVersion {
+    /// Extract a semver version from free-form text. Handles bare `1.2.3`,
+    /// `v1.2.3`, tool-prefixed `codex-cli 0.5.0`, and dash-separated tags
+    /// like `rust-v0.42.0`. Returns `Err` when no token parses.
+    ///
+    /// The *first* semver-parseable whitespace token wins, which matches the
+    /// `--version` output of both agents today (the version leads or is the
+    /// second token). A future format that emitted another semver-shaped
+    /// token first would mis-pick; the unit tests pin the current shapes.
+    fn parse(raw: &str) -> Result<Self> {
+        raw.split_whitespace()
+            .find_map(Self::from_token)
+            .map(Self)
+            .with_context(|| format!("no semver version found in {raw:?}"))
+    }
+
+    /// Try to read a version out of one whitespace-delimited token, first as
+    /// the whole token (minus a leading `v`), then as the suffix after the
+    /// last `v` (for tags such as `rust-v0.42.0`).
+    fn from_token(token: &str) -> Option<Version> {
+        let stripped = token.strip_prefix('v').unwrap_or(token);
+        if let Ok(v) = Version::parse(stripped) {
+            return Some(v);
+        }
+        let after_v = token.rsplit_once('v').map(|(_, rest)| rest)?;
+        Version::parse(after_v).ok()
+    }
+}
+
+impl std::fmt::Display for AgentVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Result of updating one agent.
+enum UpdateOutcome {
+    Updated {
+        from: Option<AgentVersion>,
+        to: AgentVersion,
+    },
+    AlreadyCurrent {
+        version: AgentVersion,
+    },
+}
+
+/// Version-comparison result for `--check`, never a sentinel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CheckStatus {
+    UpToDate,
+    UpdateAvailable,
+    /// Claude Code updates itself in the background — coop does not track a
+    /// "latest" for it.
+    AutoUpdates,
+    /// Installed or latest version could not be determined.
+    Unknown,
+}
+
+/// One row of the `--check` report.
+struct CheckRow {
+    agent: Agent,
+    installed: Option<AgentVersion>,
+    latest: Option<AgentVersion>,
+    status: CheckStatus,
+}
+
+// ── Command entry point ───────────────────────────────────────
+
+pub(crate) fn cmd_agent_update(
+    be: &backend::PlatformBackend,
+    cfg: &config::CoopConfig,
+    name: Option<&config::InstanceName>,
+    opts: &AgentUpdateOpts,
+) -> Result<()> {
+    // Resolve the running instance once (a stopped/missing one errors here
+    // with the shared "not running" guidance), then build the SSH session
+    // from it — this mirrors `open_ssh_session` but keeps the instance name
+    // for the confirmation prompt and messages without a second lookup.
+    let running = resolve_running(be, cfg, name)?;
+    let inst_name = running.instance().name.to_string();
+    let repo = backend::detect_instance_repo(running.instance());
+    let (inst, target) = running.into_parts();
+    let session = prepare_session_from_target(cfg, Some(&inst), target, repo.as_ref())?;
+
+    if opts.check {
+        return run_check(&session, opts.selection);
+    }
+
+    if !opts.yes
+        && !prompt::confirm(&format!(
+            "Update {} in '{inst_name}' to the latest version?",
+            selection_phrase(opts.selection),
+        ))?
+    {
+        tracing::info!("Update cancelled");
+        return Ok(());
+    }
+
+    run_updates(&session, opts.selection)
+}
+
+/// Comma/and-joined agent names for the confirmation prompt.
+fn selection_phrase(selection: AgentSelection) -> String {
+    let labels: Vec<&str> = selection.agents().iter().map(|a| a.display()).collect();
+    labels.join(" and ")
+}
+
+// ── Update path ───────────────────────────────────────────────
+
+/// Update every selected agent, printing each result. Continues past a
+/// per-agent failure and returns an error only after all have run, so a
+/// `Both` update reports both outcomes even when one fails.
+fn run_updates(session: &SshSession, selection: AgentSelection) -> Result<()> {
+    let out = &mut std::io::stdout();
+    let mut failed = false;
+    for &agent in selection.agents() {
+        match update_one(session, agent) {
+            Ok(outcome) => {
+                writeln!(out, "{}", outcome_line(agent, &outcome))?;
+                if agent == Agent::Claude {
+                    writeln!(
+                        out,
+                        "  note: Claude Code also auto-updates in the background."
+                    )?;
+                }
+            }
+            Err(e) => {
+                failed = true;
+                writeln!(out, "{}: update failed — {e:#}", agent.display())?;
+            }
+        }
+    }
+    if failed {
+        bail!("one or more agents failed to update");
+    }
+    Ok(())
+}
+
+/// Update a single agent and verify the result by re-reading its version.
+fn update_one(session: &SshSession, agent: Agent) -> Result<UpdateOutcome> {
+    let before = capture_version(session, agent);
+    match agent.strategy() {
+        UpdateStrategy::ReinstallAsRoot { script } => reinstall_as_root(session, script)
+            .with_context(|| format!("failed to reinstall {}", agent.display()))?,
+        UpdateStrategy::SelfUpdate => {
+            self_update(session, agent)
+                .with_context(|| format!("failed to update {}", agent.display()))?;
+        }
+    }
+    // A readable version after the update doubles as the executable check:
+    // `capture_version` runs `<bin> --version` over SSH, which fails if the
+    // binary is missing or not runnable.
+    let after = capture_version(session, agent).with_context(|| {
+        format!(
+            "could not read {} version after update — the binary may be missing or broken",
+            agent.display(),
+        )
+    })?;
+    Ok(if before.as_ref() == Some(&after) {
+        UpdateOutcome::AlreadyCurrent { version: after }
+    } else {
+        UpdateOutcome::Updated {
+            from: before,
+            to: after,
+        }
+    })
+}
+
+/// Re-run an embedded installer script as root with the force flag set,
+/// piping the script over stdin so it never lands on argv.
+fn reinstall_as_root(session: &SshSession, script: &str) -> Result<()> {
+    session.target.exec_with_stdin(
+        RemoteCommand::new().literal("sudo env COOP_FORCE_INSTALL=1 bash -s"),
+        script.as_bytes().to_vec(),
+    )
+}
+
+/// Run an agent's own updater as the guest user (no sudo).
+fn self_update(session: &SshSession, agent: Agent) -> Result<()> {
+    let bin = agent_binary(session, agent)?;
+    session
+        .target
+        .exec(RemoteCommand::new().arg(bin).literal(" update"))
+}
+
+// ── Check path ────────────────────────────────────────────────
+
+/// Report installed-vs-latest versions for the selected agents. Mutates
+/// nothing; degrades to `Unknown` when a version can't be determined.
+fn run_check(session: &SshSession, selection: AgentSelection) -> Result<()> {
+    let rows: Vec<CheckRow> = selection
+        .agents()
+        .iter()
+        .map(|&agent| check_row(session, agent))
+        .collect();
+    let out = &mut std::io::stdout();
+    for line in check_report(&rows) {
+        writeln!(out, "{line}")?;
+    }
+    Ok(())
+}
+
+/// Gather one agent's installed/latest versions and classify them.
+fn check_row(session: &SshSession, agent: Agent) -> CheckRow {
+    let installed = capture_version(session, agent);
+    let latest = match agent {
+        Agent::Claude => None,
+        Agent::Codex => codex_latest(),
+    };
+    let status = check_status(agent, installed.as_ref(), latest.as_ref());
+    CheckRow {
+        agent,
+        installed,
+        latest,
+        status,
+    }
+}
+
+/// Best-effort lookup of the newest Codex release tag. Network failures
+/// degrade to `None` (reported as `Unknown`) rather than aborting the check.
+fn codex_latest() -> Option<AgentVersion> {
+    match update::latest_release_tag(CODEX_REPO) {
+        Ok(tag) => AgentVersion::parse(&tag).ok(),
+        Err(e) => {
+            tracing::debug!("Failed to look up latest Codex release: {e:#}");
+            None
+        }
+    }
+}
+
+/// Classify an agent's installed version against the latest known one.
+fn check_status(
+    agent: Agent,
+    installed: Option<&AgentVersion>,
+    latest: Option<&AgentVersion>,
+) -> CheckStatus {
+    match agent {
+        Agent::Claude => CheckStatus::AutoUpdates,
+        Agent::Codex => match (installed, latest) {
+            (Some(i), Some(l)) if i < l => CheckStatus::UpdateAvailable,
+            (Some(_), Some(_)) => CheckStatus::UpToDate,
+            _ => CheckStatus::Unknown,
+        },
+    }
+}
+
+// ── Pure formatting ───────────────────────────────────────────
+
+/// One line describing an update outcome.
+fn outcome_line(agent: Agent, outcome: &UpdateOutcome) -> String {
+    let label = agent.display();
+    match outcome {
+        UpdateOutcome::Updated {
+            from: Some(from),
+            to,
+        } => {
+            format!("{label}: updated {from} → {to}")
+        }
+        UpdateOutcome::Updated { from: None, to } => format!("{label}: updated to {to}"),
+        UpdateOutcome::AlreadyCurrent { version } => {
+            format!("{label}: already at the latest version ({version})")
+        }
+    }
+}
+
+/// Build the `--check` report lines: one aligned row per agent.
+fn check_report(rows: &[CheckRow]) -> Vec<String> {
+    rows.iter().map(check_line).collect()
+}
+
+fn check_line(row: &CheckRow) -> String {
+    let installed = row
+        .installed
+        .as_ref()
+        .map_or_else(|| "?".to_string(), AgentVersion::to_string);
+    let (version_col, note) = match row.status {
+        CheckStatus::UpToDate => (installed, "up to date".to_string()),
+        CheckStatus::UpdateAvailable => {
+            let latest = row
+                .latest
+                .as_ref()
+                .map_or_else(|| "?".to_string(), AgentVersion::to_string);
+            (
+                format!("{installed} → {latest}"),
+                "update available — run: coop agent update --codex".to_string(),
+            )
+        }
+        CheckStatus::AutoUpdates => (
+            installed,
+            "up to date (auto-updates in background)".to_string(),
+        ),
+        CheckStatus::Unknown => (installed, "could not determine latest version".to_string()),
+    };
+    let label = row.agent.display();
+    format!("{label:<12} {version_col:<16} {note}")
+}
+
+// ── Guest binary resolution + version capture (IO) ────────────
+
+/// Absolute guest path of an agent's binary. Claude lives under the guest
+/// user's home; Codex is system-wide.
+fn agent_binary(session: &SshSession, agent: Agent) -> Result<GuestPath> {
+    Ok(match agent {
+        Agent::Claude => guest::GuestUser::new(session.target.user.as_ref())?.claude_bin(),
+        Agent::Codex => guest::codex_bin(),
+    })
+}
+
+/// Read an agent's installed version over SSH, or `None` if the binary is
+/// absent or its output doesn't parse. The path is derived from a validated
+/// guest user, so it carries no shell metacharacters.
+fn capture_version(session: &SshSession, agent: Agent) -> Option<AgentVersion> {
+    let bin = agent_binary(session, agent).ok()?;
+    let raw = session.target.capture(&format!("{bin} --version")).ok()?;
+    AgentVersion::parse(&raw).ok()
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code — panics are assertions")]
+mod tests {
+    use super::*;
+
+    fn ver(s: &str) -> AgentVersion {
+        AgentVersion::parse(s).unwrap()
+    }
+
+    // ── selection ──────────────────────────────────────────────
+
+    #[test]
+    fn from_flags_maps_all_four_combinations() {
+        assert_eq!(
+            AgentSelection::from_flags(true, false),
+            AgentSelection::Claude
+        );
+        assert_eq!(
+            AgentSelection::from_flags(false, true),
+            AgentSelection::Codex
+        );
+        assert_eq!(
+            AgentSelection::from_flags(false, false),
+            AgentSelection::Both
+        );
+        assert_eq!(AgentSelection::from_flags(true, true), AgentSelection::Both);
+    }
+
+    #[test]
+    fn agents_is_never_empty_and_both_lists_two() {
+        assert_eq!(AgentSelection::Claude.agents(), &[Agent::Claude]);
+        assert_eq!(AgentSelection::Codex.agents(), &[Agent::Codex]);
+        assert_eq!(
+            AgentSelection::Both.agents(),
+            &[Agent::Claude, Agent::Codex]
+        );
+    }
+
+    #[test]
+    fn selection_phrase_joins_with_and() {
+        assert_eq!(selection_phrase(AgentSelection::Claude), "Claude Code");
+        assert_eq!(selection_phrase(AgentSelection::Codex), "Codex");
+        assert_eq!(
+            selection_phrase(AgentSelection::Both),
+            "Claude Code and Codex"
+        );
+    }
+
+    // ── version parsing ────────────────────────────────────────
+
+    #[test]
+    fn parse_handles_bare_and_v_prefixed() {
+        assert_eq!(ver("1.2.3"), ver("v1.2.3"));
+        assert_eq!(ver("0.5.0").to_string(), "0.5.0");
+    }
+
+    #[test]
+    fn parse_extracts_version_from_tool_prefixed_output() {
+        assert_eq!(ver("codex-cli 0.5.0"), ver("0.5.0"));
+        assert_eq!(ver("claude 1.2.3 (Claude Code)"), ver("1.2.3"));
+    }
+
+    #[test]
+    fn parse_extracts_version_from_dashed_tag() {
+        assert_eq!(ver("rust-v0.42.0"), ver("0.42.0"));
+    }
+
+    #[test]
+    fn parse_preserves_prerelease() {
+        let v = ver("1.0.0-rc.1");
+        assert_eq!(v.to_string(), "1.0.0-rc.1");
+        assert!(ver("1.0.0") > v, "release must sort above its prerelease");
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        assert!(AgentVersion::parse("no version here").is_err());
+        assert!(AgentVersion::parse("").is_err());
+        assert!(AgentVersion::parse("v1").is_err());
+    }
+
+    #[test]
+    fn version_ordering_is_semver_not_lexical() {
+        assert!(ver("0.10.0") > ver("0.9.0"));
+        assert!(ver("1.0.0") > ver("0.42.0"));
+    }
+
+    // ── check classification ───────────────────────────────────
+
+    #[test]
+    fn claude_always_reports_auto_updates() {
+        assert_eq!(
+            check_status(Agent::Claude, Some(&ver("1.2.3")), None),
+            CheckStatus::AutoUpdates
+        );
+    }
+
+    #[test]
+    fn codex_update_available_when_installed_is_older() {
+        assert_eq!(
+            check_status(Agent::Codex, Some(&ver("0.4.1")), Some(&ver("0.5.0"))),
+            CheckStatus::UpdateAvailable
+        );
+    }
+
+    #[test]
+    fn codex_up_to_date_when_equal_or_newer() {
+        assert_eq!(
+            check_status(Agent::Codex, Some(&ver("0.5.0")), Some(&ver("0.5.0"))),
+            CheckStatus::UpToDate
+        );
+        assert_eq!(
+            check_status(Agent::Codex, Some(&ver("0.6.0")), Some(&ver("0.5.0"))),
+            CheckStatus::UpToDate
+        );
+    }
+
+    #[test]
+    fn codex_unknown_when_either_version_missing() {
+        assert_eq!(
+            check_status(Agent::Codex, None, Some(&ver("0.5.0"))),
+            CheckStatus::Unknown
+        );
+        assert_eq!(
+            check_status(Agent::Codex, Some(&ver("0.5.0")), None),
+            CheckStatus::Unknown
+        );
+    }
+
+    // ── report lines ───────────────────────────────────────────
+
+    #[test]
+    fn check_line_update_available_shows_arrow_and_command() {
+        let row = CheckRow {
+            agent: Agent::Codex,
+            installed: Some(ver("0.4.1")),
+            latest: Some(ver("0.5.0")),
+            status: CheckStatus::UpdateAvailable,
+        };
+        let line = check_line(&row);
+        assert!(line.contains("0.4.1 → 0.5.0"), "{line}");
+        assert!(line.contains("coop agent update --codex"), "{line}");
+    }
+
+    #[test]
+    fn check_line_up_to_date_shows_installed_only() {
+        let row = CheckRow {
+            agent: Agent::Codex,
+            installed: Some(ver("0.5.0")),
+            latest: Some(ver("0.5.0")),
+            status: CheckStatus::UpToDate,
+        };
+        let line = check_line(&row);
+        assert!(line.contains("0.5.0"), "{line}");
+        assert!(line.contains("up to date"), "{line}");
+        assert!(!line.contains("→"), "{line}");
+    }
+
+    #[test]
+    fn check_line_auto_updates_notes_background() {
+        let row = CheckRow {
+            agent: Agent::Claude,
+            installed: Some(ver("1.2.3")),
+            latest: None,
+            status: CheckStatus::AutoUpdates,
+        };
+        let line = check_line(&row);
+        assert!(line.contains("Claude Code"), "{line}");
+        assert!(line.contains("1.2.3"), "{line}");
+        assert!(line.contains("auto-updates in background"), "{line}");
+    }
+
+    #[test]
+    fn check_line_unknown_shows_placeholder() {
+        let row = CheckRow {
+            agent: Agent::Codex,
+            installed: None,
+            latest: None,
+            status: CheckStatus::Unknown,
+        };
+        let line = check_line(&row);
+        assert!(line.contains('?'), "{line}");
+        assert!(line.contains("could not determine"), "{line}");
+    }
+
+    #[test]
+    fn check_report_has_one_line_per_agent() {
+        let rows = vec![
+            CheckRow {
+                agent: Agent::Claude,
+                installed: Some(ver("1.2.3")),
+                latest: None,
+                status: CheckStatus::AutoUpdates,
+            },
+            CheckRow {
+                agent: Agent::Codex,
+                installed: Some(ver("0.4.1")),
+                latest: Some(ver("0.5.0")),
+                status: CheckStatus::UpdateAvailable,
+            },
+        ];
+        assert_eq!(check_report(&rows).len(), 2);
+    }
+
+    // ── outcome lines ──────────────────────────────────────────
+
+    #[test]
+    fn outcome_line_updated_from_known_version() {
+        let outcome = UpdateOutcome::Updated {
+            from: Some(ver("0.4.1")),
+            to: ver("0.5.0"),
+        };
+        let line = outcome_line(Agent::Codex, &outcome);
+        assert!(line.contains("Codex"), "{line}");
+        assert!(line.contains("0.4.1 → 0.5.0"), "{line}");
+    }
+
+    #[test]
+    fn outcome_line_updated_from_unknown_version() {
+        let outcome = UpdateOutcome::Updated {
+            from: None,
+            to: ver("0.5.0"),
+        };
+        let line = outcome_line(Agent::Codex, &outcome);
+        assert!(line.contains("updated to 0.5.0"), "{line}");
+    }
+
+    #[test]
+    fn outcome_line_already_current() {
+        let outcome = UpdateOutcome::AlreadyCurrent {
+            version: ver("0.5.0"),
+        };
+        let line = outcome_line(Agent::Codex, &outcome);
+        assert!(line.contains("already at the latest"), "{line}");
+        assert!(line.contains("0.5.0"), "{line}");
+    }
+
+    #[test]
+    fn strategy_matches_agent_asymmetry() {
+        assert!(matches!(
+            Agent::Codex.strategy(),
+            UpdateStrategy::ReinstallAsRoot { .. }
+        ));
+        assert!(matches!(
+            Agent::Claude.strategy(),
+            UpdateStrategy::SelfUpdate
+        ));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@
 //! and holds the cross-domain orchestration helpers the submodules share.
 
 mod admin;
+mod agent;
 mod devcontainer;
 mod github;
 pub(crate) mod json;
@@ -14,6 +15,7 @@ mod profiles;
 mod quickstart;
 
 pub(crate) use admin::{UninstallOpts, cmd_init, cmd_uninstall, cmd_validate};
+pub(crate) use agent::{AgentSelection, AgentUpdateOpts, cmd_agent_update};
 pub(crate) use devcontainer::{
     DevcontainerInput, DevcontainerOpts, cmd_devcontainer, cmd_devcontainer_check,
     resolve_devcontainer, resolve_devcontainer_collect,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,14 +66,14 @@ use clap_complete::engine::ArgValueCandidates;
 use backend::VmBackend as _;
 use commands::json;
 use commands::{
-    DevcontainerInput, DevcontainerOpts, ProfileImageTarget, ProjectTransport, QuickstartOpts,
-    ResizeOpts, StartOpts, UninstallOpts, UpDevcontainerOpts, UpOpts, UpRuntimeOpts,
-    apply_runtime_guest_env, apply_vm_overrides, cmd_commit, cmd_destroy, cmd_devcontainer,
-    cmd_devcontainer_check, cmd_exec, cmd_github, cmd_images, cmd_init, cmd_list, cmd_model,
-    cmd_profiles, cmd_quickstart, cmd_resize, cmd_restore, cmd_shell, cmd_start, cmd_status,
-    cmd_stop, cmd_uninstall, cmd_up, cmd_validate, codex_launch_args, open_ssh_session,
-    preflight_start_target, prepend_binary, resolve_devcontainer, resolve_devcontainer_collect,
-    resolve_running,
+    AgentUpdateOpts, DevcontainerInput, DevcontainerOpts, ProfileImageTarget, ProjectTransport,
+    QuickstartOpts, ResizeOpts, StartOpts, UninstallOpts, UpDevcontainerOpts, UpOpts,
+    UpRuntimeOpts, apply_runtime_guest_env, apply_vm_overrides, cmd_agent_update, cmd_commit,
+    cmd_destroy, cmd_devcontainer, cmd_devcontainer_check, cmd_exec, cmd_github, cmd_images,
+    cmd_init, cmd_list, cmd_model, cmd_profiles, cmd_quickstart, cmd_resize, cmd_restore,
+    cmd_shell, cmd_start, cmd_status, cmd_stop, cmd_uninstall, cmd_up, cmd_validate,
+    codex_launch_args, open_ssh_session, preflight_start_target, prepend_binary,
+    resolve_devcontainer, resolve_devcontainer_collect, resolve_running,
 };
 
 #[derive(Parser)]
@@ -414,6 +414,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Manage the coding agents installed inside a VM
+    Agent {
+        #[command(subcommand)]
+        action: AgentAction,
+    },
     /// Show or switch a VM's model backend (cloud vs. local)
     Model {
         /// Instance name (required if multiple instances exist)
@@ -665,6 +670,34 @@ extra line in your shell rc:
   zsh:   source <(COMPLETE=zsh coop)
   fish:  source (COMPLETE=fish coop | psub)
 ";
+
+#[derive(Subcommand)]
+enum AgentAction {
+    /// Update coding agent(s) to the latest version inside the VM.
+    ///
+    /// With no agent flag, both Claude Code and Codex are updated. The VM
+    /// must be running.
+    Update {
+        /// Instance name (required if multiple instances exist)
+        #[arg(
+            value_parser = config::InstanceName::new,
+            add = ArgValueCandidates::new(completions::instance_candidates),
+        )]
+        name: Option<config::InstanceName>,
+        /// Update Claude Code (default: update both agents)
+        #[arg(long)]
+        claude: bool,
+        /// Update Codex (default: update both agents)
+        #[arg(long)]
+        codex: bool,
+        /// Only report installed vs. latest versions — change nothing
+        #[arg(long)]
+        check: bool,
+        /// Skip the confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+}
 
 #[derive(Subcommand, Clone, Copy)]
 enum ModelAction {
@@ -1175,6 +1208,25 @@ pub fn run() -> Result<()> {
         }
         Commands::List { json } => cmd_list(&be, &cfg, json),
         Commands::Status { name, json } => cmd_status(&be, &cfg, name.as_ref(), json),
+        Commands::Agent {
+            action:
+                AgentAction::Update {
+                    name,
+                    claude,
+                    codex,
+                    check,
+                    yes,
+                },
+        } => cmd_agent_update(
+            &be,
+            &cfg,
+            name.as_ref(),
+            &AgentUpdateOpts {
+                selection: commands::AgentSelection::from_flags(claude, codex),
+                check,
+                yes,
+            },
+        ),
         Commands::Model { name, action } => {
             cmd_model(&be, &cfg, name.as_ref(), action.map(Into::into))
         }
@@ -1362,6 +1414,64 @@ mod tests {
     fn parse_then_format_normalizes_to_seconds() {
         let parsed = super::parse_duration("1h").expect("1h parses");
         assert_eq!(super::format_duration(parsed), "3600s");
+    }
+
+    #[test]
+    fn agent_update_parses_name_and_flags() {
+        let cli = parse(&["agent", "update", "myvm", "--codex", "--check"]);
+        let super::Commands::Agent {
+            action:
+                super::AgentAction::Update {
+                    name,
+                    claude,
+                    codex,
+                    check,
+                    yes,
+                },
+        } = cli.command
+        else {
+            panic!("expected Agent::Update variant");
+        };
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("myvm")
+        );
+        assert!(!claude);
+        assert!(codex);
+        assert!(check);
+        assert!(!yes);
+    }
+
+    #[test]
+    fn agent_update_defaults_are_all_false() {
+        let cli = parse(&["agent", "update"]);
+        let super::Commands::Agent {
+            action:
+                super::AgentAction::Update {
+                    name,
+                    claude,
+                    codex,
+                    check,
+                    yes,
+                },
+        } = cli.command
+        else {
+            panic!("expected Agent::Update variant");
+        };
+        assert!(name.is_none());
+        assert!(!claude && !codex && !check && !yes);
+    }
+
+    #[test]
+    fn agent_update_yes_short_flag_parses() {
+        let cli = parse(&["agent", "update", "-y"]);
+        let super::Commands::Agent {
+            action: super::AgentAction::Update { yes, .. },
+        } = cli.command
+        else {
+            panic!("expected Agent::Update variant");
+        };
+        assert!(yes);
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -170,27 +170,40 @@ impl Release {
 }
 
 pub fn fetch_latest() -> Result<Release> {
-    fetch_release_metadata("latest").context("Failed to fetch latest release metadata")
+    fetch_release_metadata(REPO, "latest").context("Failed to fetch latest release metadata")
 }
 
 pub fn fetch_by_tag(tag: &str) -> Result<Release> {
-    fetch_release_metadata(&format!("tags/{tag}"))
+    fetch_release_metadata(REPO, &format!("tags/{tag}"))
         .with_context(|| format!("Failed to fetch release metadata for {tag}"))
 }
 
-/// Fetch release JSON for the given API path suffix (`latest` or `tags/<tag>`).
+/// Fetch the `tag_name` of another repository's latest release.
+///
+/// Used by `coop agent update` to compare the guest's installed Codex
+/// against the newest upstream tag. `repo` is a compile-time `owner/name`
+/// slug (e.g. `openai/codex`) — never user input — so it carries none of
+/// the path-traversal risk `coop update --version` guards against.
+pub(crate) fn latest_release_tag(repo: &str) -> Result<String> {
+    Ok(fetch_release_metadata(repo, "latest")
+        .with_context(|| format!("Failed to fetch latest release metadata for {repo}"))?
+        .tag)
+}
+
+/// Fetch release JSON for `repo` (an `owner/name` slug) and the given API
+/// path suffix (`latest` or `tags/<tag>`).
 ///
 /// Selects an auth strategy at call time so changes to `GITHUB_TOKEN` /
 /// `gh auth` between invocations take effect.
-fn fetch_release_metadata(path_suffix: &str) -> Result<Release> {
+fn fetch_release_metadata(repo: &str, path_suffix: &str) -> Result<Release> {
     let body = match select_auth_strategy_from_env() {
-        AuthStrategy::Gh => gh_api_capture(&format!("repos/{REPO}/releases/{path_suffix}"))?,
+        AuthStrategy::Gh => gh_api_capture(&format!("repos/{repo}/releases/{path_suffix}"))?,
         AuthStrategy::CurlBearer(token) => {
-            let url = format!("{}/repos/{REPO}/releases/{path_suffix}", api_base());
+            let url = format!("{}/repos/{repo}/releases/{path_suffix}", api_base());
             curl_capture(&url, Some(&token))?
         }
         AuthStrategy::CurlBare => {
-            let url = format!("{}/repos/{REPO}/releases/{path_suffix}", api_base());
+            let url = format!("{}/repos/{repo}/releases/{path_suffix}", api_base());
             curl_capture(&url, None)?
         }
     };

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1026,6 +1026,65 @@ test_codex_sandbox_bypass() {
     fi
 }
 
+# `coop agent update` refreshes the in-guest agent binaries (issue #402).
+# `--check` is cheap and network-tolerant (the Codex latest-version lookup
+# degrades to "unknown" on failure, so the command still exits 0). The actual
+# Codex reinstall downloads the release inside the guest, so it is gated behind
+# --full.
+test_agent_update() {
+    echo ""
+    echo "=== Phase: agent update ==="
+
+    if coop agent update "$INSTANCE" --check; then
+        if echo "$HARNESS_OUT" | grep -q "Claude Code" \
+            && echo "$HARNESS_OUT" | grep -q "Codex"; then
+            pass "agent update --check reports both agents"
+        else
+            fail "agent update --check reports both agents" "out: $HARNESS_OUT"
+        fi
+    else
+        fail "agent update --check exits 0" "exit: $? stderr: $HARNESS_ERR"
+    fi
+
+    if [[ "$FULL" == "1" ]]; then
+        if coop agent update "$INSTANCE" --codex -y; then
+            pass "agent update --codex exits 0"
+        else
+            fail "agent update --codex exits 0" "exit: $? stderr: $HARNESS_ERR"
+        fi
+
+        # The reinstall must leave an executable, correctly versioned binary.
+        local ver
+        if ver=$(guest_exec /usr/local/bin/codex --version) \
+            && [[ "$ver" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            pass "codex is executable and versioned after update ($ver)"
+        else
+            fail "codex is executable and versioned after update" \
+                "got: $ver stderr: $(guest_stderr)"
+        fi
+    else
+        skip "agent update --codex" "use --full; downloads the release in-guest"
+    fi
+}
+
+# `coop agent update` requires a running VM; against a stopped instance it must
+# fail with the shared "not running" guidance and a non-zero exit (issue #402).
+test_agent_update_stopped() {
+    echo ""
+    echo "=== Phase: agent update (stopped instance) ==="
+
+    if coop_fails agent update "$INSTANCE" --check; then
+        if echo "$HARNESS_ERR" | grep -qi "not running"; then
+            pass "agent update on a stopped instance fails with 'not running'"
+        else
+            fail "agent update on a stopped instance fails with 'not running'" \
+                "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "agent update on a stopped instance exits non-zero" "out: $HARNESS_OUT"
+    fi
+}
+
 test_github_token_forwarding() {
     echo ""
     echo "=== Phase: github token forwarding ==="
@@ -4793,6 +4852,7 @@ main() {
     test_claude_onboarding_seed
     test_codex_bin_path
     test_codex_sandbox_bypass
+    test_agent_update
     test_github_token_forwarding
     test_term_handling
     test_guest_environment
@@ -4808,6 +4868,7 @@ main() {
     test_stop_idempotency
     test_auto_resolve_stopped
     test_status_stopped
+    test_agent_update_stopped
     test_list_stopped
     test_resize_status
     test_reconfigure


### PR DESCRIPTION
Closes #402.

## Summary

Both Claude Code and Codex are installed "latest at build time" during `coop setup`, and the agent version is not part of the image-staleness hash, so a plain `coop setup` never refreshes them. They go stale in long-running VMs and in new VMs created from an old image. This adds `coop agent update` to update the agent binaries inside a *running* instance, without rebuilding the golden image (`coop setup --rebuild` remains the path for refreshing the image itself).

```
coop agent update [NAME] [--claude] [--codex] [--check] [-y]
```

No agent flag updates both; `--check` reports installed vs. latest and changes nothing. The VM must be running.

## Behavior

- **Codex** lives at root-owned `/usr/local/bin/codex` and has no background updater — it is the recurring papercut. The update re-runs coop's own installer (`SCRIPT_CODEX`) over SSH via `sudo env COOP_FORCE_INSTALL=1 bash -s` with the script piped on stdin, overwriting the binary with the current release. A new `COOP_FORCE_INSTALL` guard in `scripts/guest/codex.sh` lets the forced reinstall past the "already installed" check while preserving skip-if-present during normal setup.
- **Claude Code** lives in the guest user's `~/.local/bin` and already auto-updates in the background; `--claude` runs `claude update` synchronously as a convenience.
- **`--check`** reads installed versions in-guest (`<bin> --version`) and, for Codex, the latest release tag from GitHub. A failed lookup degrades to `Unknown` rather than erroring.

## Type design

- `UpdateStrategy` encodes the root-vs-user asymmetry so a caller can't run Claude's self-update as root or Codex's reinstall without sudo.
- `AgentSelection` has no "update nothing" variant; `agents()` is always non-empty.
- Versions are parsed to semver (`AgentVersion`), so "update available" is a comparison, not a string diff; unparseable output degrades to `Unknown`.
- `Both` updates collect per-agent results, print each, and exit non-zero if any failed.

## Tests

- Unit tests for the pure helpers: `AgentSelection::from_flags`, version parsing (bare / `v`-prefixed / tool-prefixed / dashed tag / prerelease / garbage), `--check` classification, and the report/outcome line builders; plus CLI parse tests.
- Integration phases (`tests/integration.sh`, both backends): `agent update --check` reports both agents; `agent update --codex` (under `--full`) updates and leaves an executable, versioned binary; `agent update` on a stopped instance fails with the "not running" guidance.
- `.cargo/mutants.toml` scopes the new IO/SSH/network/stdout functions out and keeps the pure helpers in scope, per the repo's mutation-testing policy.

## Docs

Added an `agent update` section to `docs/commands.md` and update notes to `docs/codex-integration.md`, `docs/claude-integration.md`, and `docs/images-and-profiles.md`.

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and the unit test suite pass. The in-guest reinstall/check paths are exercised by `tests/integration.sh`, which requires a VM and was not run in this environment — please run it on both platforms before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)