### PR TITLE
Add Codex plugin marketplace support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -81,6 +81,8 @@
 # [codex]
 # config_dir = "~/.codex"  # path to copy AGENTS.md, prompts/, config.toml, auth.json from (false to disable)
 # env_forward = ["CUSTOM_TOKEN"]  # Extra env vars to forward to guest
+# marketplaces = ["trailofbits/codex-plugins"]  # owner/repo, git URL, or local path
+# plugins = ["my-lsp@codex-plugins"]  # plugin@marketplace to install
 #
 # Secrets: `api_key` accepts the same "cmd:" prefix as `claude.api_key`.
 #   api_key = "cmd:op read op://Private/OpenAI/credential"

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -103,15 +103,32 @@ url = "https://mcp.sentry.dev/mcp"
 
 If `config_dir` also provides a `config.toml`, coop preserves its other settings but replaces the `mcp_servers` table with the one derived from `codex.mcp_servers`. When the VM is in [local-model mode](#local-model-support), coop also owns the `model` and `model_provider` keys and a `[model_providers.coop_local]` block; these are written on a switch to local and removed on a switch back to remote, so they are not preserved across a mode change.
 
+### Plugin marketplaces
+
+`marketplaces` and `plugins` declare Codex [plugin marketplaces](https://developers.openai.com/codex/plugins) and the plugins to install from them, mirroring the same fields under `[claude]`:
+
+```toml
+[codex]
+marketplaces = ["trailofbits/codex-plugins"]  # owner/repo, owner/repo@ref, git URL, or local path
+plugins = ["my-lsp@codex-plugins"]             # plugin@marketplace
+```
+
+Each marketplace source is registered with `codex plugin marketplace add` and each plugin installed with `codex plugin add`. A source that is an absolute local directory is copied into the guest first; a `owner/repo`, `owner/repo@ref`, or git URL is passed through unchanged.
+
+These are **baked into the golden image** during `coop setup` (on the Lima/macOS backend) and recorded in the image's template config. On a VM's first boot coop installs only the delta not already baked in; on the Firecracker/Linux backend, where nothing is baked, the full set installs on first boot. Like Claude plugins, they are installed on **first boot only** — they persist on the guest disk across stop/start.
+
+Codex stores marketplace registrations under `[marketplaces.*]` and per-plugin enabled/disabled state under `[plugins.*]` in `~/.codex/config.toml`. Because coop rewrites that file on every boot, it reads the guest's current tables back first and preserves them across the rewrite (dropping any that came from the host's own `config.toml`), so installed plugins — and any manual enable/disable toggles you make with `/plugins` — survive a restart.
+
 ## Bootstrap sequence
 
 When `coop up` creates/restarts a project VM or `coop start` restarts a stopped VM (without `--no-agents`), coop executes the following steps after the VM boots and SSH becomes available:
 
 1. **GitHub auth**: If a `GITHUB_TOKEN` is available, run `gh auth setup-git` in the guest.
-2. **User content**: Copy the allowlisted Codex entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from `config_dir` to `~/.codex/` in the guest.
+2. **User content**: Copy the allowlisted Codex entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from `config_dir` to `~/.codex/` in the guest, preserving the guest's installed `[marketplaces.*]`/`[plugins.*]` tables.
 3. **MCP servers**: Merge configured MCP server definitions into `~/.codex/config.toml`.
+4. **Marketplaces & plugins** (first boot only): Install the configured `marketplaces`/`plugins` not already baked into the golden image.
 
-On restart (`coop start` of a stopped instance), the same Codex config files are refreshed so host-side updates are reflected in the guest.
+On restart (`coop start` of a stopped instance), the same Codex config files are refreshed so host-side updates are reflected in the guest; marketplaces and plugins are not reinstalled, but the guest's installed plugin state is preserved (step 2).
 
 ### Skipping bootstrap
 

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -105,7 +105,7 @@ If `config_dir` also provides a `config.toml`, coop preserves its other settings
 
 ### Plugin marketplaces
 
-`marketplaces` and `plugins` declare Codex [plugin marketplaces](https://developers.openai.com/codex/plugins) and the plugins to install from them, mirroring the same fields under `[claude]`:
+`marketplaces` and `plugins` declare Codex [plugin marketplaces](https://learn.chatgpt.com/docs/plugins) and the plugins to install from them, mirroring the same fields under `[claude]`:
 
 ```toml
 [codex]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ coop reads configuration from `~/.coop/config.toml` by default. Pass `--config <
 
 If the file does not exist, coop falls back to built-in defaults. A valid minimal config is an empty file.
 
-A leading `~` is expanded to the home directory in every path-valued field (`data_dir`, `firecracker_bin`, `vm.kernel_path`, `claude.config_dir`, `codex.config_dir`, and the `claude.marketplaces` / `profiles.<name>.marketplaces` lists). The shell does not expand `~` inside config-file values, so coop does it when loading the file.
+A leading `~` is expanded to the home directory in every path-valued field (`data_dir`, `firecracker_bin`, `vm.kernel_path`, `claude.config_dir`, `codex.config_dir`, and the `claude.marketplaces` / `codex.marketplaces` / `profiles.<name>.marketplaces` lists). The shell does not expand `~` inside config-file values, so coop does it when loading the file.
 
 Run `coop validate` to surface errors and warnings before anything touches a VM.
 
@@ -247,6 +247,8 @@ Codex configuration injected into the guest VM at start time. Every field is opt
 | `api_key` | string | unset (reads `$OPENAI_API_KEY` from environment) | OpenAI API key. Forwarded to the guest via SSH `SendEnv`. Never written to disk inside the VM. |
 | `config_dir` | string (path) or `false` | `~/.codex` | Source directory for Codex config files. Copies an allowlist of entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from this directory to `~/.codex/` in the guest on start. Set to `false` to disable. Supports `~` expansion. |
 | `env_forward` | array of strings | `[]` | Extra environment variable names to forward from host to guest via SSH `SendEnv`. `OPENAI_API_KEY` and `GITHUB_TOKEN` are forwarded automatically when set; list additional variables here. |
+| `marketplaces` | array of strings | `[]` | Codex plugin marketplace sources. Each entry is a `owner/repo`[`@ref`] shorthand, a git URL, or an absolute local directory path. Local directories are copied into the guest before registration. Baked into the golden image and delta-installed on first boot. |
+| `plugins` | array of strings | `[]` | Codex plugins to install from registered marketplaces. Format: `plugin-name@marketplace-name`. |
 | `mcp_servers` | table | `{}` | MCP servers to merge into the guest `~/.codex/config.toml`. Keys are server names; values are server definitions. See [MCP servers](#mcp-servers). |
 | `local_model` | table | unset | Host-side model endpoint to route Codex at when the VM is in local mode (`coop model <vm> local`). See [Local-model routing](#local-model-routing). |
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2189,6 +2189,14 @@ fn copy_codex_config(
 /// Mirrors `merge_managed_claude_settings`'s warn-on-corrupt handling of
 /// `~/.claude/settings.json`. A missing/empty file is the normal first-boot
 /// case and yields `None` quietly.
+///
+/// Note the realistic failure here is a *transient* SSH read of an
+/// otherwise-good file, not the corrupt file the Claude path deliberately
+/// resets. Since plugin install runs only on `BootMode::FirstBoot`, if this
+/// fails on a restart while a rewrite is otherwise triggered, the dropped
+/// `[marketplaces.*]`/`[plugins.*]` are not reinstalled by that stop/start —
+/// recovery requires recreating the instance (a fresh `FirstBoot`). The
+/// warning is that signal.
 fn read_codex_plugin_state(target: &SshTarget) -> Option<toml::Table> {
     match target.capture("cat ~/.codex/config.toml 2>/dev/null || true") {
         Ok(existing) => match extract_codex_plugin_state(&existing) {
@@ -3537,12 +3545,14 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
 
     #[test]
     fn extract_codex_plugin_state_round_trips_tables() {
+        // Keys mirror real guest output: marketplaces are keyed by name,
+        // plugins by `plugin@marketplace` (so the key needs quoting).
         let guest = "model = \"gpt-5\"\n\
              \n\
-             [marketplaces.mine]\n\
+             [marketplaces.codex-plugins]\n\
              source = \"trailofbits/codex-plugins\"\n\
              \n\
-             [plugins.my-lsp]\n\
+             [plugins.\"my-lsp@codex-plugins\"]\n\
              enabled = true\n";
         let state = extract_codex_plugin_state(guest).unwrap().unwrap();
         assert!(state.contains_key("marketplaces"));
@@ -3571,8 +3581,8 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         let src = tempfile::TempDir::new().unwrap();
         std::fs::write(src.path().join("config.toml"), "model = \"gpt-5\"\n").unwrap();
         let preserved = extract_codex_plugin_state(
-            "[marketplaces.mine]\nsource = \"trailofbits/codex-plugins\"\n\
-             \n[plugins.my-lsp]\nenabled = true\n",
+            "[marketplaces.codex-plugins]\nsource = \"trailofbits/codex-plugins\"\n\
+             \n[plugins.\"my-lsp@codex-plugins\"]\nenabled = true\n",
         )
         .unwrap()
         .unwrap();
@@ -3585,8 +3595,14 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
-        assert!(config.contains("[marketplaces.mine]"), "got: {config}");
-        assert!(config.contains("[plugins.my-lsp]"), "got: {config}");
+        assert!(
+            config.contains("[marketplaces.codex-plugins]"),
+            "got: {config}"
+        );
+        assert!(
+            config.contains("[plugins.\"my-lsp@codex-plugins\"]"),
+            "got: {config}"
+        );
         assert!(config.contains("model = \"gpt-5\""));
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1557,8 +1557,10 @@ fn bootstrap_codex(
     // the configured endpoint has since been removed.
     let manages_local =
         model_state.resolved_codex(codex).is_some() || model_state.codex_materialized;
+    let has_plugins = !codex.marketplaces.is_empty() || !codex.plugins.is_empty();
     let needs_codex =
-        codex_bootstrap_needed(source_dir.as_deref(), &codex.mcp_servers) || manages_local;
+        codex_bootstrap_needed(source_dir.as_deref(), &codex.mcp_servers, has_plugins)
+            || manages_local;
 
     if !needs_codex {
         return Ok(());
@@ -1579,6 +1581,24 @@ fn bootstrap_codex(
         local.as_ref(),
         manages_local,
     )?;
+
+    // Marketplaces and plugins are persisted in the guest's config.toml and
+    // plugin cache (and preserved across restarts by `copy_codex_config`), so
+    // install only the delta not already baked into the golden image, and only
+    // on first boot — marketplaces first, since `plugin add` resolves against a
+    // configured marketplace.
+    if let BootMode::FirstBoot = mode {
+        let codex_bin = crate::guest::codex_bin();
+        let (missing_marketplaces, missing_plugins) = compute_codex_plugin_delta(cfg, &inst.image);
+
+        if !missing_marketplaces.is_empty() {
+            install_codex_marketplaces(session, &codex_bin, &missing_marketplaces)?;
+        }
+
+        if !missing_plugins.is_empty() {
+            install_codex_plugins(session, &codex_bin, &missing_plugins)?;
+        }
+    }
 
     match mode {
         BootMode::Restart => tracing::info!("Codex bootstrap refreshed"),
@@ -1608,30 +1628,57 @@ pub fn persisted_guest_user(cfg: &CoopConfig, image: &ImageName) -> crate::guest
         .unwrap_or_default()
 }
 
-/// Compute which marketplaces and plugins are missing from the
+/// Pure core of the `FirstBoot` install delta: the wanted marketplaces and
+/// plugins that are not already baked into the golden image. A missing
+/// baked list (legacy/orphaned image) is passed as an empty slice, so the
+/// whole wanted set is treated as missing.
+fn plugin_delta(
+    wanted_marketplaces: &[String],
+    wanted_plugins: &[String],
+    baked_marketplaces: &[String],
+    baked_plugins: &[String],
+) -> (Vec<String>, Vec<String>) {
+    fn missing(wanted: &[String], baked: &[String]) -> Vec<String> {
+        wanted
+            .iter()
+            .filter(|w| !baked.contains(w))
+            .cloned()
+            .collect()
+    }
+    (
+        missing(wanted_marketplaces, baked_marketplaces),
+        missing(wanted_plugins, baked_plugins),
+    )
+}
+
+/// Compute which Claude marketplaces and plugins are missing from the
 /// golden image and need to be installed at start time.
 fn compute_plugin_delta(cfg: &CoopConfig, image: &ImageName) -> (Vec<String>, Vec<String>) {
-    let baked = crate::setup::TemplateConfig::load_for(cfg, image).ok();
+    let (baked_m, baked_p) = crate::setup::TemplateConfig::load_for(cfg, image)
+        .ok()
+        .map(|tc| (tc.marketplaces, tc.plugins))
+        .unwrap_or_default();
+    plugin_delta(
+        &cfg.claude.marketplaces,
+        &cfg.claude.plugins,
+        &baked_m,
+        &baked_p,
+    )
+}
 
-    let wanted_marketplaces = &cfg.claude.marketplaces;
-    let wanted_plugins = &cfg.claude.plugins;
-
-    match baked {
-        Some(tc) => {
-            let missing_m: Vec<String> = wanted_marketplaces
-                .iter()
-                .filter(|m| !tc.marketplaces.contains(m))
-                .cloned()
-                .collect();
-            let missing_p: Vec<String> = wanted_plugins
-                .iter()
-                .filter(|p| !tc.plugins.contains(p))
-                .cloned()
-                .collect();
-            (missing_m, missing_p)
-        }
-        None => (wanted_marketplaces.clone(), wanted_plugins.clone()),
-    }
+/// Compute which Codex marketplaces and plugins are missing from the
+/// golden image and need to be installed at start time.
+fn compute_codex_plugin_delta(cfg: &CoopConfig, image: &ImageName) -> (Vec<String>, Vec<String>) {
+    let (baked_m, baked_p) = crate::setup::TemplateConfig::load_for(cfg, image)
+        .ok()
+        .map(|tc| (tc.codex_marketplaces, tc.codex_plugins))
+        .unwrap_or_default();
+    plugin_delta(
+        &cfg.codex.marketplaces,
+        &cfg.codex.plugins,
+        &baked_m,
+        &baked_p,
+    )
 }
 
 /// Resolve a GitHub token for the guest given the configured auth strategy
@@ -2112,9 +2159,80 @@ fn copy_codex_config(
     local: Option<&toml::Table>,
     manages_local: bool,
 ) -> Result<()> {
-    let staged = stage_codex_files(source_dir, &codex.mcp_servers, local, manages_local)
-        .context("Failed to stage Codex config files")?;
+    // The guest's config.toml holds the Codex CLI's installed `[marketplaces.*]`
+    // / `[plugins.*]` tables. We only need to carry them across a *rewrite* of
+    // that file, so read the guest config only when a rewrite will actually
+    // happen — otherwise the file is left untouched and its state survives on
+    // its own (and we skip a needless SSH round-trip).
+    let preserved =
+        if codex_config_needs_rewrite(source_dir, &codex.mcp_servers, local, manages_local) {
+            read_codex_plugin_state(target)
+        } else {
+            None
+        };
+
+    let staged = stage_codex_files(
+        source_dir,
+        &codex.mcp_servers,
+        local,
+        manages_local,
+        preserved.as_ref(),
+    )
+    .context("Failed to stage Codex config files")?;
     copy_staged_to_guest(target, &staged, ".codex", "Codex")
+}
+
+/// Read the guest's installed Codex marketplace/plugin tables for
+/// preservation across a config.toml rewrite. Warns — rather than silently
+/// proceeding — when the file is present but the read or parse fails, since
+/// the impending rewrite would otherwise drop those tables without a trace.
+/// Mirrors `merge_managed_claude_settings`'s warn-on-corrupt handling of
+/// `~/.claude/settings.json`. A missing/empty file is the normal first-boot
+/// case and yields `None` quietly.
+fn read_codex_plugin_state(target: &SshTarget) -> Option<toml::Table> {
+    match target.capture("cat ~/.codex/config.toml 2>/dev/null || true") {
+        Ok(existing) => match extract_codex_plugin_state(&existing) {
+            Ok(state) => state,
+            Err(e) => {
+                tracing::warn!(
+                    "Could not parse guest ~/.codex/config.toml to preserve installed \
+                     Codex marketplaces/plugins across the config refresh; they may be \
+                     dropped and need reinstalling: {e:#}"
+                );
+                None
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                "Could not read guest ~/.codex/config.toml to preserve installed Codex \
+                 marketplaces/plugins across the config refresh: {e:#}"
+            );
+            None
+        }
+    }
+}
+
+/// Extract the `marketplaces` and `plugins` tables from a guest
+/// `config.toml`. These hold the Codex CLI's installed marketplace
+/// registrations (`[marketplaces.*]`) and per-plugin enabled state
+/// (`[plugins.*]`); coop preserves them verbatim when it rewrites
+/// config.toml so a stop/start does not wipe installed plugins. Returns
+/// `Ok(None)` when the input is empty or carries neither table, and `Err`
+/// when it is present but not valid TOML — so the caller can warn rather than
+/// silently dropping the tables.
+fn extract_codex_plugin_state(config_toml: &str) -> Result<Option<toml::Table>> {
+    let parsed = toml::from_str::<TomlValue>(config_toml)
+        .context("guest ~/.codex/config.toml is not valid TOML")?;
+    let Some(table) = parsed.as_table() else {
+        return Ok(None);
+    };
+    let mut preserved = toml::Table::new();
+    for key in ["marketplaces", "plugins"] {
+        if let Some(value) = table.get(key) {
+            preserved.insert(key.to_string(), value.clone());
+        }
+    }
+    Ok((!preserved.is_empty()).then_some(preserved))
 }
 
 fn resolve_config_source_dir(
@@ -2205,11 +2323,29 @@ const CODEX_ALLOWED_DIRS: &[&str] = &["prompts"];
 /// Codex config file merged with managed MCP servers rather than copied verbatim.
 const CODEX_CONFIG_FILE: &str = "config.toml";
 
+/// Whether coop will rewrite the guest `~/.codex/config.toml` on this boot:
+/// true when the host supplies a `config.toml` base, when managed
+/// `mcp_servers` must be merged, or when a local-model block is being written
+/// or dropped (`manages_local`). When false the guest file is left untouched,
+/// so its installed plugin tables survive without coop round-tripping them.
+fn codex_config_needs_rewrite(
+    source_dir: Option<&Path>,
+    mcp_servers: &std::collections::HashMap<String, McpServerDef>,
+    local: Option<&toml::Table>,
+    manages_local: bool,
+) -> bool {
+    source_dir.is_some_and(|path| path.join(CODEX_CONFIG_FILE).is_file())
+        || !mcp_servers.is_empty()
+        || local.is_some()
+        || manages_local
+}
+
 fn stage_codex_files(
     source_dir: Option<&Path>,
     mcp_servers: &std::collections::HashMap<String, McpServerDef>,
     local: Option<&toml::Table>,
     manages_local: bool,
+    preserved: Option<&toml::Table>,
 ) -> Result<tempfile::TempDir> {
     let staging = tempfile::TempDir::new().context("Failed to create staging directory")?;
 
@@ -2265,12 +2401,36 @@ fn stage_codex_files(
         }
     }
 
+    // The Codex CLI records installed marketplaces under `[marketplaces.*]`
+    // and per-plugin enabled state under `[plugins.*]` in config.toml. Since
+    // this rewrite would otherwise clobber them on every stop/start, drop any
+    // `marketplaces`/`plugins` carried in from the *host* base (host-side
+    // Codex state must not leak into the guest) and overlay the guest's own
+    // tables read back in `copy_codex_config`. This mirrors the guest-side
+    // `merge_managed_claude_settings` preservation of `enabledPlugins` /
+    // `extraKnownMarketplaces`.
+    {
+        let TomlValue::Table(root) = &mut config else {
+            bail!("Codex {CODEX_CONFIG_FILE} must deserialize to a TOML table");
+        };
+        root.remove("marketplaces");
+        root.remove("plugins");
+        if let Some(preserved) = preserved {
+            for (key, value) in preserved {
+                root.insert(key.clone(), value.clone());
+            }
+        }
+    }
+
     // `manages_local` forces a rewrite even with no other content so that
     // switching back to remote drops a previously-written provider block.
-    let should_write_config = source_dir.is_some_and(|path| path.join(CODEX_CONFIG_FILE).is_file())
-        || !mcp_servers.is_empty()
-        || local.is_some()
-        || manages_local;
+    // `preserved` alone does not force a write: when nothing else triggers a
+    // rewrite the guest's config.toml is left untouched, so its plugin state
+    // survives without coop having to round-trip it. This must stay in sync
+    // with the gate in `copy_codex_config` that decides whether to read the
+    // guest config at all — hence the shared predicate.
+    let should_write_config =
+        codex_config_needs_rewrite(source_dir, mcp_servers, local, manages_local);
 
     if should_write_config {
         std::fs::write(
@@ -2295,8 +2455,9 @@ fn codex_source_has_bootstrap_content(source_dir: Option<&Path>) -> bool {
 fn codex_bootstrap_needed(
     source_dir: Option<&Path>,
     mcp_servers: &std::collections::HashMap<String, McpServerDef>,
+    has_plugins: bool,
 ) -> bool {
-    codex_source_has_bootstrap_content(source_dir) || !mcp_servers.is_empty()
+    codex_source_has_bootstrap_content(source_dir) || !mcp_servers.is_empty() || has_plugins
 }
 
 fn resolve_codex_mcp_servers(
@@ -2337,45 +2498,63 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 
 const GUEST_MARKETPLACE_DIR: &str = "~/.coop/marketplaces";
 
+/// Resolve a marketplace source for a guest `plugin marketplace add`.
+///
+/// A local absolute directory is copied into the guest's marketplace dir
+/// and its guest-side path is returned; a URL / GitHub slug / `owner/repo`
+/// shorthand is passed through unchanged. `made_dir` tracks whether the
+/// guest marketplace dir has been created yet so it is only `mkdir -p`'d
+/// once per install pass. Shared by the Claude and Codex marketplace
+/// installers; `tool` (`"claude"` / `"codex"`) namespaces the copy dir so two
+/// local marketplaces with the same directory basename — one per agent — do
+/// not overwrite each other in the guest.
+fn stage_marketplace_source(
+    session: &SshSession,
+    tool: &str,
+    source: &str,
+    made_dir: &mut bool,
+) -> Result<String> {
+    let local_path = Path::new(source);
+    if !(local_path.is_absolute() && local_path.is_dir()) {
+        return Ok(source.to_string());
+    }
+
+    let tool_dir = format!("{GUEST_MARKETPLACE_DIR}/{tool}");
+    if !*made_dir {
+        session
+            .target
+            .exec(RemoteCommand::new().literal(format!("mkdir -p {tool_dir}")))?;
+        *made_dir = true;
+    }
+    let dir_name = local_path
+        .file_name()
+        .context("marketplace path has no directory name")?
+        .to_string_lossy();
+    let remote = GuestPath::new(format!("{tool_dir}/{dir_name}"));
+    tracing::info!(
+        "Copying local marketplace to guest: {} -> {remote}",
+        local_path.display()
+    );
+    session
+        .target
+        .scp_to_recursive(&HostPath::from(local_path), &remote)
+        .with_context(|| {
+            format!(
+                "Failed to copy marketplace '{}' to guest",
+                local_path.display()
+            )
+        })?;
+    Ok(remote.to_string())
+}
+
 pub(crate) fn install_marketplaces(
     session: &SshSession,
     claude_bin: &GuestPath,
     marketplaces: &[String],
 ) -> Result<()> {
-    let mut has_local = false;
-
+    let mut made_dir = false;
     for source in marketplaces {
-        let local_path = Path::new(source);
-        let guest_source = if local_path.is_absolute() && local_path.is_dir() {
-            if !has_local {
-                session.target.exec(
-                    RemoteCommand::new().literal(format!("mkdir -p {GUEST_MARKETPLACE_DIR}")),
-                )?;
-                has_local = true;
-            }
-            let dir_name = local_path
-                .file_name()
-                .context("marketplace path has no directory name")?
-                .to_string_lossy();
-            let remote = GuestPath::new(format!("{GUEST_MARKETPLACE_DIR}/{dir_name}"));
-            tracing::info!(
-                "Copying local marketplace to guest: {} -> {remote}",
-                local_path.display()
-            );
-            session
-                .target
-                .scp_to_recursive(&HostPath::from(local_path), &remote)
-                .with_context(|| {
-                    format!(
-                        "Failed to copy marketplace '{}' to guest",
-                        local_path.display()
-                    )
-                })?;
-            remote.to_string()
-        } else {
-            source.clone()
-        };
-
+        let guest_source = stage_marketplace_source(session, "claude", source, &mut made_dir)?;
         tracing::info!("Adding marketplace: {guest_source}");
         let cmd = RemoteCommand::new()
             .arg(claude_bin)
@@ -2404,6 +2583,55 @@ pub(crate) fn install_plugins(
         session
             .exec(cmd)
             .with_context(|| format!("Failed to install plugin '{plugin}'"))?;
+    }
+    Ok(())
+}
+
+/// Register Codex marketplaces via `codex plugin marketplace add`.
+///
+/// Unlike Claude's `claude plugin marketplace add`, the Codex CLI takes
+/// no `--scope` flag; the registration is written to `~/.codex/config.toml`
+/// under `[marketplaces.<name>]`. Local directories are copied into the
+/// guest first, mirroring [`install_marketplaces`].
+pub(crate) fn install_codex_marketplaces(
+    session: &SshSession,
+    codex_bin: &GuestPath,
+    marketplaces: &[String],
+) -> Result<()> {
+    let mut made_dir = false;
+    for source in marketplaces {
+        let guest_source = stage_marketplace_source(session, "codex", source, &mut made_dir)?;
+        tracing::info!("Adding Codex marketplace: {guest_source}");
+        let cmd = RemoteCommand::new()
+            .arg(codex_bin)
+            .literal(" plugin marketplace add ")
+            .arg(&guest_source);
+        session
+            .exec(cmd)
+            .with_context(|| format!("Failed to add Codex marketplace '{source}'"))?;
+    }
+    Ok(())
+}
+
+/// Install Codex plugins via `codex plugin add <plugin[@marketplace]>`.
+///
+/// The subcommand is `add` (not `install`, as for Claude), and there is
+/// no `-s user` scope flag; enabled state is recorded in
+/// `~/.codex/config.toml` under `[plugins.<name>]`.
+pub(crate) fn install_codex_plugins(
+    session: &SshSession,
+    codex_bin: &GuestPath,
+    plugins: &[String],
+) -> Result<()> {
+    for plugin in plugins {
+        tracing::info!("Installing Codex plugin: {plugin}");
+        let cmd = RemoteCommand::new()
+            .arg(codex_bin)
+            .literal(" plugin add ")
+            .arg(plugin);
+        session
+            .exec(cmd)
+            .with_context(|| format!("Failed to install Codex plugin '{plugin}'"))?;
     }
     Ok(())
 }
@@ -3152,7 +3380,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             },
         );
 
-        let staging = stage_codex_files(Some(src.path()), &servers, None, false).unwrap();
+        let staging = stage_codex_files(Some(src.path()), &servers, None, false, None).unwrap();
         assert!(staging.path().join("AGENTS.md").is_file());
 
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3182,7 +3410,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             },
         );
 
-        let staging = stage_codex_files(Some(src.path()), &servers, None, false).unwrap();
+        let staging = stage_codex_files(Some(src.path()), &servers, None, false, None).unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
 
         assert!(config.contains("model = \"gpt-5\""));
@@ -3203,6 +3431,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             &std::collections::HashMap::new(),
             None,
             false,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -3219,8 +3448,14 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             "http://host.lima.internal:11434/v1/",
             "gpt-oss:120b",
         );
-        let staging =
-            stage_codex_files(None, &std::collections::HashMap::new(), Some(&local), true).unwrap();
+        let staging = stage_codex_files(
+            None,
+            &std::collections::HashMap::new(),
+            Some(&local),
+            true,
+            None,
+        )
+        .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
         assert!(config.contains("model_provider = \"coop_local\""));
         assert!(config.contains("wire_api = \"responses\""));
@@ -3238,6 +3473,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             &std::collections::HashMap::new(),
             Some(&local),
             true,
+            None,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3253,7 +3489,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         // Switching back to remote: no local table, but `manages_local`
         // forces a clean rewrite that omits the provider block.
         let staging =
-            stage_codex_files(None, &std::collections::HashMap::new(), None, true).unwrap();
+            stage_codex_files(None, &std::collections::HashMap::new(), None, true, None).unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
         assert!(
             !config.contains("coop_local"),
@@ -3266,11 +3502,13 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         let src = tempfile::TempDir::new().unwrap();
         assert!(!codex_bootstrap_needed(
             Some(src.path()),
-            &std::collections::HashMap::new()
+            &std::collections::HashMap::new(),
+            false
         ));
         assert!(!codex_bootstrap_needed(
             None,
-            &std::collections::HashMap::new()
+            &std::collections::HashMap::new(),
+            false
         ));
     }
 
@@ -3281,8 +3519,167 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
 
         assert!(codex_bootstrap_needed(
             Some(src.path()),
-            &std::collections::HashMap::new()
+            &std::collections::HashMap::new(),
+            false
         ));
+    }
+
+    #[test]
+    fn codex_bootstrap_needed_is_true_with_plugins() {
+        // No source content and no MCP servers, but configured plugins alone
+        // must still trigger bootstrap so the FirstBoot install runs.
+        assert!(codex_bootstrap_needed(
+            None,
+            &std::collections::HashMap::new(),
+            true
+        ));
+    }
+
+    #[test]
+    fn extract_codex_plugin_state_round_trips_tables() {
+        let guest = "model = \"gpt-5\"\n\
+             \n\
+             [marketplaces.mine]\n\
+             source = \"trailofbits/codex-plugins\"\n\
+             \n\
+             [plugins.my-lsp]\n\
+             enabled = true\n";
+        let state = extract_codex_plugin_state(guest).unwrap().unwrap();
+        assert!(state.contains_key("marketplaces"));
+        assert!(state.contains_key("plugins"));
+        // Only the two plugin tables are preserved, not unrelated keys.
+        assert!(!state.contains_key("model"));
+    }
+
+    #[test]
+    fn extract_codex_plugin_state_none_when_absent_or_empty() {
+        assert!(extract_codex_plugin_state("").unwrap().is_none());
+        assert!(
+            extract_codex_plugin_state("model = \"gpt-5\"\n")
+                .unwrap()
+                .is_none()
+        );
+        // Present-but-invalid TOML is an error (so the caller can warn),
+        // not a silent None that would drop installed plugin state.
+        assert!(extract_codex_plugin_state("not = = valid").is_err());
+    }
+
+    #[test]
+    fn stage_codex_files_preserves_guest_plugin_state() {
+        // A host config.toml triggers a rewrite; the guest's installed
+        // marketplace/plugin tables must survive it.
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(src.path().join("config.toml"), "model = \"gpt-5\"\n").unwrap();
+        let preserved = extract_codex_plugin_state(
+            "[marketplaces.mine]\nsource = \"trailofbits/codex-plugins\"\n\
+             \n[plugins.my-lsp]\nenabled = true\n",
+        )
+        .unwrap()
+        .unwrap();
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            Some(&preserved),
+        )
+        .unwrap();
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert!(config.contains("[marketplaces.mine]"), "got: {config}");
+        assert!(config.contains("[plugins.my-lsp]"), "got: {config}");
+        assert!(config.contains("model = \"gpt-5\""));
+    }
+
+    #[test]
+    fn stage_codex_files_drops_host_base_plugin_state() {
+        // Host config.toml carries its own marketplace/plugin tables (the user
+        // runs Codex on the host too); with nothing preserved these must NOT
+        // leak into the guest.
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("config.toml"),
+            "model = \"gpt-5\"\n\
+             \n[marketplaces.host-only]\nsource = \"someone/else\"\n\
+             \n[plugins.host-plugin]\nenabled = true\n",
+        )
+        .unwrap();
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert!(config.contains("model = \"gpt-5\""));
+        assert!(
+            !config.contains("host-only"),
+            "host marketplace leaked: {config}"
+        );
+        assert!(
+            !config.contains("host-plugin"),
+            "host plugin leaked: {config}"
+        );
+    }
+
+    #[test]
+    fn plugin_delta_returns_wanted_minus_baked() {
+        let wanted_m = vec!["a".to_string(), "b".to_string()];
+        let wanted_p = vec!["p1@a".to_string(), "p2@b".to_string()];
+        let (missing_m, missing_p) = plugin_delta(
+            &wanted_m,
+            &wanted_p,
+            &["a".to_string()],
+            &["p1@a".to_string()],
+        );
+        assert_eq!(missing_m, vec!["b".to_string()]);
+        assert_eq!(missing_p, vec!["p2@b".to_string()]);
+
+        // Empty baked (legacy/orphaned image): everything wanted is missing.
+        let (all_m, all_p) = plugin_delta(&wanted_m, &wanted_p, &[], &[]);
+        assert_eq!(all_m, wanted_m);
+        assert_eq!(all_p, wanted_p);
+    }
+
+    #[test]
+    fn compute_codex_plugin_delta_reads_codex_fields_not_claude() {
+        // Pins the field wiring: the Codex delta must diff cfg.codex.* against
+        // the template's codex_* lists, ignoring the Claude marketplaces/plugins
+        // (backend.rs is mutation-excluded, so a copy-paste slip to a Claude
+        // field would otherwise go uncaught).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut cfg = CoopConfig {
+            data_dir: crate::config::ConfigPath::new(tmp.path()),
+            ..CoopConfig::default()
+        };
+        cfg.codex.marketplaces = vec!["m-baked".into(), "m-new".into()];
+        cfg.codex.plugins = vec!["p-baked@m".into(), "p-new@m".into()];
+        let image = ImageName::new("default").unwrap();
+
+        // Bake one of each Codex entry — plus decoy Claude entries that must be
+        // ignored — into the on-disk template config.
+        std::fs::create_dir_all(cfg.image_dir(&image)).unwrap();
+        let json = r#"{
+            "version": 1,
+            "created": "2026-01-01T00:00:00Z",
+            "install_script_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+            "profiles": [],
+            "extra_packages": [],
+            "post_install_hash": null,
+            "marketplaces": ["m-new"],
+            "plugins": ["p-new@m"],
+            "codex_marketplaces": ["m-baked"],
+            "codex_plugins": ["p-baked@m"]
+        }"#;
+        std::fs::write(cfg.template_config_path_for(&image), json).unwrap();
+
+        let (missing_m, missing_p) = compute_codex_plugin_delta(&cfg, &image);
+        // Only the non-baked Codex entries remain. If the delta read the Claude
+        // `marketplaces`/`plugins` (which bake "m-new"/"p-new@m"), those would
+        // be filtered out and the assertion would fail.
+        assert_eq!(missing_m, vec!["m-new".to_string()]);
+        assert_eq!(missing_p, vec!["p-new@m".to_string()]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1490,6 +1490,14 @@ pub struct CodexConfig {
     #[serde(default)]
     pub env_forward: Vec<EnvVarName>,
 
+    /// Plugin marketplace sources (URL, path, or GitHub repo)
+    #[serde(default)]
+    pub marketplaces: Vec<String>,
+
+    /// Plugins to install from marketplaces
+    #[serde(default)]
+    pub plugins: Vec<String>,
+
     /// MCP servers to register in `~/.codex/config.toml`
     #[serde(default)]
     pub mcp_servers: HashMap<String, McpServerDef>,
@@ -1822,6 +1830,20 @@ fn expand_marketplaces(entries: &mut [String]) {
     }
 }
 
+/// Push a validation error for each marketplace entry that looks like a
+/// local (absolute) path but does not exist. `field` is the config key
+/// prefix (e.g. `"claude.marketplaces"`) used in the message.
+fn check_local_marketplaces(field: &str, entries: &[String], errors: &mut Vec<String>) {
+    for mp in entries {
+        let path = Path::new(mp);
+        if path.is_absolute() && !path.exists() {
+            errors.push(format!(
+                "{field} entry '{mp}' looks like a local path but does not exist"
+            ));
+        }
+    }
+}
+
 impl CoopConfig {
     /// Default config path: `~/.coop/config.toml`.
     pub fn default_path() -> PathBuf {
@@ -1859,6 +1881,7 @@ impl CoopConfig {
     /// path-shaped ones (a leading `~`) can be expanded.
     fn expand_user_paths(&mut self) {
         expand_marketplaces(&mut self.claude.marketplaces);
+        expand_marketplaces(&mut self.codex.marketplaces);
         for profile in self.profiles.values_mut() {
             expand_marketplaces(&mut profile.marketplaces);
         }
@@ -1955,15 +1978,12 @@ impl CoopConfig {
             ));
         }
 
-        for mp in &self.claude.marketplaces {
-            let path = Path::new(mp);
-            if path.is_absolute() && !path.exists() {
-                errors.push(format!(
-                    "claude.marketplaces entry '{mp}' looks like a local \
-                     path but does not exist"
-                ));
-            }
-        }
+        check_local_marketplaces(
+            "claude.marketplaces",
+            &self.claude.marketplaces,
+            &mut errors,
+        );
+        check_local_marketplaces("codex.marketplaces", &self.codex.marketplaces, &mut errors);
 
         // `[claude.local_model]` / `[codex.local_model]` invariants
         // (http(s) scheme, present host, non-empty model) are enforced by
@@ -2297,6 +2317,8 @@ impl Default for CodexConfig {
         Self {
             api_key: std::env::var("OPENAI_API_KEY").ok().map(Secret::new),
             env_forward: Vec::new(),
+            marketplaces: Vec::new(),
+            plugins: Vec::new(),
             mcp_servers: HashMap::new(),
             config_dir: ConfigDir::Default,
             local_model: None,
@@ -3336,6 +3358,8 @@ mod tests {
         let json = r#"{
             "api_key": "sk-openai-test",
             "env_forward": ["MYORG_KEY"],
+            "marketplaces": ["https://github.com/trailofbits/codex-plugins"],
+            "plugins": ["my-lsp@codex-plugins"],
             "mcp_servers": {
                 "sentry": {
                     "type": "http",
@@ -3349,6 +3373,11 @@ mod tests {
             Some("sk-openai-test")
         );
         assert_eq!(cfg.env_forward, vec![EnvVarName::new("MYORG_KEY").unwrap()]);
+        assert_eq!(
+            cfg.marketplaces,
+            vec!["https://github.com/trailofbits/codex-plugins".to_string()]
+        );
+        assert_eq!(cfg.plugins, vec!["my-lsp@codex-plugins".to_string()]);
         assert_eq!(cfg.mcp_servers.len(), 1);
         assert!(cfg.mcp_servers.contains_key("sentry"));
     }
@@ -3359,6 +3388,8 @@ mod tests {
         let cfg: CodexConfig = serde_json::from_str(json).unwrap();
         assert!(cfg.api_key.is_none());
         assert!(cfg.env_forward.is_empty());
+        assert!(cfg.marketplaces.is_empty());
+        assert!(cfg.plugins.is_empty());
         assert!(cfg.mcp_servers.is_empty());
         assert_eq!(cfg.config_dir, ConfigDir::Default);
         assert!(cfg.local_model.is_none());
@@ -4454,6 +4485,32 @@ skip = ["not-a-slug"]
 
         let cfg = CoopConfig::load(&path).unwrap();
         assert_eq!(cfg.claude.marketplaces[0], url);
+    }
+
+    #[test]
+    fn validate_rejects_missing_local_codex_marketplace() {
+        let mut cfg = CoopConfig::default();
+        cfg.codex.marketplaces = vec!["/nonexistent/codex-plugins".into()];
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("codex.marketplaces"),
+            "expected codex marketplace error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn load_expands_tilde_in_codex_marketplaces() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, "[codex]\nmarketplaces = [\"~/codex-plugins\"]\n").unwrap();
+
+        let cfg = CoopConfig::load(&path).unwrap();
+        let mp = &cfg.codex.marketplaces[0];
+        assert!(!mp.starts_with('~'), "tilde should be expanded, got: {mp}");
+        assert!(
+            mp.contains("/codex-plugins"),
+            "should preserve path suffix, got: {mp}"
+        );
     }
 
     #[test]

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -434,6 +434,22 @@ pub fn collect_baked_lists(
     (marketplaces, plugins)
 }
 
+/// Collect Codex marketplace and plugin lists from global config.
+/// Results are sorted and deduplicated. Unlike [`collect_baked_lists`],
+/// profiles contribute nothing here: profile plugin lists are
+/// Claude-only, so Codex plugins come solely from `[codex]`.
+pub fn collect_codex_baked_lists(cfg: &CoopConfig) -> (Vec<String>, Vec<String>) {
+    let mut marketplaces = cfg.codex.marketplaces.clone();
+    let mut plugins = cfg.codex.plugins.clone();
+
+    marketplaces.sort_unstable();
+    marketplaces.dedup();
+    plugins.sort_unstable();
+    plugins.dedup();
+
+    (marketplaces, plugins)
+}
+
 #[cfg(test)]
 #[expect(clippy::panic, reason = "tests use panic for assertion failures")]
 #[expect(clippy::unwrap_used, reason = "tests use unwrap for brevity")]
@@ -446,6 +462,16 @@ mod tests {
             SCRIPT_CODEX.contains("BIN=\"$TMPDIR/${ASSET%.tar.gz}\""),
             "Codex installer should target the extracted binary path directly",
         );
+    }
+
+    #[test]
+    fn collect_codex_baked_lists_sorts_and_dedups() {
+        let mut cfg = CoopConfig::default();
+        cfg.codex.marketplaces = vec!["b".into(), "a".into(), "a".into()];
+        cfg.codex.plugins = vec!["p2@b".into(), "p1@a".into(), "p2@b".into()];
+        let (marketplaces, plugins) = collect_codex_baked_lists(&cfg);
+        assert_eq!(marketplaces, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(plugins, vec!["p1@a".to_string(), "p2@b".to_string()]);
     }
 
     #[test]

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -723,7 +723,11 @@ fn needs_rebuild(
     }
 
     let (wanted_m, wanted_p) = crate::guest::collect_baked_lists(cfg, profiles);
-    existing.marketplaces != wanted_m || existing.plugins != wanted_p
+    let (wanted_cm, wanted_cp) = crate::guest::collect_codex_baked_lists(cfg);
+    existing.marketplaces != wanted_m
+        || existing.plugins != wanted_p
+        || existing.codex_marketplaces != wanted_cm
+        || existing.codex_plugins != wanted_cp
 }
 
 fn build_golden_image(
@@ -806,7 +810,7 @@ fn build_golden_image(
         tracing::debug!("Failed to remove builder template (non-fatal): {e}");
     }
 
-    let (marketplaces, plugins) = match result {
+    let baked = match result {
         Ok(lists) => lists,
         Err(e) => {
             // Clean up failed staging image
@@ -840,8 +844,10 @@ fn build_golden_image(
         profiles: profiles.iter().map(|p| p.name.clone()).collect(),
         extra_packages: Vec::new(),
         post_install_hash: None,
-        marketplaces,
-        plugins,
+        marketplaces: baked.marketplaces,
+        plugins: baked.plugins,
+        codex_marketplaces: baked.codex_marketplaces,
+        codex_plugins: baked.codex_plugins,
         guest_user: guest_user.clone(),
         oci_features: installed_features(oci_features),
     };
@@ -859,7 +865,7 @@ fn run_builder_vm(
     builder_template: &std::path::Path,
     guest_user: &GuestUser,
     builder_timeout: Option<Duration>,
-) -> Result<(Vec<String>, Vec<String>)> {
+) -> Result<BakedLists> {
     eprintln!("  Starting builder VM and installing packages...");
     let mut command = Command::new("limactl");
     command.arg("start");
@@ -893,7 +899,7 @@ fn run_builder_vm(
     // Install marketplaces and plugins into the builder VM so they're
     // baked into the golden image. Runs after binary verification
     // (confirms claude CLI is installed) and before cloud-init clean.
-    let (marketplaces, plugins) = install_builder_plugins(cfg, profiles, guest_user)?;
+    let baked = install_builder_plugins(cfg, profiles, guest_user)?;
 
     // Clean cloud-init state so it re-runs on new instances
     eprintln!("  Preparing image for reuse...");
@@ -960,7 +966,7 @@ fn run_builder_vm(
         )
     })?;
 
-    Ok((marketplaces, plugins))
+    Ok(baked)
 }
 
 /// Get an SSH target for the builder VM.
@@ -979,18 +985,43 @@ fn builder_ssh_target(cfg: &CoopConfig, guest_user: &GuestUser) -> Result<SshTar
     })
 }
 
-/// Install marketplaces and plugins in the builder VM via SSH.
-/// Returns the lists that were installed (for recording in
+/// Marketplace/plugin lists baked into a golden image, recorded in
+/// `TemplateConfig` for staleness detection and the `FirstBoot` install delta.
+struct BakedLists {
+    marketplaces: Vec<String>,
+    plugins: Vec<String>,
+    codex_marketplaces: Vec<String>,
+    codex_plugins: Vec<String>,
+}
+
+impl BakedLists {
+    fn is_empty(&self) -> bool {
+        self.marketplaces.is_empty()
+            && self.plugins.is_empty()
+            && self.codex_marketplaces.is_empty()
+            && self.codex_plugins.is_empty()
+    }
+}
+
+/// Install Claude and Codex marketplaces and plugins in the builder VM via
+/// SSH. Returns the lists that were installed (for recording in
 /// `TemplateConfig`).
 fn install_builder_plugins(
     cfg: &CoopConfig,
     profiles: &[ProfileDef],
     guest_user: &GuestUser,
-) -> Result<(Vec<String>, Vec<String>)> {
+) -> Result<BakedLists> {
     let (marketplaces, plugins) = crate::guest::collect_baked_lists(cfg, profiles);
+    let (codex_marketplaces, codex_plugins) = crate::guest::collect_codex_baked_lists(cfg);
+    let baked = BakedLists {
+        marketplaces,
+        plugins,
+        codex_marketplaces,
+        codex_plugins,
+    };
 
-    if marketplaces.is_empty() && plugins.is_empty() {
-        return Ok((marketplaces, plugins));
+    if baked.is_empty() {
+        return Ok(baked);
     }
 
     eprintln!("  Installing marketplaces and plugins...");
@@ -1005,15 +1036,26 @@ fn install_builder_plugins(
     let session = crate::backend::SshSession { target, env };
     let claude_bin = guest_user.claude_bin();
 
-    if !marketplaces.is_empty() {
-        crate::backend::install_marketplaces(&session, &claude_bin, &marketplaces)?;
+    if !baked.marketplaces.is_empty() {
+        crate::backend::install_marketplaces(&session, &claude_bin, &baked.marketplaces)?;
+    }
+    if !baked.plugins.is_empty() {
+        crate::backend::install_plugins(&session, &claude_bin, &baked.plugins)?;
     }
 
-    if !plugins.is_empty() {
-        crate::backend::install_plugins(&session, &claude_bin, &plugins)?;
+    let codex_bin = crate::guest::codex_bin();
+    if !baked.codex_marketplaces.is_empty() {
+        crate::backend::install_codex_marketplaces(
+            &session,
+            &codex_bin,
+            &baked.codex_marketplaces,
+        )?;
+    }
+    if !baked.codex_plugins.is_empty() {
+        crate::backend::install_codex_plugins(&session, &codex_bin, &baked.codex_plugins)?;
     }
 
-    Ok((marketplaces, plugins))
+    Ok(baked)
 }
 
 /// Dump diagnostic logs from the builder VM when `limactl start` fails.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -60,6 +60,10 @@ pub struct TemplateConfig {
     #[serde(default)]
     pub plugins: Vec<String>,
     #[serde(default)]
+    pub codex_marketplaces: Vec<String>,
+    #[serde(default)]
+    pub codex_plugins: Vec<String>,
+    #[serde(default)]
     pub guest_user: GuestUser,
     #[serde(default)]
     pub oci_features: Vec<InstalledFeature>,
@@ -424,6 +428,8 @@ fn build_or_check_template(cfg: &CoopConfig, opts: &SetupOptions) -> Result<()> 
         post_install_hash: recipe.post_install_hash,
         marketplaces: Vec::new(),
         plugins: Vec::new(),
+        codex_marketplaces: Vec::new(),
+        codex_plugins: Vec::new(),
         guest_user: opts.guest_user.clone(),
         oci_features: installed_features(&opts.oci_features),
     };
@@ -1590,6 +1596,10 @@ mod tests {
         }"#;
         let tc: TemplateConfig = serde_json::from_str(json).unwrap();
         assert_eq!(tc.guest_user, GuestUser::default());
+        // Codex bake lists were added later; legacy JSON omits them and
+        // must default to empty rather than failing to deserialize.
+        assert!(tc.codex_marketplaces.is_empty());
+        assert!(tc.codex_plugins.is_empty());
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3602,9 +3602,12 @@ CFGEOF
 
     GUEST_INSTANCE="$mp_instance"
 
-    # Verify the marketplace directory was copied to the guest.
-    # Use $HOME explicitly — tilde would expand on the test host, not the guest.
-    local mp_base="\$HOME/.coop/marketplaces/$mp_name"
+    # Verify the marketplace directory was copied to the guest. Local
+    # marketplaces are copied into a per-tool subdir (`claude/` here, since this
+    # is a `[claude]` marketplace) so the two agents' same-named marketplaces
+    # cannot collide. Use $HOME explicitly — tilde would expand on the test
+    # host, not the guest.
+    local mp_base="\$HOME/.coop/marketplaces/claude/$mp_name"
 
     local manifest
     manifest=$(guest_exec sh -c "cat $mp_base/.claude-plugin/marketplace.json" \
@@ -3659,7 +3662,7 @@ CFGEOF
             fail "claude plugin marketplace add was invoked" "log: '$claude_log'"
         fi
 
-        if echo "$claude_log" | grep -q "coop/marketplaces/$mp_name"; then
+        if echo "$claude_log" | grep -q "coop/marketplaces/claude/$mp_name"; then
             pass "marketplace add uses guest path (not host path)"
         else
             fail "marketplace add uses guest path (not host path)" "log: '$claude_log'"


### PR DESCRIPTION
## What

Adds first-class support for Codex plugins and marketplaces, mirroring the existing Claude Code mechanism.

- New `[codex] marketplaces` / `[codex] plugins` config fields (with `~` expansion and local-path validation), documented in `config.example.toml`, `docs/codex-integration.md`, and `docs/configuration.md`.
- Baked into the golden image on the **Lima** backend (recorded in `TemplateConfig` as `codex_marketplaces`/`codex_plugins`, staleness-checked in `needs_rebuild`) and **delta-installed on first boot** via `codex plugin marketplace add` / `codex plugin add`. On **Firecracker** nothing is baked, so the full set installs on first boot — identical to how Claude already behaves there.
- Profiles stay Claude-only; Codex plugins are config-level `[codex]`.

## Why the config.toml handling is the tricky part

The Codex CLI stores marketplace registrations (`[marketplaces.*]`) and per-plugin enabled state (`[plugins.*]`) in `~/.codex/config.toml` — the same file coop rewrites from the host on every boot. A naive port would wipe those tables on every restart (the bug class already fixed for Claude's `settings.json`).

So coop now reads the guest's `config.toml` back and **preserves** its `[marketplaces.*]`/`[plugins.*]` tables across the rewrite, while **dropping** any that came from the host's own `config.toml` (host state must not leak into the guest). Installed plugins — and manual `/plugins` enable/disable toggles — survive stop/start. The guest read is gated on whether a rewrite will actually happen (no wasted SSH round-trip otherwise) and **warns** rather than silently dropping state when the guest config can't be read or parsed, mirroring `merge_managed_claude_settings`.

Local marketplace directories are copied into a **per-tool** guest subdir (`~/.coop/marketplaces/{claude,codex}/…`) so same-basename marketplaces from the two agents don't overwrite each other.

## Reviewer notes

- **Behavior change to call out:** marketplaces/plugins a user set *directly* in their host `~/.codex/config.toml` (rather than in coop's `[codex]`) are now stripped from the guest, where previously the host config was copied verbatim. This is intentional (declarative `[codex]` is the source of truth; don't leak host state), but it changes existing behavior.
- Shell-out installers live in `backend.rs`/`lima.rs`, which are whole-module mutation-excluded, so **no `.cargo/mutants.toml` change was needed**. The pure helpers that landed in swept modules (`collect_codex_baked_lists`, `check_local_marketplaces`) are unit-tested, and `compute_codex_plugin_delta`'s field wiring has a direct test despite `backend.rs` being excluded.
- The `codex plugin ...` CLI shape differs from Claude's (`add` not `install`; no `--scope`/`-s user`), so it needs its own installer functions — the shared local-dir copy logic is factored into `stage_marketplace_source`.

## Testing

- `cargo fmt` / `cargo clippy --all-targets` clean; **996 unit tests pass** (new tests cover config parse/validate/tilde-expansion, config.toml preservation, host-state dropping, `extract_codex_plugin_state` round-trip + error cases, `plugin_delta`, the baked-list collector, and `compute_codex_plugin_delta` field wiring).
- `cargo mutants --in-diff` on the changed mutation-swept logic: 16/16 caught, 0 missed.
- **Not yet run — needs a VM environment:** integration tests on both platforms. Suggested manual check: set `[codex] marketplaces`/`plugins`, `coop up`, verify `codex plugin list` in-guest, then `coop stop` + `coop start` and confirm the plugin survives (exercises the preservation path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)