### PR TITLE
Prepare v0.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
-## Unreleased
+## v0.5.4
+
+### New features
+
+- **`coop agent update` — refresh in-guest Claude Code and Codex** (#403) —
+  Agents are installed "latest at build time" during `coop setup` and are not
+  part of the image-staleness hash, so a plain `coop setup` never refreshes
+  them; they go stale in long-running VMs and in new VMs built from an old
+  image. `coop agent update [NAME] [--claude] [--codex] [--check] [-y]` updates
+  the agent binaries inside a *running* instance without rebuilding the golden
+  image. No agent flag updates both; `--check` reports installed vs. latest and
+  changes nothing. Codex (root-owned `/usr/local/bin/codex`, no background
+  updater) is reinstalled from the current release via coop's own installer
+  over SSH; Claude Code (`~/.local/bin`, already self-updating) runs
+  `claude update` synchronously. Versions are parsed to semver so "update
+  available" is a comparison, not a string diff; an unparseable version
+  degrades to `Unknown` rather than erroring.
+
+- **Codex plugins and marketplaces** (#407) — New `[codex] marketplaces` /
+  `[codex] plugins` config fields (with `~` expansion and local-path
+  validation), mirroring the existing Claude Code mechanism. On Lima the set is
+  baked into the golden image and staleness-checked; on Firecracker it installs
+  on first boot. coop preserves the guest's own `[marketplaces.*]`/`[plugins.*]`
+  tables across the per-boot `~/.codex/config.toml` rewrite — so plugins
+  installed in-guest and manual `/plugins` toggles survive stop/start — while
+  dropping any that came from the host config. Local marketplace directories
+  are copied into a per-tool guest subdir so same-basename marketplaces from
+  the two agents don't collide. Behavior change: marketplaces/plugins set
+  directly in the host `~/.codex/config.toml` (rather than in coop's `[codex]`)
+  are now stripped from the guest; declarative `[codex]` is the source of
+  truth.
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coop"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coop"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "Isolated VM environment for running Claude Code"
 license = "Apache-2.0"


### PR DESCRIPTION
Release prep for v0.5.4.

- Rename the `Unreleased` changelog section to `v0.5.4`.
- Add the two feature entries that landed on `main` after v0.5.3 but were missing from the changelog: `coop agent update` (#403) and Codex plugins/marketplaces (#407).
- Bump the crate version 0.5.3 → 0.5.4 (`Cargo.toml` + `Cargo.lock`).

The `Unreleased` section already carried the #404 memory-floor fix and the #401 HTTPS/docs/metadata changes; those are folded into v0.5.4 as-is.

Only CHANGELOG.md, Cargo.toml, and Cargo.lock change; nothing with runtime behavior. This branch is `origin/main` plus this commit, so it is the exact tree that will be tagged `v0.5.4`.

## Before merge
Integration tests on both platforms (macOS/Lima and Linux/Firecracker), pointed at this branch:

```
./tests/run-integration.sh --full
./tests/run-integration.sh --remote user@remote-host --full
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)