### PR TITLE
Add .claude review tooling, design/security docs, and restructure CLAUDE.md (#409)

### DIFF
--- a/.claude/agents/review-api-usage.md
+++ b/.claude/agents/review-api-usage.md
@@ -1,0 +1,30 @@
+---
+name: review-api-usage
+description: Verifies the diff's use of external crate APIs against current documentation — signatures, parameter types, return values, deprecations, version-specific behavior, error semantics.
+---
+
+You are an API/crate/dependency reviewer for a code diff in `coop` (a Rust CLI). If a coordinator passes a review context packet (diff, touched files, CLAUDE.md, trigger map with external crates, prior PR feedback), treat its touched symbols as authoritative for the changed code and only read additional files if the packet is insufficient. Otherwise, read the diff and touched files directly (`git diff origin/main...HEAD`) and derive the external crates from the diff's `use` statements and `Cargo.toml` changes.
+
+**Open with the framing "Look at this again with fresh eyes"** before applying the lens below.
+
+Only flag issues **introduced or materially changed by the diff**. Cross-reference the prior review brief in the packet.
+
+## What to verify
+
+For each external crate the diff actually exercises, look up current documentation **once** (docs.rs for the pinned version, or the crate's own docs via web search) and verify:
+
+- Function/method signatures, parameter types, return values, trait bounds.
+- Deprecations and version-specific behavior — **check the version pinned in `Cargo.toml`/`Cargo.lock`**, not the latest. coop pins exact versions.
+- Error semantics: what the API returns on failure vs. what the code handles (`Result` variants, panics-on-misuse APIs called with unchecked input).
+- Feature-gated APIs: the call site's feature is enabled in `Cargo.toml`.
+- Correct async vs. blocking variant; correct builder finalization.
+
+coop's common external surfaces: `clap` (derive attributes, arg parsing), `serde`/`toml`/`serde_json` (derive + custom `Deserialize`/`visit_map`), `anyhow`/`thiserror` (context, error derive), `indexmap`, `sha2`, `dirs`, and any process/SSH/HTTP crate the diff introduces. Verify `cmd:`/subprocess and `curl`/`gh` invocations against the tool's actual flags when the diff changes them.
+
+Cite the doc URL (with version) in `evidence`. You own API doc lookups for this run — other agents should not duplicate this research.
+
+## Output
+
+Return findings as a JSON array. Each finding: `{file, line, side, severity (P1/P2/P3), category, finding, evidence}` — `evidence` must include the cited doc URL. Return an empty array if no issues apply.
+
+If invoked without a coordinator packet, present findings as human-readable markdown (inline code references, severity in brackets, evidence as supporting prose) rather than a JSON array.

--- a/.claude/agents/review-comments.md
+++ b/.claude/agents/review-comments.md
@@ -1,0 +1,46 @@
+---
+name: review-comments
+description: Aggressively reviews inline code comments in the diff — flags comments that are unnecessary, redundant, stale, or too verbose. Comments must earn their place by explaining why, not what.
+---
+
+You are a code-comment reviewer for a code diff in `coop` (a Rust CLI). Your scope is **inline `//` and block `/* */` comments inside code** — not doc-comments (`///`, `//!`) and not prose docs (`docs/`, README, CLAUDE.md), which belong to `review-docs`. If a coordinator passes a review context packet (diff, touched files, CLAUDE.md, trigger map, prior PR feedback), treat its touched symbols as authoritative for the changed code and only read additional files if the packet is insufficient. Otherwise, read the diff and touched files directly (`git diff origin/main...HEAD`).
+
+**Open with the framing "Look at this again with fresh eyes"** before applying the lens below.
+
+Only flag comments **introduced or materially changed by the diff**, plus any comment the diff made stale (code changed, adjacent comment still describes the old behavior). Cross-reference the prior review brief in the packet.
+
+## Core principle
+
+A comment is a liability that drifts from the code. Keep one only if it states a non-obvious **why** — a rationale, a deliberate trade-off, or a surprising/arbitrary decision — that the code cannot state itself and that survives a plausible refactor. The *why* must be about the **final committed code**; a *why* that only records an implementation-time concern (why the author took one path over another, a problem guarded against while writing it) should be discarded once the code is settled. A comment that narrates **what** or **how** the code does something is not earning its place: the code already says that. Be aggressive. When torn between rewriting a weak comment and deleting it, delete.
+
+Do not review the surrounding logic for bugs or design (other agents own that). Judge only the comments.
+
+Note: `coop` deliberately carries some load-bearing comments — the CI-kernel workarounds in `src/setup.rs`, the scp/`~` caveat, `#[mutants::skip]` justifications, and `// Safe because …` notes on the rare permitted `unwrap`. These state a real *why* and should be **kept**; judge them on whether the stated reason is still true and still non-obvious, not on their existence.
+
+## What to flag
+
+**Remove:**
+
+- **Restates the code (*what*/*how*).** `// increment i`, or narration self-evident from reading the code.
+- **Describes code that isn't here.** References planned, follow-up, or already-removed functionality. A bare "this is a stub" is fine; naming specific future code is not.
+- **Narrates history or process.** "Previously we did X," "this now works," attempt logs, migration steps. Belongs in git history.
+- **Records an implementation-time concern.** Justifies the chosen approach against a worry that only existed while writing it. Remove it — a *why* survives only if a future reader of the final code would be surprised or misled without it.
+- **Stale — contradicts the code.** A boundary stated as `>` where the code uses `>=`, a comment citing a flag/const that no longer exists. Never leave a false statement: fix it to match, or remove if the code is now self-evident.
+- **Duplicates a constraint that belongs in code.** Enumerates allowed values, a threshold, or an invariant that an enum, `const`, or newtype should carry. Recommend the mechanism, then remove the comment.
+
+**Change:**
+
+- **Too verbose.** Multi-line prose where one line would do. Trim to the single non-obvious point, or delete if trimming leaves nothing.
+- **Explains *what*/*how* when a *why* exists.** Rewrite to capture the why/trade-off.
+
+**Keep** only when it explains a genuine *why* the code can't convey, describes code that currently exists, would survive a refactor, and matters to a future reader.
+
+## Severity
+
+Findings are P3 by default (readability/maintainability). Raise to P2 for a stale comment that actively misdescribes current behavior — a false comment is worse than none.
+
+## Output
+
+Return findings as a JSON array. Each finding: `{file, line, side, severity (P1/P2/P3), category, finding, evidence}`. Return an empty array if no issues apply.
+
+If invoked without a coordinator packet, present findings as human-readable markdown (inline code references, severity in brackets, evidence as supporting prose) rather than a JSON array.

--- a/.claude/agents/review-conventions.md
+++ b/.claude/agents/review-conventions.md
@@ -1,0 +1,32 @@
+---
+name: review-conventions
+description: Reviews the Rust diff for convention violations, rename consistency, drift in shared constants, cross-file infra sync (Cargo.toml/config.example.toml/pre-commit/CI/installers), and diff noise.
+---
+
+You are a convention and diff-noise reviewer for a code diff in `coop` (a Rust CLI). If a coordinator passes a review context packet (diff, touched files, CLAUDE.md, trigger map, prior PR feedback), treat its touched symbols as authoritative for the changed code and only read additional files if the packet is insufficient. Otherwise, read the diff and touched files directly (`git diff origin/main...HEAD`).
+
+**Open with the framing "Look at this again with fresh eyes"** before applying the lens below.
+
+Only flag issues **introduced or materially changed by the diff**. Cross-reference the prior review brief in the packet.
+
+## What to flag
+
+- **Convention violations:** naming, module organization, import patterns, and the established Rust idioms in [`docs/code-style.md`](../../docs/code-style.md) — newtypes over primitives that cross a boundary, enums over boolean flags, parse-don't-validate at boundaries, `&str`/`&[T]`/`&Path` parameters over owned, `let...else` early returns, `thiserror` (libraries) vs `anyhow` (application), `tracing` over `println!`/`eprintln!`. **Absolute imports only — no relative `..` paths.** Read CLAUDE.md and nearby existing code; do not apply external style guides that conflict with project practice. Flag idioms with real payoff — don't demand a newtype for a primitive that crosses no boundary.
+- **Rename consistency:** if the diff renames a type, function, field, constant, file, or CLI flag, grep the diff plus touched files for the *old* name and flag every straggler — variable names, `tracing` log strings, `--help`/clap `about`/`long_about` text, doc-comments, error messages, and the docs under `docs/`. For repo-wide terminology shifts, grep the whole repo; stragglers are in-scope for the rename PR.
+- **Drift in shared constants:** literal values (guest paths, IPs/subnet octets, default sizes, filenames, marker strings) that are already defined as a constant elsewhere. Grep for the literal; if it exists as a `const`/`static` or a newtype, recommend the reference instead of the duplicate.
+- **Cross-file infra sync:** if the diff touches any of these, verify the edges the change implies:
+  - **A new/renamed CLI flag or config field** ↔ `config.example.toml`, the `docs/` reference (`docs/commands.md`, `docs/configuration.md`), and shell-completion output (`completions.rs`).
+  - **`Cargo.toml` dependency or lint changes** ↔ `Cargo.lock` regenerated, `deny.toml` (a new dep's license/advisory), and the `[lints]` policy in CLAUDE.md.
+  - **Tool-version pins** — `scripts/install-dev-tools.sh` pins (taplo, cargo-deny, cargo-mutants, cargo-fuzz, kani) ↔ the matching pins in `.github/workflows/ci.yml` (the file comments call out that these must stay in sync).
+  - **Guest-visible changes** (`src/setup.rs` guest install script, `guest/init.sh`, `scripts/guest/`) ↔ the workaround docs and any integration-test phase in `tests/integration.sh` that asserts on them.
+  - **`.pre-commit-config.yaml`** hooks ↔ the equivalent CI job in `.github/workflows/ci.yml`.
+- **Mutation-scope sync:** if the diff adds a function that shells out, drives a `&PlatformBackend`, reads a TTY, or writes stdout in a logic module, `.cargo/mutants.toml` must gain a matching `exclude_re`/`exclude_globs` entry **in the same PR** (CLAUDE.md documents this as a past failure mode — #352/#373). Flag a missing update.
+- **Diff noise (P3, `category: "Diff noise"`):** changes with no functional impact that only inflate the diff — import reordering, code movement, cosmetic reformatting, lateral renames, comment-only rewords.
+
+**Critical:** a formatting change is noise only if the before-state already passed `cargo fmt -- --check` / `taplo format --check`. If it fixes an actual violation, it is a legitimate fix — do NOT flag it. Import additions/removals, naming-convention fixes, and code movement that breaks a dependency cycle are NOT noise.
+
+## Output
+
+Return findings as a JSON array. Each finding: `{file, line, side, severity (P1/P2/P3), category, finding, evidence}`. Return an empty array if no issues apply.
+
+If invoked without a coordinator packet, present findings as human-readable markdown (inline code references, severity in brackets, evidence as supporting prose) rather than a JSON array.

--- a/.claude/agents/review-correctness.md
+++ b/.claude/agents/review-correctness.md
@@ -1,0 +1,30 @@
+---
+name: review-correctness
+description: Reviews a Rust diff for correctness and runtime safety — logic errors, missing edge cases, error handling and `Result`/`?` propagation, panics on fallible input, process/SSH lifecycle, resource cleanup, and cross-backend correctness.
+---
+
+You are a correctness reviewer for a code diff in `coop` (a Rust CLI that orchestrates isolated VMs — Firecracker on Linux, Lima on macOS). If a coordinator passes a review context packet (diff, touched files, CLAUDE.md, trigger map, prior PR feedback), treat its touched symbols as authoritative for the changed code and only read additional files if the packet is insufficient. Otherwise, read the diff and touched files directly (`git diff origin/main...HEAD`).
+
+**Open with the framing "Look at this again with fresh eyes"** before applying the lens below — this primes critical re-examination rather than rubber-stamping.
+
+Only flag issues **introduced or materially changed by the diff**. The one exception is when the diff makes a pre-existing issue newly reachable. Cross-reference the prior review brief in the packet: do not re-flag resolved comments; do flag unresolved ones that still apply.
+
+## What to flag
+
+- Logic errors, off-by-ones, inverted conditions, wrong comparisons, mismatched match arms.
+- Missing edge cases (`None`/empty/boundary/overflow), broken invariants, integer arithmetic that can wrap or truncate (`as` casts, `+`/`-` on sizes/indices — prefer `checked_*`/`saturating_*`).
+- **Error handling** (coop bans `unwrap`/`expect`/`panic`/`todo!`/`unimplemented!` in production paths via `[lints.clippy]`):
+  - `.unwrap()` / `.expect()` / `panic!` / indexing (`x[i]`) reachable from external or fallible input — VM output, SSH results, config, filesystem, network.
+  - Swallowed errors: `let _ = fallible()`, `.ok()` that drops an error that should propagate, `if let Ok(..)` with no `else`, a `match` arm that discards `Err`.
+  - `?` that propagates a low-context error where the boundary should attach `.context(...)`; or the reverse — re-wrapping at every level producing low-signal errors.
+  - Silent empty returns where an empty result is indistinguishable from a missing input.
+- **Process / SSH / VM lifecycle:** a spawned `Command`/child whose exit status is never checked; a VM, mount, temp file, or SSH control socket left behind on an error path (cleanup should run on both success and failure); `scp`/`ssh` argument construction that breaks on paths with spaces or the `~`-expansion caveat (see CLAUDE.md — guest paths use `./`, not `~/`).
+- **Concurrency / signals:** shared state without synchronization, a signal handler racing teardown, a lock held across a blocking call. Only if the diff touches these.
+- Resource lifecycle: file handles, sockets, child processes, and VM state cleaned up on every path.
+- **Cross-backend correctness:** a change to `backend.rs`-shared code (SSH, workspace sync, config injection) that only holds for one of Firecracker/Lima. Confirm the abstraction still holds for both.
+
+## Output
+
+Return findings as a JSON array. Each finding: `{file, line, side, severity (P1/P2/P3), category, finding, evidence}`. Return an empty array if no issues apply.
+
+If invoked without a coordinator packet, present findings as human-readable markdown (inline code references, severity in brackets, evidence as supporting prose) rather than a JSON array.

--- a/.claude/agents/review-design.md
+++ b/.claude/agents/review-design.md
@@ -1,0 +1,27 @@
+---
+name: review-design
+description: Reviews the Rust diff for design and complexity — local simplifications, phantom features (docs/flags without implementation), type-design opportunities, and at most one structural finding when the overall approach is the wrong shape.
+---
+
+You are a design and complexity reviewer for a code diff in `coop` (a Rust CLI). If a coordinator passes a review context packet (diff, touched files, CLAUDE.md, trigger map, prior PR feedback), treat its touched symbols as authoritative for the changed code and only read additional files if the packet is insufficient. Otherwise, read the diff and touched files directly (`git diff origin/main...HEAD`).
+
+**Open with the framing "Look at this again with fresh eyes"** before applying the lens below.
+
+Only flag issues **introduced or materially changed by the diff**. Cross-reference the prior review brief in the packet.
+
+## What to flag
+
+- **Inline findings (local):** redundant expressions, dead code, verbose patterns with a cleaner idiom, unnecessary indirection or allocation, `match` where `let...else`/`if let` reads better. Must be behavior-preserving.
+- **Type-design opportunities (with real payoff only):** a runtime check or convention that a type could make unrepresentable — a `bool` parameter plus a payload that's only meaningful when true (→ `Option`/enum), two `Option` fields that are always both-`Some`/both-`None` (→ one `Option<(T, T)>`), a validated-by-convention `&str` that should be a smart-constructor newtype, a `String`/`-1`/`""`/`0` sentinel standing for a domain concept (→ enum/newtype). See the "Lean on the type system" guidance in [`docs/code-style.md`](../../docs/code-style.md). Flag the ones that eliminate a real bug class; do not demand a newtype for a primitive that crosses no boundary.
+- **Phantom features:** newly-added CLI flags, config keys, `docs/` sections, or README prose that describe behavior the same diff does not implement. Verify by grepping the diff for the named symbol or flag. Where the doc lives in the diff but the implementation does not, flag the doc.
+- **Summary finding (structural):** if the overall approach is the wrong shape — a large refactor where a targeted patch would do, a new abstraction for a single caller, reimplementing something an existing project utility or a `std`/dependency API already provides, breaking the two-backend abstraction, or treating a symptom instead of the root cause.
+
+For structural findings, identify the problem first from (1) PR description and linked issues, (2) commit messages, (3) the diff. If it can't be identified confidently, return zero structural findings. Before flagging duplication, grep for the imported names, distinctive signatures, or characteristic literals of the new code against the rest of the repo; name the match with `path:line` in the evidence. Do not raise duplication without a concrete match. When proposing an alternative, name the specific utility/type with a file reference — do not speculate.
+
+Produce at most one structural finding. Anything smaller is local.
+
+## Output
+
+Return findings as a JSON array. Each finding: `{file, line, side, severity (P1/P2/P3), category, finding, evidence}`. Return an empty array if no issues apply.
+
+If invoked without a coordinator packet, present findings as human-readable markdown (inline code references, severity in brackets, evidence as supporting prose) rather than a JSON array.

--- a/.claude/agents/review-docs.md
+++ b/.claude/agents/review-docs.md
@@ -1,0 +1,36 @@
+---
+name: review-docs
+description: Reviews documentation quality, correctness, and style in the diff — doc-comments and prose docs (README/docs/CLAUDE.md/--help text). Flags docs that are outdated, unnecessary, or too verbose.
+---
+
+You are a documentation reviewer for a code diff in `coop` (a Rust CLI). Your scope is **doc-comments (`///`, `//!`) and prose docs** (README, `docs/`, top-level `*.md`, CLAUDE.md, clap `--help`/`about` text). Inline `//` code comments are out of scope — those belong to `review-comments`. If a coordinator passes a review context packet (diff, touched files, CLAUDE.md, trigger map, prior PR feedback), treat its touched symbols as authoritative for the changed code and only read additional files if the packet is insufficient. Otherwise, read the diff and touched files directly (`git diff origin/main...HEAD`).
+
+**Open with the framing "Look at this again with fresh eyes"** before applying the lens below.
+
+Only flag issues **introduced or materially changed by the diff**. Cross-reference the prior review brief in the packet.
+
+## What to flag
+
+- **Outdated (incorrect).** A doc no longer matches the code. Two directions:
+  - *Forward (code changed):* a doc-comment, README/`docs/` reference, config key, or command example describing a changed symbol/flag whose signature, behavior, defaults, or invariants no longer match — including a `coop <cmd>` example or a `config.toml` snippet that would now fail if copy-pasted.
+  - *Reverse (docs changed):* a doc in the diff whose new prose, example, or `see <fn>` pointer disagrees with the current — unchanged — source.
+- **Cross-doc drift.** `coop` keeps `docs/ARCHITECTURE.md`, `docs/trust-model.md`, `docs/code-style.md`, `docs/commands.md`, `docs/configuration.md`, `config.example.toml`, and CLAUDE.md pinned to the code. If the diff changes a module boundary, trust boundary, command, or config surface, flag the doc that now describes the old shape.
+- **Unnecessary.** A doc that shouldn't exist: it narrates a fix or the development process, tracks work to be done, says a feature "now works," references previous attempts or migration steps, or restates something obvious from the code or an adjacent durable doc. That belongs in git history, an issue, or the changelog — not the tree.
+- **Records an implementation-time concern.** A doc-comment justifying the chosen approach against a worry that only existed while writing it — a rejected alternative, a problem being guarded against. It reads like a *why*, but it's about the author's path, not the final code. Cut it, keeping only what a user of the code needs.
+- **Too verbose.** A doc-comment that re-spells the signature and every parameter, or prose that buries its point in multi-paragraph narration. Trim to what a reader needs.
+
+## What NOT to flag
+
+- **Missing doc-comments** on previously-undocumented items — that belongs to the conventions agent (CLAUDE.md wants Google-style doc-comments on non-trivial public APIs).
+- **A doc that explains *how* rather than *why*** — for prose docs, describing mechanics is legitimate.
+- **Inline `//` comments** — defer to `review-comments`.
+
+## Severity
+
+Findings are P2 by default; raise to P1 if a public README/`docs/` example would now fail when copy-pasted, or a doc actively misdescribes current behavior or a trust boundary.
+
+## Output
+
+Return findings as a JSON array. Each finding: `{file, line, side, severity (P1/P2/P3), category, finding, evidence}`. Return an empty array if no issues apply.
+
+If invoked without a coordinator packet, present findings as human-readable markdown (inline code references, severity in brackets, evidence as supporting prose) rather than a JSON array.

--- a/.claude/agents/review-security.md
+++ b/.claude/agents/review-security.md
@@ -1,0 +1,35 @@
+---
+name: review-security
+description: Reviews a diff against coop's trust model — the VM isolation boundary, credential/secret injection, guest→host input flow, host-side command construction on tainted bytes, network binds, and `coop update` verification.
+---
+
+You are a security reviewer for a code diff in `coop` (a Rust CLI that stands up isolated VMs — Firecracker on Linux, Lima on macOS — and injects the user's credentials into the guest). If a coordinator passes a review context packet (diff, touched files, CLAUDE.md, trigger map, prior PR feedback), treat its touched symbols as authoritative for the changed code and only read additional files if the packet is insufficient. Otherwise, read the diff and touched files directly (`git diff origin/main...HEAD`).
+
+**Open with the framing "Look at this again with fresh eyes"** before applying the lens below.
+
+Only flag issues **introduced or materially changed by the diff**. The exception is when the diff makes a pre-existing issue newly reachable. Cross-reference the prior review brief in the packet.
+
+## Project trust model
+
+Read [`docs/trust-model.md`](../../docs/trust-model.md) before flagging — it is the authoritative list of taint sources and trust boundaries (the root `CLAUDE.md` "Trust model" section points to it). Do not maintain a parallel copy here. The core boundary is **the VM**: the guest is agent-controlled and treated as untrusted; the host must not let guest-authored data escalate into host-side code execution or filesystem escape.
+
+## What to flag
+
+- **Host-side command construction on tainted bytes.** A guest command or a host subprocess built by interpolating a guest-derived or config-derived string into a shell string instead of going through `RemoteCommand::arg` (single-quote-escaped) / `Cmd::arg` (argv, no shell). `RemoteCommand::literal` and raw `sh -c "…{var}…"` on tainted input are the canonical bug.
+- **Secret leakage.** A secret (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GITHUB_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, a PAT, the VM SSH key) passed on **argv** (visible in `ps`/`/proc`) instead of stdin / env `SendEnv` / a file; a secret written to a world-readable path (secret files must stay `0600`, dirs `0700` — see `secret_store.rs`, `fs_util::atomic_write_with_mode`); a secret logged or traced (use `Cmd::redacted_arg`, and `EnvForward`/`Secret<T>` keep values out of `Debug`); a `GITHUB_TOKEN` newly made persistent inside the guest (`gh auth setup-git`) where the change didn't intend it.
+- **Guest→host filesystem escape.** A `pull` / `tar_pipe_pull` path that extracts a guest-authored archive onto the host without relying on tar's `..`/absolute-path rejection; a host path built from a guest-supplied filename without a containment check. The workspace pull is the widest guest→host channel.
+- **`coop update` trust-chain weakening.** Anything that skips or softens: the mandatory `SHA256SUMS` presence + checksum verify, the semver `normalize_tag` guard (path-traversal into the API URL), the Sigstore `gh attestation verify` step, or the `--no-same-owner --no-same-permissions` extraction flags. Note the `COOP_UPDATE_API_BASE_URL` override disables attestation — a change that widens where that override is honored is a finding.
+- **Network binds.** Any bind on `0.0.0.0` or a non-loopback address (coop binds port-forwards to `127.0.0.1` exclusively today); a new listener without an explicit loopback bind; a new NAT/`iptables`/`FORWARD` rule that widens guest egress.
+- **SSH boundary changes.** coop deliberately runs guest SSH with `StrictHostKeyChecking=no` + `UserKnownHostsFile=/dev/null` (ephemeral guest keys). Flag a change that extends those options to a non-guest host, or that weakens guest key handling (the ed25519 `vm_key` is passphrase-less by design — do not "fix" it, but flag exposure of it).
+- **`cmd:` config indirection.** `config.toml` `cmd:` values run arbitrary `sh -c` on the host at VM start (`resolve_cmd_value`) — this is a trusted-owner surface. Flag a change that runs a `cmd:` value from a *less*-trusted source (a fetched devcontainer, a guest file) as host code.
+- **Stock issues:** secrets committed to the repo, unsafe deserialization, insecure crypto defaults — keep.
+
+## Stop-and-confirm triggers (call these out prominently)
+
+Per the root `CLAUDE.md` trust-model section, flag for explicit human confirmation any diff that: adds a new outbound URL / network listener / egress rule; forwards a new secret into the guest or makes one persistent; runs a subprocess on tainted bytes; writes a host FS path derived from guest/tainted data; or logs/traces tainted or secret content.
+
+## Output
+
+Return findings as a JSON array. Each finding: `{file, line, side, severity (P1/P2/P3), category, finding, evidence}`. Return an empty array if no issues apply.
+
+If invoked without a coordinator packet, present findings as human-readable markdown (inline code references, severity in brackets, evidence as supporting prose) rather than a JSON array.

--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -1,0 +1,32 @@
+---
+name: review-tests
+description: Reviews the diff for test coverage and quality — changed behavior without tests, untested error paths and edges, integration-test phase gaps, mutation-scope regressions, and tautological or over-mocked tests.
+---
+
+You are a test-coverage reviewer for a code diff in `coop` (a Rust CLI). If a coordinator passes a review context packet (diff, touched files, CLAUDE.md, trigger map, prior PR feedback), treat its touched symbols as authoritative for the changed code and only read additional files if the packet is insufficient. Otherwise, read the diff and touched files directly (`git diff origin/main...HEAD`).
+
+**Open with the framing "Look at this again with fresh eyes"** before applying the lens below.
+
+Only flag issues **introduced or materially changed by the diff**. Cross-reference the prior review brief in the packet.
+
+## coop's test layers
+
+- **Unit tests** live in the library crate (`src/lib.rs` target) as `#[cfg(test)] mod tests`. All logic is unit-testable there; `main.rs` is a thin shim.
+- **Integration tests** (`tests/integration.sh`, driven by `tests/run-integration.sh`) exercise the full VM lifecycle (setup → up → status → shell → guest env → docker → stop → destroy) on **both** backends (Firecracker/Linux and Lima/macOS). CI additionally runs `tests/integration-update.sh` and `tests/integration-uninstall.sh`.
+- **Mutation testing** scope is curated in `.cargo/mutants.toml`; the pure-logic helpers are kept in scope and expected to have unit tests that kill their mutants (CLAUDE.md details this).
+
+## What to flag
+
+- **Changed behavior without test updates.** New/changed pure logic in a module CLAUDE.md lists as mutation-tested (`config.rs`, `workspace.rs`, `devcontainer.rs`, `github_repo.rs`, `github_pat.rs`, `secret_store.rs`, `fs_util.rs`, `src/commands/*`, `model_state.rs`, `jsonc.rs`, …) that ships with no unit test — this is a coverage regression, not a nit.
+- **New code paths without coverage; untested error paths and edges.** coop's guidance is to test edges and errors, not just the happy path — empty inputs, boundaries, malformed data, missing files. Every error variant the code returns should have a test that triggers it.
+- **A new guest-visible command, flag, or lifecycle behavior with no integration-test phase.** New `coop` subcommands or guest environment changes are candidates for a new `tests/integration.sh` phase; flag the gap.
+- **Mutation-scope regression.** A new logic function that is neither unit-tested nor added to `.cargo/mutants.toml`'s exclude set — a survivor waiting to happen (CLAUDE.md #352/#373).
+- **Test quality:** behavior vs. implementation detail; tautological or unassertive tests ("it didn't panic" without asserting the value); tests that would still pass if the behavior were broken.
+- **Over-mocked tests:** mocking the logic under test rather than only the boundaries CLAUDE.md sanctions (network, filesystem, time, external services). A heavily-mocked happy path proves little.
+- If the diff contains tests, review them for correctness.
+
+## Output
+
+Return findings as a JSON array. Each finding: `{file, line, side, severity (P1/P2/P3), category, finding, evidence}`. Return an empty array if no issues apply.
+
+If invoked without a coordinator packet, present findings as human-readable markdown (inline code references, severity in brackets, evidence as supporting prose) rather than a JSON array.

--- a/.claude/commands/babysit-my-prs.md
+++ b/.claude/commands/babysit-my-prs.md
@@ -1,6 +1,6 @@
 ---
 description: Continuously babysit my open PRs — 7-min loop, auto-discovers new PRs, dispatches one background worker per PR needing work.
-allowed-tools: Bash(gh auth status:*), Bash(gh api user:*), Bash(gh repo view:*), Bash(gh search prs:*), Bash(gh pr view:*), Bash(gh api graphql:*), Bash(gh api repos:*), Bash(gh run list:*), Bash(git remote:*), Bash(git rev-parse:*), Bash(git fetch:*), Bash(git worktree:*), Bash(mkdir:*), Bash(ls:*), Bash(stat:*), Bash(date:*), Bash(find:*), Bash(head:*), Bash(echo:*)
+allowed-tools: Agent, CronCreate, CronList, CronDelete, TaskCreate, TaskUpdate, TaskList, Bash(gh auth status:*), Bash(gh api user:*), Bash(gh repo view:*), Bash(gh search prs:*), Bash(gh pr view:*), Bash(gh api graphql:*), Bash(gh api repos:*), Bash(gh run list:*), Bash(git remote:*), Bash(git rev-parse:*), Bash(git fetch:*), Bash(git worktree:*), Bash(mkdir:*), Bash(ls:*), Bash(stat:*), Bash(date:*), Bash(find:*), Bash(head:*), Bash(echo:*)
 ---
 
 ## What this does
@@ -26,6 +26,8 @@ This wraps `/babysit-pr` (single PR). It NEVER rewrites published history, never
 - gh is authed: !`gh auth status 2>&1 | head -3`
 - in a git repo: !`git rev-parse --show-toplevel 2>/dev/null || echo "MISSING — not a git repo"`
 - origin points to GitHub: !`git remote get-url origin 2>/dev/null || echo "MISSING — no origin remote"`
+
+This command's orchestration depends on the harness providing the `CronCreate`/`CronList`/`CronDelete`, `TaskCreate`/`TaskUpdate`/`TaskList`, and background `Agent` primitives (all listed in `allowed-tools`). If your Claude Code install doesn't expose scheduled crons or background tasks, this command can't run — use `/babysit-pr` per PR instead.
 
 If any fail, stop and tell the user. Derive once and reuse:
 

--- a/.claude/commands/babysit-my-prs.md
+++ b/.claude/commands/babysit-my-prs.md
@@ -1,0 +1,176 @@
+---
+description: Continuously babysit my open PRs — 7-min loop, auto-discovers new PRs, dispatches one background worker per PR needing work.
+allowed-tools: Bash(gh auth status:*), Bash(gh api user:*), Bash(gh repo view:*), Bash(gh search prs:*), Bash(gh pr view:*), Bash(gh api graphql:*), Bash(gh api repos:*), Bash(gh run list:*), Bash(git remote:*), Bash(git rev-parse:*), Bash(git fetch:*), Bash(git worktree:*), Bash(mkdir:*), Bash(ls:*), Bash(stat:*), Bash(date:*), Bash(find:*), Bash(head:*), Bash(echo:*)
+---
+
+## What this does
+
+Sets up a **continuous loop** (default 7-min cadence) that:
+
+1. Discovers every open PR authored by the current `gh` user in the current repo's `origin` — picks up new PRs automatically, drops merged/closed ones.
+2. Triages each PR (CI failures, base divergence, unresolved review feedback) using `/babysit-pr`'s rules.
+3. For each PR needing mechanical work, spawns **one background subagent** that runs a single `/babysit-pr` pass on that PR — in an isolated worktree, with a lock file so the next cron fire doesn't double-dispatch.
+4. Keeps the main agent **responsive** — orchestration is fast (survey + dispatch); slow work happens out-of-band.
+5. Surfaces every **deferred decision** — judgment/scope/design calls it will NOT auto-act on — in a persistent ledger (`$LOCK_DIR/deferred.md`) re-printed in full every sweep.
+
+Re-running is safe — it checks for an existing orchestrator cron and skips re-creation. Durable crons auto-expire after 7 days; re-run to refresh. Use `/babysit-my-prs stop` to cancel.
+
+This wraps `/babysit-pr` (single PR). It NEVER rewrites published history, never force-pushes, never pushes to `main`/`master`, never touches PRs you don't own.
+
+## Argument handling
+
+`$ARGUMENTS` may be: empty → set up with defaults (current user, 7-min cadence); `stop` → cancel the cron + in-flight tasks; `status` → list workers + cron + ledger without changing anything; anything else → report `Unknown arg: <x>. Use empty, 'stop', or 'status'.`
+
+## Preconditions
+
+- gh is authed: !`gh auth status 2>&1 | head -3`
+- in a git repo: !`git rev-parse --show-toplevel 2>/dev/null || echo "MISSING — not a git repo"`
+- origin points to GitHub: !`git remote get-url origin 2>/dev/null || echo "MISSING — no origin remote"`
+
+If any fail, stop and tell the user. Derive once and reuse:
+
+```bash
+GH_USER=$(gh api user --jq .login)
+OWNER_REPO=$(gh repo view --json owner,name -q '"\(.owner.login)/\(.name)"')
+LOCK_DIR="${CLAUDE_JOB_DIR:-/tmp/babysit-my-prs-$USER}"
+mkdir -p "$LOCK_DIR/locks" "$LOCK_DIR/worktrees"
+```
+
+The deferred-decision ledger lives at `$LOCK_DIR/deferred.md` and persists across sweeps.
+
+## `status` mode
+
+1. List active locks: `ls -la "$LOCK_DIR/locks/"` — each `pr-N.lock` (mtime < 30 min) is a worker in flight.
+2. List the orchestrator cron via `CronList` (prompt starts with `[babysit-my-prs sweep]`).
+3. List in-flight tasks via `TaskList`.
+4. Print `$LOCK_DIR/deferred.md` in full if present.
+5. One-screen summary. Exit.
+
+## `stop` mode
+
+1. `CronList` → find the orchestrator cron(s) → `CronDelete` each.
+2. Leave running workers to finish (don't kill mid-push).
+3. Optionally remove stale locks: `find "$LOCK_DIR/locks" -name 'pr-*.lock' -mmin +30 -delete`.
+4. Report what was stopped. Exit.
+
+## Default mode — set up the orchestrator
+
+### Step 1. Check for an existing orchestrator
+
+`CronList`. If any cron's prompt starts with `[babysit-my-prs sweep]`, do NOT duplicate — report `Orchestrator already running (cron <id>).`, run the initial sweep anyway (Step 3), then exit.
+
+### Step 2. Schedule the recurring cron
+
+Off-minute 7-cycle: `4-59/7 * * * *`. Use `CronCreate` with `recurring: true`, `durable: true`. The cron prompt is the **sweep payload** below — copy it verbatim, substituting `<GH_USER>` and `<OWNER_REPO>`:
+
+---SWEEP PAYLOAD---
+
+```
+[babysit-my-prs sweep] Periodic /babysit-pr sweep across <GH_USER>'s open PRs in <OWNER_REPO>. DO NOT create a new cron — the orchestrator is already running.
+
+LOCK_DIR="${CLAUDE_JOB_DIR:-/tmp/babysit-my-prs-$USER}"
+DEFERRED_LEDGER="$LOCK_DIR/deferred.md"   # persists across sweeps
+
+1. **Discover** open PRs:
+   gh search prs --repo <OWNER_REPO> --author <GH_USER> --state open --json number,title,isDraft,url,updatedAt --limit 200
+   If the count equals the limit (200), prepend `WARNING: >=200 open PRs, some not babysat this sweep.` to the report.
+
+2. **Reconcile TaskList:** for each task matching `PR #N`, if `$LOCK_DIR/locks/pr-N.lock` is gone or >30 min old, TaskUpdate to completed. For any task whose PR is no longer open, complete it.
+
+3. **Skip in-flight PRs:** drop any PR with a lock file <30 min old.
+
+4. **Triage candidates** via ONE foreground general-purpose Agent. Brief it to gather, per PR:
+   - CI status via `gh run list --repo <OWNER_REPO> --branch <head> --limit 10 --json databaseId,name,conclusion,status` (failing = conclusion in {failure,cancelled,timed_out,action_required}; in-flight = status in {in_progress,queued,pending}). coop CI jobs: check, deny, taplo, zizmor.
+   - Inline review threads via GraphQL `reviewThreads(first:50){nodes{id isResolved comments(first:10){nodes{author{login} body createdAt path line}}}}` — unresolved iff `isResolved=false`.
+   - Top-level reviews + PR-level comments via `gh pr view <N> --repo <OWNER_REPO> --json reviews,comments`. Parse the CI review bot's structured findings as first-class feedback; a finding is addressed if a later commit references its substance.
+   - Base divergence via `gh api repos/<OWNER_REPO>/compare/<base>...<head> --jq '{ahead,behind,status}'`.
+
+   Sort every PR into exactly ONE of three buckets:
+   - **WORK NEEDED** (mechanical / auto-actionable): settled CI failure (not a flake or an integration-test failure needing the maintainer's VM host), DIRTY merge resolvable by `git merge --no-ff`, or an unresolved thread whose fix is mechanical (concrete diff handed over, or a plain factual correction). Drafts get CI fixes, base merges, and existing review-comment fixes — NO unprompted deep review.
+   - **DEFERRED** (needs the USER's decision — do NOT dispatch): a judgment/scope call — an optional/"non-blocking" suggestion, a design reconcile, a semantic merge conflict, a conflict the author is iterating on, or feedback where the right answer isn't mechanically obvious. Capture: PR number, head SHA, the one-line decision the USER must make, and why it's not auto-actionable.
+   - **CLEAN**: green CI, no conflict, no unresolved actionable feedback (approved-awaiting-merge counts).
+
+   Output THREE buckets: `WORK NEEDED: [(N, reason), ...]`, `DEFERRED: [(N, head_sha, decision, why-not-auto), ...]`, `CLEAN: [N, ...]`. Under 700 words.
+
+5. **Dispatch background workers** — one Agent per PR in WORK NEEDED (NEVER for DEFERRED), run_in_background=true. Each worker prompt MUST contain:
+
+   a) **Lock + worktree setup** (verbatim, substituting <N>):
+   ```
+   LOCK="$LOCK_DIR/locks/pr-<N>.lock"
+   if [ -f "$LOCK" ]; then
+     AGE=$(( $(date +%s) - $(stat -c %Y "$LOCK") ))
+     [ $AGE -lt 1800 ] && { echo "Worker active on PR #<N> ($AGE s)"; exit 0; }
+   fi
+   date +%s > "$LOCK"
+   trap 'find "$LOCK_DIR/locks" -name "pr-<N>.lock" -delete 2>/dev/null' EXIT
+
+   PARENT=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || echo "<repo-root>")
+   BRANCH=$(gh pr view <N> --repo <OWNER_REPO> --json headRefName -q .headRefName)
+   WORKTREE="$LOCK_DIR/worktrees/pr-<N>"
+   git -C "$PARENT" fetch origin "$BRANCH"
+   git -C "$PARENT" worktree add --detach "$WORKTREE" "origin/$BRANCH" 2>/dev/null || {
+     git -C "$PARENT" worktree remove --force "$WORKTREE" 2>/dev/null
+     git -C "$PARENT" worktree prune
+     git -C "$PARENT" worktree add --detach "$WORKTREE" "origin/$BRANCH"
+   }
+   cd "$WORKTREE"
+   ```
+
+   b) **Task description** — the specific reason from triage. Be concrete: file paths, line numbers, the substance of the ask. Restate the work.
+
+   c) **`/babysit-pr` guardrails** (copy into the worker prompt — never relax):
+   - Integrate base via `git merge --no-ff origin/<base>` ONLY; NEVER rebase.
+   - Never `--force` / `--force-with-lease` / `--no-verify`.
+   - One logical change per commit.
+   - Never push to `main`/`master` or a branch you don't own.
+   - The worktree is detached — push with `git push origin HEAD:refs/heads/$BRANCH` so the local branch ref is never touched.
+   - Local gate before each push: `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the narrowest `cargo test`; `taplo format --check` if a .toml changed. Fix only mechanical issues; surface anything semantic.
+   - For inline threads (A): when a pushed commit addresses the ask, reply via GraphQL `addPullRequestReviewThreadReply` with body EXACTLY `Fixed in <sha>.` or `Fixed in <sha>: <one-line>.`, then `resolveReviewThread`. NEVER reply on the user's behalf to judgment-call findings.
+   - For reviews (B) / PR-level comments (C): the commit message restating the substance is the close-out; optionally one PR-level `Addressed in <sha1>, <sha2>` after the batch.
+   - On push rejection: STOP, surface — never force-push. On non-mechanical conflicts or design-judgment findings: STOP, surface.
+
+   d) **Report format** — single line: `Pushed <sha> — <msg>` or `No-op: <reason>` or `Aborted: <reason>`. Under 250 words.
+
+6. **Create tasks** — for each dispatched worker, `TaskCreate(subject="PR #<N> — <one-line goal>", description="<triage reason>: <pr_url>")`.
+
+7. **Update the deferred ledger** at `$DEFERRED_LEDGER`:
+   - Read current (absent → empty).
+   - PRUNE entries now resolved (PR no longer open, head SHA advanced past the recorded short-sha, or the PR is WORK NEEDED/CLEAN this sweep); collect them as "resolved since last sweep."
+   - ADD each DEFERRED item as one line: `- #<N> @<short-sha> — <decision> — WHY NOT AUTO: <reason> — since <YYYY-MM-DDThh:mmZ>`. Keep the original `since` if the line exists and head SHA is unchanged.
+   - Rewrite with exactly the still-open deferred set.
+
+8. **Report** — ALWAYS emit both parts every sweep:
+   - Status line: `Sweep @ <time>: <X> open, <Y> in flight, dispatched <Z>, deferred <D>, clean <W>.`
+   - Deferred block — re-print the FULL current ledger every iteration:
+     ```
+     ⚠ AWAITING YOUR DECISION (<D>) — I will NOT act on these without your go-ahead:
+       • #<N> — <decision> — why I skipped it: <reason>   [since <when>]
+     ```
+     If empty, print `No deferred decisions.` If anything was pruned, append `Resolved since last sweep: #<N> (<merged | author acted | now clean>).`
+```
+
+---END SWEEP PAYLOAD---
+
+### Step 3. Run the initial sweep immediately
+
+Execute the sweep payload now (discovery → triage subagent → worker dispatches → TaskCreates → ledger → report) so the user sees dispatch happen now, not in 7 minutes.
+
+### Step 4. Final report
+
+```
+/babysit-my-prs orchestrator running (cron <id>, every 7 min: 4-59/7 * * * *).
+Initial sweep: <X> open, <Z> dispatched, <D> deferred, <W> clean, <K> already in flight.
+Deferred decisions re-printed every sweep; see $LOCK_DIR/deferred.md.
+Auto-expires after 7 days; re-run to refresh. Stop with: /babysit-my-prs stop
+```
+
+## Constraints (do not violate)
+
+- Only orchestrate the current `gh` user's own PRs.
+- Drafts get CI/rebase + existing review-comment fixes; never unsolicited deep review.
+- All worker writes go through `/babysit-pr`'s guardrails. The orchestrator MUST NOT bypass them.
+- Workers operate in `$LOCK_DIR/worktrees/pr-<N>` only — never on the parent repo's checked-out branch.
+- Locks prevent double-dispatch. Don't dispatch if `pr-N.lock` is <30 min old.
+- Don't `CronDelete` the orchestrator unless `$ARGUMENTS == "stop"`.
+- Skip terminal PRs (`MERGED`); surface `CLOSED` without dispatching.
+- Never modify other people's branches. Never auto-act on a DEFERRED item — record it and re-print the full ledger every sweep.

--- a/.claude/commands/babysit-pr.md
+++ b/.claude/commands/babysit-pr.md
@@ -1,6 +1,6 @@
 ---
 description: Single-pass PR shepherding — watch CI, fix failures, address review comments, keep the branch up to date with its base.
-allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api graphql:*), Bash(gh api repos:*), Bash(gh run list:*), Bash(gh run view:*), Bash(git fetch:*), Bash(git log:*), Bash(git status:*), Bash(git rev-list:*), Bash(git rev-parse:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git merge:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo check:*), Bash(taplo format:*)
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh api graphql:*), Bash(gh api repos:*), Bash(gh run list:*), Bash(gh run view:*), Bash(git fetch:*), Bash(git log:*), Bash(git status:*), Bash(git rev-list:*), Bash(git rev-parse:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git merge:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo check:*), Bash(taplo format:*)
 ---
 
 ## What this does

--- a/.claude/commands/babysit-pr.md
+++ b/.claude/commands/babysit-pr.md
@@ -1,0 +1,186 @@
+---
+description: Single-pass PR shepherding — watch CI, fix failures, address review comments, keep the branch up to date with its base.
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api graphql:*), Bash(gh api repos:*), Bash(gh run list:*), Bash(gh run view:*), Bash(git fetch:*), Bash(git log:*), Bash(git status:*), Bash(git rev-list:*), Bash(git rev-parse:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git merge:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo check:*), Bash(taplo format:*)
+---
+
+## What this does
+
+One pass over the PR for the current branch:
+
+1. **Survey** the PR state once (CI checks, review threads, base divergence, mergeability).
+2. **Triage** what's actionable now vs. waiting on something external.
+3. **Act** in priority order: base merge / conflicts → CI failures → unresolved review comments.
+4. **Report** what changed and **suggest a `/loop` cadence** if work remains.
+
+This shepherds your own open PRs. It does **not** merge, close, or reopen the PR. It **never** rewrites published history — base updates land as merge commits so the integration is visible and auditable. It only writes to this PR's own branch (never to `main`/`master` or branches you don't own).
+
+## Preconditions
+
+Stop and tell the user if any fail:
+
+- Current dir is a git working tree: !`git rev-parse --show-toplevel 2>/dev/null || echo "MISSING — not a git repo"`
+- A PR exists for the current branch: !`out=$(gh pr view --json number,state,headRefName 2>/dev/null) && echo "$out" | head -3 || echo "MISSING — no PR for current branch"`
+- Working tree is clean: !`git status --porcelain | head -5 | grep . || echo "clean"`
+
+If the worktree is dirty, stop and ask how to proceed — do not stash silently.
+
+## Terminal-state short-circuit
+
+Before the survey, peek at the PR's high-level state:
+
+```bash
+gh pr view --json state,reviewDecision
+```
+
+If `state` is `MERGED`, report `PR is MERGED — nothing to babysit` and exit. In a `/loop`, tell the user to stop the loop. `reviewDecision == APPROVED` is **not** a short-circuit — keep babysitting until the PR actually merges. `state == CLOSED` (without merge) is not auto-terminal — surface to the user instead of exiting.
+
+## Step 1 — Survey the PR state (once)
+
+```bash
+gh pr view --json number,state,isDraft,headRefName,baseRefName,headRefOid,url,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,title,reviews,comments
+git fetch origin "$(gh pr view --json baseRefName -q .baseRefName)" --quiet
+git log --oneline "origin/$(gh pr view --json baseRefName -q .baseRefName)..HEAD"
+git rev-list --left-right --count "HEAD...origin/$(gh pr view --json baseRefName -q .baseRefName)"
+```
+
+Also fetch inline review threads (the resolution source of truth):
+
+```bash
+gh api graphql -f query='query($owner:String!,$repo:String!,$n:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$n){reviewThreads(first:50){nodes{id isResolved diffSide comments(first:10){nodes{databaseId path line body author{login}}}}}}}}' -F owner=<owner> -F repo=<repo> -F n=<n>
+```
+
+Extract: `pr_number`, `pr_url`, `head_sha`, `base_ref`, `is_draft`, `merge_state`
+(`CLEAN`/`DIRTY`/`BEHIND`/`BLOCKED`/`UNSTABLE`), failing checks (`statusCheckRollup`
+items with `conclusion` in `{FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED}`),
+in-flight checks (`status` in `{IN_PROGRESS, QUEUED, PENDING}`), and unresolved
+feedback from three streams:
+
+- **A — inline threads** (`reviewThreads`): unresolved iff `isResolved == false`.
+- **B — top-level reviews** (`reviews`): a `CHANGES_REQUESTED` body with no inline comments shows up only here.
+- **C — PR-level comments** (`comments`): free-form asks, and structured findings from the CI review bot (a `<K> finding(s) posted inline.` summary or `### file:line` sections). Parse each as first-class actionable feedback.
+
+For B/C (no resolution field), treat as needing action unless: it's a bot
+greeting/CI summary with no findings, it's from the PR author, or a commit
+**after** the comment's `createdAt` references its substance. When unsure, treat
+as unaddressed.
+
+Print a one-screen summary before acting:
+
+```
+PR #<n> <title>  (<url>)
+state: <OPEN|DRAFT>  merge: <CLEAN|DIRTY|BEHIND|...>  review: <APPROVED|CHANGES_REQUESTED|REVIEW_REQUIRED>
+base: <base_ref>  ahead/behind: <a>/<b>
+checks: <X passed> / <Y failing> / <Z pending>
+unresolved comments: <K>
+```
+
+## Step 2 — Decide what to act on
+
+Priority order (act on the first applicable, then re-survey):
+
+1. **Merge base / conflicts** — `merge_state` is `DIRTY`, or base is ahead and the PR has stale CI against an old base.
+2. **CI failures** — any check failing.
+3. **Unresolved review comments** — reviewer comments the author hasn't addressed.
+4. **Nothing actionable** — report and exit (Step 4).
+
+Skip and report (don't act) when: PR is `DRAFT` with no review requested; a
+failing check is external/flaky the user owns separately; a failing check has no
+fetchable logs; or a comment needs product/design judgment the user hasn't given.
+
+## Step 3 — Act
+
+Each round: make the smallest change that addresses one issue, run the relevant
+local gate, commit, push, then return to Step 1 if budget remains.
+
+Local gate (run only what the change touches — not the full suite every time):
+
+```bash
+cargo fmt -- --check          # or `cargo fmt` to apply
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test                    # narrow with `cargo test <name>` when possible
+taplo format --check          # only if a .toml changed
+```
+
+### 3a. Merge base / resolve conflicts
+
+Integrate `<base_ref>` with a merge commit — never a rebase:
+
+```bash
+git fetch origin <base_ref>
+git merge --no-ff origin/<base_ref>
+```
+
+Resolve conflicts by reading both sides; prefer the PR's semantic intent; never
+`--theirs`/`--ours` blindly. Re-run the gate after resolving. If a conflict
+touches code outside the PR's scope, stop and surface. Then `git push origin
+<head_ref>`. If the push is rejected (someone pushed concurrently), stop and
+surface — do **not** force-push.
+
+### 3b. CI failures
+
+For each failing check (coop CI jobs: `check` = fmt/clippy/test + integration-update/uninstall; `deny`; `taplo`; `zizmor`):
+
+1. `gh run view --log-failed <run-id>` (resolve `run-id` from the check's `detailsUrl` or `gh run list --branch <head_ref> --limit 5 --json databaseId,name,conclusion`).
+2. Categorize:
+   - **fmt** → `cargo fmt`; commit as `style: cargo fmt`.
+   - **clippy** → fix the warning properly (coop is zero-warnings); never `#[allow]` to silence unless it's a justified, commented exception.
+   - **test** → reproduce with `cargo test <name>`; fix the underlying bug. Do NOT `#[ignore]` or delete a test to make CI pass.
+   - **taplo** → `taplo format` the TOML.
+   - **deny** → a new/updated dependency tripped an advisory/license/ban/source rule; fix `deny.toml` or the dependency, regenerate `Cargo.lock`.
+   - **zizmor** → a workflow-security finding; fix the workflow (pin SHA, `persist-credentials: false`, least-privilege permissions).
+   - **integration** → these run real VMs; a failure usually needs the maintainer's environment. Surface with the run URL rather than faking a fix.
+   - **flaky / environmental** → do NOT push a fake fix. Surface with the URL and stop.
+3. Commit the fix as a focused commit (never mix refactor with behavior change).
+4. `git push origin <head_ref>`.
+
+### 3c. Unresolved review comments
+
+For each finding (inline thread, review body, or one parsed section of a structured comment), in file→line order:
+
+1. Read it in context; open the file at the cited line.
+2. If it's a clear, mechanical ask (typo, rename, dead-code removal, missing test case, broken doc example): apply it.
+3. If it needs a design/judgment call: surface to the user, don't guess.
+4. If already addressed by a later commit: leave it.
+5. Commit with a message referencing the finding's substance (not the comment ID).
+
+**3c.i — inline threads (Stream A).** After the fix is pushed, reply and resolve. Reply body exactly `Fixed in <sha>.` or `Fixed in <sha>: <one-line>.` — no other prose. Both are GraphQL mutations on the thread node `id`:
+
+- Reply: `gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<thread_id>", body:"Fixed in <sha>."}) { comment { databaseId } } }'`
+- Resolve: `gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<thread_id>"}) { thread { isResolved } } }'`
+
+Only reply+resolve when a pushed commit actually addresses the ask. Threads escalated to the user stay unanswered.
+
+**3c.ii — reviews (B) / PR-level comments (C).** No thread to resolve. The commit message restating the finding's substance is the close-out; optionally post one PR-level `Addressed in <sha1>, <sha2>` after the batch.
+
+## Step 4 — Report and suggest a cadence
+
+```
+Babysat PR #<n>:
+  • <K> change(s) pushed: <one-line per commit, with sha>
+  • <Y> failing check(s) remaining
+  • <Z> unresolved comment(s) remaining
+  • merge state: <state>
+```
+
+Then suggest a `/loop` cadence only if there's a concrete signal worth waking for:
+
+| Situation | Suggested cadence |
+|---|---|
+| CI running, no other work | `/loop 5m /babysit-pr` |
+| Awaiting reviewer | `/loop 30m /babysit-pr` |
+| Blocked on user judgment | none — wait for the user |
+| Clean, approved, mergeable | none — tell the user it's ready to merge |
+| Draft with nothing pending | none |
+
+Phrase it as a question — don't start a loop unsolicited.
+
+## Guardrails (do not violate)
+
+- One logical change per commit. Don't bundle a base merge, a fmt fix, and a review-comment fix into one commit.
+- Never rewrite published history. No `git rebase` on the PR branch, no `--force`/`--force-with-lease`. Integrate the base via `git merge --no-ff`.
+- Never `--no-verify`, never skip hooks.
+- Never push to `main`/`master` or a branch you don't own.
+- Never close, reopen, or merge the PR. Never dismiss reviews. Never edit the PR title/body unless asked.
+- Replies to inline threads must be `Fixed in <sha>.`/`Fixed in <sha>: <one-line>.` and only when a pushed commit addresses the ask.
+- PR-level structured findings from the CI review bot are first-class feedback — apply mechanical ones, surface judgment calls.
+- If a step needs destructive recovery (`git reset --hard`, deleting unfamiliar files), stop and ask first.

--- a/.claude/commands/integration.md
+++ b/.claude/commands/integration.md
@@ -1,0 +1,57 @@
+---
+description: Run coop's integration test suite — the full VM lifecycle — locally (Lima) and/or on a remote Linux host (Firecracker).
+argument-hint: [--remote user@host] [--full] [--profile LIST] [--name NAME]
+allowed-tools: Bash(./tests/run-integration.sh:*), Bash(git rev-parse:*), Bash(uname:*)
+---
+
+## What this does
+
+Wraps `tests/run-integration.sh` — the runner that builds `coop`, deploys it
+(cross-compiling for a remote host), and runs `tests/integration.sh`, which
+exercises the **full VM lifecycle**: setup → start → status → shell → guest
+environment → docker → stop → destroy.
+
+coop supports two backends, and CLAUDE.md requires the suite to pass on **both**
+before a commit:
+
+- **Local (macOS/Lima)** — builds a native release binary and runs against Lima.
+- **Remote (Linux/Firecracker)** — detects the remote arch, cross-compiles
+  (`x86_64-unknown-linux-musl`), copies the binary over, and runs there.
+
+## Argument
+
+`$ARGUMENTS` is forwarded to the runner. Common forms:
+
+- (empty) — run locally against Lima (macOS host).
+- `--remote user@host` — cross-compile and run on a Linux/Firecracker host.
+- `--full` — extended tests (workspace sync, multi-instance).
+- `--profile python,node` — install these guest profiles during the run.
+- `--name my-test` — instance-name prefix (default `test-<pid>`).
+
+Flags combine, e.g. `--remote user@host --full`.
+
+## Preconditions
+
+- In the coop repo: !`git rev-parse --show-toplevel 2>/dev/null || echo "MISSING — not a git repo"`
+- Local host: `./tests/run-integration.sh` (no `--remote`) requires macOS + Lima. On a Linux host, use `--remote` to reach a Firecracker box, or run the suite there directly.
+
+If the caller asked for "both platforms," you need a macOS host for the local
+Lima run and a `--remote` Linux host for the Firecracker run — a single machine
+only covers one. Surface that if only one is available.
+
+## Your task
+
+1. Determine which run(s) the arguments call for. If the user said "both
+   platforms" and gave a `--remote` host, run the remote one and remind them to
+   run the local Lima pass on their Mac (or vice-versa).
+2. Redirect output to a file rather than piping to grep/head — the run is
+   expensive (a `PreToolUse` hook enforces this). e.g.:
+   ```bash
+   ./tests/run-integration.sh $ARGUMENTS > "${TMPDIR:-/tmp}/coop-integration.out" 2>&1
+   ```
+3. Read the output file, report pass/fail per phase, and quote the failing
+   phase's output on any failure. Don't declare success unless the suite exits 0.
+4. Clean up the output file when done.
+
+Narrate each step. This drives real VMs and takes minutes; use a generous
+timeout and don't busy-poll.

--- a/.claude/commands/my-review.md
+++ b/.claude/commands/my-review.md
@@ -119,7 +119,11 @@ one pass:
    consensus.
 4. **Cross-reference prior feedback** — drop findings duplicating resolved
    comments; add unresolved comments agents missed.
-5. For `review-api-usage` claims, confirm the cited doc URL is current.
+5. For `review-api-usage` claims, confirm the cited doc URL is current when web
+   access is available. The `claude-review` CI workflow withholds `WebFetch`/
+   `WebSearch` (they'd be an exfiltration channel for the untrusted diff), so in
+   CI skip this check and phrase the finding as unverified against upstream docs
+   rather than asserting the URL was confirmed.
 
 Separate surviving findings into substantive vs. `category: "Diff noise"`.
 

--- a/.claude/commands/my-review.md
+++ b/.claude/commands/my-review.md
@@ -21,14 +21,22 @@ Design goals:
 
 ## 0. Determine the diff
 
-Resolve the base ref from `gh pr view <n> --json baseRefName` and `git fetch
-origin <base>` if its tip isn't local. The diff range is `<base>...HEAD`.
+With a PR (CI, or a branch that has one): resolve the base ref from `gh pr view
+<n> --json baseRefName` and `git fetch origin <base>` if its tip isn't local.
+The diff range is `<base>...HEAD`.
 
 ```bash
 gh pr view <n> --json number,baseRefName,headRefOid,title,url
 git fetch origin <base> --quiet
 git diff --stat <base>...HEAD
 ```
+
+Invoked locally with **no PR** (e.g. from the `closeout-review` skill on
+uncommitted work): there is no PR number to query. Take the base as the current
+branch's PR base if one exists, else `origin/main`, and review the working diff
+— `git diff` (and `git diff --staged`) for uncommitted work, or `<base>...HEAD`
+for a committed branch. Don't post inline comments in this mode; the caller
+resolves findings locally. The rest of this command is unchanged.
 
 If the diff is empty, stop.
 

--- a/.claude/commands/my-review.md
+++ b/.claude/commands/my-review.md
@@ -1,0 +1,149 @@
+---
+description: Review a pull request with self-validated findings, posted as inline comments.
+---
+
+Review the diff between a PR's base branch and its head, dispatching the
+`review-*` sub-agents and posting validated findings as inline review comments.
+
+This is a **read-and-report review only**. Do NOT commit, push, merge, or modify
+the PR's code.
+
+When run from CI (the `claude-review` workflow), the calling prompt provides
+`REPO` and `PR NUMBER`. When run locally, resolve the current branch's PR with
+`gh pr view`.
+
+Design goals:
+
+- Build the review context **once** and share it with every agent, so agents
+  don't each re-discover the diff, changed files, CLAUDE.md, and prior feedback.
+- **Conditionally skip** agents whose domain the diff doesn't touch.
+- **Batch validation by file.**
+
+## 0. Determine the diff
+
+Resolve the base ref from `gh pr view <n> --json baseRefName` and `git fetch
+origin <base>` if its tip isn't local. The diff range is `<base>...HEAD`.
+
+```bash
+gh pr view <n> --json number,baseRefName,headRefOid,title,url
+git fetch origin <base> --quiet
+git diff --stat <base>...HEAD
+```
+
+If the diff is empty, stop.
+
+## 1. Build the review context packet (once)
+
+`coop` has no packet-builder script — assemble the context inline, once, and
+pass it verbatim to every agent. Gather:
+
+- **Diff**: `git diff <base>...HEAD` (trim generated files — `Cargo.lock`,
+  `completions/*`, snapshots — to a name + line count; note them as omitted).
+- **Changed files** and, for each changed `src/*.rs`, the touched function
+  bodies (read the post-change file, not just the hunk).
+- **Guidance**: root `CLAUDE.md`, and the relevant `docs/` — `code-style.md`
+  (conventions/design), `trust-model.md` (security), `testing.md` +
+  `.cargo/mutants.toml` (tests), `ARCHITECTURE.md` (structure).
+- **Prior PR feedback**: `gh pr view <n> --json reviews,comments` and the inline
+  review threads via GraphQL `reviewThreads` (id, isResolved, path, line, body).
+- **Trigger map**: from the changed paths and diff content, note which domains
+  are touched — security-relevant surfaces (secrets, subprocess, network,
+  filesystem writes, SSH, update), external crates (from `use`/`Cargo.toml`
+  changes), tests, docs, comments.
+
+This packet is the sole input to every agent below. Agents may read more files
+if needed, but must treat packet content as context, not proof — final
+validation re-opens the post-change files.
+
+## 2. Decide which agents to run
+
+Agent definitions live in `.claude/agents/review-*.md`. Each embeds its own
+lens, output format, and framing (fresh eyes, packet-as-truth, diff-introduced
+findings only, prior-feedback cross-reference). This section governs only which
+to invoke.
+
+Always run: `review-correctness`, `review-design`, `review-conventions`.
+
+Conditionally run:
+
+- `review-security` — if the trigger map hits secrets, subprocess/`Command`,
+  network/binds, filesystem writes, SSH/scp, guest↔host data flow, `coop update`,
+  or `cmd:` config evaluation.
+- `review-api-usage` — if the diff changes `use` statements, `Cargo.toml`/
+  `Cargo.lock`, or external-crate call sites.
+- `review-tests` — unless the packet marks the diff docs-only or config-only
+  with no behavior change.
+- `review-docs` — if docs changed, doc-comments changed, `--help`/clap text
+  changed, or a touched symbol is named in `docs/`/README.
+- `review-comments` — if the diff adds or changes inline `//` comments, or
+  changes code adjacent to existing comments. Skip on docs-only diffs.
+
+If the diff is docs-only, run only `review-conventions` and `review-docs`.
+
+Track which agents were skipped and why — this becomes the coverage line.
+
+## 3. Parallel review
+
+Launch the selected sub-agents **in parallel** (single message, multiple Agent
+tool calls with `subagent_type` set to the agent's `name`). Pass the review
+context packet verbatim as each agent's input.
+
+Each returns a JSON array of findings: `{file, line, side, severity (P1/P2/P3),
+category, finding, evidence}`.
+
+## 4. Batched validation
+
+Collect all findings, group **by file**, and validate each file's findings in
+one pass:
+
+1. Open the post-change file once; re-read the hunks plus surrounding context.
+2. Walk every finding against that context, checking:
+   - **Diff-introduced and grounded.** The flagged line was added/modified by
+     the diff (or the diff made a pre-existing issue reachable). The claim must
+     be backed by *quoted* code from the file, not a paraphrase. Drop it if it
+     can't be quoted.
+   - **Nuance** — surrounding code (a guard, a type, a newtype constructor)
+     doesn't already handle the concern.
+   - **Convention** — the project's established practice, if relevant.
+   - **Hunk membership** — `(line, side)` lands within a diff hunk; snap to the
+     nearest changed line if slightly off, drop if no fit.
+3. **Deduplicate across agents** — keep the more specific description; note
+   consensus.
+4. **Cross-reference prior feedback** — drop findings duplicating resolved
+   comments; add unresolved comments agents missed.
+5. For `review-api-usage` claims, confirm the cited doc URL is current.
+
+Separate surviving findings into substantive vs. `category: "Diff noise"`.
+
+## 5. Post findings to the PR
+
+Substantive findings go inline; diff-noise and the coverage line go in one
+summary comment at the end.
+
+### Inline review comments (substantive findings)
+
+When the `mcp__github_inline_comment__create_inline_comment` tool is available
+(CI under `claude-code-action`), post each finding with it — pass `path`, `line`
+(and `startLine` for multi-line), `body`, and `confirmed: true`. The MCP server
+reads owner/repo/PR from the environment; don't pass them. `side` defaults to
+`RIGHT` — only set it for LEFT-side comments.
+
+Locally (no MCP tool), fall back to `gh api
+repos/{owner}/{repo}/pulls/{n}/comments -f body=... -f commit_id=<head_sha> -f
+path=<file> -F line=<line> -f side=<RIGHT|LEFT>`. Resolve `<head_sha>` once via
+`gh pr view <n> --json headRefOid -q .headRefOid`.
+
+For each substantive finding:
+
+- Body is the `finding` text, `evidence` folded in where useful. Drop the
+  category tag unless it adds something a reviewer wouldn't infer.
+- **No severity markers** (P1/P2/P3) in the body — internal triage only.
+- Group by severity (P1 first) when ordering posts.
+
+### Summary comment (always posted)
+
+After the inline comments, post one top-level comment via `gh pr comment <n>`:
+
+1. **Header** — `<K> finding(s) posted inline.` (or `No substantive findings.`).
+2. **Diff noise** (optional) — a short list, one row per file with line ranges.
+3. **Coverage line** — which agents ran and which were skipped (and why).

--- a/.claude/hooks/cargo-fmt.sh
+++ b/.claude/hooks/cargo-fmt.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PostToolUse formatter: run `cargo fmt` after Claude writes or edits a Rust
+# file, mirroring the `cargo fmt` pre-commit hook so in-progress edits stay
+# formatted and don't surface later as CI `cargo fmt -- --check` failures.
+#
+# Format only. `cargo clippy --fix` is deliberately NOT run here: autofixing
+# mid-edit rewrites code Claude is about to build on, causing an edit/undo
+# churn loop. Clippy and the zero-warnings policy are surfaced (and enforced)
+# by the pre-commit hook and CI. `cargo fmt` is idempotent and never surprises
+# an in-progress edit.
+#
+# We format the whole crate (like the pre-commit hook) rather than a single
+# file, so rustfmt always reads the project edition/config and never drifts.
+# The hook must never block the tool, so a formatter failure is surfaced on
+# stderr but does not propagate.
+
+INPUT=$(cat)
+FILE=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' <<<"$INPUT" 2>/dev/null || true)
+
+if [ -z "$FILE" ] || [ "${FILE##*.}" != "rs" ]; then
+  exit 0
+fi
+
+command -v cargo >/dev/null 2>&1 || exit 0
+cargo fmt --quiet 2>/dev/null || echo "cargo fmt failed" >&2
+
+exit 0

--- a/.claude/hooks/cargo-fmt.sh
+++ b/.claude/hooks/cargo-fmt.sh
@@ -1,29 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# PostToolUse formatter: run `cargo fmt` after Claude writes or edits a Rust
-# file, mirroring the `cargo fmt` pre-commit hook so in-progress edits stay
+# PostToolUse formatter: run rustfmt on the Rust file Claude just wrote or
+# edited, mirroring the `cargo fmt` pre-commit hook so in-progress edits stay
 # formatted and don't surface later as CI `cargo fmt -- --check` failures.
 #
-# Format only. `cargo clippy --fix` is deliberately NOT run here: autofixing
-# mid-edit rewrites code Claude is about to build on, causing an edit/undo
-# churn loop. Clippy and the zero-warnings policy are surfaced (and enforced)
-# by the pre-commit hook and CI. `cargo fmt` is idempotent and never surprises
-# an in-progress edit.
+# We format the single edited file with `rustfmt`, NOT whole-crate `cargo fmt`:
+# `cargo fmt` discovers its workspace from the hook's cwd, so for an edit to a
+# file in a linked worktree it would format the wrong crate (missing the edited
+# file entirely) and silently rewrite every other file in that crate. rustfmt
+# on the path touches only what changed and reads any `rustfmt.toml` from the
+# file's directory upward.
 #
-# We format the whole crate (like the pre-commit hook) rather than a single
-# file, so rustfmt always reads the project edition/config and never drifts.
+# Format only. `cargo clippy --fix` is deliberately NOT run here: autofixing
+# mid-edit rewrites code Claude is about to build on. Clippy and the
+# zero-warnings policy are enforced by the pre-commit hook and CI. rustfmt is
+# idempotent and never surprises an in-progress edit.
+#
 # The hook must never block the tool, so a formatter failure is surfaced on
-# stderr but does not propagate.
+# stderr (with the file and rustfmt's own error) but does not propagate.
 
 INPUT=$(cat)
 FILE=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' <<<"$INPUT" 2>/dev/null || true)
 
-if [ -z "$FILE" ] || [ "${FILE##*.}" != "rs" ]; then
+if [ -z "$FILE" ] || [ "${FILE##*.}" != "rs" ] || [ ! -f "$FILE" ]; then
   exit 0
 fi
 
-command -v cargo >/dev/null 2>&1 || exit 0
-cargo fmt --quiet 2>/dev/null || echo "cargo fmt failed" >&2
+command -v rustfmt >/dev/null 2>&1 || exit 0
+
+# Edition must match the crate (coop is edition 2024); rustfmt defaults to 2015
+# otherwise. CI's `cargo fmt` remains the authoritative check if this ever
+# drifts from a future edition bump.
+if ! err=$(rustfmt --edition 2024 "$FILE" 2>&1); then
+  printf 'cargo-fmt hook: rustfmt failed on %s\n%s\n' "$FILE" "$err" >&2
+fi
 
 exit 0

--- a/.claude/hooks/closeout-review-gate.sh
+++ b/.claude/hooks/closeout-review-gate.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PreToolUse gate: block `gh pr create` until a closeout review has run to a
+# clean verdict on the branch the PR is created FROM, at that branch's current
+# tip. The closeout-review skill records the marker as its final step; this
+# hook only checks it.
+#
+# Worktree-aware: the branch under review usually lives in a linked worktree
+# while this hook runs from the main checkout (CLAUDE_PROJECT_DIR). So we
+# (a) resolve the git context from the command's `cd` prefix or the hook-
+# provided cwd instead of the hook's own PWD, (b) take the target branch from
+# `--head` when it is given (a PR can be opened for a branch you are not on),
+# and (c) store markers under the shared git common dir so a marker written
+# from a worktree is visible from every other worktree and the main checkout.
+#
+# Fail-open by design: anything that isn't an identifiable `gh pr create` in a
+# git repo is allowed through, so the gate never wedges unrelated work.
+
+INPUT=$(cat)
+COMMAND=$(jq -r '.tool_input.command // .tool_input.cmd // .command // .cmd // empty' <<<"$INPUT")
+
+[ -z "$COMMAND" ] && exit 0
+
+# Only gate PR creation. `pr create` is contiguous (subcommand follows `pr`).
+echo "$COMMAND" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b' || exit 0
+
+# Locate the directory the command actually runs git/gh in: an explicit
+# `cd <dir> && ...` prefix wins, else the cwd the hook was invoked with.
+WORKDIR=""
+if [[ "$COMMAND" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  WORKDIR="${BASH_REMATCH[1]}"
+  WORKDIR="${WORKDIR%[\"\']}"
+  WORKDIR="${WORKDIR#[\"\']}"
+fi
+[ -z "$WORKDIR" ] && WORKDIR=$(jq -r '.cwd // empty' <<<"$INPUT")
+[ -z "$WORKDIR" ] && WORKDIR="$PWD"
+[ -d "$WORKDIR" ] || exit 0
+
+git -C "$WORKDIR" rev-parse --show-toplevel >/dev/null 2>&1 || exit 0
+
+# Read the value of an actual `--head`/`-H` flag with a quote-aware scan. A
+# regex over the raw command takes the leftmost match, so a `--head`/`-H` token
+# quoted inside a `--body`/`--title` string would hijack branch selection
+# whenever it names a resolvable ref (`main`, `develop`). Tokenizing first keeps
+# such a token bound inside its quoted argument, where it is never the flag.
+head_flag_value() {
+  local s="$1" c i n q="" tok="" want=0
+  local -a toks=()
+  n=${#s}
+  for ((i = 0; i < n; i++)); do
+    c="${s:i:1}"
+    if [ -n "$q" ]; then
+      if [ "$c" = "$q" ]; then q=""; else tok+="$c"; fi
+    elif [ "$c" = '"' ] || [ "$c" = "'" ]; then
+      q="$c"
+    elif [[ "$c" == [[:space:]] ]]; then
+      if [ -n "$tok" ]; then
+        toks+=("$tok")
+        tok=""
+      fi
+    else
+      tok+="$c"
+    fi
+  done
+  [ -n "$tok" ] && toks+=("$tok")
+  for tok in "${toks[@]}"; do
+    if [ "$want" = 1 ]; then
+      printf '%s' "$tok"
+      return
+    fi
+    case "$tok" in
+      --head | -H) want=1 ;;
+      --head=*)
+        printf '%s' "${tok#--head=}"
+        return
+        ;;
+      -H=*)
+        printf '%s' "${tok#-H=}"
+        return
+        ;;
+    esac
+  done
+}
+
+# Target branch: the `--head`/`-H` value (strip any `owner:` fork prefix) when it
+# names a real ref, else the branch currently checked out in WORKDIR. A head
+# that does not resolve to a commit falls back to the current branch, so the
+# gate still evaluates a real branch.
+BRANCH=""
+candidate=$(head_flag_value "$COMMAND")
+candidate="${candidate##*:}"
+if [ -n "$candidate" ] &&
+  git -C "$WORKDIR" rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1; then
+  BRANCH="$candidate"
+fi
+if [ -z "$BRANCH" ]; then
+  BRANCH=$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+fi
+
+HEAD_SHA=$(git -C "$WORKDIR" rev-parse --verify "${BRANCH}^{commit}" 2>/dev/null) || exit 0
+
+# Markers live under the shared git common dir so one written from any linked
+# worktree is found from every other worktree (and the main checkout).
+COMMON_DIR=$(git -C "$WORKDIR" rev-parse --git-common-dir 2>/dev/null) || exit 0
+case "$COMMON_DIR" in
+  /*) ;;
+  *) COMMON_DIR="$WORKDIR/$COMMON_DIR" ;;
+esac
+COMMON_DIR=$(cd "$COMMON_DIR" 2>/dev/null && pwd) || exit 0
+
+MARKER="${COMMON_DIR}/closeout-review/$(echo "$BRANCH" | tr '/' '-')"
+
+if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$HEAD_SHA" ]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+Closeout gate: a closeout review has not run on this branch at the current
+commit, so this PR cannot be created yet.
+
+Branch: ${BRANCH}
+HEAD:   ${HEAD_SHA}
+
+Run the closeout-review skill now (invoke it via the Skill tool). Work the
+diff to a clean verdict — fix in-scope blockers, defer follow-ups. As its
+final step it records the gate marker for this exact commit, after which
+\`gh pr create\` is allowed.
+
+If you commit again after the review, re-run it: the marker is bound to the
+reviewed commit, so new commits re-arm the gate.
+EOF
+exit 2

--- a/.claude/hooks/closeout-review-gate.sh
+++ b/.claude/hooks/closeout-review-gate.sh
@@ -18,12 +18,13 @@ set -euo pipefail
 # git repo is allowed through, so the gate never wedges unrelated work.
 
 INPUT=$(cat)
-COMMAND=$(jq -r '.tool_input.command // .tool_input.cmd // .command // .cmd // empty' <<<"$INPUT")
+COMMAND=$(jq -r '.tool_input.command // .tool_input.cmd // .command // .cmd // empty' <<<"$INPUT" 2>/dev/null || true)
 
 [ -z "$COMMAND" ] && exit 0
 
 # Only gate PR creation. `pr create` is contiguous (subcommand follows `pr`).
-echo "$COMMAND" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b' || exit 0
+# POSIX anchors (no `\b`) so detection behaves the same under GNU and BSD grep.
+printf '%s' "$COMMAND" | grep -qE '(^|[[:space:]])gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
 
 # Locate the directory the command actually runs git/gh in: an explicit
 # `cd <dir> && ...` prefix wins, else the cwd the hook was invoked with.
@@ -32,8 +33,13 @@ if [[ "$COMMAND" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
   WORKDIR="${BASH_REMATCH[1]}"
   WORKDIR="${WORKDIR%[\"\']}"
   WORKDIR="${WORKDIR#[\"\']}"
+  # A `cd` target we can't resolve — unexpanded `~`/`$VAR`, or a path truncated
+  # at its first space — must NOT suppress the fallbacks below, or the gate
+  # fails open on idiomatic `cd ~/wt && gh pr create`. Drop it and let the
+  # hook-provided cwd / $PWD decide.
+  [ -d "$WORKDIR" ] || WORKDIR=""
 fi
-[ -z "$WORKDIR" ] && WORKDIR=$(jq -r '.cwd // empty' <<<"$INPUT")
+[ -z "$WORKDIR" ] && WORKDIR=$(jq -r '.cwd // empty' <<<"$INPUT" 2>/dev/null || true)
 [ -z "$WORKDIR" ] && WORKDIR="$PWD"
 [ -d "$WORKDIR" ] || exit 0
 
@@ -77,6 +83,10 @@ head_flag_value() {
         ;;
       -H=*)
         printf '%s' "${tok#-H=}"
+        return
+        ;;
+      -H?*)
+        printf '%s' "${tok#-H}"
         return
         ;;
     esac

--- a/.claude/hooks/no-pipe-test-output.sh
+++ b/.claude/hooks/no-pipe-test-output.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(jq -r '.tool_input.command // .tool_input.cmd // .command // .cmd // empty' <<<"$INPUT")
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Expensive commands in this project: the cargo quality gates, mutation and
+# fuzzing sweeps, and the integration-test scripts. \b handles subcommand
+# suffixes like `cargo test --lib` and `./tests/run-integration.sh --remote`.
+EXPENSIVE='\b(cargo (test|clippy|mutants|build)|cargo \+nightly fuzz|cargo kani|tests/(run-)?integration([a-z-]*)\.sh)\b'
+
+# Filters that indicate the command output is being searched rather than
+# inspected as a whole.
+FILTERS='\|\s*(grep|rg|head|tail|awk|sed)\b'
+
+if echo "$COMMAND" | grep -qE "$EXPENSIVE" \
+  && echo "$COMMAND" | grep -qE "$FILTERS"; then
+  tmpdir=${TMPDIR:-/tmp}
+  OUTFILE=$(mktemp "${tmpdir%/}/test-output.XXXXXX")
+
+  cat >&2 <<EOF
+Do not pipe this output through grep/rg/head/tail/awk/sed — it forces the
+command to run again every time you want to examine different parts of the
+output. This applies to cargo test/clippy/build, cargo mutants, cargo fuzz,
+cargo kani, and the tests/*integration*.sh scripts.
+
+Instead:
+Redirect output to a file:  <command> > ${OUTFILE} 2>&1
+Read the file:              Read tool or cat ${OUTFILE}
+Search the file:            grep "pattern" ${OUTFILE}
+
+This way the command runs once and you can inspect the results as many times
+as needed. Do not forget to delete the file once you are done using it.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/no-pipe-test-output.sh
+++ b/.claude/hooks/no-pipe-test-output.sh
@@ -2,25 +2,31 @@
 set -euo pipefail
 
 INPUT=$(cat)
-COMMAND=$(jq -r '.tool_input.command // .tool_input.cmd // .command // .cmd // empty' <<<"$INPUT")
+COMMAND=$(jq -r '.tool_input.command // .tool_input.cmd // .command // .cmd // empty' <<<"$INPUT" 2>/dev/null || true)
 
 if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Expensive commands in this project: the cargo quality gates, mutation and
-# fuzzing sweeps, and the integration-test scripts. \b handles subcommand
-# suffixes like `cargo test --lib` and `./tests/run-integration.sh --remote`.
-EXPENSIVE='\b(cargo (test|clippy|mutants|build)|cargo \+nightly fuzz|cargo kani|tests/(run-)?integration([a-z-]*)\.sh)\b'
+# Expensive commands: the cargo quality gates, mutation/fuzz/kani sweeps, and
+# the integration-test scripts. Anchored to a command position (start of line
+# or after a `;`/`&`/`|` separator) so a cargo/tests string quoted inside a
+# `grep`/`echo` argument is not mistaken for the command being run. Flexible
+# whitespace and an optional `+toolchain` prefix catch `cargo   test` and
+# `cargo +nightly test`. POSIX classes only (`[[:space:]]`, no `\s`/`\b`) so it
+# behaves the same under GNU and BSD/macOS grep.
+EXPENSIVE='(^|[;&|][[:space:]]*)(cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|clippy|mutants|build|fuzz|kani)|(\./)?tests/(run-)?integration[a-z-]*\.sh)'
 
-# Filters that indicate the command output is being searched rather than
-# inspected as a whole.
-FILTERS='\|\s*(grep|rg|head|tail|awk|sed)\b'
+# A pipe (optionally `|&`) into a tool that inspects part of the output —
+# i.e. the output is being searched, not viewed whole.
+FILTERS='\|&?[[:space:]]*(grep|rg|head|tail|awk|sed)'
 
-if echo "$COMMAND" | grep -qE "$EXPENSIVE" \
-  && echo "$COMMAND" | grep -qE "$FILTERS"; then
-  tmpdir=${TMPDIR:-/tmp}
-  OUTFILE=$(mktemp "${tmpdir%/}/test-output.XXXXXX")
+if printf '%s' "$COMMAND" | grep -qE "$EXPENSIVE" \
+  && printf '%s' "$COMMAND" | grep -qE "$FILTERS"; then
+  # Suggest a path without creating the file: the command is about to be
+  # blocked, so nothing writes here, and a failed `mktemp` under `set -e` would
+  # abort the hook with exit 1 (allow) instead of the intended exit 2 (block).
+  OUTFILE="${TMPDIR:-/tmp}/test-output.$$"
 
   cat >&2 <<EOF
 Do not pipe this output through grep/rg/head/tail/awk/sed — it forces the

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,113 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(pwd)",
+      "Bash(which:*)",
+      "Bash(type:*)",
+      "Bash(tree:*)",
+      "Bash(wc:*)",
+      "Bash(sort:*)",
+      "Bash(uniq:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(cat:*)",
+      "Bash(file:*)",
+      "Bash(stat:*)",
+      "Bash(du:*)",
+      "Bash(df:*)",
+      "Bash(env)",
+      "Bash(printenv:*)",
+      "Bash(echo:*)",
+      "Bash(date:*)",
+      "Bash(rg:*)",
+      "Bash(fd:*)",
+      "Bash(ast-grep:*)",
+      "Bash(jq:*)",
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff)",
+      "Bash(git diff:*)",
+      "Bash(git log)",
+      "Bash(git log:*)",
+      "Bash(git show)",
+      "Bash(git show:*)",
+      "Bash(git blame:*)",
+      "Bash(git branch)",
+      "Bash(git stash list)",
+      "Bash(git stash show:*)",
+      "Bash(git add:*)",
+      "Bash(git restore --staged:*)",
+      "Bash(git commit:*)",
+      "Bash(git fetch:*)",
+      "Bash(git remote show:*)",
+      "Bash(git remote get-url:*)",
+      "Bash(git tag)",
+      "Bash(git tag -l:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git rev-list:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git ls-tree:*)",
+      "Bash(git describe:*)",
+      "Bash(git worktree list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh workflow view:*)",
+      "Bash(gh workflow list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh api user:*)",
+      "Bash(cargo fmt -- --check)",
+      "Bash(cargo fmt --check)",
+      "Bash(cargo clippy:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo tree:*)",
+      "Bash(cargo metadata:*)",
+      "Bash(cargo deny check:*)",
+      "Bash(cargo mutants --list:*)",
+      "Bash(taplo format --check)",
+      "Bash(taplo format --check:*)",
+      "Bash(shellcheck:*)",
+      "Bash(shfmt:*)",
+      "Bash(actionlint:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/no-pipe-test-output.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/closeout-review-gate.sh",
+            "statusMessage": "closeout review gate"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/cargo-fmt.sh",
+            "timeout": 60,
+            "statusMessage": "cargo fmt"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/closeout-review/SKILL.md
+++ b/.claude/skills/closeout-review/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: closeout-review
+description: Use when finishing a change and about to commit, push, or open a PR — to run a final closeout review on the working diff and decide what to fix WITHOUT scope-creeping the change into a refactor, migration, or redesign. Triggers: "review before I commit", "closeout review", "is this ready to ship", "self-review this branch", "what should I fix before the PR", running this on a loop over a branch.
+---
+
+# Closeout Review
+
+## Overview
+
+A closeout review is the **final gate** before you commit, push, or open a PR.
+It runs coop's review machinery (`/my-review`) against your working diff, then
+applies three disciplines an unguided review skips:
+
+1. **Advisory, not authoritative** — every finding is a *hypothesis*. Verify it
+   against real code before acting. Reject speculative risks and unreal edges.
+2. **Scope governance** — freeze what this change is *supposed* to do first.
+   Findings outside that boundary become follow-ups, not edits.
+3. **Convergence** — patch-and-re-review converges fast or you stop and report.
+   It must not spiral into an open-ended rework.
+
+**Core principle:** the review's job is to find what is *wrong with this diff*,
+not to expand the diff. A clean closeout means "this change is correct and in
+scope," not "this file is now perfect."
+
+## When to use
+
+- Before `git commit` on a non-trivial change, before pushing, or before a PR.
+- When self-reviewing a branch and deciding blocker vs. follow-up.
+- On a loop over a branch as you iterate toward "ready."
+
+**When NOT to use:**
+
+- CI / posting inline comments on a GitHub PR → use `/my-review` directly (it
+  owns the comment posting and read-only contract). Closeout reuses
+  `/my-review`'s engine (§3) but resolves findings locally instead of posting.
+- A reviewer-style read of someone else's PR → use `/review`.
+- Trivial one-line / docs-typo changes — the gate is overhead.
+
+## Workflow
+
+### 1. Freeze the scope baseline (before reviewing)
+
+Write down, in one place, what this change *is*:
+
+- The original request / intended behavior.
+- The **owner boundary** — which module(s) and surface this change belongs to.
+- `git diff --stat` against the base: changed files + non-test, non-generated
+  LOC (`Cargo.lock` and completions don't count).
+
+Freeze this *before* you see findings, so the review can't silently redefine the
+task.
+
+### 2. Determine the target diff
+
+In priority order:
+
+- Uncommitted work → `git diff` (and `git diff --staged`).
+- A branch → diff against its base: open PR base (`gh pr view --json
+  baseRefName`) if one exists, else `origin/main`.
+- A specific commit → `git show <ref>` / `git diff <ref>^..<ref>`.
+
+Do not auto-fetch new history; review what is local. Empty diff → stop.
+
+### 3. Run the review engine
+
+Run `/my-review` against the target diff — don't hand-roll the agent dispatch.
+`/my-review` builds the shared context, selects the relevant `review-*`
+subagents from the diff's trigger map, runs them in parallel, and
+batch-validates. Reuse it instead of re-deciding which agents to run.
+
+`/my-review`'s last step posts findings as inline PR comments — that does
+**not** apply to a pre-PR closeout. Take its validated findings as input and
+resolve them locally through the scope governance below; post nothing.
+
+### 4. Verify each finding independently
+
+**Treat review output as advisory. Never blindly apply it.** Before accepting a
+finding, confirm all of:
+
+- **Diff-introduced & grounded** — the flagged line was added/changed by this
+  diff (or this diff made a latent bug reachable), and the claim is backed by
+  *quoted* code, not a paraphrase.
+- **Not already handled** — a guard, a newtype constructor, or a type doesn't
+  already cover it.
+- **Dependency contract checked** — for any claim about a crate/API, read the
+  actual signature/docs, not memory.
+- **Fix stays simple** — the fix doesn't overcomplicate the code or add a
+  phantom feature to satisfy a hypothetical.
+
+Drop findings that fail any check. When you reject a real-but-intentional finding
+(a deliberate invariant or ownership decision — coop has several, e.g. the
+passphrase-less VM key, `bypassPermissions` in the guest), leave a one-line note
+so the next reviewer doesn't re-raise it.
+
+### 5. Classify with the Scope Governor
+
+Every surviving finding gets exactly one label:
+
+| Label | Meaning | Action |
+|-------|---------|--------|
+| **In-scope blocker** | Introduced by this diff, same owner boundary, fixable without reframing the task. | Fix now. |
+| **Follow-up** | Real, but a different bug class / adjacent surface / cleanup track. | Note it (TODO, issue, PR description); do **not** fix here. |
+| **Stop-and-escalate** | Needs a new contract, protocol/storage/API change, or a design decision outside this change. | Stop. Surface to the human. Don't absorb it. |
+
+When in doubt between blocker and follow-up, it's a follow-up.
+
+### 6. Patch, re-test, re-review (converge)
+
+- Apply only **in-scope blockers**.
+- Re-run the focused gate for what you touched — the narrowest relevant
+  `cargo test <name>`, plus `cargo clippy --all-targets --all-features -- -D
+  warnings` and `cargo fmt -- --check` (and `taplo format --check` if a `.toml`
+  changed). If the change is guest-visible or touches the VM lifecycle, note
+  that `tests/integration.sh` should run on both backends before merge (see
+  [`docs/testing.md`](../../../docs/testing.md)) — you generally can't run it
+  here, so flag it as a pre-merge requirement.
+- Re-review the new diff. Repeat until no in-scope blockers remain.
+
+## Stop conditions (hard)
+
+Pause and report — do not keep editing — when any hit:
+
+- **Two cycles without convergence.**
+- **Diff grows past ~2× the baseline files / LOC** without explicit approval.
+- **The narrow change is turning into** an architecture change, a config-schema
+  migration, a broad refactor, or a release-process change.
+- **The best fix is "define the canonical contract first"** rather than a local
+  inference — that's a design decision, not a closeout edit.
+
+## Final report
+
+Always close with a short report:
+
+- **What ran** — the review agents and the gate command(s) you re-ran.
+- **Findings** — accepted (and fixed) vs. rejected (one-line reasoning each),
+  and any follow-ups / escalations carried out of scope.
+- **Verdict** — `clean` (no in-scope blockers; ready) or `blocked` (with the
+  reason and the stop condition that fired).
+
+### Record the gate marker (only on a `clean` verdict)
+
+A `PreToolUse` hook (`closeout-review-gate.sh`) blocks `gh pr create` until this
+marker exists for the current branch at the current commit. When — and only when
+— the verdict is `clean`, record it as the last step. Run this from the worktree
+you reviewed; it stores the marker under the shared git common dir so the gate
+finds it even though the hook runs from the main checkout:
+
+```bash
+COMMON_DIR="$(git rev-parse --git-common-dir)"
+case "$COMMON_DIR" in /*) ;; *) COMMON_DIR="$PWD/$COMMON_DIR" ;; esac
+COMMON_DIR="$(cd "$COMMON_DIR" && pwd)"
+DIR="$COMMON_DIR/closeout-review"
+mkdir -p "$DIR"
+git rev-parse HEAD > "$DIR/$(git rev-parse --abbrev-ref HEAD | tr '/' '-')"
+```
+
+The marker is bound to the reviewed commit. If you commit again afterward, the
+gate re-arms and the review must be re-run. Never write the marker to bypass a
+`blocked` verdict — that defeats the gate.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Applying findings verbatim | They're hypotheses — verify against real code first (§4). |
+| Letting the review redefine the task | Freeze the scope baseline *before* reviewing (§1). |
+| Fixing every nit "while I'm here" | Nits in adjacent code are follow-ups, not blockers (§5). |
+| Looping forever on "one more finding" | Two-cycle rule and 2× growth are hard stops. |
+| Re-implementing review from scratch | Run `/my-review`'s engine (§3). |

--- a/.claude/skills/mutation-check/SKILL.md
+++ b/.claude/skills/mutation-check/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: mutation-check
+description: Use when a change touches a logic-dense coop module (config, workspace, devcontainer, github_*, secret_store, fs_util, commands/*, model_state, jsonc) to run cargo-mutants correctly AND verify .cargo/mutants.toml was updated in the same PR. Triggers: "run mutation testing", "check mutants", "did I break the mutation baseline", before merging a change to a scoped module, before refactoring one.
+---
+
+# Mutation Check
+
+## Overview
+
+coop uses [`cargo-mutants`](https://mutants.rs/) as a manual quality gate: it
+mutates the code and checks whether the unit tests notice. A **surviving mutant**
+(`missed`) is a unit test that would still pass with the code broken — a real
+coverage gap. This skill runs the sweep correctly and, critically, catches the
+**documented failure mode**: adding a new shell-out / IO / backend / TTY function
+without updating `.cargo/mutants.toml`, which silently breaks the "0 missed"
+baseline (this is exactly what happened in #352, surfaced late in #373).
+
+Read [`docs/testing.md`](../../../docs/testing.md) for the full scoping model
+and baselines — this skill is the operational checklist, that doc is the
+reference.
+
+## When to use
+
+- A change adds or edits logic in a scoped module: `config.rs`, `workspace.rs`,
+  `devcontainer.rs`, `guest_env_state.rs`, `github_repo.rs`, `github_pat.rs`,
+  `secret_store.rs`, `fs_util.rs`, `src/commands/*`, `model_state.rs`, `jsonc.rs`.
+- Before refactoring one of those (capture survivors first to know what behavior
+  isn't pinned down).
+
+**When NOT to use:** changes only to `backend.rs`, `lima.rs`, `setup.rs`,
+`update.rs`, `ssh.rs`, `vm.rs`, `network.rs`, `port_forward.rs`, `cmd.rs`,
+`prompt.rs`, `main.rs`, or the `cmd_*`/`&PlatformBackend`/TTY handlers — these
+are scoped out because a `--lib` test structurally can't reach them; the
+integration suite covers them. Don't burn minutes mutating them.
+
+## Workflow
+
+### 1. Sync the scope config in the SAME PR (do this first)
+
+Before running anything, diff the change and ask: does it add a function that
+**shells out, drives a `&PlatformBackend`, reads a TTY, or writes stdout** inside
+a logic module?
+
+- **Yes** → the function must be scoped out in `.cargo/mutants.toml` in this same
+  PR — either an `exclude_re` line (`\b`-anchored to the function name or
+  `Type::method`) or, for a `..Default::default()` field-deletion mutant that
+  `exclude_re` can't reach, an in-source `#[mutants::skip]` with a back-reference
+  to the note in `.cargo/mutants.toml`. **And** extract any pure logic the new
+  function contains into a separate, kept, unit-tested helper (the pattern the
+  #321–#327 fixes established). Do this before merging — it is not a follow-up.
+- **No / pure logic** → leave it in scope; it needs a unit test that kills its
+  mutants.
+
+If you edited `.cargo/mutants.toml`, sanity-check the list resolves:
+
+```bash
+cargo mutants --list -f <touched file>
+```
+
+### 2. Run the sweep (scoped, `--lib`)
+
+Always scope with `-f` and pass `-- --lib` (all logic is in the library crate;
+`-- --bins` runs zero tests and reports every mutant as missed):
+
+```bash
+# The touched files
+cargo mutants -f src/<file>.rs -- --lib
+
+# PR-scoped alternative: only lines changed vs main
+cargo mutants --in-diff <(git diff origin/main -- 'src/*.rs') -- --lib
+```
+
+**Prefer the full-file `-f` sweep over `--in-diff` for the touched files** — the
+in-diff sweep only mutates changed lines, so it misses pre-existing same-class
+survivors in a file you touched. Redirect output to a file (a `PreToolUse` hook
+enforces this for cargo-mutants); the run takes minutes.
+
+### 3. Read `mutants.out/` and handle survivors
+
+- `caught.txt` — killed (good). `unviable.txt` — broke the build (ignore).
+  `timeout.txt` — hung (rare; `jsonc.rs` scanner-index mutants live here, not a
+  gap). `missed.txt` — the survivors to triage.
+
+For each line in `missed.txt`, classify (see `docs/testing.md` for detail):
+
+1. **Real test gap** → add a test that asserts the actual value (not "it didn't
+   panic") so it distinguishes the mutant. Re-run the file to confirm the kill.
+2. **Equivalent mutant** → behavior no caller can observe (`Display` returning a
+   default, a getter whose default matches the real value). `#[mutants::skip]`
+   with a one-line reason.
+3. **Dead code** → delete it (per "replace, don't deprecate").
+
+A kill rate of 70–80% on viable mutants is healthy. But for the scoped logic
+modules the documented baseline is **0 missed** — treat any new survivor there
+as a coverage regression, not noise. First confirm it isn't a shell-out/IO
+function that belongs in `.cargo/mutants.toml`, then add the test.
+
+### 4. Report
+
+Close with: which files were swept, `missed` count before/after, what you did
+with each survivor (test added / skipped-equivalent / deleted), and whether
+`.cargo/mutants.toml` needed (and got) an update in this PR.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,62 @@
+name: Claude On-Demand Review
+
+# Triggered only when a user explicitly mentions @claude in a PR comment or
+# inline review comment. Per anthropics/claude-code-action docs, this is the
+# recommended pattern for explicit, user-requested runs — it does not run on
+# every PR automatically.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# Cancel an in-progress run on the same PR when a newer @claude request arrives.
+# Bot-authored comments (the action's own progress updates) get a unique
+# per-run group so they don't preempt the run that is posting them.
+concurrency:
+  group: ${{ github.event.comment.user.type == 'Bot' && github.run_id || format('{0}-{1}', github.workflow, github.event.issue.number || github.event.pull_request.number) }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    # Run only when the comment contains @claude AND is on a pull request
+    # (issue_comment fires for plain issues too; pull_request_review_comment is
+    # always on a PR).
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      (github.event_name == 'pull_request_review_comment' ||
+       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      # claude-code-action calls getIDToken() unconditionally to label
+      # telemetry; without id-token: write the action exits before the API-key
+      # path is reached.
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: anthropics/claude-code-action@e58dfa55559035499a4982426bb73605e8b5ad8e # v1.0.105
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+
+            A user requested a review by mentioning @claude in a comment on this pull request.
+
+            Run the /my-review command against this pull request (diff from the PR's base branch).
+            Post substantive findings as inline review comments on the PR, following the
+            "Post findings to the PR" section of the command.
+
+          claude_args: |
+            --allowedTools "Agent,Read,Grep,Glob,WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api:*),Bash(cargo tree:*),Bash(cargo metadata:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(ls:*),Bash(find:*),Bash(jq:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,11 +22,13 @@ permissions:
 
 jobs:
   review:
-    # Run only when the comment contains @claude AND is on a pull request
-    # (issue_comment fires for plain issues too; pull_request_review_comment is
-    # always on a PR).
+    # Run only when the comment contains @claude, is authored by a trusted
+    # member (not any drive-by outside account — this spends ANTHROPIC_API_KEY),
+    # AND is on a pull request (issue_comment fires for plain issues too;
+    # pull_request_review_comment is always on a PR).
     if: |
       contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
       (github.event_name == 'pull_request_review_comment' ||
        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null))
     runs-on: ubuntu-latest
@@ -58,5 +60,12 @@ jobs:
             Post substantive findings as inline review comments on the PR, following the
             "Post findings to the PR" section of the command.
 
+          # The agent reads the untrusted PR diff/comment into its context, so
+          # the allowlist deliberately excludes any way to read process env and
+          # exfiltrate it: no `cat` (would match /proc/self/environ), no
+          # WebSearch/WebFetch (arbitrary outbound), and no broad `gh api` — only
+          # `gh api graphql` for the read-only reviewThreads query /my-review
+          # needs. File reads go through the sandboxed `Read`/`Grep` tools. The
+          # only write surfaces are PR comments (the review's actual output).
           claude_args: |
-            --allowedTools "Agent,Read,Grep,Glob,WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api:*),Bash(cargo tree:*),Bash(cargo metadata:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(ls:*),Bash(find:*),Bash(jq:*)"
+            --allowedTools "Agent,Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(cargo tree:*),Bash(cargo metadata:*),Bash(rg:*),Bash(grep:*),Bash(ls:*),Bash(find:*),Bash(jq:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,284 +1,107 @@
-# coop
+# coop — Claude / Codex / contributor guide
 
-Isolated VM environment for running Claude Code and Codex — Firecracker on Linux, Lima on macOS.
+Isolated VM environment for running Claude Code and Codex — Firecracker on
+Linux, Lima on macOS.
 
-## Architecture
+## Agent entrypoint
 
-Rust CLI that orchestrates VM lifecycle: setup, start, shell, stop, destroy, status, logs.
+Shared entrypoint for Claude, Codex, and humans. Keep this short and
+navigational; durable detail lives in [`docs/`](docs/).
 
-Two backends, auto-detected by platform:
-- **Linux**: Firecracker microVMs with KVM. Cross-compiled from arm64 macOS (`x86_64-unknown-linux-musl` via `musl-cross`).
-- **macOS**: Lima VMs using Apple Virtualization.framework (`limactl`). Native arm64 binary.
+- [`docs/index.md`](docs/index.md) — system-of-record map.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — module map, the two-backend
+  design, host→guest data flow, architectural invariants.
+- [`docs/trust-model.md`](docs/trust-model.md) — trust boundaries and taint
+  sources (the security spec; read before touching secrets, subprocess,
+  network, or the guest boundary).
+- [`docs/code-style.md`](docs/code-style.md) — Rust authoring idioms + review /
+  authoring checklists.
+- [`docs/testing.md`](docs/testing.md) — integration, mutation, fuzzing, kani.
+- [`docs/platform-notes.md`](docs/platform-notes.md) — CI-kernel workarounds,
+  Docker networking, scp `~` caveat, tracing-to-stderr.
+- Review tooling: `.claude/agents/review-*.md`, `.claude/commands/`,
+  `.claude/skills/`.
 
-Backend abstraction in `src/backend.rs` provides `SshTarget` and `Backend` enum. All SSH-based operations (config injection, workspace sync, VS Code) are shared across backends.
+## Architecture (one paragraph)
+
+A Rust CLI that orchestrates VM lifecycle (setup → up/start → shell → stop →
+destroy → status/logs). Two backends are selected at **compile time** by
+`#[cfg]` behind the `backend::VmBackend` trait / `PlatformBackend` alias:
+Firecracker microVMs on Linux (KVM), Lima VMs on macOS
+(Virtualization.framework). Everything above the trait — SSH, workspace sync,
+config/secret injection, agent bootstrap, `commands/` — is backend-shared and
+must hold for both. Full detail: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+## Trust model
+
+**The VM is the isolation boundary.** The guest is deliberately permissive
+(passwordless sudo, agents run in bypass mode) because the whole VM is the blast
+radius — so the guest is **untrusted from the host's view**, and guest-authored
+data must never escalate into host code execution, filesystem escape, or
+credential exposure. Authoritative boundaries and the stop-and-confirm checklist:
+[`docs/trust-model.md`](docs/trust-model.md). This is the engineering spec;
+[`SECURITY.md`](SECURITY.md) remains the vulnerability-disclosure policy.
+
+Stop and confirm before merging code that adds an outbound URL / network
+listener / egress rule, forwards a new secret into the guest, runs a subprocess
+on tainted bytes, writes a host path from tainted data, logs/traces tainted or
+secret content, or softens the `coop update` verification chain.
+
+## Development commands
+
+Runtime: Rust `1.94.0` (see `rust-toolchain.toml`), edition 2024.
+
+```bash
+cargo build                                                    # debug build
+cargo fmt -- --check                                           # format check
+cargo clippy --all-targets --all-features -- -D warnings       # lints (zero-warnings)
+cargo test                                                     # unit tests (lib)
+cargo deny check                                               # advisories/licenses/bans
+taplo format --check                                           # TOML formatting
+prek run                                                       # all pre-commit hooks
+```
+
+Install pinned local dev tools (prek, taplo, cargo-deny, cargo-mutants,
+cargo-fuzz, kani) with `./scripts/install-dev-tools.sh --all`, then `prek
+install`. CI pins its own taplo/cargo-deny versions in
+`.github/workflows/ci.yml`; keep those in sync with the installer.
 
 ## Before committing
 
-Pre-commit hooks (prek) run automatically: cargo fmt, clippy, test, `taplo format --check` (TOML — also enforced by the `taplo` CI job), trailing whitespace, EOF fixer, large file check, merge conflict check. Install the hook runner and formatter at pinned versions with `./scripts/install-dev-tools.sh` (the pinned installer for local dev tools; CI pins its own taplo/cargo-deny in `.github/workflows/ci.yml`), then `prek install`. taplo's 2-space indent (its default, pinned in `.taplo.toml`, which also excludes `revm-kani/`/`target/`) is what `.editorconfig` declares for editors.
-
-After hooks pass, run integration tests on **both platforms** — these are too slow for hooks:
-
-```bash
-# Local (macOS/Lima) — builds and runs automatically
-./tests/run-integration.sh
-
-# Remote (Linux/Firecracker) — detects remote arch, cross-compiles, copies, and runs
-./tests/run-integration.sh --remote user@remote-host
-```
-
-## Testing
-
-### Integration tests
-
-Two scripts:
-- `tests/integration.sh` — the test suite. Runs locally, requires `--binary`.
-- `tests/run-integration.sh` — the runner. Builds, deploys (if remote), and invokes the test suite.
-
-Run on **both platforms** before every commit:
+Pre-commit hooks (prek) run automatically: `cargo fmt`, `cargo clippy`, `cargo
+test`, `taplo format --check`, plus trailing-whitespace / EOF / large-file /
+merge-conflict checks. After hooks pass, run the integration suite on **both
+platforms** — too slow for hooks:
 
 ```bash
-# Local (macOS/Lima)
-./tests/run-integration.sh
-
-# Remote (Linux/Firecracker)
-./tests/run-integration.sh --remote user@remote-host
-
-# With options (forwarded to integration.sh)
-./tests/run-integration.sh --remote user@remote-host --full
-./tests/run-integration.sh --profile python,node --name my-test
+./tests/run-integration.sh                       # local (macOS/Lima)
+./tests/run-integration.sh --remote user@host    # remote (Linux/Firecracker)
 ```
 
-You can also run the test script directly if you already have a binary:
-
-```bash
-./tests/integration.sh --binary /path/to/coop --full
-```
-
-When adding new features, consider whether they should be covered by the integration test. The test exercises the full VM lifecycle (setup → start → status → shell → guest environment → docker → stop → destroy). New commands or guest-visible changes are good candidates for new test phases.
-
-### Mutation testing
-
-Mutation testing finds unit tests that pass even when the code is broken — i.e. real behavioral gaps. We use [`cargo-mutants`](https://mutants.rs/). It's a manual quality check, not a CI gate.
-
-**Install once** — via the pinned installer `./scripts/install-dev-tools.sh --all`, or directly:
-
-```bash
-cargo install cargo-mutants --locked
-```
-
-**When to run.** After significant edits to a logic-dense module, or before refactoring one (capture surviving mutants first to know what behavior isn't pinned down). Don't run it routinely — runs take minutes per module.
-
-**Where it pays off in this crate.** Mutation testing only earns its keep on code with branches, arithmetic, parsing, or state composition. In coop that means:
-
-- `src/config.rs` — parsing, validation, defaults, env composition
-- `src/workspace.rs` — rsync arg construction, mount-state record/remove
-- `src/devcontainer.rs`, `src/guest_env_state.rs` — env merging and persistence
-- `src/github_repo.rs`, `src/github_pat.rs`, `src/secret_store.rs` — slug parsing, secret routing
-- `src/fs_util.rs` — path manipulation helpers
-- `src/commands/` (`lifecycle.rs`, `profiles.rs`, `commands/devcontainer.rs`, `quickstart.rs`, `admin.rs`) — the pure helpers the command handlers were carved into: input-compatibility guards, summary/message builders, the `TranslatorInputs` builder, byte→GiB arithmetic kernels, and predicates like `discovered_local_devcontainer` / `is_sensitive_workspace`
-
-**Don't bother with:** `backend.rs`, `lima.rs`, `setup.rs`, `update.rs`, `shell.rs`, `port_forward.rs`, `cmd.rs`, `ssh.rs`, `vm.rs`, `prompt.rs` (TTY prompts), `main.rs`, and — inside `src/commands/` — the `cmd_*` dispatch entrypoints and the handlers that take a `&PlatformBackend`, write stdout, or open a TTY prompt (e.g. `create_up_instance`, `restart_instance`, `find_stopped_instance`, `resolve_running`, `resolve_devcontainer`, `purge_all_data`, and `model.rs`'s `render_status`/`set_local`/`set_remote`/`report_switch`/`apply_to_running`/`prompt_endpoint`), plus the `lib.rs` `run`/`init_tracing` shims. These mostly shell out, run SSH, or talk to external services — unit tests can't catch behavioral changes there. `tests/integration.sh` does that job. This list is enforced (not just advised) by `.cargo/mutants.toml` — see **Scoping** below.
-
-**Scoping (`.cargo/mutants.toml`).** The mutation surface is curated in `.cargo/mutants.toml` so the `missed` list means "real unit-test gap," not "code a `--lib` test structurally cannot reach." cargo-mutants reads this file automatically on every run (`--list` included). It scopes out three things:
-
-- **The whole-module "Don't bother with" files above** (`main.rs`, and `prompt.rs` — every function in it short-circuits off a TTY and otherwise reads stdin, with no pure logic a `--lib` test can reach), via `exclude_globs` — they only shell out, drive SSH, read a TTY, or hit external services.
-- **`cfg(kani)` proofs** (`config.rs mod proofs`), via `exclude_re = ["proofs::"]` — never compiled in a normal build, so every mutation is a silent no-op that always reports `missed`. They are exercised by `cargo kani`, not mutation testing.
-- **Individual shell-out / IO / terminal functions inside otherwise-logic-bearing modules** (`github_pat.rs`, `workspace.rs`, `devcontainer.rs`, `secret_store.rs`, `fs_util.rs`, `commands/model.rs`'s stdout/backend/TTY functions), via `exclude_re`. Each pattern is `\b`-anchored to a function name (or qualified `Type::method`) so it scopes the whole function without catching longer names that share a prefix. The module-agnostic `replace gh_auth_token ->` pattern also covers the identical `gh_auth_token` shell-out in `git_repo_devcontainer.rs`.
-- **The `src/commands/` dispatch entrypoints and backend-driving / TTY handlers**, via `exclude_re`: a single `\bcmd_[a-z_]+\b` covers every `coop <subcommand>` entrypoint across the command modules, plus `\b`-anchored names for the `&PlatformBackend` handlers (`create_*`, `restart_instance`, `start_instance`, `find_stopped_instance`, `resolve_running`, `preflight_start_target`, `current_disk_gib`, …), the IO handlers in `admin.rs`/`profiles.rs`/`commands/devcontainer.rs`/`quickstart.rs`, and the `lib.rs` `run`/`init_tracing` shims.
-
-A cargo-mutants quirk to know about: `exclude_re` does **not** match `delete field … from struct …` mutants — these are emitted for every struct literal that uses `..Default::default()`, and no pattern (function name, struct path, or `file:line`) filters them. In this crate they all target `devcontainer::TranslatorInputs`, assembled in four places. The one pure builder (`up_translator_inputs`) stays in scope and is unit-tested, which kills its field-deletion mutants; the three shell-out handlers that build it inline (`run`, `cmd_devcontainer_check`, `quickstart_fresh_start`) carry an in-source `#[mutants::skip]` with a back-reference to the note in `.cargo/mutants.toml`, because `exclude_re` cannot reach them.
-
-What is deliberately *kept* (a survivor here is a genuine coverage regression, not noise): the pure-logic helpers the #321–#327 fixes carved the shell-out/IO functions down to. Those fixes extracted the testable logic into separate functions, which stay in scope: `parse_curl_status_body`, `parse_user_login` (split from `probe_user_login`), `github_pat.rs`'s `render_status` (split from `run_status` — note `commands/model.rs` has a *different*, excluded `render_status` that drives the backend, so its exclude is file-anchored), `parse_gh_token` / `normalize_token` (split from the two `gh_auth_token`s), `pick_backend`, `doc_contains_literal_token`, the SSH-config marker-block helpers (`remove_marker_blocks` / `remove_named_marker_block` / `remove_all_ssh_config_at` / `remove_ssh_config_at`, split from `remove_all_ssh_config` / `remove_ssh_config`), `CmdToken::from_words`'s Linux/`op`/`cat` arms (only the macOS keychain arm is scoped, since it is compiled out on the Linux sweep host and pinned on macOS by `parse_recognises_macos_keychain`), `Report::push`, `atomic_write_with_mode`, and `vscode_strategies`. The thin wrappers those helpers were split out of (`probe_user_login`, `run_status`, `remove_*_ssh_config`, `gh_auth_token`) are excluded — a `--lib` test cannot reach them without a real `$HOME` or network. When adding a new shell-out or IO function to one of these modules, add a matching `exclude_re` line; when adding logic, leave it in scope.
-
-The same split applies in `src/commands/`. Kept in scope (a survivor here is a real gap): the input-compatibility guards (`ensure_up_existing_inputs_are_compatible[_for_git_repo]`, `up_has_restart_only_inputs`, `restart_has_ignored_creation_flags`, `validate_copy_workspace_mounts`), the config-IO lookups (`find_workspace_instance`, `find_git_repo_instance`), the message/summary builders (`no_stopped_instance_message`, `creation_options_rejected_message`, `builtin_summary`, `format_custom_summary`, `script_summary`), the `up_translator_inputs` builder, the arithmetic kernels `bytes_to_gib` (split from `current_disk_gib`) and `format_dir_size` (split from `dir_size_display`), `project_dir_to_str`, and the predicates `discovered_local_devcontainer` / `is_sensitive_workspace`. The backend-driving wrappers those kernels were carved out of (`current_disk_gib`, `dir_size_display`) are excluded, mirroring the `_at`-suffix split used for the SSH-config helpers.
-
-The `coop model` feature (#352) follows the same split. Kept in scope (and unit-tested): `tools_needing_prompt`, `switch_report_lines`, `ModelState::resolved_claude` / `resolved_codex` / `is_default` / `load_or_default`, and `ModelMode::as_str`; plus `From<ModelAction> for ModelMode` in `lib.rs`. (`load_or_default` is tempdir-testable, so it stays in scope: `load_or_default_returns_saved_state` kills its `Ok(Default::default())` mutant, which the missing-file test alone cannot — the default IS Remote there.) Excluded as IO/backend/TTY: `model.rs`'s `render_status` / `write_tool_line` / `set_local` / `set_remote` / `report_switch` / `apply_to_running` / `prompt_endpoint`, and `lifecycle.rs`'s `bootstrap_and_post_start` / `prepare_session_from_target`.
-
-**Keep `.cargo/mutants.toml` in sync in the same PR that adds the code** — this is not a follow-up chore. #352 was merged without scoping its new IO/backend/TTY functions, which silently broke the documented baseline and surfaced 22 survivors only at the next release preflight (#373). When a change adds a function that shells out, drives a `&PlatformBackend`, reads a TTY, or writes stdout, add its `exclude_re`/`exclude_globs` entry (and extract any pure logic into a kept, tested helper) before merging. Verify with `cargo mutants -f <touched files> -- --lib` — not just the `--in-diff` sweep, which only mutates changed lines and so misses pre-existing same-class survivors in a touched file (e.g. `prompt.rs`'s `confirm`/`confirm_default_yes`, invisible to the #352 in-diff run but caught by the full-file sweep here).
-
-**Running it.** Always scope with `-f`; all logic lives in the library crate
-(`src/lib.rs`; `main.rs` is a thin `coop::run()` shim), and every unit test runs
-in the lib target, so pass `-- --lib`. (`-- --bins` runs zero tests and reports
-every mutant as missed.)
-
-```bash
-# One file
-cargo mutants -f src/config.rs -- --lib
-
-# Several logic modules at once
-cargo mutants -f src/config.rs -f src/workspace.rs -f src/devcontainer.rs -- --lib
-
-# PR-scoped: mutate only lines changed vs main
-cargo mutants --in-diff <(git diff origin/main -- 'src/*.rs') -- --lib
-
-# Estimate cost without running
-cargo mutants --list -f src/config.rs
-```
-
-A baseline run on `config.rs` (197 mutants) takes ~8 minutes on a workstation. Budget similarly for other modules and run them one at a time.
-
-**Reading the output.** Results land in `mutants.out/` (gitignored):
-
-- `caught.txt` — mutants tests killed (good)
-- `missed.txt` — mutants tests didn't catch (the interesting ones)
-- `unviable.txt` — mutants that broke the build (ignore; not test gaps)
-- `timeout.txt` — mutants that hung (rare; bump `--timeout` if needed)
-
-A kill rate around 70–80% on viable mutants is healthy for this code. Aim to drop the *number* of survivors, not chase 100% — many remaining mutants will be equivalent.
-
-**Handling survivors.** For each line in `missed.txt`:
-
-1. **Real test gap.** The mutation alters observable behavior and nothing fails. Add a test that distinguishes the mutant from the original (assert on the actual value, not just "it didn't panic"). Re-run on that file to confirm.
-2. **Equivalent mutant.** The mutation doesn't change behavior any caller can observe. Common cases: `fmt::Display` impls returning `Ok(Default::default())`, getter functions returning `Default::default()` when the default happens to match the real value, constant accessors (`default_boot_args`, `mode_name`). Skip with an attribute and a one-line reason:
-    ```rust
-    #[mutants::skip] // equivalent: Display output isn't asserted by callers
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { ... }
-    ```
-3. **Dead code.** If the function is genuinely unused, delete it (per the global "replace, don't deprecate" rule). Surviving mutants on truly dead code are a useful smell.
-
-**Baseline (recorded 2026-06-17, after the #329 scoping and #321–#330 fixes).** A sweep of the eight logic modules (`config.rs`, `workspace.rs`, `devcontainer.rs`, `guest_env_state.rs`, `github_repo.rs`, `github_pat.rs`, `secret_store.rs`, `fs_util.rs`) under `.cargo/mutants.toml` reports **0 missed**. The two equivalent `||`→`&&` mutations that previously survived in `github_repo::canonicalize` are gone: #330 removed the redundant `owner.is_empty() || repo.is_empty() || repo.contains('/')` guard, since `RepoSlug::new` already rejects the same inputs, so there is no longer any guard to mutate. Everything else is either caught or scoped out by the config. Treat any *new* survivor as a coverage regression — first confirm it isn't a shell-out/IO function that belongs in `.cargo/mutants.toml`, then add a test.
-
-**Commands + jsonc baseline (recorded 2026-06-24, issue #344).** After the `src/commands/` scoping and the helper tests added for it, a sweep of `lifecycle.rs`, `profiles.rs`, `commands/devcontainer.rs`, `quickstart.rs`, `admin.rs`, `commands/mod.rs`, `lib.rs`, and `jsonc.rs` reports **0 missed** out of 229 mutants. The non-caught results are not coverage gaps: ~18 are `unviable` (the mutation broke the build) and ~16–17 are `timeout` — all of the latter are `jsonc.rs` scanner-index increment mutants (`i += 1`→`-=`/`*=`), where mutating a byte-scanner's step makes the loop never terminate, so cargo-mutants buckets them separately from `missed`.
-
-**`coop model` baseline (recorded 2026-06-26, issue #373).** After scoping the #352 local-model IO/backend/TTY functions (`commands/model.rs`, `lifecycle.rs`'s two session/bootstrap helpers, and the whole `prompt.rs` module via `exclude_globs`) and adding the `mode_as_str_round_trips`, `model_action_maps_to_mode`, and `load_or_default_returns_saved_state` tests, a sweep of `src/commands/model.rs`, `src/model_state.rs`, and `src/prompt.rs` reports **0 missed** (32 caught, 3 unviable; `prompt.rs` now contributes no mutants), and a full `src/lib.rs` sweep reports **0 missed** (11 caught — including the `From<ModelAction>` mutant, killed by the new test). `lifecycle.rs`'s two excluded helpers no longer appear in `--list`.
-
-### Fuzzing
-
-Fuzzing is reserved for parsers of **untrusted or user-editable input** — it finds panics/hangs/OOM, not correctness (there's no oracle), so a standing harness only earns its keep where input crosses a trust boundary. Like mutation testing, it's a manual check, not a CI gate. We use [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz) (libFuzzer), which needs a nightly toolchain.
-
-Targets live in `fuzz/fuzz_targets/`. `coop` exposes a library target (`src/lib.rs`), so a target depends on the crate directly and imports the parser under test with `use coop::…` — no `#[path]` includes. `fuzz/Cargo.toml` is its own workspace, so the main `cargo build`/`test`/`fmt`/`clippy`/`deny` never touch it.
-
-**Install once** (or `./scripts/install-dev-tools.sh --all`): `cargo install cargo-fuzz --locked`
-
-```bash
-cargo +nightly fuzz build                                  # compile all targets
-cargo +nightly fuzz run parse_repo_slug                    # fuzz until a crash (Ctrl-C to stop)
-cargo +nightly fuzz run parse_repo_slug -- -max_total_time=60   # bounded run
-```
-
-A crash is written to `fuzz/artifacts/<target>/`; reproduce it with `cargo +nightly fuzz run <target> <artifact-path>`.
-
-**Current targets:**
-
-- `parse_repo_slug` — `coop::github_repo::parse_repo_slug_from_url`, fed `git remote get-url` output and `--git-repo` CLI args. Property: never panics.
-- `jsonc_to_json` — `coop::jsonc::jsonc_to_json`, fed hand-authored `devcontainer.json` text. Property: never panics.
-- `config_load` — `toml::from_str` into `coop::config::CoopConfig` then `validate`, fed `config.toml` text. Exercises the custom `Deserialize`/`visit_map` impls (`SubnetMask`, `HostInterface`, `PortForward`). Property: never panics, only returns `Err`.
-
-### Formal verification (kani)
-
-[Kani](https://model-checking.github.io/kani/) is a bounded model checker that proves the *absence* of a property (here: arithmetic overflow / panics) over all inputs in a range, rather than sampling like proptest. It is a **narrow fit** in this crate — the type system already makes most illegal states unrepresentable, so kani earns its keep only on bounded integer/float arithmetic. Like mutation testing and fuzzing, it is a manual check, not a CI gate; it needs its own toolchain.
-
-Proofs live in a `#[cfg(kani)]` module so the normal `cargo build`/`test`/`fmt`/`clippy` never compile them. They run as one module in `src/config.rs`.
-
-**Install once** (or `./scripts/install-dev-tools.sh --all`): `cargo install --locked kani-verifier && cargo kani setup`
-
-```bash
-cargo kani                                       # run every proof harness (~5s total)
-cargo kani --harness disk_relative_add_never_wraps   # one harness
-```
-
-**Current proofs (`src/config.rs`, `mod proofs`):**
-
-- `disk_relative_add_never_wraps` — the arithmetic kernel of `DiskSize::resolve`'s relative branch (`current.checked_add(delta)`): for any two non-zero `u32` sizes it yields `Some(current + delta)` exactly when the sum fits, and `None` otherwise — never wraps, never panics.
-- `mib_as_gib_f64_is_finite_and_positive` — `MiB::as_gib_f64` is finite and strictly positive across the whole non-zero range.
-- `instance_index_octet_stays_in_range` — the guest IP/MAC last octet (`index + 2`) stays in `2..=254` for every valid `InstanceIndex` (`0..=252`).
-
-A note on the disk proof: the harness verifies the `checked_add` kernel directly rather than calling `DiskSize::resolve`, because `resolve` wraps the overflow case with `anyhow`'s heap-allocating error construction, which CBMC cannot model tractably (it does not terminate). `resolve` adds only that infallible `.context()` on top of the kernel; its end-to-end behavior — including overflow → `Err` — is pinned by the deterministic unit tests `disk_size_resolve_relative` / `disk_size_resolve_relative_overflows`. This is the general rule for kani here: prove the arithmetic kernel, not code paths that route through `anyhow`/allocation.
-
-The `InstanceIndex` range is also pinned the cheaper way — by the exhaustive `0..=252` unit test `instance_network_derivations_over_full_range`, which the kani harness above demonstrates rather than replaces. `SubnetMask` was considered (#303) but carries no arithmetic: it is stored and rendered as `/N`, with the `0..=32` bound enforced by its constructor, so there is nothing for a model checker to prove.
-
-## Known workarounds (revisit later)
-
-The Firecracker CI kernel (`vmlinux-6.1.155`) is minimal and missing several modules. Two workarounds are applied in the guest install script (`src/setup.rs`, `guest_install_script()`):
-
-1. **iptables-legacy** — The kernel lacks nftables support (`CONFIG_NF_TABLES` not set). Docker's default `iptables-nft` backend fails with "Protocol not supported". Fix: `update-alternatives --set iptables /usr/sbin/iptables-legacy`. A custom kernel with nftables enabled would remove this workaround.
-
-2. **Static resolv.conf** — The CI rootfs ships `/etc/resolv.conf` as a symlink to systemd-resolved's stub (`127.0.0.53`), but `systemd-resolved` is not installed. DNS fails silently. Fix: replace the symlink with a static file pointing to `8.8.8.8`. Installing `systemd-resolved` in the guest would be the proper fix, letting systemd-networkd's DNS= directives propagate automatically.
-
-Both could be resolved by building a custom Firecracker kernel with the needed netfilter modules enabled, rather than using the minimal CI kernel.
-
-## Docker networking in the guest
-
-The Firecracker CI kernel lacks the `iptable_raw` module (`CONFIG_IP_NF_RAW` not set). Docker 28+ uses the raw table for "direct access filtering" — a PREROUTING DROP rule that prevents direct routing to published container ports, ensuring traffic goes through Docker's port-mapping rules.
-
-Without the raw table, Docker refuses to start bridge networking. The fix uses Docker 28.0.2's `DOCKER_INSECURE_NO_IPTABLES_RAW=1` env var (moby/moby#49621), set via a systemd drop-in at `/etc/systemd/system/docker.service.d/no-raw.conf`. This tells Docker to skip raw table rules while keeping full bridge networking: NAT, port mapping (`-p`), container-to-container communication, and embedded DNS all work normally.
-
-The "insecure" label refers to the fact that without raw table rules, other hosts on the local network could route directly to published container ports even if they're bound to loopback. This is irrelevant here — the guest's only network neighbor is the Firecracker host, and the VM itself is the isolation boundary.
-
-## scp tilde expansion (OpenSSH 9+)
-
-Modern scp (OpenSSH 9+) uses SFTP by default, which does **not** expand `~` in remote paths. `scp file user@host:~/.claude/CLAUDE.md` silently creates a literal `~` directory instead of writing to the home directory.
-
-Fix: `GuestPath` values use `./` instead of `~/` in remote paths (e.g., `GuestPath::new("./.claude")`). SFTP defaults to the user's home directory, so `./path` is equivalent to `~/path`. This convention is used in `scp_to` and `scp_to_recursive`.
-
-SSH commands (`exec`) are unaffected — the remote shell expands `~` normally. Only scp's SFTP mode has this issue.
-
-## Tracing output goes to stderr
-
-The coop binary's tracing output (INFO/DEBUG/WARN logs) goes to **stderr**.
-
-## Authoring and reviewing Rust code
-
-These notes complement the global Rust guidance (clippy lints, `thiserror`/`anyhow`, `tracing`, newtypes, enums over bools). The focus here is on **using the type system to eliminate error states** — not on style. Apply these patterns when they pay for themselves; skip them when a primitive is genuinely fine. A type system that fights the reader is worse than one that lets a bug through.
-
-### Lean on the type system before lean on validation
-
-The default move when you see a bug is to add a runtime check. The better move is usually to change a type so the bug cannot be expressed. Before writing a check or returning an error, ask: *can the function signature make this case unreachable?*
-
-- **Parse, don't validate.** A function that takes a `&str` and returns `Result<Url, _>` is better than one that takes a validated `&str` by convention. Downstream code should not have to re-check what an earlier layer already proved. Convert untrusted inputs to strong types at the boundary; pass the strong type inward.
-- **Smart constructors.** When an invariant cannot be expressed structurally, wrap the type in a module-private struct and expose a `fn new(...) -> Result<Self, Error>`. The invariant then holds by construction everywhere the type appears.
-- **Make illegal states unrepresentable.** Two `Option<T>` fields that are always both-`Some` or both-`None` should be one `Option<(T, T)>`. A `bool` plus a payload that's only meaningful when the bool is true should be an `Option`. A `String` that holds one of three values should be an enum.
-
-### Type-state for lifecycles
-
-This crate orchestrates VMs through a sequence — `setup → start → shell → stop → destroy`. Operations are only legal on certain states (you can't `shell` into a stopped VM). When you find yourself writing `if self.state == State::Running { ... } else { return Err(...) }`, consider whether the state belongs in the type rather than in a field.
-
-Two flavors, pick the lightest that works:
-
-- **State enum with method gating.** Cheap and clear: an enum representing the state, and methods that pattern-match the variant and return an error for illegal transitions. Use this when the call sites are few and an explicit error is reasonable.
-- **Type-state with phantom markers.** `Vm<Stopped>`, `Vm<Running>`, where `start(self) -> Vm<Running>` consumes the stopped value. Illegal transitions become compile errors. Use this when the lifecycle is the *primary* abstraction a type exposes and call sites would benefit from compile-time enforcement. Don't reach for it on a type that mostly does something else.
-
-### Newtypes that earn their keep
-
-The global guidance says "newtypes over primitives." In practice the win comes when:
-
-- Two primitives of the same underlying type are easy to swap at a call site (`fn copy(src: PathBuf, dst: PathBuf)` — newtype the destination, or use a struct).
-- A primitive carries an invariant (non-empty, valid UTF-8, an absolute path, a hostname). The newtype's constructor is the one place that invariant is checked.
-- A primitive is a domain concept that shows up in many signatures (a VM name, a guest path, an SSH user). The newtype reads as documentation and resists drift.
-
-If a primitive appears in one place and crosses no boundary, leave it alone. Wrapping `u8` because "newtypes are good" is noise.
-
-### Error design
-
-- Distinct failure modes → distinct enum variants. A function that can fail because the VM is missing *or* because SSH timed out should return an error type whose variants reflect that. Callers can then handle them differently without string-matching.
-- Attach context at boundaries, not at every `?`. Use `anyhow::Context` at the layer where an error becomes user-facing; let library code propagate clean variants. Re-wrapping at every level produces verbose, low-signal errors.
-- `unwrap`/`expect` are forbidden by the global lints in production paths. If you genuinely need one, the comment should explain *why the invariant holds*, not just *what is being unwrapped*. "Safe because `parse` was called above" is a smell — restructure to carry the parsed value through.
-
-### Other small idioms worth checking
-
-- `&str` over `&String`, `&[T]` over `&Vec<T>` in parameters — accepts more callers, costs nothing.
-- `Cow<'_, str>` when a function sometimes returns a borrowed slice and sometimes an owned modification.
-- `NonZeroU32` / `NonZeroUsize` when zero is a real invariant (capacities, indices into a known-nonempty structure).
-- `#[non_exhaustive]` on public enums and structs that may grow variants/fields; saves a breaking change later.
-- `From`/`Into` for infallible conversions, `TryFrom`/`TryInto` for fallible. Don't write `fn from_x(...) -> Result<Self, _>` — that's `TryFrom`.
-- Sealed traits when you publish a trait but want to control implementations.
-
-### Review checklist (in priority order)
-
-1. **Correctness against the spec.** Does the change do what was asked, including edge cases the author may not have surfaced? Run the relevant tests and re-read the diff against the request.
-2. **Invariants in types vs. checks.** Scan for `bool` parameters, primitive types representing domain concepts, sentinel values (`-1`, `""`, `0` meaning "missing"), and `Option<Option<T>>`. Each is a candidate for a stronger type. Flag the ones with real payoff; don't demand a refactor for every primitive.
-3. **Error paths.** Every `?` produces an error that bubbles somewhere. Is the eventual user-facing message specific enough to act on? Are distinct failures distinguishable by the caller without string matching?
-4. **`unwrap`/`expect`/`panic`.** Forbidden by global lints, but easy to slip in. If one exists, the justification must be in a comment and must be load-bearing.
-5. **API surface.** New public items: do they need to be public? Public types: are they `#[non_exhaustive]` where appropriate? Public functions: do they accept the most general parameter types (`&str`, `&[T]`, `impl AsRef<Path>`) without overreaching?
-6. **Tests cover behavior, not shape.** Refactoring the implementation shouldn't break tests if the behavior is the same. Edge cases — empty inputs, boundaries, the error variants the code actually returns — should each have a test.
-7. **Tracing.** New operations that can take time, fail, or alter state should log at an appropriate level. INFO for user-visible lifecycle, DEBUG for internals, WARN/ERROR for actual problems. No `println!`/`eprintln!` outside the CLI's intentional output.
-8. **Cross-platform.** Touching anything backend-shared? Confirm the abstraction still holds for both Firecracker and Lima paths. Integration tests must run on both platforms per the "Before committing" section.
-
-### Authoring checklist
-
-1. **Sketch the types first.** Before writing the body, write the signatures. If the signatures don't make the legal call sequences obvious, the types are wrong — fix them before the implementation locks them in.
-2. **Take the smallest input you need.** `&str` not `String`, `&Path` not `PathBuf`, `&[T]` not `Vec<T>`. Owning is the caller's choice.
-3. **Return owned values; let callers borrow.** The reverse forces lifetimes through the call graph.
-4. **One `?` per error category.** If a function has five `?`s that all produce different user-meaningful errors, the function probably wants an error enum with five variants, not one `anyhow::Error` with five contexts.
-5. **Resist the "configuration knob" reflex.** A new flag, env var, or option is a long-lived commitment. Add it only when a real caller needs it. (See global "no speculative features.")
-6. **Re-read your diff.** Before pushing for review, read your own change as if you were the reviewer. Most cleanup happens here, not in review.
+The `/integration` command wraps this; [`docs/testing.md`](docs/testing.md) has
+the full testing reference (including the `.cargo/mutants.toml` mutation scoping
+and the [`mutation-check`](.claude/skills/mutation-check/SKILL.md) skill).
+
+## Code style
+
+Follow the global Rust guidance (clippy lint policy, `thiserror`/`anyhow`,
+`tracing`, newtypes, enums over bools) plus coop's own conventions in
+[`docs/code-style.md`](docs/code-style.md): parse-don't-validate at boundaries,
+smart-constructor newtypes, type-state for lifecycles, absolute imports only,
+tracing to **stderr**. Prefer changing a type to make a bug unrepresentable over
+adding a runtime check.
+
+## Pull requests
+
+- **One PR = one logical change.** Refactors/renames first, then behavior —
+  never mixed. Split if the description needs "and" / unrelated bullets.
+- Run the gates before opening: `cargo fmt -- --check`, `cargo clippy … -D
+  warnings`, `cargo test`, and the integration suite on both platforms for
+  guest-visible or lifecycle changes.
+- Keep cross-file infra in sync in the same PR — a new CLI flag/config field ↔
+  `config.example.toml` + `docs/`; tool-version pins ↔ CI; a new shell-out/IO
+  function in a scoped module ↔ `.cargo/mutants.toml`.
+- Before opening, run the [`closeout-review`](.claude/skills/closeout-review/SKILL.md)
+  skill on the working diff (a `PreToolUse` hook gates `gh pr create` on it).
+  Describe what the code does now — plain, factual language; a bug fix is a bug
+  fix.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ coop also carries mutation tests (`cargo-mutants`), fuzz targets
 (`cargo-fuzz`), and formal proofs (`kani`). These are manual quality checks,
 not required for every change. If you touch a logic-dense module — config
 parsing, the JSONC reader, the arithmetic kernels — see
-[CLAUDE.md](CLAUDE.md) for when and how to run them.
+[docs/testing.md](docs/testing.md) for when and how to run them.
 
 ## Code style
 
@@ -119,8 +119,8 @@ parsing, the JSONC reader, the arithmetic kernels — see
 - Log with `tracing` (`error!`/`warn!`/`info!`/`debug!`), not `println!`.
   Tracing output goes to stderr.
 
-[CLAUDE.md](CLAUDE.md) documents the project's conventions in detail, including
-the Rust patterns reviewers look for.
+[docs/code-style.md](docs/code-style.md) documents the project's conventions in
+detail, including the Rust patterns reviewers look for.
 
 ## Commits
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,10 @@ VMs on macOS — to run coding agents such as Claude Code and Codex. **The
 security boundary is the VM.** coop's job is to stand that boundary up and hand
 work to it without weakening it.
 
+This policy is the disclosure process. The engineering-facing trust boundaries,
+taint sources, and invariants that define what "weakening the boundary" means
+live in [`docs/trust-model.md`](docs/trust-model.md).
+
 In scope:
 
 - Flaws in coop that weaken or escape the VM isolation boundary.
@@ -59,7 +63,9 @@ Out of scope:
   the raw iptables table, another host on the guest's network could reach a
   published container port, even one bound to loopback. The guest's only network
   neighbor is its own Firecracker host, and the VM is the isolation boundary, so
-  this crosses no trust boundary. See `CLAUDE.md` for details.
+  this crosses no trust boundary. See
+  [`docs/platform-notes.md`](docs/platform-notes.md) and
+  [`docs/trust-model.md`](docs/trust-model.md) for details.
 - Vulnerabilities in the software coop runs or orchestrates rather than ships —
   the guest agents (Claude Code, Codex), Docker, the guest OS, Firecracker, and
   Lima. Report those to their respective projects.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,216 @@
+# Architecture
+
+`coop` is a Rust CLI that orchestrates isolated VM environments for running AI
+coding agents (Claude Code, Codex). It manages the full VM lifecycle — setup,
+start, shell, stop, destroy, status, logs — behind two platform backends:
+
+- **Linux** — Firecracker microVMs on KVM.
+- **macOS** — Lima VMs on Apple Virtualization.framework (`limactl`).
+
+This document maps the modules, the two-backend design, the data flow from host
+to guest, and the architectural invariants. For the security view of the same
+system, see [`trust-model.md`](trust-model.md); for Rust conventions, see
+[`code-style.md`](code-style.md).
+
+## Layout
+
+```
+coop/
+├── src/
+│   ├── main.rs             # thin binary shim → coop::run()
+│   ├── lib.rs              # clap CLI definition + central command dispatcher
+│   ├── backend.rs          # VmBackend trait, PlatformBackend alias, shared guest ops
+│   ├── vm.rs               # Firecracker process management (typestate machine)
+│   ├── lima.rs             # macOS/Lima backend implementation
+│   ├── setup.rs            # Firecracker host setup + golden-image builder
+│   ├── network.rs          # Firecracker TAP/bridge/NAT networking
+│   ├── config.rs           # config model + loading (the type-safe core)
+│   ├── workspace.rs        # workspace sync (rsync/tar) + ~/.ssh/config injection
+│   ├── devcontainer.rs     # devcontainer.json parse + translate to coop config
+│   ├── devcontainer_oci.rs # devcontainer Features from the GHCR OCI registry
+│   ├── git_repo_devcontainer.rs # fetch devcontainer.json from a remote repo
+│   ├── guest.rs            # guest profiles, required binaries, baked package lists
+│   ├── guest_env_state.rs  # persisted guest env vars
+│   ├── model_state.rs      # per-instance local/remote model routing
+│   ├── secret_store.rs     # pluggable secret backends (keychain/op/secret-tool/file)
+│   ├── github_pat.rs       # `coop github` PAT wizard (setup/rotate/status/forget)
+│   ├── github_repo.rs      # RepoSlug + repo-URL parsing
+│   ├── github_submodules.rs# submodule discovery for PAT scoping
+│   ├── pat_prompt.rs       # interactive pre-start PAT prompt
+│   ├── ssh.rs              # interactive SSH launching
+│   ├── remote_command.rs   # injection-safe remote shell-command builder
+│   ├── cmd.rs              # host std::process::Command wrapper (redaction, sudo)
+│   ├── port_forward.rs     # ssh -L port forwards + state
+│   ├── signal.rs           # SIGINT/SIGTERM cooperative cancellation
+│   ├── paths.rs            # GuestPath / HostPath type split
+│   ├── fs_util.rs          # atomic file writes, file locks
+│   ├── sha256_hash.rs      # Sha256Hash newtype
+│   ├── jsonc.rs            # JSONC → JSON (for devcontainer.json)
+│   ├── naming.rs           # safe-name character class
+│   ├── completions.rs      # shell completion (static + dynamic candidates)
+│   ├── prompt.rs           # TTY prompts
+│   ├── update.rs           # `coop update` self-update + background notifier
+│   └── commands/           # one module per command domain (see below)
+├── scripts/guest/          # guest-image provisioning scripts (embedded at build)
+├── guest/init.sh           # guest first-boot init
+├── tests/                  # integration test scripts (see CLAUDE.md "Testing")
+├── fuzz/                   # cargo-fuzz targets (own workspace)
+└── docs/                   # this tree
+```
+
+All application logic lives in the **library crate** (`src/lib.rs`); `main.rs`
+is a six-line shim calling `coop::run()`. This is why unit and mutation tests
+run against `--lib`.
+
+## The two-backend design
+
+The central abstraction is the `backend::VmBackend` trait — every VM operation
+(`setup`, `create_and_start`, `start_existing`, `stop`, `destroy_instance`,
+`resize_disk`, `commit_disk`, `status`, `stream_logs`, `ssh_target`, …) goes
+through it. Two implementations exist:
+
+- `FirecrackerBackend` — `#[cfg(not(target_os = "macos"))]`; delegates to
+  `setup`, `vm::FirecrackerVm`, and `network`.
+- `LimaBackend` — `#[cfg(target_os = "macos")]`; delegates to `lima`.
+
+**Backend selection is compile-time, not runtime.** `backend::PlatformBackend`
+is a type alias resolved by `#[cfg]` — `LimaBackend` on macOS, `FirecrackerBackend`
+elsewhere. There is no runtime backend enum and no dispatch cost. (Note: the
+`Backend` enum in `secret_store.rs` is unrelated — it names *secret-storage*
+backends.)
+
+Everything above the trait is **backend-shared**: the entire "shared guest
+operations" surface in `backend.rs` (env/secret forwarding, agent bootstrap,
+Claude/Codex config injection, git-repo cloning), plus `workspace.rs`,
+`ssh.rs`, `config.rs`, and the `commands/` handlers. When you touch shared
+code, it must hold for **both** backends. Known intentional divergences:
+
+| Aspect | Firecracker | Lima |
+|--------|-------------|------|
+| `guest_host_address` | TAP gateway (`network.host_ip`) | `host.lima.internal` |
+| `mounts_are_live` | `false` (one-time rsync/tar sync) | `true` (virtiofs) |
+| `ssh_target` | built from `guest_ip` + `ssh_port` | queried from `limactl` (per-boot forwarded port) |
+| workspace/mounts | rsync or tar-pipe over SSH | live mounts |
+
+### Typestate invariants
+
+Two lifecycle machines are encoded in the type system rather than in runtime
+flags — this is a load-bearing design choice (see
+[`code-style.md`](code-style.md#type-state-for-lifecycles)):
+
+- **`RunningInstance` / `StoppedInstance`** (`backend.rs`) are unforgeable
+  liveness proofs with private fields, minted only by the probes `as_running`
+  / `as_stopped`. Operations that require a live (or stopped) VM take the proof
+  by value, so the precondition is checked once and then witnessed by the type.
+- **`FirecrackerVm<Configured>` / `FirecrackerVm<Running>`** (`vm.rs`) gate
+  `start()`/`stop()` transitions at compile time.
+- **`boot_preflight(cfg)`** (`backend.rs`) is the single choke point every boot
+  path calls first; it runs `cfg.validate()` so no VM starts on an invalid
+  config.
+
+## Command dispatch
+
+`lib.rs:run()` is the entrypoint. Order matters:
+
+1. Emit dynamic shell completions (before arg parsing) if requested.
+2. Parse `Cli` (clap derive), init tracing (→ **stderr**).
+3. Handle commands that must work **without** a loaded config —
+   `Completions`, `Init`, `Update`, `Uninstall`, `Devcontainer check` — first.
+4. `config::CoopConfig::load`, then fire the update-notifier check.
+5. Construct `backend::PlatformBackend::new()`.
+6. `match` each `Commands` variant to a `commands::cmd_*` handler. Lifecycle
+   handlers call `cfg.validate_and_warn()?` before VM work; query commands
+   (`list`/`status`/`logs`) skip it.
+
+The `commands/` submodules own the domains: `lifecycle.rs` (up/start/shell/
+exec/stop/destroy/status/list/resize/commit/restore), `quickstart.rs`,
+`devcontainer.rs`, `profiles.rs` (+ images), `agent.rs` (`coop agent update`),
+`model.rs` (`coop model`), `github.rs`, `admin.rs` (init/validate/uninstall),
+and `json.rs` (machine-readable `--json` output types). `commands/mod.rs`
+re-exports the dispatch surface and holds cross-domain helpers
+(`merge_runtime_guest_env`, `purge_all_data`).
+
+## Data flow: host → guest
+
+The lifecycle is **setup → up/start → shell → stop → destroy**. A first boot
+(`lifecycle.rs:start_instance`, `BootMode::FirstBoot`) runs roughly:
+
+1. **Resolve** the target repo/workspace and optionally prompt for a GitHub PAT
+   (`pat_prompt::maybe_prompt`).
+2. **Ports** — merge forward-port specs and fail fast on host-port collisions
+   (`port_forward::check_host_port_collisions`).
+3. **Boot** the VM (`be.create_and_start`), then `wait_until_ready` (SSH probe
+   with backoff).
+4. **Forwards + state** — spawn `ssh -L` forwards, persist `ForwardsState`,
+   `GuestEnvState`, `DevcontainerState` as JSON sidecars in the instance dir.
+5. **Bootstrap** (`backend.rs:bootstrap_agents`): if a `GITHUB_TOKEN` is present,
+   `gh auth setup-git`; then `bootstrap_claude` / `bootstrap_codex` inject the
+   allowlisted config files and a managed `settings.json`, and on first boot
+   install the *delta* of marketplaces/plugins/MCP servers not already baked
+   into the golden image.
+6. **Workspace** — `--workspace` copies via tar-pipe; `--git-repo` clones inside
+   the guest; mounts are live on Lima and rsync'd on Firecracker. Persist
+   `WorkspaceState`.
+7. **`postStartCommand`** hook (warned, not fatal).
+
+Config, secrets, and workspace all cross the host→guest boundary here; the
+security-relevant details of each crossing are in
+[`trust-model.md`](trust-model.md).
+
+### Config model
+
+`config::CoopConfig` is the type-safe core. Loading reads TOML (or JSON by
+extension) or defaults, then expands user paths. Value bounds are enforced by
+**newtype constructors** (`VmMemory` has a 128-MiB floor, `InstanceIndex` is
+`0..=252`, `SubnetMask` is `0..=32`, `Hostname`/`SshUser`/`EnvVarName` validate
+their character classes), so `validate()` only checks *environmental* facts
+(paths exist, binaries are present). Secrets are stored indirected as `cmd:`
+retrieval commands and resolved at VM-start by `resolve_cmd_value`.
+
+Per-instance runtime state is a set of JSON sidecar files under the instance
+dir: `instance.json`, `vm_config.json`, `workspace.json`, `forwards.json`,
+`guest_env.json`, `model.json`, `devcontainer_state.json`, plus the Firecracker
+`.pid`/`.socket`/`.log`/vsock files.
+
+## `coop update`
+
+`update.rs` self-updates the binary: fetch release metadata from the pinned
+`trailofbits/coop` repo, download the platform tarball + `SHA256SUMS`, verify
+the checksum (mandatory), verify Sigstore attestation via `gh` (best-effort),
+extract with path-escape-safe `tar` flags, and atomically `rename` the new
+binary over the running one. A background notifier checks for new versions on a
+24-hour interval (disabled in dev/CI/non-TTY). The full verification chain and
+its trust properties are documented in [`trust-model.md`](trust-model.md#coop-update-trust-chain).
+
+## Guest image
+
+The guest runs from a golden image built once and reused (reflink-cloned per
+instance on Firecracker). `setup.rs` builds it via a chroot, running the
+embedded provisioning scripts in `scripts/guest/` (`preamble.sh`,
+`guest-config.sh`, `cleanup.sh`) plus the profile/package installers referenced
+from `guest.rs`. Firecracker uses a minimal CI kernel that is missing several
+netfilter modules; the resulting workarounds (iptables-legacy, static
+`resolv.conf`, `DOCKER_INSECURE_NO_IPTABLES_RAW=1`) are applied in
+`guest-config.sh` and explained in [`CLAUDE.md`](../CLAUDE.md) and
+[`trust-model.md`](trust-model.md#documented-accepted-trade-offs).
+
+## Architectural invariants
+
+Hold these when changing the code; the review agents check for their violation:
+
+1. **The VM is the isolation boundary.** The guest is untrusted from the host's
+   view; guest-authored data must not escalate into host code execution or
+   filesystem escape. See [`trust-model.md`](trust-model.md).
+2. **Backend selection is compile-time.** Don't add a runtime backend enum;
+   keep shared code correct for both Firecracker and Lima.
+3. **Liveness is a type, not a flag.** Route VM operations through
+   `RunningInstance`/`StoppedInstance` and `boot_preflight`, not ad-hoc
+   `if is_running` checks.
+4. **Value invariants live in constructors.** Parse into a newtype at the
+   boundary; don't re-validate primitives downstream.
+5. **Secrets never touch argv or logs.** Env/`SendEnv`/stdin only; redact in
+   traces.
+6. **Remote commands are built with `RemoteCommand::arg`, host commands with
+   `Cmd::arg`** — no shell-string interpolation of tainted input.
+7. **State is transparent JSON sidecars** written atomically
+   (`fs_util::atomic_write_*`) without relaxing permissions.

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -1,0 +1,146 @@
+# Authoring and reviewing Rust code
+
+These notes are coop's project-specific Rust conventions. They complement the
+global Rust guidance (clippy lint policy, `thiserror`/`anyhow`, `tracing`,
+newtypes, enums over bools) rather than restating it. The focus here is on
+**using the type system to eliminate error states** — not on style. The
+[`review-conventions`](../.claude/agents/review-conventions.md) and
+[`review-design`](../.claude/agents/review-design.md) agents enforce these; the
+[architecture doc](ARCHITECTURE.md) shows where the patterns already live in the
+codebase.
+
+Apply these patterns when they pay for themselves; skip them when a primitive is
+genuinely fine. A type system that fights the reader is worse than one that lets
+a bug through.
+
+## Lean on the type system before lean on validation
+
+The default move when you see a bug is to add a runtime check. The better move
+is usually to change a type so the bug cannot be expressed. Before writing a
+check or returning an error, ask: *can the function signature make this case
+unreachable?*
+
+- **Parse, don't validate.** A function that takes a `&str` and returns
+  `Result<Url, _>` is better than one that takes a validated `&str` by
+  convention. Downstream code should not re-check what an earlier layer proved.
+  Convert untrusted inputs to strong types at the boundary; pass the strong type
+  inward. coop does this pervasively in `config.rs` — value bounds live in
+  newtype constructors, so `validate()` only checks environmental facts.
+- **Smart constructors.** When an invariant can't be expressed structurally,
+  wrap the type in a module-private struct and expose `fn new(...) -> Result<Self, Error>`.
+  The invariant then holds by construction everywhere the type appears
+  (`Hostname`, `SshUser`, `RepoSlug`, `EnvVarName`, `InstanceIndex`).
+- **Make illegal states unrepresentable.** Two `Option<T>` fields that are
+  always both-`Some`/both-`None` should be one `Option<(T, T)>`. A `bool` plus a
+  payload meaningful only when the bool is true should be an `Option`. A
+  `String` holding one of three values should be an enum.
+
+## Type-state for lifecycles
+
+coop orchestrates VMs through a sequence — `setup → start → shell → stop →
+destroy`. Operations are only legal on certain states (you can't `shell` into a
+stopped VM). When you find yourself writing `if self.state == State::Running
+{ ... } else { return Err(...) }`, consider whether the state belongs in the
+type rather than in a field. Two flavors, pick the lightest that works:
+
+- **State enum with method gating.** An enum for the state, methods that
+  pattern-match the variant and return an error for illegal transitions. Use
+  when call sites are few and an explicit error is reasonable.
+- **Type-state with phantom markers.** `Vm<Stopped>`, `Vm<Running>`, where
+  `start(self) -> Vm<Running>` consumes the stopped value. Illegal transitions
+  become compile errors. Use when the lifecycle is the *primary* abstraction a
+  type exposes. coop uses this for `FirecrackerVm<Configured|Running>` (`vm.rs`)
+  and for the `RunningInstance`/`StoppedInstance` liveness proofs (`backend.rs`)
+  — don't reach for it on a type that mostly does something else.
+
+## Newtypes that earn their keep
+
+The global guidance says "newtypes over primitives." In practice the win comes
+when:
+
+- Two primitives of the same underlying type are easy to swap at a call site
+  (`fn copy(src: PathBuf, dst: PathBuf)` — newtype the destination, or use a
+  struct).
+- A primitive carries an invariant (non-empty, valid UTF-8, an absolute path, a
+  hostname). The newtype's constructor is the one place that invariant is
+  checked.
+- A primitive is a domain concept that shows up in many signatures (a VM name, a
+  guest path, an SSH user). The newtype reads as documentation and resists drift
+  — see `GuestPath`/`HostPath`, `ImageName`/`InstanceName`, `Sha256Hash`.
+
+If a primitive appears in one place and crosses no boundary, leave it alone.
+Wrapping `u8` because "newtypes are good" is noise.
+
+## Error design
+
+- Distinct failure modes → distinct enum variants. A function that can fail
+  because the VM is missing *or* because SSH timed out should return an error
+  type whose variants reflect that, so callers can branch without string
+  matching.
+- Attach context at boundaries, not at every `?`. Use `anyhow::Context` at the
+  layer where an error becomes user-facing; let library code propagate clean
+  variants. Re-wrapping at every level produces verbose, low-signal errors.
+- `unwrap`/`expect`/`panic` are forbidden by the global lints in production
+  paths. If you genuinely need one, the comment must explain *why the invariant
+  holds*, not just what is unwrapped. "Safe because `parse` was called above" is
+  a smell — restructure to carry the parsed value through.
+
+## Other small idioms worth checking
+
+- `&str` over `&String`, `&[T]` over `&Vec<T>`, `&Path`/`impl AsRef<Path>` over
+  `PathBuf` in parameters — accepts more callers, costs nothing.
+- `Cow<'_, str>` when a function sometimes returns a borrowed slice and sometimes
+  an owned modification.
+- `NonZeroU32` / `NonZeroUsize` when zero is a real invariant.
+- `#[non_exhaustive]` on public enums/structs that may grow.
+- `From`/`Into` for infallible conversions, `TryFrom`/`TryInto` for fallible.
+  Don't write `fn from_x(...) -> Result<Self, _>` — that's `TryFrom`.
+- Sealed traits when you publish a trait but want to control implementations.
+- Absolute imports only — no relative (`..`) paths.
+
+## Review checklist (in priority order)
+
+Before reviewing, sync to latest remote (`git fetch origin`).
+
+1. **Correctness against the spec.** Does the change do what was asked, including
+   edge cases the author may not have surfaced? Run the relevant tests and
+   re-read the diff against the request.
+2. **Invariants in types vs. checks.** Scan for `bool` parameters, primitive
+   types representing domain concepts, sentinel values (`-1`, `""`, `0` meaning
+   "missing"), and `Option<Option<T>>`. Each is a candidate for a stronger type.
+   Flag the ones with real payoff; don't demand a refactor for every primitive.
+3. **Error paths.** Every `?` produces an error that bubbles somewhere. Is the
+   eventual user-facing message specific enough to act on? Are distinct failures
+   distinguishable without string matching?
+4. **`unwrap`/`expect`/`panic`.** Forbidden by global lints, but easy to slip in.
+   If one exists, the justification must be in a comment and must be load-bearing.
+5. **API surface.** New public items: do they need to be public? Public types:
+   `#[non_exhaustive]` where appropriate? Public functions: most general
+   parameter types (`&str`, `&[T]`, `impl AsRef<Path>`) without overreaching?
+6. **Tests cover behavior, not shape.** Refactoring the implementation shouldn't
+   break tests if behavior is unchanged. Edge cases — empty inputs, boundaries,
+   the error variants the code returns — should each have a test.
+7. **Tracing.** New operations that can take time, fail, or alter state should
+   log at an appropriate level (INFO for user-visible lifecycle, DEBUG for
+   internals, WARN/ERROR for problems). No `println!`/`eprintln!` outside the
+   CLI's intentional output. Tracing goes to **stderr**.
+8. **Cross-platform.** Touching backend-shared code? Confirm the abstraction
+   still holds for both Firecracker and Lima. Integration tests must run on both
+   platforms (see [`CLAUDE.md`](../CLAUDE.md) "Before committing").
+
+## Authoring checklist
+
+1. **Sketch the types first.** Write the signatures before the body. If they
+   don't make the legal call sequences obvious, the types are wrong — fix them
+   before the implementation locks them in.
+2. **Take the smallest input you need.** `&str` not `String`, `&Path` not
+   `PathBuf`, `&[T]` not `Vec<T>`. Owning is the caller's choice.
+3. **Return owned values; let callers borrow.** The reverse forces lifetimes
+   through the call graph.
+4. **One `?` per error category.** Five `?`s that all produce different
+   user-meaningful errors want an error enum with five variants, not one
+   `anyhow::Error` with five contexts.
+5. **Resist the "configuration knob" reflex.** A new flag, env var, or option is
+   a long-lived commitment. Add it only when a real caller needs it.
+6. **Re-read your diff.** Read your own change as the reviewer would before
+   pushing. Most cleanup happens here, not in review.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+# Documentation index
+
+System-of-record map for `coop`. The root [`CLAUDE.md`](../CLAUDE.md) is the
+short navigational entrypoint; durable detail lives here.
+
+## For contributors (engineering)
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — module map, the two-backend design,
+  host→guest data flow, architectural invariants.
+- [`trust-model.md`](trust-model.md) — trust boundaries, taint sources, secret
+  handling, `coop update` verification. The authoritative security spec the
+  `review-security` agent reads. (Disclosure policy is [`SECURITY.md`](../SECURITY.md).)
+- [`code-style.md`](code-style.md) — Rust authoring idioms and the review /
+  authoring checklists.
+- [`testing.md`](testing.md) — integration tests, mutation testing (+
+  `.cargo/mutants.toml` scoping and baselines), fuzzing, kani.
+- [`platform-notes.md`](platform-notes.md) — Firecracker CI-kernel workarounds,
+  Docker networking, scp `~` caveat, tracing-to-stderr.
+
+## For users
+
+- [`getting-started.md`](getting-started.md) — install and first VM.
+- [`commands.md`](commands.md) — every `coop` subcommand.
+- [`configuration.md`](configuration.md) — `config.toml` reference.
+- [`backends.md`](backends.md) — Lima (macOS) and Firecracker (Linux) setup.
+- [`images-and-profiles.md`](images-and-profiles.md),
+  [`workspaces.md`](workspaces.md), [`multi-instance.md`](multi-instance.md),
+  [`devcontainer.md`](devcontainer.md), [`vscode.md`](vscode.md),
+  [`shell-completion.md`](shell-completion.md).
+- [`claude-integration.md`](claude-integration.md),
+  [`codex-integration.md`](codex-integration.md) — agent integration.
+- [`json-output-design.md`](json-output-design.md) — the `--json` design
+  (a good precedent for design-doc style).
+
+## Agent tooling (`.claude/`)
+
+- `agents/review-*.md` — single-lens PR review sub-agents.
+- `commands/` — `my-review`, `babysit-pr`, `babysit-my-prs`, `integration`.
+- `skills/` — `closeout-review` (pre-PR gate), `mutation-check`.
+- `hooks/` + `settings.json` — the closeout gate, `cargo fmt` formatter, the
+  no-pipe-test-output guard, and the read-only Bash allowlist.

--- a/docs/json-output-design.md
+++ b/docs/json-output-design.md
@@ -474,7 +474,7 @@ Lower demand; wrap only when reached. Shapes:
 
 ## Testing
 
-Follow `CLAUDE.md`'s testing and mutation-testing rules.
+Follow the testing and mutation-testing rules in [`testing.md`](testing.md).
 
 ### Unit tests — assert the serialized shape
 
@@ -496,8 +496,8 @@ Also test the pure projections you add — e.g. `BackendKind::of`,
 
 ### Mutation testing — keep `.cargo/mutants.toml` in sync **in the same PR**
 
-`CLAUDE.md` is emphatic about this (see the `coop model` #352 regression). When
-you add these functions:
+[`testing.md`](testing.md) is emphatic about this (see the `coop model` #352
+regression). When you add these functions:
 
 - **`render_json`** and any handler branch that writes JSON to stdout are **IO** —
   add an `exclude_re` entry (they only write stdout; a `--lib` test cannot observe
@@ -510,7 +510,7 @@ you add these functions:
   guard them.
 
 Verify with `cargo mutants -f <touched files> -- --lib` (full-file sweep, not
-just `--in-diff`), per `CLAUDE.md`.
+just `--in-diff`), per [`testing.md`](testing.md).
 
 ### Integration test
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -1,0 +1,62 @@
+# Platform notes and gotchas
+
+Durable, non-obvious environment facts that repeatedly bite contributors. These
+are engineering notes, not user documentation — for user-facing backend setup
+see [`backends.md`](backends.md).
+
+## Firecracker CI-kernel workarounds
+
+The Firecracker CI kernel (`vmlinux-6.1.155`) is minimal and missing several
+modules. Two workarounds are applied when provisioning the guest image
+(`scripts/guest/guest-config.sh`, baked into the golden image):
+
+1. **iptables-legacy.** The kernel lacks nftables support (`CONFIG_NF_TABLES`
+   not set). Docker's default `iptables-nft` backend fails with "Protocol not
+   supported". Fix: `update-alternatives --set iptables /usr/sbin/iptables-legacy`.
+2. **Static `resolv.conf`.** The CI rootfs ships `/etc/resolv.conf` as a symlink
+   to systemd-resolved's stub (`127.0.0.53`), but `systemd-resolved` is not
+   installed, so DNS fails silently. Fix: replace the symlink with a static file
+   pointing to `8.8.8.8` / `8.8.4.4`.
+
+Both would be resolved by building a custom Firecracker kernel with the needed
+netfilter modules enabled, rather than using the minimal CI kernel. The Lima
+backend uses a full kernel and needs neither.
+
+## Docker networking in the guest
+
+The Firecracker CI kernel also lacks the `iptable_raw` module (`CONFIG_IP_NF_RAW`
+not set). Docker 28+ uses the raw table for "direct access filtering" — a
+PREROUTING DROP rule that prevents direct routing to published container ports,
+ensuring traffic goes through Docker's port-mapping rules.
+
+Without the raw table, Docker refuses to start bridge networking. The fix uses
+Docker 28.0.2's `DOCKER_INSECURE_NO_IPTABLES_RAW=1` env var (moby/moby#49621),
+set via a systemd drop-in at `/etc/systemd/system/docker.service.d/no-raw.conf`.
+This tells Docker to skip raw-table rules while keeping full bridge networking:
+NAT, port mapping (`-p`), container-to-container communication, and embedded DNS
+all work normally.
+
+The "insecure" label refers to the fact that without raw-table rules, other
+hosts on the local network could route directly to published container ports
+even if they're bound to loopback. This is irrelevant here — the guest's only
+network neighbor is the Firecracker host, and the VM itself is the isolation
+boundary. See [`trust-model.md`](trust-model.md#documented-accepted-trade-offs).
+
+## scp tilde expansion (OpenSSH 9+)
+
+Modern scp (OpenSSH 9+) uses SFTP by default, which does **not** expand `~` in
+remote paths. `scp file user@host:~/.claude/CLAUDE.md` silently creates a literal
+`~` directory instead of writing to the home directory.
+
+Fix: `GuestPath` values use `./` instead of `~/` in remote paths (e.g.
+`GuestPath::new("./.claude")`). SFTP defaults to the user's home directory, so
+`./path` is equivalent to `~/path`. This convention is used in `scp_to` and
+`scp_to_recursive`.
+
+SSH commands (`exec`) are unaffected — the remote shell expands `~` normally.
+Only scp's SFTP mode has this issue.
+
+## Tracing output goes to stderr
+
+The coop binary's tracing output (INFO/DEBUG/WARN logs) goes to **stderr**, so
+stdout stays clean for machine-readable (`--json`) output and piped consumers.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,321 @@
+# Testing
+
+coop has four test layers: integration tests (the primary gate), unit tests,
+and three manual quality checks — mutation testing, fuzzing, and formal
+verification (kani). Only the integration and unit tests run in CI; the other
+three are manual, run when a change warrants them.
+
+## Integration tests
+
+Two scripts:
+
+- `tests/integration.sh` — the test suite. Runs locally, requires `--binary`.
+- `tests/run-integration.sh` — the runner. Builds, deploys (if remote), and
+  invokes the test suite.
+
+Run on **both platforms** before every commit:
+
+```bash
+# Local (macOS/Lima) — builds and runs automatically
+./tests/run-integration.sh
+
+# Remote (Linux/Firecracker) — detects remote arch, cross-compiles, copies, runs
+./tests/run-integration.sh --remote user@remote-host
+
+# With options (forwarded to integration.sh)
+./tests/run-integration.sh --remote user@remote-host --full
+./tests/run-integration.sh --profile python,node --name my-test
+```
+
+You can also run the suite directly if you already have a binary:
+
+```bash
+./tests/integration.sh --binary /path/to/coop --full
+```
+
+The test exercises the full VM lifecycle (setup → start → status → shell →
+guest environment → docker → stop → destroy). CI additionally runs
+`tests/integration-update.sh` and `tests/integration-uninstall.sh`.
+
+When adding new features, consider whether they should be covered here. New
+commands or guest-visible changes are good candidates for a new test phase.
+
+## Mutation testing
+
+Mutation testing finds unit tests that pass even when the code is broken — real
+behavioral gaps. We use [`cargo-mutants`](https://mutants.rs/). It's a manual
+quality check, not a CI gate.
+
+**Install once** — via `./scripts/install-dev-tools.sh --all`, or directly:
+
+```bash
+cargo install cargo-mutants --locked
+```
+
+**When to run.** After significant edits to a logic-dense module, or before
+refactoring one (capture surviving mutants first to know what behavior isn't
+pinned down). Don't run it routinely — runs take minutes per module.
+
+**Where it pays off in this crate.** Only on code with branches, arithmetic,
+parsing, or state composition:
+
+- `src/config.rs` — parsing, validation, defaults, env composition
+- `src/workspace.rs` — rsync arg construction, mount-state record/remove
+- `src/devcontainer.rs`, `src/guest_env_state.rs` — env merging and persistence
+- `src/github_repo.rs`, `src/github_pat.rs`, `src/secret_store.rs` — slug
+  parsing, secret routing
+- `src/fs_util.rs` — path manipulation helpers
+- `src/commands/` (`lifecycle.rs`, `profiles.rs`, `commands/devcontainer.rs`,
+  `quickstart.rs`, `admin.rs`) — the pure helpers the command handlers were
+  carved into: input-compatibility guards, summary/message builders, the
+  `TranslatorInputs` builder, byte→GiB arithmetic kernels, and predicates like
+  `discovered_local_devcontainer` / `is_sensitive_workspace`
+
+**Don't bother with:** `backend.rs`, `lima.rs`, `setup.rs`, `update.rs`,
+`shell.rs`, `port_forward.rs`, `cmd.rs`, `ssh.rs`, `vm.rs`, `prompt.rs` (TTY
+prompts), `main.rs`, and — inside `src/commands/` — the `cmd_*` dispatch
+entrypoints and the handlers that take a `&PlatformBackend`, write stdout, or
+open a TTY prompt (e.g. `create_up_instance`, `restart_instance`,
+`find_stopped_instance`, `resolve_running`, `resolve_devcontainer`,
+`purge_all_data`, and `model.rs`'s `render_status`/`set_local`/`set_remote`/
+`report_switch`/`apply_to_running`/`prompt_endpoint`), plus the `lib.rs`
+`run`/`init_tracing` shims. These mostly shell out, run SSH, or talk to external
+services — unit tests can't catch behavioral changes there. `tests/integration.sh`
+does that job. This list is enforced (not just advised) by `.cargo/mutants.toml`
+— see **Scoping** below.
+
+### Scoping (`.cargo/mutants.toml`)
+
+The mutation surface is curated in `.cargo/mutants.toml` so the `missed` list
+means "real unit-test gap," not "code a `--lib` test structurally cannot reach."
+cargo-mutants reads this file automatically on every run (`--list` included). It
+scopes out three things:
+
+- **The whole-module "Don't bother with" files above** (`main.rs`, and
+  `prompt.rs` — every function short-circuits off a TTY and otherwise reads
+  stdin, with no pure logic a `--lib` test can reach), via `exclude_globs`.
+- **`cfg(kani)` proofs** (`config.rs mod proofs`), via `exclude_re = ["proofs::"]`
+  — never compiled in a normal build, so every mutation is a silent no-op that
+  always reports `missed`. They are exercised by `cargo kani`.
+- **Individual shell-out / IO / terminal functions inside otherwise-logic-bearing
+  modules** (`github_pat.rs`, `workspace.rs`, `devcontainer.rs`,
+  `secret_store.rs`, `fs_util.rs`, `commands/model.rs`'s stdout/backend/TTY
+  functions), via `exclude_re`. Each pattern is `\b`-anchored to a function name
+  (or qualified `Type::method`) so it scopes the whole function without catching
+  longer names that share a prefix. The module-agnostic `replace gh_auth_token ->`
+  pattern also covers the identical `gh_auth_token` shell-out in
+  `git_repo_devcontainer.rs`.
+- **The `src/commands/` dispatch entrypoints and backend-driving / TTY handlers**,
+  via `exclude_re`: a single `\bcmd_[a-z_]+\b` covers every `coop <subcommand>`
+  entrypoint, plus `\b`-anchored names for the `&PlatformBackend` handlers
+  (`create_*`, `restart_instance`, `start_instance`, `find_stopped_instance`,
+  `resolve_running`, `preflight_start_target`, `current_disk_gib`, …), the IO
+  handlers in `admin.rs`/`profiles.rs`/`commands/devcontainer.rs`/`quickstart.rs`,
+  and the `lib.rs` `run`/`init_tracing` shims.
+
+A cargo-mutants quirk to know about: `exclude_re` does **not** match `delete
+field … from struct …` mutants — emitted for every struct literal that uses
+`..Default::default()`, and no pattern filters them. In this crate they all
+target `devcontainer::TranslatorInputs`, assembled in four places. The one pure
+builder (`up_translator_inputs`) stays in scope and is unit-tested, which kills
+its field-deletion mutants; the three shell-out handlers that build it inline
+(`run`, `cmd_devcontainer_check`, `quickstart_fresh_start`) carry an in-source
+`#[mutants::skip]` with a back-reference to `.cargo/mutants.toml`.
+
+What is deliberately *kept* (a survivor here is a genuine coverage regression):
+the pure-logic helpers the #321–#327 fixes carved the shell-out/IO functions
+down to — `parse_curl_status_body`, `parse_user_login`, `github_pat.rs`'s
+`render_status` (note `commands/model.rs` has a *different*, excluded
+`render_status`, so its exclude is file-anchored), `parse_gh_token` /
+`normalize_token`, `pick_backend`, `doc_contains_literal_token`, the SSH-config
+marker-block helpers (`remove_marker_blocks` / `remove_named_marker_block` /
+`remove_all_ssh_config_at` / `remove_ssh_config_at`), `CmdToken::from_words`'s
+Linux/`op`/`cat` arms (only the macOS keychain arm is scoped, pinned on macOS by
+`parse_recognises_macos_keychain`), `Report::push`, `atomic_write_with_mode`,
+and `vscode_strategies`. The thin wrappers those were split out of
+(`probe_user_login`, `run_status`, `remove_*_ssh_config`, `gh_auth_token`) are
+excluded — a `--lib` test can't reach them without a real `$HOME` or network.
+When adding a new shell-out or IO function to one of these modules, add a
+matching `exclude_re` line; when adding logic, leave it in scope.
+
+The same split applies in `src/commands/`. Kept in scope: the
+input-compatibility guards (`ensure_up_existing_inputs_are_compatible[_for_git_repo]`,
+`up_has_restart_only_inputs`, `restart_has_ignored_creation_flags`,
+`validate_copy_workspace_mounts`), the config-IO lookups
+(`find_workspace_instance`, `find_git_repo_instance`), the message/summary
+builders (`no_stopped_instance_message`, `creation_options_rejected_message`,
+`builtin_summary`, `format_custom_summary`, `script_summary`), the
+`up_translator_inputs` builder, the arithmetic kernels `bytes_to_gib` and
+`format_dir_size`, `project_dir_to_str`, and the predicates
+`discovered_local_devcontainer` / `is_sensitive_workspace`. The backend-driving
+wrappers those kernels were carved out of (`current_disk_gib`,
+`dir_size_display`) are excluded.
+
+The `coop model` feature (#352) follows the same split. Kept in scope (and
+unit-tested): `tools_needing_prompt`, `switch_report_lines`,
+`ModelState::resolved_claude` / `resolved_codex` / `is_default` /
+`load_or_default`, and `ModelMode::as_str`; plus `From<ModelAction> for
+ModelMode` in `lib.rs`. Excluded as IO/backend/TTY: `model.rs`'s `render_status`
+/ `write_tool_line` / `set_local` / `set_remote` / `report_switch` /
+`apply_to_running` / `prompt_endpoint`, and `lifecycle.rs`'s
+`bootstrap_and_post_start` / `prepare_session_from_target`.
+
+**Keep `.cargo/mutants.toml` in sync in the same PR that adds the code** — this
+is not a follow-up chore. #352 was merged without scoping its new IO/backend/TTY
+functions, which silently broke the documented baseline and surfaced 22
+survivors only at the next release preflight (#373). When a change adds a
+function that shells out, drives a `&PlatformBackend`, reads a TTY, or writes
+stdout, add its `exclude_re`/`exclude_globs` entry (and extract any pure logic
+into a kept, tested helper) before merging. Verify with `cargo mutants -f
+<touched files> -- --lib` — not just the `--in-diff` sweep, which only mutates
+changed lines and so misses pre-existing same-class survivors in a touched file.
+The [`mutation-check`](../.claude/skills/mutation-check/SKILL.md) skill walks
+this workflow.
+
+### Running it
+
+Always scope with `-f`; all logic lives in the library crate, and every unit
+test runs in the lib target, so pass `-- --lib`. (`-- --bins` runs zero tests
+and reports every mutant as missed.)
+
+```bash
+# One file
+cargo mutants -f src/config.rs -- --lib
+
+# Several logic modules at once
+cargo mutants -f src/config.rs -f src/workspace.rs -f src/devcontainer.rs -- --lib
+
+# PR-scoped: mutate only lines changed vs main
+cargo mutants --in-diff <(git diff origin/main -- 'src/*.rs') -- --lib
+
+# Estimate cost without running
+cargo mutants --list -f src/config.rs
+```
+
+A baseline run on `config.rs` (197 mutants) takes ~8 minutes on a workstation.
+
+### Reading the output
+
+Results land in `mutants.out/` (gitignored): `caught.txt` (killed — good),
+`missed.txt` (not caught — the interesting ones), `unviable.txt` (broke the
+build; ignore), `timeout.txt` (hung; rare). A kill rate around 70–80% on viable
+mutants is healthy. Aim to drop the *number* of survivors, not chase 100% —
+many remaining mutants are equivalent.
+
+### Handling survivors
+
+For each line in `missed.txt`:
+
+1. **Real test gap.** The mutation alters observable behavior and nothing fails.
+   Add a test that distinguishes the mutant from the original (assert on the
+   actual value, not "it didn't panic"). Re-run to confirm.
+2. **Equivalent mutant.** The mutation doesn't change behavior any caller can
+   observe (`fmt::Display` returning `Ok(Default::default())`, getters returning
+   a default that matches the real value, constant accessors). Skip with an
+   attribute and a one-line reason:
+   ```rust
+   #[mutants::skip] // equivalent: Display output isn't asserted by callers
+   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { ... }
+   ```
+3. **Dead code.** If genuinely unused, delete it (per "replace, don't
+   deprecate"). Surviving mutants on dead code are a useful smell.
+
+### Baselines
+
+- **2026-06-17 (after #329 scoping, #321–#330 fixes).** A sweep of the eight
+  logic modules (`config.rs`, `workspace.rs`, `devcontainer.rs`,
+  `guest_env_state.rs`, `github_repo.rs`, `github_pat.rs`, `secret_store.rs`,
+  `fs_util.rs`) reports **0 missed**. Treat any *new* survivor as a coverage
+  regression — first confirm it isn't a shell-out/IO function that belongs in
+  `.cargo/mutants.toml`, then add a test.
+- **2026-06-24 (issue #344).** A sweep of `lifecycle.rs`, `profiles.rs`,
+  `commands/devcontainer.rs`, `quickstart.rs`, `admin.rs`, `commands/mod.rs`,
+  `lib.rs`, and `jsonc.rs` reports **0 missed** out of 229 mutants. The
+  non-caught results are `unviable` (~18) and `timeout` (~16–17, all `jsonc.rs`
+  scanner-index increment mutants where mutating the step makes the loop never
+  terminate).
+- **2026-06-26 (issue #373).** After scoping the #352 local-model IO/backend/TTY
+  functions and adding the `mode_as_str_round_trips`, `model_action_maps_to_mode`,
+  and `load_or_default_returns_saved_state` tests, a sweep of
+  `src/commands/model.rs`, `src/model_state.rs`, and `src/prompt.rs` reports
+  **0 missed** (32 caught, 3 unviable), and a full `src/lib.rs` sweep reports
+  **0 missed** (11 caught).
+
+## Fuzzing
+
+Fuzzing is reserved for parsers of **untrusted or user-editable input** — it
+finds panics/hangs/OOM, not correctness (there's no oracle), so a standing
+harness only earns its keep where input crosses a trust boundary. A manual
+check, not a CI gate. We use [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz)
+(libFuzzer), which needs a nightly toolchain.
+
+Targets live in `fuzz/fuzz_targets/`. `coop` exposes a library target, so a
+target depends on the crate directly and imports the parser under test with
+`use coop::…` — no `#[path]` includes. `fuzz/Cargo.toml` is its own workspace,
+so the main `cargo build`/`test`/`fmt`/`clippy`/`deny` never touch it.
+
+**Install once** (or `./scripts/install-dev-tools.sh --all`): `cargo install
+cargo-fuzz --locked`
+
+```bash
+cargo +nightly fuzz build                                       # compile all targets
+cargo +nightly fuzz run parse_repo_slug                         # fuzz until a crash
+cargo +nightly fuzz run parse_repo_slug -- -max_total_time=60   # bounded run
+```
+
+A crash is written to `fuzz/artifacts/<target>/`; reproduce with `cargo +nightly
+fuzz run <target> <artifact-path>`.
+
+**Current targets:**
+
+- `parse_repo_slug` — `coop::github_repo::parse_repo_slug_from_url`, fed `git
+  remote get-url` output and `--git-repo` CLI args. Property: never panics.
+- `jsonc_to_json` — `coop::jsonc::jsonc_to_json`, fed hand-authored
+  `devcontainer.json` text. Property: never panics.
+- `config_load` — `toml::from_str` into `coop::config::CoopConfig` then
+  `validate`, fed `config.toml` text. Exercises the custom `Deserialize`/
+  `visit_map` impls (`SubnetMask`, `HostInterface`, `PortForward`). Property:
+  never panics, only returns `Err`.
+
+## Formal verification (kani)
+
+[Kani](https://model-checking.github.io/kani/) is a bounded model checker that
+proves the *absence* of a property (here: arithmetic overflow / panics) over all
+inputs in a range, rather than sampling like proptest. It is a **narrow fit** —
+the type system already makes most illegal states unrepresentable, so kani earns
+its keep only on bounded integer/float arithmetic. A manual check, not a CI gate;
+it needs its own toolchain.
+
+Proofs live in a `#[cfg(kani)]` module so the normal build never compiles them.
+They run as one module in `src/config.rs`.
+
+**Install once** (or `./scripts/install-dev-tools.sh --all`): `cargo install
+--locked kani-verifier && cargo kani setup`
+
+```bash
+cargo kani                                            # run every proof harness (~5s)
+cargo kani --harness disk_relative_add_never_wraps    # one harness
+```
+
+**Current proofs (`src/config.rs`, `mod proofs`):**
+
+- `disk_relative_add_never_wraps` — the arithmetic kernel of `DiskSize::resolve`'s
+  relative branch (`current.checked_add(delta)`): for any two non-zero `u32`
+  sizes it yields `Some(current + delta)` exactly when the sum fits, and `None`
+  otherwise — never wraps, never panics.
+- `mib_as_gib_f64_is_finite_and_positive` — `MiB::as_gib_f64` is finite and
+  strictly positive across the whole non-zero range.
+- `instance_index_octet_stays_in_range` — the guest IP/MAC last octet
+  (`index + 2`) stays in `2..=254` for every valid `InstanceIndex` (`0..=252`).
+
+A note on the disk proof: the harness verifies the `checked_add` kernel directly
+rather than calling `DiskSize::resolve`, because `resolve` wraps the overflow
+case with `anyhow`'s heap-allocating error construction, which CBMC cannot model
+tractably. `resolve` adds only that infallible `.context()` on top of the
+kernel; its end-to-end behavior is pinned by the deterministic unit tests
+`disk_size_resolve_relative` / `disk_size_resolve_relative_overflows`. This is
+the general rule for kani here: prove the arithmetic kernel, not code paths that
+route through `anyhow`/allocation. The `InstanceIndex` range is also pinned the
+cheaper way by the exhaustive `0..=252` unit test
+`instance_network_derivations_over_full_range`, which the kani harness
+demonstrates rather than replaces.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,0 +1,180 @@
+# Trust model
+
+This is the engineering-facing trust model for `coop` — the authoritative list
+of trust boundaries, taint sources, and the invariants that hold the isolation
+together. The [`review-security`](../.claude/agents/review-security.md) agent
+reads this file, and the root [`CLAUDE.md`](../CLAUDE.md) "Trust model" section
+points here. Apply these checks whenever you build or review a change.
+
+This complements — it does not replace — [`SECURITY.md`](../SECURITY.md), which
+is the vulnerability-disclosure policy. `SECURITY.md` tells outsiders how to
+report a problem; this document tells contributors where the boundaries are so
+they don't introduce one.
+
+## The core boundary: the VM
+
+**coop's isolation boundary is the guest VM itself** — a Firecracker microVM on
+Linux, a Lima VM (Apple Virtualization.framework) on macOS. The point of the
+tool is to run AI coding agents (Claude Code, Codex) with broad autonomy
+*inside* that boundary, so the guest is deliberately permissive:
+
+- The guest user has passwordless `sudo` (`NOPASSWD:ALL`).
+- Claude runs with a managed `~/.claude/settings.json` carrying
+  `defaultMode: bypassPermissions`; the `codex`/`claude` launchers pass
+  `--dangerously-bypass-approvals-and-sandbox` / `--dangerously-skip-permissions`
+  unless the user passes `--ask`.
+
+This is intentional and correct: there is **no privilege boundary inside the
+guest to protect** — the whole VM is the blast radius. The security model is
+"anything the agent does stays in the VM." Every rule below exists to keep that
+true: to stop guest-authored (therefore untrusted) data from escalating across
+the VM boundary into host code execution, host filesystem escape, or credential
+exposure.
+
+Treat the guest as **untrusted** from the host's point of view, even though the
+user launched it.
+
+## Trust zones
+
+| Zone | Trust | Notes |
+|------|-------|-------|
+| Host user + `config.toml` | Trusted | `config.toml` `cmd:` values run arbitrary `sh -c` on the host (`config.rs:resolve_cmd_value`). The config file is a host code-execution surface; only the owner should write it. |
+| coop process (host) | Trusted | Holds/relays secrets, constructs guest commands, runs `iptables`/`firecracker` via `sudo`. |
+| The guest VM | **Untrusted** | Agent-controlled. Anything it emits — file contents, paths, archive members, command output — is a taint source once it crosses back to the host. |
+| GitHub API / model endpoints / DNS | External | `api.github.com` (PAT probe, release metadata), the model endpoint, `8.8.8.8`. Reached over the network; authenticated where applicable. |
+
+## Taint sources (treat as untrusted)
+
+- **Guest filesystem content pulled to the host.** `workspace.rs` `pull` /
+  `tar_pipe_pull` / `rsync_pull` bring guest-authored file contents, filenames,
+  and symlinks onto the host filesystem. This is the **widest guest→host
+  channel** and the primary place a path-traversal or symlink escape could land.
+- **Guest command output read by the host.** e.g. `check_guest_dirty` reads
+  `git status --porcelain` from the guest. Today this only gates control flow /
+  is printed to the user — it is never fed into `sh -c` on the host. Keep it
+  that way.
+- **A fetched `devcontainer.json`.** `git_repo_devcontainer.rs` /
+  `devcontainer.rs` parse devcontainer JSON that may originate from a remote
+  repo. Its values configure the guest; they must never reach a host `cmd:`
+  evaluation or host shell.
+- **Downloaded update artifacts.** `update.rs` tarball + `SHA256SUMS` from the
+  release host — gated by checksum and (best-effort) Sigstore attestation.
+- **OCI feature blobs.** `devcontainer_oci.rs` pulls devcontainer *Features*
+  from GHCR; the install snippet runs **in the guest**, not the host.
+
+## Secrets and how they cross into the guest
+
+coop relays several secrets from the host into the guest: `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, `GITHUB_TOKEN`/PAT, `CLAUDE_CODE_OAUTH_TOKEN`, arbitrary
+user `env_forward` entries, and the VM SSH key. The invariants:
+
+- **Never on argv.** Secrets ride SSH `SendEnv` (env channel) or process env
+  (`backend.rs:prepare_env_forwarding`, `EnvForward`), or are piped via **stdin**
+  (`SshTarget::exec_with_stdin`, the git-clone credential helper
+  `build_clone_with_token_script`, `curl -H @-` in `github_pat.rs`/`update.rs`).
+  Never build a command line with the secret as an argument — it is visible in
+  `ps`/`/proc`. Known exceptions are the macOS `security` and 1Password `op`
+  backends, which take the secret on argv because their CLIs offer no stdin
+  path; this is documented at the call sites and limited to the store step.
+- **`GITHUB_TOKEN` defaults to Off.** It is only forwarded with an explicit
+  `github = auto|env|pat` opt-in (`backend.rs:resolve_github_token`). When
+  forwarded, `bootstrap_agents` runs `gh auth setup-git`, which makes the token
+  **persistent guest state** (a git credential helper any guest process can
+  read). A change that forwards it by default, or makes it persistent where it
+  wasn't, is a finding.
+- **Secret files stay `0600`, dirs `0700`.** File-backend PATs live at
+  `<state_dir>/github-pat/<account>.txt` (`secret_store.rs:store_file`); all
+  managed writes go through `fs_util::atomic_write_with_mode` / `atomic_write_ssh`,
+  which never relax permissions.
+- **Secrets stay out of logs.** `Cmd::redacted_arg` redacts argv in traces;
+  `EnvForward`/`Secret<T>` custom `Debug` impls keep values out of debug output.
+  Do not log a resolved secret.
+- **The stored token is indirected, never inlined.** `config.toml` holds a
+  `cmd:...` retrieval command (`secret_store.rs:CmdToken`), not the plaintext
+  token; coop runs it at VM-start to fetch the value.
+
+## SSH boundary
+
+- coop connects to the guest with `StrictHostKeyChecking=no`,
+  `UserKnownHostsFile=/dev/null`, `IdentitiesOnly=yes`
+  (`backend.rs:SshTarget::ssh_opts`, `workspace.rs:ssh_config_block`). This is
+  deliberate: guest keys are ephemeral and regenerated per VM, so there is no
+  stable host key to pin. The trade-off is that a MITM on the path to the guest
+  is not detected — acceptable because that path is loopback / a local TAP link
+  to a VM the host itself owns.
+- The guest SSH key (`<data_dir>/vm_key`, ed25519, **passphrase-less by
+  design**) is a VM-access credential. Do not "harden" it with a passphrase
+  (it must be used non-interactively), but do flag any change that exposes it
+  or copies it off the host.
+- Flag any change that extends the no-host-key-checking options to a
+  **non-guest** host.
+
+## Network
+
+- **Port-forwards bind to `127.0.0.1` only** (`port_forward.rs`): both the
+  collision probe and the `ssh -L 127.0.0.1:<host>:127.0.0.1:<guest>` spec.
+  There are **no `0.0.0.0` binds** anywhere in the tree. A new listener must
+  bind loopback explicitly.
+- Firecracker networking (`network.rs`) sets up a `br0` bridge + per-instance
+  TAP, enables `ip_forward`, and adds a `MASQUERADE` + `FORWARD` ruleset so the
+  guest reaches the internet through the host's default interface. A change
+  that widens guest egress or adds inbound reachability is a finding.
+- `rewrite_host_url` rewrites a loopback local-model endpoint to the
+  guest-visible gateway address so the guest can reach a model server running
+  on the host; non-loopback URLs pass through unchanged.
+
+## `coop update` trust chain
+
+Self-update (`update.rs`) must preserve, in order:
+
+1. Metadata from the pinned `trailofbits/coop` GitHub repo (compile-time const).
+2. `normalize_tag` — the version tag is validated as semver **before** it enters
+   the API URL path (path-traversal guard).
+3. **Mandatory checksum.** The `SHA256SUMS` asset must be present (install is
+   refused otherwise) and every downloaded tarball is verified against it
+   (`verify_sha256`, constant-size `Sha256Hash` compare).
+4. **Best-effort attestation.** `gh attestation verify --repo trailofbits/coop`
+   (Sigstore provenance). Skipped with a logged note if `gh` is absent, and
+   skipped entirely when `COOP_UPDATE_API_BASE_URL` is overridden (test mode).
+   So provenance is *not* guaranteed on hosts without `gh` — checksum is the
+   floor.
+5. Extraction with `tar -xzf --no-same-owner --no-same-permissions` (path-escape
+   safe), then an atomic `rename`-over-self.
+
+`COOP_UPDATE_API_BASE_URL` redirects the update origin **and** disables
+attestation; the checksum then only proves integrity against *that* server's own
+`SHA256SUMS`, giving no provenance. Only the pinned `github.com` default +
+attestation provide provenance. Flag any change that widens where that override
+is honored, or that softens any step above.
+
+## Documented, accepted trade-offs
+
+These are deliberate and documented in [`CLAUDE.md`](../CLAUDE.md) /
+[`docs/ARCHITECTURE.md`](ARCHITECTURE.md). Don't "fix" them without
+understanding the rationale; do flag a change that *widens* them:
+
+- **`DOCKER_INSECURE_NO_IPTABLES_RAW=1`** in the guest. The Firecracker CI
+  kernel lacks `iptable_raw`, so Docker 28+ can't install its raw-table
+  "direct access filtering" rule. Without it, other hosts on the guest's LAN
+  could route to published container ports bound to loopback — irrelevant here
+  because the guest's only network neighbor is the host and the VM *is* the
+  isolation boundary.
+- **iptables-legacy** and a **static `/etc/resolv.conf`** in the guest — both
+  work around the minimal CI kernel (no nftables, no systemd-resolved). Guest
+  config only; no host-side trust impact.
+
+## Stop-and-confirm checklist
+
+Stop and get explicit human confirmation before merging a change that:
+
+- adds an outbound URL, a network listener, or an egress/`FORWARD`/NAT rule —
+  name the boundary it crosses and what authenticates it;
+- forwards a new secret into the guest, or makes an existing one persistent
+  inside the guest;
+- runs a host subprocess on tainted (guest- or fetch-derived) bytes — no shell
+  strings; use `Cmd::arg`/`RemoteCommand::arg`;
+- writes a **host** filesystem path derived from tainted data — validate against
+  traversal first;
+- logs or traces tainted or secret content — that channel becomes an
+  exfiltration path;
+- softens any step of the `coop update` verification chain.

--- a/scripts/guest/guest-config.sh
+++ b/scripts/guest/guest-config.sh
@@ -48,7 +48,7 @@ DNSEOF
 # Firecracker CI kernel lacks CONFIG_IP_NF_RAW (iptable_raw module). Docker 28+
 # requires the raw table for bridge networking. This env var tells Docker to skip
 # raw table rules. The "insecure" label is irrelevant here — the VM's only
-# network neighbor is the Firecracker host. See CLAUDE.md for full context.
+# network neighbor is the Firecracker host. See docs/platform-notes.md for full context.
 # Lima does NOT need this — its kernel has the raw table module.
 echo '  [guest] Configuring Docker daemon...'
 mkdir -p /etc/docker

--- a/src/config.rs
+++ b/src/config.rs
@@ -2596,7 +2596,7 @@ fn default_firecracker_bin() -> ConfigPath {
 
 /// Bounded no-panic proofs (Kani), gated so normal `cargo build`/`test`/
 /// `clippy` never compile them. Run manually with `cargo kani`; see the
-/// "Formal verification" section in `CLAUDE.md`.
+/// "Formal verification (kani)" section in `docs/testing.md`.
 ///
 /// Kani is a narrow fit in a string-heavy CLI — the type system carries
 /// most invariants here. These proofs target the only genuine fit:

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1593,7 +1593,7 @@ chown "{user}:{user}" /workspace
 
 # No iptables-legacy or NO_IPTABLES_RAW needed — Lima uses a full kernel with
 # nftables and iptable_raw support. These workarounds are Firecracker-only
-# (see scripts/guest/guest-config.sh and CLAUDE.md).
+# (see scripts/guest/guest-config.sh and docs/platform-notes.md).
 
 echo '  [guest] Enabling services...'
 systemctl enable docker ssh

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -4,7 +4,7 @@
 //! distinguish source from destination by type rather than by argument
 //! order. `GuestPath` additionally carries the SFTP-friendly `./...`
 //! vs. absolute `/...` distinction that prevents the OpenSSH 9+
-//! tilde-expansion gotcha (see CLAUDE.md).
+//! tilde-expansion gotcha (see docs/platform-notes.md).
 
 use std::path::{Path, PathBuf};
 
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn new_accepts_relative_dot_slash() {
         // Permissive constructor: `./...` is intentional (SFTP tilde
-        // expansion gotcha, see CLAUDE.md).
+        // expansion gotcha, see docs/platform-notes.md).
         let p = GuestPath::new("./.claude");
         assert_eq!(p.to_string(), "./.claude");
     }


### PR DESCRIPTION
Closes #409.

Gives `coop` the same agent-assisted contribution guardrails as `upgrade-do-no-harm`, adapted to coop's Rust/cargo and dual-backend (Firecracker/Lima) workflow: a navigational root `CLAUDE.md`, a `.claude/` directory of review agents/commands/skills/hooks, design + trust-model docs, and an on-demand CI review workflow.

Per the issue's open questions, this PR takes the maximal scope: foundational docs + the full `.claude/` set, restructures `CLAUDE.md` now, and adds both the local review machinery and a CI workflow.

## Docs (`docs/`)

- **`ARCHITECTURE.md`** — module map, the compile-time two-backend design (`VmBackend`/`PlatformBackend`), host→guest data flow, and architectural invariants.
- **`trust-model.md`** — the engineering-facing trust boundaries, taint sources, secret-handling rules, and the `coop update` verification chain. The spec the `review-security` agent reads; `SECURITY.md` stays the disclosure policy and now cross-links it.
- **`code-style.md`** — the Rust authoring idioms and review/authoring checklists (extracted from `CLAUDE.md`).
- **`testing.md`** — integration, mutation testing (full `.cargo/mutants.toml` scoping + baselines), fuzzing, kani.
- **`platform-notes.md`** — Firecracker CI-kernel workarounds, Docker networking trade-off, scp `~` caveat, tracing-to-stderr.
- **`index.md`** — documentation map.

## `CLAUDE.md`

Slimmed from 284 lines into a short navigational entrypoint (agent entrypoint, one-paragraph architecture + trust-model summary, dev commands, before-committing, PR rules). Deep material moved verbatim into the docs above. References that pointed at the relocated content (`CONTRIBUTING.md`, `SECURITY.md`, `docs/json-output-design.md`, and comments in `guest-config.sh`/`lima.rs`/`config.rs`/`paths.rs`) were retargeted.

## `.claude/`

- **`agents/review-*.md`** — eight single-lens PR review sub-agents (correctness, conventions, design, docs, comments, tests, security, api-usage), each scoped to only flag diff-introduced issues.
- **`commands/`** — `my-review`, `babysit-pr`, `babysit-my-prs`, `integration` (wraps `tests/run-integration.sh`).
- **`skills/`** — `closeout-review` (pre-PR gate with scope governance) and `mutation-check` (guided `cargo-mutants` that verifies `.cargo/mutants.toml` was updated in the same PR — the #352/#373 failure mode).
- **`hooks/` + `settings.json`** — `PreToolUse` closeout-review gate before `gh pr create`, `PostToolUse` `cargo fmt`, the no-pipe-test-output guard, and a read-only Bash allowlist.

## CI

`.github/workflows/claude-review.yml` — on-demand review triggered by an `@claude` PR comment, running `/my-review`. **Requires an `ANTHROPIC_API_KEY` repo secret** to function.

## Decisions on the issue's open questions

1. **Review dispatch** — both: the local `closeout-review`/`my-review` machinery and the CI workflow.
2. **Agent set** — the full set of eight.
3. **CLAUDE.md restructure** — done now, in this PR.
4. **Worktree hooks** — omitted. coop has no per-worktree dev-stack setup (unlike DNH's `wt`-based compose stack); the harness's native git worktrees suffice, so DNH-style `WorktreeCreate`/`WorktreeRemove` hooks would be speculative here.
5. **`trust-model.md` vs `SECURITY.md`** — split as proposed: `SECURITY.md` stays the disclosure policy, `docs/trust-model.md` is the engineering boundary spec, cross-linked both ways.

## Verification

- `cargo build` and `cargo fmt -- --check` pass; source edits are comment-only.
- All internal doc links resolve; `settings.json` and the workflow YAML validate; the hook scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)