### PR TITLE
Bump h2 to 0.4.17 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Bumps `h2` 0.4.15 → 0.4.17 in `Cargo.lock` to clear RUSTSEC-2026-0258.

## The advisory

`h2` 0.4.15 queues empty HTTP/2 DATA frames without limit. A peer that does not
let streams drain can drive unbounded memory growth, or a panic on length
overflow. Patched in 0.4.16.

## Why CI is red on every open PR

`h2` enters the graph only through `coop-proxy`'s `hyper` dependency, which
enables the `http2` feature. The workspace has a root package and no
`default-members`, so a plain `cargo deny check` walks only `coop` and never
sees it. CI runs `cargo deny --workspace check`, which does — so the failure
predates any individual PR and is inherited by all of them from `main`.

## Exposure

Reachable but narrow. The guest-facing listener in `coop-proxy/src/proxy.rs`
uses the auto-negotiating builder with no `.http1_only()`, and the guest hop is
cleartext, so prior-knowledge h2c reaches the vulnerable codec. That listener is
bound to the guest VM and host loopback, never the LAN, so the worst case is an
agent denying itself model access inside its own blast radius. No credential
exposure.

The client side is unaffected: upstream is pinned to `http1::handshake` with no
ALPN, so a malicious upstream cannot reach the `h2` code path.

## Scope

Lockfile-only. The `h2` dependency set is unchanged between 0.4.15 and 0.4.17,
so the edit is confined to the `h2` stanza and `cargo` accepts the lockfile
under `--locked` without rewriting it.

## Verification

- `cargo check --locked` — passes, lockfile not rewritten
- `cargo deny --workspace check` — advisories, bans, licenses, sources all ok
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace` — 22 unit + 4 gate tests pass
- `cargo fmt -- --check`, `taplo format --check`

`./tests/run-integration.sh` has not been run on either backend; `coop-proxy` is
guest-facing, so that is worth doing before merge.

## Follow-ups (not in this PR)

- `.http1_only()` on the guest listener would remove the `h2` server surface
  permanently rather than patching one CVE. Behavior change; needs confirmation
  that neither agent uses h2c prior-knowledge over cleartext loopback.
- Local `cargo deny check` not matching CI's `--workspace` is what let this hide.