### PR TITLE
Enforce guest-memory floor by construction (#404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Fixes
 
+- **Guest-memory floor enforced by construction** (#404) — `coop up --mem 16`,
+  `coop setup --mem 16`, a `config.toml` with `mem_size_mib = 16`, and a
+  cloned repo whose `devcontainer.json` sets `hostRequirements.memory` below
+  the 128 MiB minimum are now all rejected up front, instead of booting an
+  unbootable VM that never comes up on SSH. The floor lives in a new
+  `VmMemory` type whose constructor every entry point routes through (CLI,
+  `config.toml`, `coop resize`, the devcontainer translator), so no lifecycle
+  path can hold a sub-floor value. The stale `Validated` witness — which
+  vouched for a config that lifecycle commands mutated afterward, and which
+  the actual VM boot (`create_and_start`) never even consumed — is removed;
+  the environmental (path-existence) checks it stood in for now run at the
+  backend boot choke point on the freshest filesystem state, so a new
+  lifecycle path cannot skip them. The start-time mount set gains a
+  `ValidatedMounts` constructor that enforces guest-path uniqueness on every
+  path, closing a gap where `coop quickstart` skipped the check.
+
 - **Firecracker CI artifact listing fetched over HTTPS** (#401) — the S3
   `ListObjectsV2` request that discovers kernel/rootfs versions during
   setup used plain HTTP: the bucket name contains dots, which breaks TLS

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -12,8 +12,8 @@ use toml::Value as TomlValue;
 
 use crate::cmd::Cmd;
 use crate::config::{
-    ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, LocalModel, McpServerDef, MiB,
-    NetworkConfig, Validated,
+    ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, LocalModel, McpServerDef,
+    NetworkConfig, VmMemory,
 };
 use crate::model_state::ModelState;
 use crate::paths::{GuestPath, HostPath};
@@ -741,13 +741,27 @@ fn parse_meminfo_kib(value: &str) -> Option<u64> {
 
 // ── Backend trait ──────────────────────────────────────────────
 
+/// Environmental preconditions for booting: the path-existence checks in
+/// [`CoopConfig::validate`], run at the boot choke point on the freshest
+/// filesystem state.
+///
+/// Every backend boot entry (`setup`, `create_and_start`, `start_existing`)
+/// calls this first, so the check is unforgettable — a new lifecycle path
+/// that reaches boot cannot skip it, and it sees the world as it is at boot
+/// time rather than trusting a witness minted earlier. Warnings are dropped
+/// here; they are surfaced once at the handler via
+/// [`CoopConfig::validate_and_warn`].
+pub fn boot_preflight(cfg: &CoopConfig) -> Result<()> {
+    cfg.validate().map(drop)
+}
+
 /// VM backend for managing guest lifecycle.
 ///
 /// Two impls: `FirecrackerBackend` (Linux) and `LimaBackend` (macOS).
 /// The `PlatformBackend` type alias selects the correct one at compile
 /// time via `#[cfg]`.
 pub trait VmBackend: std::fmt::Display {
-    fn setup(&self, cfg: &CoopConfig, validated: &Validated, opts: &SetupOptions) -> Result<()>;
+    fn setup(&self, cfg: &CoopConfig, opts: &SetupOptions) -> Result<()>;
     fn create_and_start(
         &self,
         cfg: &CoopConfig,
@@ -788,7 +802,7 @@ pub trait VmBackend: std::fmt::Display {
         &self,
         cfg: &CoopConfig,
         stopped: &StoppedInstance,
-        mem: Option<MiB>,
+        mem: Option<VmMemory>,
         vcpus: Option<NonZeroU8>,
         start_after: bool,
     ) -> Result<()>;
@@ -886,7 +900,8 @@ impl std::fmt::Display for FirecrackerBackend {
 
 #[cfg(not(target_os = "macos"))]
 impl VmBackend for FirecrackerBackend {
-    fn setup(&self, cfg: &CoopConfig, _: &Validated, opts: &SetupOptions) -> Result<()> {
+    fn setup(&self, cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
+        boot_preflight(cfg)?;
         crate::setup::run(cfg, opts)
     }
 
@@ -897,6 +912,7 @@ impl VmBackend for FirecrackerBackend {
         disk_gib: Option<crate::config::GiB>,
         mounts: &[crate::config::Mount],
     ) -> Result<()> {
+        boot_preflight(cfg)?;
         // Mounts are handled after boot via rsync (not virtiofs).
         // Validation already happened in Mount::parse().
         let _ = mounts;
@@ -909,6 +925,7 @@ impl VmBackend for FirecrackerBackend {
     }
 
     fn start_existing(&self, cfg: &CoopConfig, inst: &Instance) -> Result<()> {
+        boot_preflight(cfg)?;
         let vm = crate::vm::FirecrackerVm::new(cfg, inst);
         vm.configure()?;
         crate::network::setup_tap(&cfg.network, inst)?;
@@ -992,7 +1009,7 @@ impl VmBackend for FirecrackerBackend {
         &self,
         cfg: &CoopConfig,
         stopped: &StoppedInstance,
-        mem: Option<MiB>,
+        mem: Option<VmMemory>,
         vcpus: Option<NonZeroU8>,
         start_after: bool,
     ) -> Result<()> {
@@ -1001,7 +1018,7 @@ impl VmBackend for FirecrackerBackend {
         // back — otherwise `configure()` would re-read the rejected value on
         // every subsequent `coop start` and the instance would stay wedged.
         let previous = crate::vm::machine_resources(inst)?;
-        crate::vm::set_machine_resources(inst, mem, vcpus)?;
+        crate::vm::set_machine_resources(inst, mem.map(VmMemory::get), vcpus)?;
         if start_after && let Err(e) = self.start_existing(cfg, inst) {
             if let Err(revert) =
                 crate::vm::set_machine_resources(inst, Some(previous.0), Some(previous.1))
@@ -1119,7 +1136,8 @@ impl std::fmt::Display for LimaBackend {
 
 #[cfg(target_os = "macos")]
 impl VmBackend for LimaBackend {
-    fn setup(&self, cfg: &CoopConfig, _: &Validated, opts: &SetupOptions) -> Result<()> {
+    fn setup(&self, cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> {
+        boot_preflight(cfg)?;
         crate::lima::setup(cfg, opts)
     }
 
@@ -1130,10 +1148,12 @@ impl VmBackend for LimaBackend {
         disk_gib: Option<crate::config::GiB>,
         mounts: &[crate::config::Mount],
     ) -> Result<()> {
+        boot_preflight(cfg)?;
         crate::lima::create_and_start(cfg, inst, disk_gib, mounts)
     }
 
     fn start_existing(&self, cfg: &CoopConfig, inst: &Instance) -> Result<()> {
+        boot_preflight(cfg)?;
         crate::lima::start_existing(cfg, inst)
     }
 
@@ -1188,11 +1208,17 @@ impl VmBackend for LimaBackend {
         &self,
         cfg: &CoopConfig,
         stopped: &StoppedInstance,
-        mem: Option<MiB>,
+        mem: Option<VmMemory>,
         vcpus: Option<NonZeroU8>,
         start_after: bool,
     ) -> Result<()> {
-        crate::lima::set_machine_resources(cfg, stopped.instance(), mem, vcpus, start_after)
+        crate::lima::set_machine_resources(
+            cfg,
+            stopped.instance(),
+            mem.map(VmMemory::get),
+            vcpus,
+            start_after,
+        )
     }
 
     fn commit_disk(
@@ -2617,6 +2643,24 @@ Buffers:          128000 kB
 Filesystem     1M-blocks  Used Available Use% Mounted on
 /dev/vda1          20480  3200     16000  17% /
 ";
+
+    #[test]
+    fn boot_preflight_fails_on_missing_config_dir() {
+        // The boot choke point must reject a config whose custom
+        // claude.config_dir does not exist, before any VM cost (issue #404).
+        let mut cfg = CoopConfig::default();
+        cfg.claude.config_dir =
+            ConfigDir::Custom(crate::config::ConfigPath::new("/nonexistent/claude-config"));
+        let err = boot_preflight(&cfg).unwrap_err();
+        assert!(err.to_string().contains("claude.config_dir"));
+    }
+
+    #[test]
+    fn boot_preflight_passes_for_default_config() {
+        // Default config has no custom config dirs or marketplace paths, so
+        // the environmental (errors-only) check passes; warnings are dropped.
+        boot_preflight(&CoopConfig::default()).unwrap();
+    }
 
     #[test]
     fn onboarding_marked_complete_detects_true_flag() {

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -23,7 +23,7 @@ pub(crate) struct UpOpts<'a> {
     pub(crate) extra_mount: Vec<config::Mount>,
     pub(crate) git_repo: Option<&'a str>,
     pub(crate) vcpus: Option<u8>,
-    pub(crate) mem: Option<config::MiB>,
+    pub(crate) mem: Option<config::VmMemory>,
     pub(crate) disk: Option<config::GiB>,
     /// Explicit `--image NAME`, or `None` when unset. `None` selects the
     /// profile-derived image when `--profile` is given, else the default.
@@ -102,12 +102,11 @@ fn canonical_profile_list(profiles: &[String]) -> Vec<String> {
 pub(crate) fn cmd_up(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
-    validated: &config::Validated,
     config_path: &Path,
     opts: &UpOpts<'_>,
 ) -> Result<()> {
     if let Some(repo_url) = opts.git_repo {
-        return cmd_up_git_repo(be, cfg, validated, config_path, opts, repo_url);
+        return cmd_up_git_repo(be, cfg, config_path, opts, repo_url);
     }
 
     let transport = opts.transport;
@@ -159,7 +158,7 @@ pub(crate) fn cmd_up(
         return Ok(());
     }
 
-    ensure_profile_image(be, cfg, validated, opts.profile_target.as_ref())?;
+    ensure_profile_image(be, cfg, opts.profile_target.as_ref())?;
 
     create_up_instance(
         be,
@@ -175,7 +174,6 @@ pub(crate) fn cmd_up(
 fn cmd_up_git_repo(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
-    validated: &config::Validated,
     config_path: &Path,
     opts: &UpOpts<'_>,
     repo_url: &str,
@@ -211,7 +209,7 @@ fn cmd_up_git_repo(
         return Ok(());
     }
 
-    ensure_profile_image(be, cfg, validated, opts.profile_target.as_ref())?;
+    ensure_profile_image(be, cfg, opts.profile_target.as_ref())?;
     create_git_repo_instance(be, cfg, config_path, opts, repo_url)
 }
 
@@ -271,7 +269,7 @@ fn emit_up_dry_run(
         guest_user: &guest_user,
         vm: json::VmOverrides {
             vcpus: opts.vcpus,
-            mem_mib: opts.mem,
+            mem_mib: opts.mem.map(config::VmMemory::get),
             disk_gib: opts.disk,
         },
     };
@@ -335,15 +333,17 @@ fn create_up_instance(
         .unwrap_or_default();
     mounts.extend(opts.extra_mount.clone());
 
-    let workspace_dir = match opts.transport {
-        ProjectTransport::Copy => Some(project_dir_to_str(project_dir)?),
+    let (workspace_dir, rule) = match opts.transport {
+        ProjectTransport::Copy => (
+            Some(project_dir_to_str(project_dir)?),
+            workspace::WorkspaceMountRule::CopyProject,
+        ),
         ProjectTransport::Mount => {
             mounts.insert(0, project_mount.clone());
-            None
+            (None, workspace::WorkspaceMountRule::ProjectMountedOrNone)
         }
     };
-    validate_copy_workspace_mounts(opts.transport, &mounts)?;
-    config::validate_unique_guest_paths(&mounts)?;
+    let mounts = workspace::ValidatedMounts::assemble(rule, mounts)?.into_vec();
 
     let start_opts = StartOpts {
         name: None,
@@ -427,8 +427,9 @@ fn create_git_repo_instance(
         .map(|t| t.mounts.clone())
         .unwrap_or_default();
     mounts.extend(opts.extra_mount.clone());
-    workspace::validate_git_repo_workspace_mounts(&mounts)?;
-    config::validate_unique_guest_paths(&mounts)?;
+    let mounts =
+        workspace::ValidatedMounts::assemble(workspace::WorkspaceMountRule::GitRepoClone, mounts)?
+            .into_vec();
 
     let start_opts = StartOpts {
         name: None,
@@ -465,7 +466,6 @@ fn create_git_repo_instance(
 fn ensure_profile_image(
     be: &backend::PlatformBackend,
     cfg: &config::CoopConfig,
-    validated: &config::Validated,
     target: Option<&ProfileImageTarget>,
 ) -> Result<()> {
     let Some(target) = target else {
@@ -475,7 +475,6 @@ fn ensure_profile_image(
     let _guard = signal::install_handlers();
     be.setup(
         cfg,
-        validated,
         &setup::SetupOptions {
             skip_confirm: true,
             rebuild: false,
@@ -727,27 +726,6 @@ fn reject_running_up_restart_inputs(inst: &config::Instance, opts: &UpOpts<'_>) 
     Ok(())
 }
 
-fn validate_copy_workspace_mounts(
-    transport: ProjectTransport,
-    mounts: &[config::Mount],
-) -> Result<()> {
-    if transport != ProjectTransport::Copy {
-        return Ok(());
-    }
-    let workspace_path = workspace::default_workspace_path().to_string();
-    if mounts
-        .iter()
-        .any(|mount| mount.guest_path.to_string() == workspace_path)
-    {
-        bail!(
-            "`coop up --copy` already uses /workspace for the project. \
-             Give --extra-mount an explicit non-/workspace guest path, or use \
-             `coop up --mount` to mount the project itself."
-        );
-    }
-    Ok(())
-}
-
 /// Find the (single) instance whose persisted workspace state's `host_path`
 /// matches `workspace` (after canonicalisation). Returns `None` when no
 /// instance has been started for this directory; bails when multiple do
@@ -819,7 +797,7 @@ fn find_git_repo_instance(
 pub(crate) fn apply_vm_overrides(
     cfg: &mut config::CoopConfig,
     vcpus: Option<u8>,
-    mem: Option<config::MiB>,
+    mem: Option<config::VmMemory>,
     template_size: Option<config::GiB>,
 ) -> Result<()> {
     if let Some(v) = vcpus {
@@ -929,7 +907,6 @@ pub(crate) fn preflight_start_target(
 pub(crate) fn cmd_start(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
-    _: &config::Validated,
     opts: &StartOpts<'_>,
 ) -> Result<config::Instance> {
     let ws_path = opts.workspace_dir.map(Path::new);
@@ -1752,7 +1729,7 @@ pub(crate) fn cmd_status(
 pub(crate) struct ResizeOpts<'a> {
     pub(crate) name: Option<&'a config::InstanceName>,
     pub(crate) disk: Option<config::DiskSize>,
-    pub(crate) mem: Option<config::MiB>,
+    pub(crate) mem: Option<config::VmMemory>,
     pub(crate) vcpus: Option<std::num::NonZeroU8>,
     pub(crate) start: bool,
 }
@@ -1762,13 +1739,10 @@ pub(crate) fn cmd_resize(
     cfg: &config::CoopConfig,
     opts: &ResizeOpts<'_>,
 ) -> Result<()> {
-    // Reject a below-minimum memory before touching any artifact, so a bad
-    // value never leaves a half-applied instance (the CLI ArgGroup already
-    // guarantees at least one of size/mem/vcpus is present).
-    if let Some(mem) = opts.mem {
-        config::validate_mem_size(mem)?;
-    }
-
+    // A below-minimum `--mem` is rejected at the CLI boundary by
+    // `VmMemory::parse_cli`, so `opts.mem` is already provably bootable
+    // here; no half-applied instance can result from a bad value. (The CLI
+    // ArgGroup guarantees at least one of size/mem/vcpus is present.)
     let inst = cfg.resolve_instance(opts.name)?;
     let stopped = be.as_stopped(inst)?;
 
@@ -2247,8 +2221,11 @@ mod tests {
         std::fs::create_dir(&data).expect("data");
         let mounts = vec![super::config::Mount::parse(data.to_str().unwrap()).expect("mount")];
 
-        let err = super::validate_copy_workspace_mounts(super::ProjectTransport::Copy, &mounts)
-            .expect_err("expected /workspace collision");
+        let err = crate::workspace::ValidatedMounts::assemble(
+            crate::workspace::WorkspaceMountRule::CopyProject,
+            mounts,
+        )
+        .expect_err("expected /workspace collision");
         assert!(format!("{err}").contains("/workspace"));
     }
 
@@ -2485,7 +2462,8 @@ mod tests {
 
         let mut opts = up_opts_for_tests(None);
         opts.vcpus = Some(7);
-        opts.mem = super::config::MiB::new(2048);
+        opts.mem =
+            Some(super::config::VmMemory::new(super::config::MiB::new(2048).unwrap()).unwrap());
         opts.disk = super::config::GiB::new(50);
         opts.extra_mount =
             vec![super::config::Mount::parse(mount_dir.to_str().unwrap()).expect("mount")];
@@ -2503,7 +2481,10 @@ mod tests {
         let inputs = super::up_translator_inputs(&cfg, &opts);
 
         assert_eq!(inputs.cli_vcpus, Some(7));
-        assert_eq!(inputs.cli_mem_mib, super::config::MiB::new(2048));
+        assert_eq!(
+            inputs.cli_mem_mib,
+            Some(super::config::VmMemory::new(super::config::MiB::new(2048).unwrap()).unwrap())
+        );
         assert_eq!(inputs.cli_disk_gib, super::config::GiB::new(50));
         assert_eq!(inputs.cli_post_start.as_deref(), Some("echo hi"));
         assert_eq!(
@@ -2616,7 +2597,8 @@ mod tests {
         };
 
         let mut opts = up_opts_for_tests(project.to_str());
-        opts.mem = super::config::MiB::new(2048);
+        opts.mem =
+            Some(super::config::VmMemory::new(super::config::MiB::new(2048).unwrap()).unwrap());
         reject(&opts).expect_err("--mem must be rejected");
 
         let mut opts = up_opts_for_tests(project.to_str());
@@ -2703,7 +2685,8 @@ mod tests {
         let dc = tmp.path().join("devcontainer.json");
 
         let mut opts = up_opts_for_tests(None);
-        opts.mem = super::config::MiB::new(2048);
+        opts.mem =
+            Some(super::config::VmMemory::new(super::config::MiB::new(2048).unwrap()).unwrap());
         super::ensure_up_existing_inputs_are_compatible_for_git_repo(&inst, &opts)
             .expect_err("--mem must be rejected");
 

--- a/src/commands/quickstart.rs
+++ b/src/commands/quickstart.rs
@@ -33,7 +33,7 @@ pub(crate) fn cmd_quickstart(
     config_path: &Path,
     opts: &QuickstartOpts,
 ) -> Result<()> {
-    let validated = cfg.validate_and_warn()?;
+    cfg.validate_and_warn()?;
     let image = config::default_image_name();
 
     if be.image_is_built(cfg, &image) {
@@ -43,7 +43,6 @@ pub(crate) fn cmd_quickstart(
         let _guard = signal::install_handlers();
         be.setup(
             cfg,
-            &validated,
             &setup::SetupOptions {
                 skip_confirm: true,
                 rebuild: false,
@@ -78,7 +77,6 @@ pub(crate) fn cmd_quickstart(
             cmd_start(
                 be,
                 cfg,
-                &validated,
                 &StartOpts {
                     name: Some(&inst.name),
                     workspace_dir: None,
@@ -101,7 +99,6 @@ pub(crate) fn cmd_quickstart(
             be,
             cfg,
             config_path,
-            &validated,
             &image,
             workspace_dir.as_deref(),
             opts.no_devcontainer,
@@ -127,7 +124,6 @@ fn quickstart_fresh_start(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
     config_path: &Path,
-    validated: &config::Validated,
     image: &config::ImageName,
     workspace_dir: Option<&Path>,
     no_devcontainer: bool,
@@ -170,10 +166,14 @@ fn quickstart_fresh_start(
         devcontainer::effective_disk(None, translation.as_ref().unwrap_or(&default_translation));
     let post_start_override = translation.as_ref().and_then(|t| t.post_start.clone());
 
-    let final_mounts = translation
-        .as_ref()
-        .map(|t| t.mounts.clone())
-        .unwrap_or_default();
+    let final_mounts = crate::workspace::ValidatedMounts::assemble(
+        crate::workspace::WorkspaceMountRule::ProjectMountedOrNone,
+        translation
+            .as_ref()
+            .map(|t| t.mounts.clone())
+            .unwrap_or_default(),
+    )?
+    .into_vec();
 
     let workspace_str = workspace_dir
         .map(|p| {
@@ -199,7 +199,6 @@ fn quickstart_fresh_start(
         applied_devcontainer: translation.as_ref().and_then(|t| t.applied.clone()),
     };
 
-    let _ = validated;
     allocate_and_start(be, cfg, None, image, workspace_dir, &start_opts)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,19 +228,58 @@ impl Quantity<MibUnit> {
 }
 
 /// Smallest guest memory that boots reliably. Below this the kernel
-/// fails to come up, so it is rejected both when validating the global
-/// config and when reconfiguring an existing instance via `coop resize`.
+/// fails to come up, so it is the floor enforced by [`VmMemory::new`].
 pub const MIN_MEM_MIB: MiB = MiB::from_nonzero(NonZeroU32::new(128).unwrap());
 
-/// Reject a requested memory size below [`MIN_MEM_MIB`].
+/// Guest RAM that is provably bootable: at least [`MIN_MEM_MIB`].
 ///
-/// Shared by `CoopConfig::validate` (global config) and `coop resize`
-/// (`--mem` on an existing instance) so both enforce the same floor.
-pub fn validate_mem_size(mem: MiB) -> Result<()> {
-    if mem < MIN_MEM_MIB {
-        bail!("mem_size_mib={mem} is too low (minimum {MIN_MEM_MIB})");
+/// `MiB` is a generic byte quantity whose only invariant is non-zero;
+/// the 128 MiB floor is domain-specific to *VM memory*, so it lives here
+/// rather than on `MiB`. Every entry point that sets guest memory — the
+/// `--mem` CLI flag, `config.toml`, `coop resize`, and the devcontainer
+/// translator — constructs through [`Self::new`], so no path can hold an
+/// unbootable value. This is parse-don't-validate: the floor is a
+/// property of the type, not a check a caller must remember to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VmMemory(MiB);
+
+impl VmMemory {
+    /// Wrap a `MiB`, rejecting anything below [`MIN_MEM_MIB`].
+    pub fn new(mib: MiB) -> Result<Self> {
+        if mib < MIN_MEM_MIB {
+            bail!("mem_size_mib={mib} is too low (minimum {MIN_MEM_MIB})");
+        }
+        Ok(Self(mib))
     }
-    Ok(())
+
+    /// Clap value parser for `--mem`: a positive integer at or above the floor.
+    pub fn parse_cli(s: &str) -> Result<Self> {
+        Self::new(MiB::parse_cli(s)?)
+    }
+
+    /// The underlying mebibyte quantity.
+    pub fn get(self) -> MiB {
+        self.0
+    }
+}
+
+impl fmt::Display for VmMemory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Serialize for VmMemory {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for VmMemory {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let mib = MiB::deserialize(d)?;
+        Self::new(mib).map_err(serde::de::Error::custom)
+    }
 }
 
 /// Disk size specification: absolute (`150`) or relative (`+20`), in GiB.
@@ -739,9 +778,10 @@ pub struct VmConfig {
     #[serde(default = "default_vcpus")]
     pub vcpu_count: NonZeroU8,
 
-    /// Memory size in MiB
+    /// Memory size in MiB. Typed [`VmMemory`], so the [`MIN_MEM_MIB`]
+    /// floor holds by construction — including on `config.toml` load.
     #[serde(default = "default_mem_mib")]
-    pub mem_size_mib: MiB,
+    pub mem_size_mib: VmMemory,
 
     /// Path to vmlinux kernel image
     #[serde(default = "default_kernel_path")]
@@ -1768,16 +1808,6 @@ fn unique_instance_name(base: &str, instances: &[Instance]) -> Result<InstanceNa
     bail!("Could not find unique instance name for '{base}'")
 }
 
-/// Witness that [`CoopConfig::validate_and_warn`] has been run.
-///
-/// Only obtainable via [`CoopConfig::validate_and_warn`] (the unit field
-/// is private). Functions that depend on the paths probed by
-/// [`CoopConfig::validate`] take `&Validated` so the compiler refuses
-/// calls that skipped validation. Sibling to `RunningInstance` in
-/// `backend.rs`.
-#[must_use]
-pub struct Validated(());
-
 /// Expand a leading `~` in each marketplace entry that is a path.
 ///
 /// Marketplace entries can be a URL, a GitHub repo slug, or a host
@@ -1834,22 +1864,25 @@ impl CoopConfig {
         }
     }
 
-    /// Run `validate` and surface warnings via `tracing::warn`, returning
-    /// a [`Validated`] witness.
+    /// Fail fast on config errors and surface warnings via `tracing::warn`.
     ///
-    /// Commands that consume the paths probed by [`Self::validate`]
-    /// (`setup`, `build`, `start`) take `&Validated` so the compiler
-    /// enforces the precondition. Query commands (`list`/`status`/`logs`)
-    /// skip the call and don't need the witness, so an unrelated config
-    /// error (e.g. a stale `claude.config_dir`) can't block them.
+    /// Lifecycle commands (`up`/`setup`/`start`/`quickstart`) call this at
+    /// the handler boundary so a broken config aborts before any expensive
+    /// work (image build, PAT prompt, VM boot). It is *not* the gate: the
+    /// authoritative environmental check runs at the boot choke point
+    /// ([`crate::backend::boot_preflight`], inside each backend's
+    /// `setup`/`create_and_start`/`start_existing`) on the freshest
+    /// filesystem state, so a new lifecycle path cannot skip it. Query
+    /// commands (`list`/`status`/`logs`) skip this call, so an unrelated
+    /// config error (e.g. a stale `claude.config_dir`) can't block them.
     ///
-    /// `coop validate` keeps using [`Self::validate`] directly because
-    /// it prints warnings to stdout instead of routing them to tracing.
-    pub fn validate_and_warn(&self) -> Result<Validated> {
+    /// `coop validate` uses [`Self::validate`] directly because it prints
+    /// warnings to stdout instead of routing them to tracing.
+    pub fn validate_and_warn(&self) -> Result<()> {
         for w in self.validate()? {
             tracing::warn!("{w}");
         }
-        Ok(Validated(()))
+        Ok(())
     }
 
     /// Validate config values, returning all problems found.
@@ -1861,12 +1894,18 @@ impl CoopConfig {
         let mut errors: Vec<String> = Vec::new();
         let mut warnings: Vec<String> = Vec::new();
 
-        // VM config bounds
-        // vcpu_count, mem_size_mib, template_size_gib, and ssh_port are
-        // NonZero types — zero is rejected at deserialization time.
-        if let Err(e) = validate_mem_size(self.vm.mem_size_mib) {
-            errors.push(e.to_string());
-        }
+        // VM config value bounds are enforced by construction, not here:
+        // `vcpu_count`/`template_size_gib`/`ssh_port` are NonZero types
+        // (zero rejected at deserialization) and `mem_size_mib` is
+        // `VmMemory` (the 128 MiB floor holds by construction). `validate`
+        // is therefore environmental-only — every check below probes
+        // filesystem state, which no value invariant can witness.
+        //
+        // Keep it that way: a new *value* bound belongs in the field's
+        // constructor (parse-don't-validate), not in this pass, so it
+        // cannot be bypassed by a lifecycle path that mutates config after
+        // validation. Only *environmental* checks (path existence) belong
+        // here; they are re-run at the boot choke point on fresh state.
 
         // Path checks
         if let Some(parent) = self.data_dir.parent()
@@ -2489,9 +2528,12 @@ fn default_vcpus() -> NonZeroU8 {
     NonZeroU8::new(2).expect("2 is non-zero")
 }
 
-fn default_mem_mib() -> MiB {
-    #[expect(clippy::expect_used, reason = "literal is provably non-zero")]
-    MiB::new(4096).expect("4096 is non-zero")
+fn default_mem_mib() -> VmMemory {
+    #[expect(
+        clippy::expect_used,
+        reason = "literal is provably non-zero and above the 128 MiB floor"
+    )]
+    VmMemory::new(MiB::new(4096).expect("4096 is non-zero")).expect("4096 MiB is above the floor")
 }
 
 fn default_kernel_path() -> ConfigPath {
@@ -3768,7 +3810,7 @@ skip = ["not-a-slug"]
     fn load_missing_file_returns_defaults() {
         let cfg = CoopConfig::load(Path::new("/nonexistent/config.toml")).unwrap();
         assert_eq!(cfg.vm.vcpu_count.get(), 2);
-        assert_eq!(cfg.vm.mem_size_mib, MiB::new(4096).unwrap());
+        assert_eq!(cfg.vm.mem_size_mib.get(), MiB::new(4096).unwrap());
         assert_eq!(cfg.ssh_port.get(), 22);
         assert_eq!(cfg.network.host_ip, Ipv4Addr::new(172, 16, 0, 1));
         assert_eq!(cfg.network.subnet_mask, SubnetMask::new(24).unwrap());
@@ -4129,7 +4171,7 @@ skip = ["not-a-slug"]
         assert_eq!(cfg.ssh_port.get(), 2222);
         assert_eq!(cfg.vm.vcpu_count.get(), 4);
         // Unspecified fields get defaults
-        assert_eq!(cfg.vm.mem_size_mib, MiB::new(4096).unwrap());
+        assert_eq!(cfg.vm.mem_size_mib.get(), MiB::new(4096).unwrap());
         assert_eq!(cfg.network.host_ip, Ipv4Addr::new(172, 16, 0, 1));
     }
 
@@ -4170,7 +4212,7 @@ skip = ["not-a-slug"]
         fs::write(&path, "[vm]\nmem_size_mib = 8192\n").unwrap();
 
         let cfg = CoopConfig::load(&path).unwrap();
-        assert_eq!(cfg.vm.mem_size_mib, MiB::new(8192).unwrap());
+        assert_eq!(cfg.vm.mem_size_mib.get(), MiB::new(8192).unwrap());
         assert_eq!(cfg.vm.vcpu_count.get(), 2);
         assert_eq!(cfg.vm.template_size_gib, GiB::new(8).unwrap());
     }
@@ -4300,29 +4342,44 @@ skip = ["not-a-slug"]
         assert!(warnings.len() <= 3, "unexpected warnings: {warnings:?}");
     }
 
-    // Zero-value rejection is now enforced by NonZero types at
-    // deserialization time (tested in the "NonZero type enforcement"
-    // section above). The validate() method only checks semantic
-    // bounds like mem_size_mib >= 128.
+    // Zero-value rejection is enforced by NonZero types at deserialization
+    // time (tested in the "NonZero type enforcement" section above). The
+    // guest-memory floor is enforced by construction via `VmMemory::new`
+    // (tested below), not in `validate()` — so an unbootable value is
+    // unrepresentable rather than caught by a late pass.
 
     #[test]
-    fn validate_rejects_low_memory() {
-        let mut cfg = CoopConfig::default();
-        cfg.vm.mem_size_mib = MiB::new(64).unwrap();
-        let err = cfg.validate().unwrap_err();
-        assert!(err.to_string().contains("mem_size_mib=64 is too low"));
-    }
-
-    #[test]
-    fn validate_mem_size_rejects_below_minimum() {
-        let err = super::validate_mem_size(MiB::new(127).unwrap()).unwrap_err();
+    fn vm_memory_rejects_below_minimum() {
+        let err = VmMemory::new(MiB::new(127).unwrap()).unwrap_err();
         assert!(err.to_string().contains("mem_size_mib=127 is too low"));
     }
 
     #[test]
-    fn validate_mem_size_accepts_minimum_and_above() {
-        super::validate_mem_size(super::MIN_MEM_MIB).unwrap();
-        super::validate_mem_size(MiB::new(4096).unwrap()).unwrap();
+    fn vm_memory_accepts_minimum_and_above() {
+        assert_eq!(VmMemory::new(MIN_MEM_MIB).unwrap().get(), MIN_MEM_MIB);
+        assert_eq!(
+            VmMemory::new(MiB::new(4096).unwrap()).unwrap().get(),
+            MiB::new(4096).unwrap()
+        );
+    }
+
+    #[test]
+    fn vm_memory_parse_cli_enforces_floor() {
+        assert!(VmMemory::parse_cli("16").is_err());
+        assert!(VmMemory::parse_cli("0").is_err());
+        assert_eq!(VmMemory::parse_cli("128").unwrap().get(), MIN_MEM_MIB);
+    }
+
+    #[test]
+    fn vm_memory_deserialize_enforces_floor() {
+        // config.toml with a below-floor mem_size_mib is rejected at load.
+        let err = toml::from_str::<CoopConfig>("[vm]\nmem_size_mib = 16\n").unwrap_err();
+        assert!(
+            err.to_string().contains("is too low"),
+            "expected floor error, got: {err}"
+        );
+        let cfg: CoopConfig = toml::from_str("[vm]\nmem_size_mib = 256\n").unwrap();
+        assert_eq!(cfg.vm.mem_size_mib.get(), MiB::new(256).unwrap());
     }
 
     #[test]
@@ -4402,14 +4459,17 @@ skip = ["not-a-slug"]
     #[test]
     fn validate_collects_multiple_errors() {
         let mut cfg = CoopConfig::default();
-        cfg.vm.mem_size_mib = MiB::new(64).unwrap();
         cfg.claude.config_dir = ConfigDir::Custom(ConfigPath::new("/nonexistent/claude-config"));
+        cfg.codex.config_dir = ConfigDir::Custom(ConfigPath::new("/nonexistent/codex-config"));
         let err = cfg.validate().unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("mem_size_mib"), "missing mem error: {msg}");
         assert!(
             msg.contains("claude.config_dir"),
-            "missing config_dir error: {msg}"
+            "missing claude config_dir error: {msg}"
+        );
+        assert!(
+            msg.contains("codex.config_dir"),
+            "missing codex config_dir error: {msg}"
         );
     }
 
@@ -4433,16 +4493,9 @@ skip = ["not-a-slug"]
         }
     }
 
-    // Pins `mem_size_mib < 128` against `<= 128`: the boundary value
-    // 128 must be accepted.
-    #[test]
-    fn validate_accepts_min_memory_boundary() {
-        let tmp = TempDir::new().unwrap();
-        let mut cfg = validate_fixture(tmp.path());
-        cfg.vm.mem_size_mib = MiB::new(128).unwrap();
-        // 128 is the documented minimum; the boundary value itself must pass.
-        cfg.validate().unwrap();
-    }
+    // The `mem_size_mib < 128` vs `<= 128` boundary is pinned by
+    // `vm_memory_rejects_below_minimum` / `vm_memory_accepts_minimum_and_above`
+    // now that the floor lives in `VmMemory::new`, not `validate()`.
 
     // Pins both `!parent.as_os_str().is_empty()` and `!parent.exists()`:
     // with a non-empty, non-existent parent, the warning must fire.
@@ -5793,7 +5846,10 @@ skip = ["not-a-slug"]
     /// without an `Arbitrary` impl for every leaf type.
     fn arb_config() -> impl Strategy<Value = CoopConfig> {
         (
-            1u32..=u32::MAX,
+            // Guest memory must stay at or above the floor: `VmMemory`
+            // rejects anything below `MIN_MEM_MIB` at deserialize, so a
+            // lower value would fail the serde round-trip this drives.
+            MIN_MEM_MIB.as_u32()..=u32::MAX,
             1u8..=u8::MAX,
             1u32..=u32::MAX,
             arb_subnet_mask(),
@@ -5804,7 +5860,7 @@ skip = ["not-a-slug"]
             .prop_map(
                 |(mem, vcpu, template, subnet_mask, host_iface, forward_ports, post_start)| {
                     let mut cfg = CoopConfig::default();
-                    cfg.vm.mem_size_mib = MiB::new(mem).unwrap();
+                    cfg.vm.mem_size_mib = VmMemory::new(MiB::new(mem).unwrap()).unwrap();
                     cfg.vm.vcpu_count = NonZeroU8::new(vcpu).unwrap();
                     cfg.vm.template_size_gib = GiB::new(template).unwrap();
                     cfg.network.subnet_mask = subnet_mask;

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::config::{self, CoopConfig, GiB, MiB, Mount, PortForward};
+use crate::config::{self, CoopConfig, GiB, MiB, Mount, PortForward, VmMemory};
 use crate::devcontainer_oci::{FeatureRequest, ResolvedFeature};
 use crate::guest::{BuiltinProfile, GuestUser, builtin_for_feature};
 use crate::guest_env_state::EnvVarName;
@@ -501,7 +501,7 @@ impl Report {
 #[derive(Debug, Default)]
 pub struct TranslatorInputs {
     pub cli_vcpus: Option<u8>,
-    pub cli_mem_mib: Option<MiB>,
+    pub cli_mem_mib: Option<VmMemory>,
     pub cli_disk_gib: Option<GiB>,
     pub cli_post_start: Option<String>,
     pub cli_guest_env_keys: Vec<EnvVarName>,
@@ -1569,7 +1569,11 @@ pub fn apply_to_config(cfg: &mut CoopConfig, t: &Translation) -> Result<()> {
             std::num::NonZeroU8::new(v).context("translated --vcpus value resolved to zero")?;
     }
     if let Some(m) = t.mem_mib {
-        cfg.vm.mem_size_mib = m;
+        // Enforce the guest-memory floor on the devcontainer vector too: a
+        // cloned repo's `hostRequirements.memory` is external, user-editable
+        // input and must not be able to request an unbootable VM.
+        cfg.vm.mem_size_mib = VmMemory::new(m)
+            .context("devcontainer.json hostRequirements.memory is below the guest-memory floor")?;
     }
     if let Some(p) = &t.post_start {
         cfg.post_start = Some(p.clone());
@@ -2215,7 +2219,7 @@ mod tests {
         apply_to_config(&mut cfg, &t).unwrap();
 
         assert_eq!(cfg.vm.vcpu_count.get(), 6);
-        assert_eq!(cfg.vm.mem_size_mib.as_u32(), 2048);
+        assert_eq!(cfg.vm.mem_size_mib.get().as_u32(), 2048);
         assert_eq!(cfg.post_start.as_deref(), Some("echo go"));
         assert_eq!(
             cfg.guest_env
@@ -2223,6 +2227,26 @@ mod tests {
                 .map(String::as_str),
             Some("bar"),
         );
+    }
+
+    #[test]
+    fn apply_to_config_rejects_below_floor_devcontainer_memory() {
+        // hostRequirements.memory from a cloned repo's devcontainer.json is
+        // external input; a below-floor value must be rejected here rather
+        // than booting an unbootable VM (issue #404).
+        let mut cfg = CoopConfig::default();
+        let before = cfg.vm.mem_size_mib;
+        let t = Translation {
+            mem_mib: MiB::new(16),
+            ..Translation::default()
+        };
+        let err = apply_to_config(&mut cfg, &t).unwrap_err();
+        assert!(
+            err.to_string().contains("hostRequirements.memory")
+                || format!("{err:#}").contains("is too low"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(cfg.vm.mem_size_mib, before, "config must be left unchanged");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,8 @@ enum Commands {
         #[arg(long)]
         vcpus: Option<u8>,
         /// Memory in MiB (overrides config when creating a new instance)
-        #[arg(long, value_parser = config::MiB::parse_cli)]
-        mem: Option<config::MiB>,
+        #[arg(long, value_parser = config::VmMemory::parse_cli)]
+        mem: Option<config::VmMemory>,
         /// Instance disk size in GiB (only used when creating a new instance)
         #[arg(long, value_parser = config::GiB::parse_cli)]
         disk: Option<config::GiB>,
@@ -203,8 +203,8 @@ enum Commands {
         #[arg(long)]
         vcpus: Option<u8>,
         /// Memory in MiB (overrides config)
-        #[arg(long, value_parser = config::MiB::parse_cli)]
-        mem: Option<config::MiB>,
+        #[arg(long, value_parser = config::VmMemory::parse_cli)]
+        mem: Option<config::VmMemory>,
         /// Force rebuild of template rootfs
         #[arg(long)]
         rebuild: bool,
@@ -555,8 +555,8 @@ enum Commands {
         #[arg(long, value_parser = config::DiskSize::parse)]
         size: Option<config::DiskSize>,
         /// New memory in MiB (minimum 128)
-        #[arg(long, value_parser = config::MiB::parse_cli)]
-        mem: Option<config::MiB>,
+        #[arg(long, value_parser = config::VmMemory::parse_cli)]
+        mem: Option<config::VmMemory>,
         /// New vCPU count
         #[arg(long)]
         vcpus: Option<std::num::NonZeroU8>,
@@ -947,7 +947,7 @@ pub fn run() -> Result<()> {
             dry_run,
             json,
         } => {
-            let validated = cfg.validate_and_warn()?;
+            cfg.validate_and_warn()?;
             let transport = match (copy, mount) {
                 (_, true) => ProjectTransport::Mount,
                 (_, false) => ProjectTransport::Copy,
@@ -989,7 +989,7 @@ pub fn run() -> Result<()> {
                     json,
                 },
             };
-            cmd_up(&be, &mut cfg, &validated, &cli.config, &opts)
+            cmd_up(&be, &mut cfg, &cli.config, &opts)
         }
         Commands::Quickstart {
             no_workspace,
@@ -1020,7 +1020,7 @@ pub fn run() -> Result<()> {
             no_devcontainer,
             dry_run,
         } => {
-            let validated = cfg.validate_and_warn()?;
+            cfg.validate_and_warn()?;
             let ws_path = workspace.as_deref().map(Path::new);
             let inputs = devcontainer::TranslatorInputs {
                 cli_vcpus: vcpus,
@@ -1069,7 +1069,6 @@ pub fn run() -> Result<()> {
             let _guard = signal::install_handlers();
             be.setup(
                 &cfg,
-                &validated,
                 &setup::SetupOptions {
                     skip_confirm: yes,
                     rebuild,
@@ -1100,7 +1099,7 @@ pub fn run() -> Result<()> {
             dry_run,
             json: json_out,
         } => {
-            let validated = cfg.validate_and_warn()?;
+            cfg.validate_and_warn()?;
             if raw_args_use_deprecated_no_claude(&raw_args) {
                 tracing::warn!(
                     "--no-claude is deprecated and will be removed in a future release; use --no-agents"
@@ -1169,7 +1168,7 @@ pub fn run() -> Result<()> {
             };
             preflight_start_target(&be, &cfg, &start_opts)?;
             apply_runtime_guest_env(&mut cfg, &guest_env, None, &mut start_opts);
-            cmd_start(&be, &mut cfg, &validated, &start_opts).map(|_| ())
+            cmd_start(&be, &mut cfg, &start_opts).map(|_| ())
         }
         Commands::Shell { name, command } => cmd_shell(&be, &cfg, name.as_ref(), &command),
         Commands::Claude {

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -132,7 +132,7 @@ pub fn create_and_start(
         // size can't be read.
         base_image_size_gib(&base_img).unwrap_or(cfg.vm.template_size_gib)
     });
-    let mem_gib = cfg.vm.mem_size_mib.as_gib_f64();
+    let mem_gib = cfg.vm.mem_size_mib.get().as_gib_f64();
     let mut child = Command::new("limactl")
         .arg("start")
         .arg(&effective_template)
@@ -1286,7 +1286,7 @@ containerd:
         image_path = base_img.display(),
         arch = arch,
         vcpus = cfg.vm.vcpu_count,
-        mem_gib = cfg.vm.mem_size_mib.as_gib_f64(),
+        mem_gib = cfg.vm.mem_size_mib.get().as_gib_f64(),
         disk_gib = cfg.vm.template_size_gib,
     );
 
@@ -1358,7 +1358,7 @@ provision:
 {script}
 "#,
         vcpus = cfg.vm.vcpu_count,
-        mem_gib = cfg.vm.mem_size_mib.as_gib_f64(),
+        mem_gib = cfg.vm.mem_size_mib.get().as_gib_f64(),
         disk_gib = cfg.vm.template_size_gib,
         script = indented,
     )

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -97,7 +97,7 @@ fn build_config(cfg: &CoopConfig, inst: &Instance) -> FirecrackerConfig {
         }],
         machine_config: MachineConfig {
             vcpu_count: cfg.vm.vcpu_count.get(),
-            mem_size_mib: cfg.vm.mem_size_mib.as_u32(),
+            mem_size_mib: cfg.vm.mem_size_mib.get().as_u32(),
         },
         network_interfaces: vec![NetworkInterface {
             iface_id: "eth0".to_string(),
@@ -454,7 +454,7 @@ impl<'a> FirecrackerVm<'a, Running> {
         // authoritative per-instance config, not the global default.
         let machine = read_machine_config(&self.inst.vm_config_path()).unwrap_or(MachineConfig {
             vcpu_count: self.cfg.vm.vcpu_count.get(),
-            mem_size_mib: self.cfg.vm.mem_size_mib.as_u32(),
+            mem_size_mib: self.cfg.vm.mem_size_mib.get().as_u32(),
         });
 
         let mut out = format!(

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -377,20 +377,67 @@ pub(crate) fn default_workspace_path() -> GuestPath {
     GuestPath::absolute(GUEST_WORKSPACE).expect("GUEST_WORKSPACE constant is absolute")
 }
 
-/// Reject an extra mount that would collide with the `/workspace` path a
-/// `coop up --git-repo` clone occupies.
-pub(crate) fn validate_git_repo_workspace_mounts(mounts: &[Mount]) -> Result<()> {
-    let workspace_path = default_workspace_path().to_string();
-    if mounts
-        .iter()
-        .any(|mount| mount.guest_path.to_string() == workspace_path)
-    {
-        bail!(
-            "`coop up --git-repo` clones into /workspace. \
-             Give --extra-mount an explicit non-/workspace guest path."
-        );
+/// Which project-mount policy applies when assembling a start-time mount
+/// set. Only the workspace-collision message differs between rules; every
+/// rule also enforces guest-path uniqueness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkspaceMountRule {
+    /// `coop up --copy`: the project occupies `/workspace` via copy, so an
+    /// extra mount targeting `/workspace` collides.
+    CopyProject,
+    /// `coop up --git-repo`: the clone occupies `/workspace`.
+    GitRepoClone,
+    /// The project is itself mounted at `/workspace` (`coop up --mount`), or
+    /// there is no project mount (`coop quickstart`). `/workspace` is either
+    /// legitimately in use or absent, so only uniqueness applies (a second
+    /// `/workspace` mount is still caught, as a duplicate guest path).
+    ProjectMountedOrNone,
+}
+
+/// A start-time mount set that has passed collection-level validation: no
+/// two mounts target the same guest path, and — per [`WorkspaceMountRule`]
+/// — no extra mount collides with the project's `/workspace`.
+///
+/// [`Self::assemble`] is the single place these invariants are enforced, so
+/// no lifecycle path (`up --copy`, `up --mount`, `up --git-repo`,
+/// `quickstart`) can build a mount set and forget to check it.
+#[derive(Debug)]
+pub(crate) struct ValidatedMounts(Vec<Mount>);
+
+impl ValidatedMounts {
+    /// Validate an assembled mount set under `rule`. `mounts` is the final
+    /// set (project mount already inserted for `--mount`, extra mounts
+    /// appended), so the checks see exactly what boot will use.
+    pub(crate) fn assemble(rule: WorkspaceMountRule, mounts: Vec<Mount>) -> Result<Self> {
+        let collision_message = match rule {
+            WorkspaceMountRule::CopyProject => Some(
+                "`coop up --copy` already uses /workspace for the project. \
+                 Give --extra-mount an explicit non-/workspace guest path, or use \
+                 `coop up --mount` to mount the project itself.",
+            ),
+            WorkspaceMountRule::GitRepoClone => Some(
+                "`coop up --git-repo` clones into /workspace. \
+                 Give --extra-mount an explicit non-/workspace guest path.",
+            ),
+            WorkspaceMountRule::ProjectMountedOrNone => None,
+        };
+        if let Some(message) = collision_message {
+            let workspace_path = default_workspace_path().to_string();
+            if mounts
+                .iter()
+                .any(|mount| mount.guest_path.to_string() == workspace_path)
+            {
+                bail!("{message}");
+            }
+        }
+        crate::config::validate_unique_guest_paths(&mounts)?;
+        Ok(Self(mounts))
     }
-    Ok(())
+
+    /// The validated mount set, ready to hand to [`crate::commands::StartOpts`].
+    pub(crate) fn into_vec(self) -> Vec<Mount> {
+        self.0
+    }
 }
 
 fn load_or_default(inst: &Instance, dir: Option<&str>, cmd: &str) -> Result<WorkspaceState> {
@@ -1259,9 +1306,49 @@ mod tests {
         std::fs::create_dir(&data).expect("data");
         let mounts = vec![Mount::parse(data.to_str().unwrap()).expect("mount")];
 
-        let err =
-            validate_git_repo_workspace_mounts(&mounts).expect_err("expected /workspace collision");
+        let err = ValidatedMounts::assemble(WorkspaceMountRule::GitRepoClone, mounts)
+            .expect_err("expected /workspace collision");
         assert!(format!("{err}").contains("/workspace"));
+    }
+
+    #[test]
+    fn project_mounted_rule_allows_workspace_mount() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data = tmp.path().join("proj");
+        std::fs::create_dir(&data).expect("data");
+        // A project legitimately mounted at /workspace (coop up --mount) is
+        // fine; the ProjectMountedOrNone rule skips the collision check.
+        let mounts = vec![Mount::parse(data.to_str().unwrap()).expect("mount")];
+        let validated =
+            ValidatedMounts::assemble(WorkspaceMountRule::ProjectMountedOrNone, mounts.clone())
+                .expect("workspace mount allowed under ProjectMountedOrNone");
+        assert_eq!(validated.into_vec().len(), 1);
+    }
+
+    #[test]
+    fn assemble_rejects_duplicate_guest_paths_under_every_rule() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        std::fs::create_dir(&a).expect("a");
+        std::fs::create_dir(&b).expect("b");
+        // Two distinct hosts, same guest path — a duplicate the uniqueness
+        // check must catch regardless of the workspace rule (this is the
+        // invariant quickstart previously skipped).
+        let dup = || {
+            vec![
+                Mount::parse(&format!("{}:/data", a.to_str().unwrap())).expect("a"),
+                Mount::parse(&format!("{}:/data", b.to_str().unwrap())).expect("b"),
+            ]
+        };
+        for rule in [
+            WorkspaceMountRule::CopyProject,
+            WorkspaceMountRule::GitRepoClone,
+            WorkspaceMountRule::ProjectMountedOrNone,
+        ] {
+            let err = ValidatedMounts::assemble(rule, dup()).expect_err("duplicate guest path");
+            assert!(format!("{err}").contains("Duplicate mount guest path"));
+        }
     }
 
     /// Run `f` with a thread-local WARN-level subscriber and return its

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -314,6 +314,53 @@ test_invalid_names() {
     fi
 }
 
+# ── Guest-memory floor (issue #404) ───────────────────────────
+#
+# A below-floor `--mem` must be rejected at the CLI boundary
+# (`VmMemory::parse_cli`), before any VM is created — so these are fast
+# negative checks that never boot. This is the headline #404 regression:
+# `coop up --mem 16` previously created an unbootable VM instead of failing.
+test_mem_floor() {
+    echo ""
+    echo "=== Phase: guest-memory floor rejection ==="
+
+    if coop_fails up --mem 16 --no-agents "$tmpdir"; then
+        pass "up rejects --mem below the 128 MiB floor"
+    else
+        fail "up rejects --mem below the 128 MiB floor" "should have failed fast"
+    fi
+
+    if coop_fails setup --mem 16 --yes; then
+        pass "setup rejects --mem below the 128 MiB floor"
+    else
+        fail "setup rejects --mem below the 128 MiB floor" "should have failed fast"
+    fi
+
+    # config.toml vector: a below-floor mem_size_mib is rejected at load.
+    local bad_cfg="$tmpdir/mem-floor-config.toml"
+    printf '[vm]\nmem_size_mib = 16\n' >"$bad_cfg"
+    if "$BINARY" --config "$bad_cfg" validate 2>"$tmpdir/mem_floor_cfg_stderr"; then
+        fail "config.toml rejects mem_size_mib below the floor" "load should have failed"
+    elif grep -q "is too low" "$tmpdir/mem_floor_cfg_stderr"; then
+        pass "config.toml rejects mem_size_mib below the floor"
+    else
+        fail "config.toml rejects mem_size_mib below the floor" \
+            "failed for the wrong reason: $(cat "$tmpdir/mem_floor_cfg_stderr")"
+    fi
+
+    # The floor is a floor, not a ban: the boundary value is accepted by the
+    # parser (this still fails later for other reasons, so only assert the
+    # error is not the floor message).
+    if coop up --mem 128 --dry-run "$tmpdir" 2>"$tmpdir/mem_floor_stderr"; then
+        pass "up accepts --mem at the 128 MiB boundary (dry-run)"
+    elif ! grep -q "is too low" "$tmpdir/mem_floor_stderr"; then
+        pass "up accepts --mem at the 128 MiB boundary (no floor error)"
+    else
+        fail "up accepts --mem at the 128 MiB boundary" \
+            "128 MiB was rejected as too low"
+    fi
+}
+
 # ── Profiles list/show ────────────────────────────────────────
 
 test_profiles_cli() {
@@ -4830,6 +4877,7 @@ main() {
     # Pre-VM tests
     test_validate
     test_invalid_names
+    test_mem_floor
     test_profiles_cli
     test_completions
     test_devcontainer_translator


### PR DESCRIPTION
Fixes #404.

Config was mutated **after** `validate()` ran on the `up`/`setup`/`start`/`quickstart`/`resize` paths, so config bounds were silently bypassed. `coop up --mem 16` (below the 128 MiB floor) created an unbootable VM instead of failing fast; the same floor was bypassable with no flag at all via a cloned repo's `devcontainer.json` `hostRequirements.memory`, and via `config.toml` `mem_size_mib`.

This implements the agreed approach from the issue's final comment (the §0′ reconsideration — value invariants into constructors, environmental checks at the boot choke point — **not** the rejected `ValidatedConfig` witness).

## What changed

- **`VmMemory` newtype** (`src/config.rs`) enforces the `MIN_MEM_MIB` floor by construction. `VmConfig.mem_size_mib` is now `VmMemory`. Every entry point routes through it: the `--mem` CLI parser (up/setup/resize), `config.toml` deserialize, `coop resize`, and the devcontainer translator. A sub-floor value is now unrepresentable rather than caught by a late pass. `validate_mem_size` and the mem branch of `validate()` are deleted.
- **`Validated` witness deleted.** It witnessed an *event* ("validate ran"), not a value, so the compiler allowed holding it alongside a `&mut CoopConfig` that lifecycle commands then mutated — and the actual VM boot (`create_and_start`) never took it anyway. The environmental (path-existence) checks it stood in for now run in `backend::boot_preflight`, called at the start of each backend's `setup`/`create_and_start`/`start_existing` on the freshest filesystem state, so a new lifecycle path cannot skip them. `validate_and_warn` still runs at the handler for fail-fast + tracing warnings.
- **`ValidatedMounts::assemble`** (`src/workspace.rs`) gives the start-time mount set one validated constructor: guest-path uniqueness on every path (closing a gap where `quickstart` skipped it) plus the transport-specific `/workspace` collision checks. Replaces the two ad-hoc `validate_*_workspace_mounts` helpers.

`VmCpus` was deliberately not added: `vcpu_count` is already `NonZeroU8` (its only real invariant) and no upper bound was agreed, so a newtype would be ceremony without a value invariant to enforce.

## Tests

- Unit: `VmMemory` boundary/`parse_cli`/`Deserialize` floor tests; `apply_to_config` rejects below-floor devcontainer memory; `boot_preflight` fails on a missing `claude.config_dir` and passes for the default config; `ValidatedMounts` uniqueness across all rules and the `--mount` `/workspace` allowance.
- Integration: a fast pre-VM `test_mem_floor` phase asserts `coop up --mem 16` / `coop setup --mem 16` / a `config.toml` `mem_size_mib = 16` are all rejected up front, and the 128 MiB boundary is accepted.

Verified on the built binary: `--mem 16` (up/setup/resize) and `config.toml mem_size_mib = 16` all fail fast with `mem_size_mib=16 is too low (minimum 128)` (the message the issue specifies); `--mem 128` and a valid config load succeed.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` are clean (973 lib tests pass). `.cargo/mutants.toml` needs no changes: `boot_preflight` lives in the glob-excluded `backend.rs`, and the new pure helpers (`VmMemory::new`, `ValidatedMounts::assemble`) stay in scope as intended.

> Integration tests still need a run on **both** Lima and Firecracker per `CLAUDE.md` — the `boot_preflight` gate is only exercised end-to-end per backend. That requires the VM backends and could not be run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)