### PR TITLE
Fix flaky coop-proxy gate tests on the readiness probe

### DIFF
--- a/coop-proxy/src/proxy.rs
+++ b/coop-proxy/src/proxy.rs
@@ -114,8 +114,8 @@ impl Ctx {
 /// must be reachable only over the private host-guest link, never every host
 /// interface.
 ///
-/// The `Ctx` is built before the bind, so a bound listener means the proxy can
-/// serve: nothing fallible remains between the bind and `accept_loop`.
+/// `Ctx::new` runs before the bind so that a bound listener means the proxy can
+/// serve — nothing fallible may sit between the bind and `accept_loop`.
 pub async fn serve(
     cfg: ProxyConfig,
     shutdown: impl std::future::Future<Output = ()>,

--- a/coop-proxy/src/proxy.rs
+++ b/coop-proxy/src/proxy.rs
@@ -113,26 +113,28 @@ impl Ctx {
 /// Refuses to bind an unspecified address (`0.0.0.0` / `[::]`): the proxy
 /// must be reachable only over the private host-guest link, never every host
 /// interface.
+///
+/// The `Ctx` is built before the bind, so a bound listener means the proxy can
+/// serve: nothing fallible remains between the bind and `accept_loop`.
 pub async fn serve(
     cfg: ProxyConfig,
     shutdown: impl std::future::Future<Output = ()>,
 ) -> Result<()> {
-    if cfg.listen.ip().is_unspecified() {
+    let listen = cfg.listen;
+    if listen.ip().is_unspecified() {
         anyhow::bail!(
-            "refusing to bind unspecified address {} — the proxy must bind only the \
-             private host-guest interface",
-            cfg.listen
+            "refusing to bind unspecified address {listen} — the proxy must bind only the \
+             private host-guest interface"
         );
     }
-    let listener = TcpListener::bind(cfg.listen)
-        .await
-        .with_context(|| format!("failed to bind proxy listener on {}", cfg.listen))?;
-    tracing::info!(
-        "coop-proxy listening on {} → https://{}",
-        cfg.listen,
-        cfg.upstream_host
-    );
     let ctx = Ctx::new(cfg)?;
+    let listener = TcpListener::bind(listen)
+        .await
+        .with_context(|| format!("failed to bind proxy listener on {listen}"))?;
+    tracing::info!(
+        "coop-proxy listening on {listen} → https://{}",
+        ctx.cfg.upstream_host
+    );
     accept_loop(ctx, listener, shutdown).await;
     Ok(())
 }

--- a/coop-proxy/tests/gate.rs
+++ b/coop-proxy/tests/gate.rs
@@ -9,6 +9,10 @@
 //! credential reaching a real service. The authorized header-rewrite/injection
 //! logic is covered by the unit tests in `src/proxy.rs`, and end-to-end against
 //! a mock upstream by coop's VM integration suite.
+//!
+//! The `readiness_probe_*` tests are the exception: they drive no binary and no
+//! gate, but pin the harness's own readiness probe, whose failure modes are
+//! what made this file flaky (issue 435).
 
 #![expect(clippy::unwrap_used, reason = "tests")]
 #![expect(clippy::expect_used, reason = "tests")]
@@ -21,7 +25,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::process::{Child, Command};
 
 const BIN: &str = env!("CARGO_BIN_EXE_coop-proxy");
@@ -40,12 +44,13 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 /// Read budget for a test's own request, which waits on the real upstream path.
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// How many ports to try before giving up (see [`spawn_serving`]).
+/// How many ports to try before giving up (see [`spawn_serving`], [`bind_fresh`]).
 const PORT_ATTEMPTS: usize = 10;
 
-/// Ports already handed out in this process. `bind(0)` can return a port a
-/// sibling test just released, and these tests run concurrently in one binary,
-/// so without this two of them would race to give the same port to two proxies.
+/// Every loopback port this process has taken, so no two tests in this binary
+/// are handed the same one — `bind(0)` will otherwise return a port a sibling
+/// just released, and these tests run concurrently. Only [`bind_fresh`] adds to
+/// it, so every port in the binary comes from there.
 static HANDED_OUT: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
 
 /// A config whose upstream can never resolve, so any request that passes the
@@ -69,19 +74,27 @@ enum Startup {
     Unresponsive,
 }
 
-/// A loopback port that is free *right now* and not yet used by this process.
-/// Nothing holds it, so it can still be taken before the child binds — see
-/// [`spawn_serving`].
-async fn free_loopback_addr() -> SocketAddr {
-    loop {
-        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = probe.local_addr().unwrap();
-        drop(probe);
-        let fresh = HANDED_OUT.lock().unwrap().insert(addr.port());
+/// A listener on a loopback port no other test in this process has been given.
+async fn bind_fresh() -> TcpListener {
+    for _ in 0..PORT_ATTEMPTS {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let fresh = HANDED_OUT.lock().unwrap().insert(port);
         if fresh {
-            return addr;
+            return listener;
         }
     }
+    panic!("no unused loopback port after {PORT_ATTEMPTS} attempts");
+}
+
+/// A loopback port that is free *right now*. Nothing holds it once this
+/// returns, so it can still be taken before the child binds — see
+/// [`spawn_serving`].
+async fn free_loopback_addr() -> SocketAddr {
+    let listener = bind_fresh().await;
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
 }
 
 /// Spawn the proxy binary on a free loopback port and wait until it answers
@@ -100,8 +113,6 @@ async fn spawn_serving() -> (SocketAddr, Child) {
         match wait_until_serving(&mut child, addr).await {
             Startup::Serving => return (addr, child),
             Startup::Unresponsive => {
-                // Kill first: `drain_stderr` reads to EOF, which only arrives
-                // once the child closes the pipe.
                 let _ = child.kill().await;
                 let stderr = drain_stderr(&mut child).await;
                 panic!("proxy did not answer on {addr} within {READY_TIMEOUT:?}: {stderr}");
@@ -125,10 +136,8 @@ async fn spawn_proxy(addr: SocketAddr) -> Child {
     // `--jail-selftest` in the VM integration suite.
     let mut child = Command::new(BIN)
         .arg("--no-jail")
-        // Pin both so the child's stderr is what the harness expects whatever
-        // the developer's environment: `LC_ALL` keeps the `EADDRINUSE` text
-        // untranslated for the retry check below, and `RUST_LOG` keeps the
-        // volume to the couple of lines that fit the undrained pipe buffer.
+        // LC_ALL keeps the EADDRINUSE text untranslated for `spawn_serving`'s
+        // retry check; RUST_LOG bounds the volume on this never-drained pipe.
         .env("LC_ALL", "C")
         .env("RUST_LOG", "info")
         .stdin(Stdio::piped())
@@ -154,9 +163,9 @@ async fn wait_until_serving(child: &mut Child, addr: SocketAddr) -> Startup {
                 return Startup::Exited;
             }
             if is_serving(addr).await {
-                // A probe only proves *something* answers on `addr`. If our
-                // child lost the port it is already gone, and the answer came
-                // from whoever won it.
+                // A probe only proves *something* answers on `addr`. This
+                // establishes that our child had not already lost the port as
+                // of this poll — not that it is the one answering.
                 if child.try_wait().unwrap().is_some() {
                     return Startup::Exited;
                 }
@@ -181,22 +190,30 @@ async fn drain_stderr(child: &mut Child) -> String {
 }
 
 /// Whether a proxy is answering requests on `addr`.
-///
-/// A bare `connect()` is not a readiness signal: the kernel can give this
-/// probe's own outgoing socket the very port it is probing, and
-/// `127.0.0.1:X → 127.0.0.1:X` is a TCP simultaneous open that succeeds with
-/// nothing listening, then echoes back whatever the probe writes. Such a socket
-/// has `peer_addr() == local_addr()`; requiring a reply that *starts with*
-/// `HTTP/` rejects it a second time, since the echo of the request line merely
-/// contains that text.
-///
-/// Every failure is a `false`, never a panic — this runs during the startup
-/// window, where a peer may reset the connection at any point, and the retry
-/// loop is what should absorb that.
 async fn is_serving(addr: SocketAddr) -> bool {
     let Ok(stream) = TcpStream::connect(addr).await else {
         return false;
     };
+    probe_reply(stream).await
+}
+
+/// Whether `stream` reached a serving proxy.
+///
+/// A successful `connect()` is not enough: the kernel can give this probe's own
+/// outgoing socket the very port it is probing, and `127.0.0.1:X →
+/// 127.0.0.1:X` is a TCP simultaneous open that succeeds with nothing
+/// listening, then echoes back whatever the probe writes.
+///
+/// Two checks reject that. `peer_addr() == local_addr()` identifies it up
+/// front, which is what keeps it cheap: a self-connect never sends EOF, so
+/// without that check every probe of a stolen port would wait out
+/// [`PROBE_TIMEOUT`]. Requiring a reply that *starts with* `HTTP/` is the
+/// backstop, since the echoed request line merely contains that text.
+///
+/// Every failure is a `false`, never a panic — this runs during the startup
+/// window, where a peer may reset the connection at any point, and the retry
+/// loop is what should absorb that.
+async fn probe_reply(stream: TcpStream) -> bool {
     let (Ok(local), Ok(peer)) = (stream.local_addr(), stream.peer_addr()) else {
         return false;
     };
@@ -212,7 +229,7 @@ async fn request_status(addr: SocketAddr, auth_header: Option<&str>) -> String {
     let stream = TcpStream::connect(addr).await.unwrap();
     status_line(stream, auth_header, RESPONSE_TIMEOUT)
         .await
-        .unwrap_or_default()
+        .expect("request to the proxy failed at the socket level")
 }
 
 /// Send a minimal HTTP/1.1 request over `stream` and return the status line, or
@@ -238,10 +255,14 @@ async fn status_line(
 
 /// Accept once on a fresh loopback port, reply with `reply`, and close.
 async fn serve_one(reply: &'static [u8]) -> SocketAddr {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = bind_fresh().await;
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
         if let Ok((mut sock, _)) = listener.accept().await {
+            // Read the request first: closing with data still queued makes the
+            // kernel send RST, which on BSD-derived stacks discards the reply.
+            let mut discard = [0u8; 1024];
+            let _ = sock.read(&mut discard).await;
             let _ = sock.write_all(reply).await;
         }
     });
@@ -249,23 +270,68 @@ async fn serve_one(reply: &'static [u8]) -> SocketAddr {
 }
 
 #[tokio::test]
-async fn readiness_probe_rejects_a_dead_port() {
+async fn readiness_probe_rejects_unbound_port() {
     let addr = free_loopback_addr().await;
     assert!(!is_serving(addr).await);
 }
 
 #[tokio::test]
-async fn readiness_probe_rejects_an_echoed_request_line() {
-    // What a self-connected socket returns. It contains "HTTP/" but does not
-    // start with it, which is why `is_serving` matches on the prefix.
+async fn readiness_probe_rejects_self_connect() {
+    // Force the simultaneous open that issue 435 hit by accident: a socket
+    // connecting to its own bound address completes with nothing listening.
+    // Binding `:0` and reading the port back keeps the socket in possession of
+    // it throughout — sampling a free port first would reintroduce the very
+    // steal this file exists to eliminate.
+    let socket = tokio::net::TcpSocket::new_v4().unwrap();
+    socket.set_reuseaddr(true).unwrap();
+    socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = socket.local_addr().unwrap();
+    let stream = socket.connect(addr).await.unwrap();
+    assert_eq!(
+        stream.local_addr().unwrap(),
+        stream.peer_addr().unwrap(),
+        "expected a self-connected socket"
+    );
+
+    // Rejected on the peer check rather than by waiting out the read budget.
+    // The `starts_with("HTTP/")` backstop would also reject the echo, so only
+    // the promptness distinguishes the two — and promptness is the point: a
+    // self-connect never sends EOF.
+    let verdict = tokio::time::timeout(PROBE_TIMEOUT / 2, probe_reply(stream))
+        .await
+        .expect("a self-connect should be rejected without waiting out the read budget");
+    assert!(!verdict);
+}
+
+#[tokio::test]
+async fn readiness_probe_rejects_echoed_request_line() {
+    // The self-connect echo: contains "HTTP/" but does not start with it.
     let addr = serve_one(b"GET /v1/messages HTTP/1.1\r\n\r\n").await;
     assert!(!is_serving(addr).await);
 }
 
 #[tokio::test]
-async fn readiness_probe_accepts_an_http_status_line() {
+async fn readiness_probe_accepts_http_status_line() {
     let addr = serve_one(b"HTTP/1.1 401 Unauthorized\r\n\r\n").await;
     assert!(is_serving(addr).await);
+}
+
+#[tokio::test]
+async fn spawned_proxy_exits_when_its_port_is_taken() {
+    // Hold the port for the child's whole life, so its bind cannot succeed.
+    let listener = bind_fresh().await;
+    let addr = listener.local_addr().unwrap();
+    let mut child = spawn_proxy(addr).await;
+    match wait_until_serving(&mut child, addr).await {
+        Startup::Exited => {}
+        Startup::Serving => panic!("proxy reported serving on an already-bound port"),
+        Startup::Unresponsive => panic!("proxy neither served nor exited on a taken port"),
+    }
+    let stderr = drain_stderr(&mut child).await;
+    assert!(
+        stderr.contains("Address already in use"),
+        "expected the EADDRINUSE text `spawn_serving` retries on, got: {stderr}"
+    );
 }
 
 #[tokio::test]
@@ -308,7 +374,7 @@ async fn refuses_to_bind_unspecified_address() {
         .unwrap();
     drop(stdin);
 
-    let output = tokio::time::timeout(RESPONSE_TIMEOUT, child.wait_with_output())
+    let output = tokio::time::timeout(Duration::from_secs(20), child.wait_with_output())
         .await
         .expect("proxy should exit promptly on a bad bind address")
         .unwrap();

--- a/coop-proxy/tests/gate.rs
+++ b/coop-proxy/tests/gate.rs
@@ -10,9 +10,10 @@
 //! logic is covered by the unit tests in `src/proxy.rs`, and end-to-end against
 //! a mock upstream by coop's VM integration suite.
 //!
-//! The `readiness_probe_*` tests are the exception: they drive no binary and no
-//! gate, but pin the harness's own readiness probe, whose failure modes are
-//! what made this file flaky (issue 435).
+//! The `readiness_probe_*` and `spawned_proxy_*` tests are the exception: they
+//! assert nothing about the gate, but pin the harness that reaches it — the
+//! readiness probe and its `EADDRINUSE` retry — whose failure modes are what
+//! made this file flaky (issue 435).
 
 #![expect(clippy::unwrap_used, reason = "tests")]
 #![expect(clippy::expect_used, reason = "tests")]
@@ -44,13 +45,17 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 /// Read budget for a test's own request, which waits on the real upstream path.
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// How long a proxy that refuses its config gets to exit. It never binds, so
+/// this bounds a process exit rather than any socket read.
+const EXIT_TIMEOUT: Duration = Duration::from_secs(20);
+
 /// How many ports to try before giving up (see [`spawn_serving`], [`bind_fresh`]).
 const PORT_ATTEMPTS: usize = 10;
 
 /// Every loopback port this process has taken, so no two tests in this binary
 /// are handed the same one — `bind(0)` will otherwise return a port a sibling
-/// just released, and these tests run concurrently. Only [`bind_fresh`] adds to
-/// it, so every port in the binary comes from there.
+/// just released, and these tests run concurrently. A port is claimed here only
+/// once its socket already holds it, never before.
 static HANDED_OUT: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
 
 /// A config whose upstream can never resolve, so any request that passes the
@@ -259,8 +264,9 @@ async fn serve_one(reply: &'static [u8]) -> SocketAddr {
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
         if let Ok((mut sock, _)) = listener.accept().await {
-            // Read the request first: closing with data still queued makes the
+            // Drain the request first: closing with data still queued makes the
             // kernel send RST, which on BSD-derived stacks discards the reply.
+            // One read suffices — the probe's request is one small write.
             let mut discard = [0u8; 1024];
             let _ = sock.read(&mut discard).await;
             let _ = sock.write_all(reply).await;
@@ -275,17 +281,24 @@ async fn readiness_probe_rejects_unbound_port() {
     assert!(!is_serving(addr).await);
 }
 
+// Linux only, in both directions: macOS and the BSDs reject a connect to the
+// socket's own bound address with `EINVAL` inside `tcp_connect`, so neither the
+// accidental collision behind issue 435 nor this deliberate reconstruction of
+// it can happen there. The guard under test is likewise a Linux-only concern.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn readiness_probe_rejects_self_connect() {
     // Force the simultaneous open that issue 435 hit by accident: a socket
     // connecting to its own bound address completes with nothing listening.
     // Binding `:0` and reading the port back keeps the socket in possession of
     // it throughout — sampling a free port first would reintroduce the very
-    // steal this file exists to eliminate.
+    // steal this file exists to eliminate. No `SO_REUSEADDR`: the construction
+    // does not need it, and without it the kernel will not hand this port to a
+    // sibling's listener.
     let socket = tokio::net::TcpSocket::new_v4().unwrap();
-    socket.set_reuseaddr(true).unwrap();
     socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = socket.local_addr().unwrap();
+    HANDED_OUT.lock().unwrap().insert(addr.port());
     let stream = socket.connect(addr).await.unwrap();
     assert_eq!(
         stream.local_addr().unwrap(),
@@ -374,7 +387,7 @@ async fn refuses_to_bind_unspecified_address() {
         .unwrap();
     drop(stdin);
 
-    let output = tokio::time::timeout(Duration::from_secs(20), child.wait_with_output())
+    let output = tokio::time::timeout(EXIT_TIMEOUT, child.wait_with_output())
         .await
         .expect("proxy should exit promptly on a bad bind address")
         .unwrap();

--- a/coop-proxy/tests/gate.rs
+++ b/coop-proxy/tests/gate.rs
@@ -24,6 +24,15 @@ use tokio::process::{Child, Command};
 
 const BIN: &str = env!("CARGO_BIN_EXE_coop-proxy");
 
+/// How long a freshly spawned proxy gets to answer its first request.
+const READY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How often to probe while waiting for that first answer.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// How many ports to try before giving up (see [`spawn_serving`]).
+const PORT_ATTEMPTS: usize = 10;
+
 /// A config whose upstream can never resolve, so any request that passes the
 /// gate fails closed rather than reaching a real service.
 fn config_json(listen: &str) -> String {
@@ -37,6 +46,21 @@ fn config_json(listen: &str) -> String {
     )
 }
 
+/// How a spawned proxy left the readiness wait.
+enum Startup {
+    /// It answered a request on its address.
+    Serving,
+    /// It exited before answering.
+    Exited,
+    /// It never answered within [`READY_TIMEOUT`].
+    Unresponsive,
+}
+
+/// A loopback port that is free *right now*.
+///
+/// Nothing holds it: binding and dropping only samples the kernel's free list,
+/// so the port can be taken again before the caller uses it. [`spawn_serving`]
+/// handles losing that race.
 async fn free_loopback_addr() -> SocketAddr {
     let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = probe.local_addr().unwrap();
@@ -44,9 +68,39 @@ async fn free_loopback_addr() -> SocketAddr {
     addr
 }
 
-/// Spawn the proxy binary, feed it `listen` config on stdin, and wait until it
-/// accepts connections on `addr`.
-async fn spawn_serving(addr: SocketAddr) -> Child {
+/// Spawn the proxy binary on a free loopback port and wait until it answers
+/// requests, returning the address it is serving on.
+///
+/// The port cannot be reserved for the child. `free_loopback_addr` yields a
+/// port from the ephemeral range, and until the child binds it the kernel may
+/// hand that same port to any other socket — including this process's own
+/// outgoing probe connections, which do not set `SO_REUSEADDR` and so block the
+/// child's listening bind. The child then exits with `EADDRINUSE`; retrying on
+/// a fresh port is what makes this deterministic. A child that fails for any
+/// other reason fails the test immediately, with its stderr.
+async fn spawn_serving() -> (SocketAddr, Child) {
+    for _ in 0..PORT_ATTEMPTS {
+        let addr = free_loopback_addr().await;
+        let mut child = spawn_proxy(addr).await;
+        match wait_until_serving(&mut child, addr).await {
+            Startup::Serving => return (addr, child),
+            Startup::Unresponsive => {
+                panic!("proxy did not answer on {addr} within {READY_TIMEOUT:?}")
+            }
+            Startup::Exited => {
+                let stderr = drain_stderr(&mut child).await;
+                assert!(
+                    stderr.contains("Address already in use"),
+                    "proxy exited instead of serving on {addr}: {stderr}"
+                );
+            }
+        }
+    }
+    panic!("proxy lost the race for a free loopback port {PORT_ATTEMPTS} times");
+}
+
+/// Spawn the proxy binary and feed it the config for `addr` on stdin.
+async fn spawn_proxy(addr: SocketAddr) -> Child {
     // `--no-jail`: this test drives the gate logic, not the jail, and runs on
     // CI hosts that may lack Landlock (where the fail-closed jail would abort
     // startup). coop never passes this flag; the jail is asserted separately by
@@ -55,7 +109,7 @@ async fn spawn_serving(addr: SocketAddr) -> Child {
         .arg("--no-jail")
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
         .unwrap();
@@ -65,19 +119,62 @@ async fn spawn_serving(addr: SocketAddr) -> Child {
         .await
         .unwrap();
     drop(stdin);
+    child
+}
 
-    for _ in 0..200 {
-        if TcpStream::connect(addr).await.is_ok() {
-            return child;
+/// Poll `addr` until the proxy answers, the child exits, or time runs out.
+async fn wait_until_serving(child: &mut Child, addr: SocketAddr) -> Startup {
+    let poll = async {
+        loop {
+            if child.try_wait().unwrap().is_some() {
+                return Startup::Exited;
+            }
+            if is_serving(addr).await {
+                return Startup::Serving;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
         }
-        tokio::time::sleep(Duration::from_millis(10)).await;
+    };
+    tokio::time::timeout(READY_TIMEOUT, poll)
+        .await
+        .unwrap_or(Startup::Unresponsive)
+}
+
+/// Read the exited child's stderr to EOF.
+async fn drain_stderr(child: &mut Child) -> String {
+    let mut buf = Vec::new();
+    if let Some(mut stderr) = child.stderr.take() {
+        stderr.read_to_end(&mut buf).await.unwrap();
     }
-    panic!("proxy did not start listening on {addr}");
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Whether a proxy is answering requests on `addr`.
+///
+/// A bare `connect()` is not a readiness signal. `addr` is an ephemeral-range
+/// port, so before the child binds the kernel can hand that same port to this
+/// probe's own outgoing socket; `127.0.0.1:X → 127.0.0.1:X` is a TCP
+/// simultaneous open that connects with nothing listening, and echoes back
+/// whatever the probe writes. Rejecting a peer that is our own local address,
+/// and requiring an HTTP status line in reply, separates a serving proxy from
+/// that self-connect.
+async fn is_serving(addr: SocketAddr) -> bool {
+    let Ok(stream) = TcpStream::connect(addr).await else {
+        return false;
+    };
+    if stream.local_addr().unwrap() == stream.peer_addr().unwrap() {
+        return false;
+    }
+    status_line(stream, None).await.starts_with("HTTP/")
 }
 
 /// Send a minimal HTTP/1.1 request and return the status line.
 async fn request_status(addr: SocketAddr, auth_header: Option<&str>) -> String {
-    let mut stream = TcpStream::connect(addr).await.unwrap();
+    status_line(TcpStream::connect(addr).await.unwrap(), auth_header).await
+}
+
+/// Send a minimal HTTP/1.1 request over `stream` and return the status line.
+async fn status_line(mut stream: TcpStream, auth_header: Option<&str>) -> String {
     let mut req = String::from("GET /v1/messages HTTP/1.1\r\nHost: proxy\r\n");
     if let Some(h) = auth_header {
         req.push_str(h);
@@ -94,24 +191,21 @@ async fn request_status(addr: SocketAddr, auth_header: Option<&str>) -> String {
 
 #[tokio::test]
 async fn rejects_missing_token_with_401() {
-    let addr = free_loopback_addr().await;
-    let _child = spawn_serving(addr).await;
+    let (addr, _child) = spawn_serving().await;
     let status = request_status(addr, None).await;
     assert!(status.contains("401"), "expected 401, got: {status:?}");
 }
 
 #[tokio::test]
 async fn rejects_wrong_token_with_401() {
-    let addr = free_loopback_addr().await;
-    let _child = spawn_serving(addr).await;
+    let (addr, _child) = spawn_serving().await;
     let status = request_status(addr, Some("Authorization: Bearer wrong-token")).await;
     assert!(status.contains("401"), "expected 401, got: {status:?}");
 }
 
 #[tokio::test]
 async fn valid_token_passes_gate_and_fails_closed_at_upstream() {
-    let addr = free_loopback_addr().await;
-    let _child = spawn_serving(addr).await;
+    let (addr, _child) = spawn_serving().await;
     let status = request_status(addr, Some("Authorization: Bearer the-right-token")).await;
     assert!(status.contains("502"), "expected 502, got: {status:?}");
 }

--- a/coop-proxy/tests/gate.rs
+++ b/coop-proxy/tests/gate.rs
@@ -14,8 +14,10 @@
 #![expect(clippy::expect_used, reason = "tests")]
 #![expect(clippy::panic, reason = "tests")]
 
+use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::process::Stdio;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -30,8 +32,21 @@ const READY_TIMEOUT: Duration = Duration::from_secs(10);
 /// How often to probe while waiting for that first answer.
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+/// Read budget for one readiness probe. Well under [`READY_TIMEOUT`] so that a
+/// peer which accepts but never replies costs one poll, not the whole budget —
+/// the loop keeps checking whether the child died.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Read budget for a test's own request, which waits on the real upstream path.
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(20);
+
 /// How many ports to try before giving up (see [`spawn_serving`]).
 const PORT_ATTEMPTS: usize = 10;
+
+/// Ports already handed out in this process. `bind(0)` can return a port a
+/// sibling test just released, and these tests run concurrently in one binary,
+/// so without this two of them would race to give the same port to two proxies.
+static HANDED_OUT: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
 
 /// A config whose upstream can never resolve, so any request that passes the
 /// gate fails closed rather than reaching a real service.
@@ -46,60 +61,63 @@ fn config_json(listen: &str) -> String {
     )
 }
 
-/// How a spawned proxy left the readiness wait.
+/// How a spawned proxy left the readiness wait: it answered, it exited first,
+/// or it outlived [`READY_TIMEOUT`] without answering.
 enum Startup {
-    /// It answered a request on its address.
     Serving,
-    /// It exited before answering.
     Exited,
-    /// It never answered within [`READY_TIMEOUT`].
     Unresponsive,
 }
 
-/// A loopback port that is free *right now*.
-///
-/// Nothing holds it: binding and dropping only samples the kernel's free list,
-/// so the port can be taken again before the caller uses it. [`spawn_serving`]
-/// handles losing that race.
+/// A loopback port that is free *right now* and not yet used by this process.
+/// Nothing holds it, so it can still be taken before the child binds — see
+/// [`spawn_serving`].
 async fn free_loopback_addr() -> SocketAddr {
-    let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = probe.local_addr().unwrap();
-    drop(probe);
-    addr
+    loop {
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = probe.local_addr().unwrap();
+        drop(probe);
+        let fresh = HANDED_OUT.lock().unwrap().insert(addr.port());
+        if fresh {
+            return addr;
+        }
+    }
 }
 
 /// Spawn the proxy binary on a free loopback port and wait until it answers
 /// requests, returning the address it is serving on.
 ///
-/// The port cannot be reserved for the child. `free_loopback_addr` yields a
-/// port from the ephemeral range, and until the child binds it the kernel may
-/// hand that same port to any other socket — including this process's own
-/// outgoing probe connections, which do not set `SO_REUSEADDR` and so block the
-/// child's listening bind. The child then exits with `EADDRINUSE`; retrying on
-/// a fresh port is what makes this deterministic. A child that fails for any
-/// other reason fails the test immediately, with its stderr.
+/// The port cannot be reserved for the child: between `free_loopback_addr`
+/// sampling it and the child binding it, the kernel can hand the same port to
+/// another socket — including this process's own outgoing probe connections —
+/// and the child then exits with `EADDRINUSE`. Retrying on a fresh port is what
+/// keeps that from flaking.
 async fn spawn_serving() -> (SocketAddr, Child) {
+    let mut last_stderr = String::new();
     for _ in 0..PORT_ATTEMPTS {
         let addr = free_loopback_addr().await;
         let mut child = spawn_proxy(addr).await;
         match wait_until_serving(&mut child, addr).await {
             Startup::Serving => return (addr, child),
             Startup::Unresponsive => {
-                panic!("proxy did not answer on {addr} within {READY_TIMEOUT:?}")
+                // Kill first: `drain_stderr` reads to EOF, which only arrives
+                // once the child closes the pipe.
+                let _ = child.kill().await;
+                let stderr = drain_stderr(&mut child).await;
+                panic!("proxy did not answer on {addr} within {READY_TIMEOUT:?}: {stderr}");
             }
             Startup::Exited => {
-                let stderr = drain_stderr(&mut child).await;
+                last_stderr = drain_stderr(&mut child).await;
                 assert!(
-                    stderr.contains("Address already in use"),
-                    "proxy exited instead of serving on {addr}: {stderr}"
+                    last_stderr.contains("Address already in use"),
+                    "proxy exited instead of serving on {addr}: {last_stderr}"
                 );
             }
         }
     }
-    panic!("proxy lost the race for a free loopback port {PORT_ATTEMPTS} times");
+    panic!("proxy lost the race for a free loopback port {PORT_ATTEMPTS} times: {last_stderr}");
 }
 
-/// Spawn the proxy binary and feed it the config for `addr` on stdin.
 async fn spawn_proxy(addr: SocketAddr) -> Child {
     // `--no-jail`: this test drives the gate logic, not the jail, and runs on
     // CI hosts that may lack Landlock (where the fail-closed jail would abort
@@ -107,6 +125,12 @@ async fn spawn_proxy(addr: SocketAddr) -> Child {
     // `--jail-selftest` in the VM integration suite.
     let mut child = Command::new(BIN)
         .arg("--no-jail")
+        // Pin both so the child's stderr is what the harness expects whatever
+        // the developer's environment: `LC_ALL` keeps the `EADDRINUSE` text
+        // untranslated for the retry check below, and `RUST_LOG` keeps the
+        // volume to the couple of lines that fit the undrained pipe buffer.
+        .env("LC_ALL", "C")
+        .env("RUST_LOG", "info")
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
@@ -130,6 +154,12 @@ async fn wait_until_serving(child: &mut Child, addr: SocketAddr) -> Startup {
                 return Startup::Exited;
             }
             if is_serving(addr).await {
+                // A probe only proves *something* answers on `addr`. If our
+                // child lost the port it is already gone, and the answer came
+                // from whoever won it.
+                if child.try_wait().unwrap().is_some() {
+                    return Startup::Exited;
+                }
                 return Startup::Serving;
             }
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -140,53 +170,102 @@ async fn wait_until_serving(child: &mut Child, addr: SocketAddr) -> Startup {
         .unwrap_or(Startup::Unresponsive)
 }
 
-/// Read the exited child's stderr to EOF.
+/// Call only once the child has exited or been killed — this reads to EOF, and
+/// a live child holds the pipe open.
 async fn drain_stderr(child: &mut Child) -> String {
     let mut buf = Vec::new();
     if let Some(mut stderr) = child.stderr.take() {
-        stderr.read_to_end(&mut buf).await.unwrap();
+        let _ = stderr.read_to_end(&mut buf).await;
     }
     String::from_utf8_lossy(&buf).into_owned()
 }
 
 /// Whether a proxy is answering requests on `addr`.
 ///
-/// A bare `connect()` is not a readiness signal. `addr` is an ephemeral-range
-/// port, so before the child binds the kernel can hand that same port to this
-/// probe's own outgoing socket; `127.0.0.1:X → 127.0.0.1:X` is a TCP
-/// simultaneous open that connects with nothing listening, and echoes back
-/// whatever the probe writes. Rejecting a peer that is our own local address,
-/// and requiring an HTTP status line in reply, separates a serving proxy from
-/// that self-connect.
+/// A bare `connect()` is not a readiness signal: the kernel can give this
+/// probe's own outgoing socket the very port it is probing, and
+/// `127.0.0.1:X → 127.0.0.1:X` is a TCP simultaneous open that succeeds with
+/// nothing listening, then echoes back whatever the probe writes. Such a socket
+/// has `peer_addr() == local_addr()`; requiring a reply that *starts with*
+/// `HTTP/` rejects it a second time, since the echo of the request line merely
+/// contains that text.
+///
+/// Every failure is a `false`, never a panic — this runs during the startup
+/// window, where a peer may reset the connection at any point, and the retry
+/// loop is what should absorb that.
 async fn is_serving(addr: SocketAddr) -> bool {
     let Ok(stream) = TcpStream::connect(addr).await else {
         return false;
     };
-    if stream.local_addr().unwrap() == stream.peer_addr().unwrap() {
+    let (Ok(local), Ok(peer)) = (stream.local_addr(), stream.peer_addr()) else {
+        return false;
+    };
+    if local == peer {
         return false;
     }
-    status_line(stream, None).await.starts_with("HTTP/")
+    status_line(stream, None, PROBE_TIMEOUT)
+        .await
+        .is_some_and(|status| status.starts_with("HTTP/"))
 }
 
-/// Send a minimal HTTP/1.1 request and return the status line.
 async fn request_status(addr: SocketAddr, auth_header: Option<&str>) -> String {
-    status_line(TcpStream::connect(addr).await.unwrap(), auth_header).await
+    let stream = TcpStream::connect(addr).await.unwrap();
+    status_line(stream, auth_header, RESPONSE_TIMEOUT)
+        .await
+        .unwrap_or_default()
 }
 
-/// Send a minimal HTTP/1.1 request over `stream` and return the status line.
-async fn status_line(mut stream: TcpStream, auth_header: Option<&str>) -> String {
+/// Send a minimal HTTP/1.1 request over `stream` and return the status line, or
+/// `None` if the exchange failed at the socket level.
+async fn status_line(
+    mut stream: TcpStream,
+    auth_header: Option<&str>,
+    read_budget: Duration,
+) -> Option<String> {
     let mut req = String::from("GET /v1/messages HTTP/1.1\r\nHost: proxy\r\n");
     if let Some(h) = auth_header {
         req.push_str(h);
         req.push_str("\r\n");
     }
     req.push_str("Connection: close\r\n\r\n");
-    stream.write_all(req.as_bytes()).await.unwrap();
+    stream.write_all(req.as_bytes()).await.ok()?;
 
     let mut buf = Vec::new();
-    let _ = tokio::time::timeout(Duration::from_secs(20), stream.read_to_end(&mut buf)).await;
+    let _ = tokio::time::timeout(read_budget, stream.read_to_end(&mut buf)).await;
     let text = String::from_utf8_lossy(&buf);
-    text.lines().next().unwrap_or_default().to_string()
+    Some(text.lines().next().unwrap_or_default().to_string())
+}
+
+/// Accept once on a fresh loopback port, reply with `reply`, and close.
+async fn serve_one(reply: &'static [u8]) -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((mut sock, _)) = listener.accept().await {
+            let _ = sock.write_all(reply).await;
+        }
+    });
+    addr
+}
+
+#[tokio::test]
+async fn readiness_probe_rejects_a_dead_port() {
+    let addr = free_loopback_addr().await;
+    assert!(!is_serving(addr).await);
+}
+
+#[tokio::test]
+async fn readiness_probe_rejects_an_echoed_request_line() {
+    // What a self-connected socket returns. It contains "HTTP/" but does not
+    // start with it, which is why `is_serving` matches on the prefix.
+    let addr = serve_one(b"GET /v1/messages HTTP/1.1\r\n\r\n").await;
+    assert!(!is_serving(addr).await);
+}
+
+#[tokio::test]
+async fn readiness_probe_accepts_an_http_status_line() {
+    let addr = serve_one(b"HTTP/1.1 401 Unauthorized\r\n\r\n").await;
+    assert!(is_serving(addr).await);
 }
 
 #[tokio::test]
@@ -213,7 +292,7 @@ async fn valid_token_passes_gate_and_fails_closed_at_upstream() {
 #[tokio::test]
 async fn refuses_to_bind_unspecified_address() {
     // `--no-jail` so the bind guard is asserted regardless of host Landlock
-    // support (see spawn_serving).
+    // support (see spawn_proxy).
     let mut child = Command::new(BIN)
         .arg("--no-jail")
         .stdin(Stdio::piped())
@@ -229,7 +308,7 @@ async fn refuses_to_bind_unspecified_address() {
         .unwrap();
     drop(stdin);
 
-    let output = tokio::time::timeout(Duration::from_secs(20), child.wait_with_output())
+    let output = tokio::time::timeout(RESPONSE_TIMEOUT, child.wait_with_output())
         .await
         .expect("proxy should exit promptly on a bad bind address")
         .unwrap();


### PR DESCRIPTION
Fixes the intermittent failures of the three port-using tests in
`coop-proxy/tests/gate.rs`, which have hit `main`, dependabot branches and
feature branches since 2026-08-05.

Closes #435.

## The races

`free_loopback_addr` bound `127.0.0.1:0`, recorded the port and dropped the
listener, then `spawn_serving` waited for the child with a bare
`TcpStream::connect`. Two things went wrong.

The probe could satisfy itself. The recorded port comes from the ephemeral
range, so before the child bound it the kernel could hand the same port to the
probe's own outgoing socket. `127.0.0.1:X -> 127.0.0.1:X` is a TCP simultaneous
open, so `connect` returned `Ok` with nothing listening and the test fired at a
proxy that was not up — the reported `ConnectionReset`, `ConnectionRefused` and
`expected 502, got: ""` signatures.

That probe socket also blocked the child. It sets no `SO_REUSEADDR`, so the
child's listening bind failed with `EADDRINUSE` and the proxy exited. This one
is not in the issue; it showed up while verifying the first fix, and on its own
still failed 2 runs in 40.

## The fix

`spawn_serving` owns port acquisition. It rejects a connection whose peer is its
own local address, requires an HTTP status line before reporting ready, and
retries on a fresh port when the child exits with `EADDRINUSE`. A child that
exits for any other reason, or that runs without answering, fails the test with
its stderr rather than being retried. Child stderr is piped rather than
discarded, and the child is spawned with `LC_ALL=C` so the text the retry
matches is not translated, and `RUST_LOG=info` so that pipe cannot fill.

Ports are claimed in a process-wide set as soon as a socket holds one, so two of
the concurrent tests in this binary are never handed the same port.

`serve` builds the `Ctx` before `TcpListener::bind`, closing the issue's
secondary point: nothing fallible now sits between the bind and `accept_loop`,
so a bound listener means the proxy can serve. This also tightens the production
path — previously a TLS-config failure happened after binding, leaving a window
in which coop's `await_proxy_ready` could see a connectable port milliseconds
before the proxy died, and start a VM with a dead credential proxy.

## Verification

Old and new test binaries were run interleaved in one loop under a narrowed
`net.ipv4.ip_local_port_range`, so both saw the same port-pool state. Across
150-round runs the old tests failed 4, 8 and 2 times with the signatures from
the issue; the new ones failed 0 times, with a further ~900 clean runs including
40 at the issue's own 200-port range. Instrumenting the `EADDRINUSE` retry
confirmed it fires (6 hits in 30 runs) and that those runs still pass.

Four tests cover the harness itself, so the probe's branches are not carried by
inspection alone. Deleting the peer-equality check fails
`readiness_probe_rejects_self_connect`; relaxing `starts_with` to `contains`
fails `readiness_probe_rejects_echoed_request_line`.

`readiness_probe_rejects_self_connect` is Linux-only: Darwin's `tcp_connect`
rejects a connect to the socket's own bound address with `EINVAL`, so neither
the accidental collision nor a deliberate reconstruction of it happens there.

## Notes for the reviewer

- The gate suite runs in ~1.0s, unchanged.
- `.cargo/mutants.toml` needs no entry: `coop-proxy` is a separate, non-default
  workspace member with no lib target, already outside the sweep.
- Known and accepted gaps: `wait_until_serving`'s post-probe `try_wait` arm and
  `bind_fresh`'s exhaustion panic are only reachable by losing a real port race,
  so they are covered by reasoning rather than tests.
- The VM integration suite has not been run on either backend. The change is the
  test harness plus a startup-ordering swap, but it touches the credential-proxy
  path, so it is worth running before merge.
