### PR TITLE
Add Codex ChatGPT account auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@
 - **Codex ChatGPT account auth** — New `[codex] auth = "chatgpt"` mode for
   account/workspace access without OpenAI API billing. coop installs Linux
   Secret Service support in the guest image, writes Codex's
-  `cli_auth_credentials_store = "keyring"` setting, launches `coop codex`
-  through a D-Bus/GNOME Keyring wrapper, suppresses every `OPENAI_API_KEY`
-  forwarding path, and stops copying host `auth.json` into the guest. Existing
-  images must be rebuilt with `coop setup --rebuild` before using this mode.
+  `cli_auth_credentials_store = "keyring"` setting, launches Codex through a
+  D-Bus/GNOME Keyring wrapper (`/usr/local/bin/codex-account`, which the
+  in-guest `codex-yolo` shortcut also uses and which execs Codex unchanged when
+  the mode is off), suppresses every `OPENAI_API_KEY` forwarding path, and stops
+  copying host `auth.json` into the guest. Sign in with `coop codex -- login
+  --device-auth`; `login` and `logout` now run without the sandbox-bypass flag
+  that Codex rejects on them. Existing images must be rebuilt with `coop setup
+  --rebuild` before using this mode.
 
 - **Credential-injecting proxy — keep the model API keys out of the guest**
   (#411) — New opt-in `[proxy]` config. When set, coop runs a small host-side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@
   in-guest `codex-yolo` shortcut also uses and which execs Codex unchanged when
   the mode is off), suppresses every `OPENAI_API_KEY` forwarding path, and stops
   copying host `auth.json` into the guest. Sign in with `coop codex -- login
-  --device-auth`; `login` and `logout` now run without the sandbox-bypass flag
-  that Codex rejects on them. Existing images must be rebuilt with `coop setup
-  --rebuild` before using this mode.
+  --device-auth`; `login` and `logout` now run without the sandbox-bypass flag,
+  which is meaningless on subcommands that never start an agent session.
+  Existing images must be rebuilt with `coop setup --rebuild` before using this
+  mode. A restart reuses the old guest disk, so an existing VM also needs
+  `coop restore <vm> --image <image>` (or a destroy and recreate) to pick up
+  the new guest packages.
 
 - **Credential-injecting proxy — keep the model API keys out of the guest**
   (#411) — New opt-in `[proxy]` config. When set, coop runs a small host-side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### New features
 
+- **Codex ChatGPT account auth** — New `[codex] auth = "chatgpt"` mode for
+  account/workspace access without OpenAI API billing. coop installs Linux
+  Secret Service support in the guest image, writes Codex's
+  `cli_auth_credentials_store = "keyring"` setting, launches `coop codex`
+  through a D-Bus/GNOME Keyring wrapper, suppresses every `OPENAI_API_KEY`
+  forwarding path, and stops copying host `auth.json` into the guest. Existing
+  images must be rebuilt with `coop setup --rebuild` before using this mode.
+
 - **Credential-injecting proxy — keep the model API keys out of the guest**
   (#411) — New opt-in `[proxy]` config. When set, coop runs a small host-side
   reverse proxy (`coop-proxy`, a new binary shipped in the same tarball) — one

--- a/config.example.toml
+++ b/config.example.toml
@@ -79,12 +79,16 @@
 # auth_token = "sk-..."             # Optional; permissive servers ignore it.
 
 # [codex]
+# auth = "api_key"  # "api_key" (default) or "chatgpt" for ChatGPT account/workspace auth
 # config_dir = "~/.codex"  # path to copy AGENTS.md, prompts/, config.toml, auth.json from (false to disable)
+# auth = "chatgpt" stores Codex credentials in the guest Linux keyring and
+# does not copy auth.json or forward OPENAI_API_KEY.
 # env_forward = ["CUSTOM_TOKEN"]  # Extra env vars to forward to guest
 # marketplaces = ["trailofbits/codex-plugins"]  # owner/repo, git URL, or local path
 # plugins = ["my-lsp@codex-plugins"]  # plugin@marketplace to install
 #
-# Secrets: `api_key` accepts the same "cmd:" prefix as `claude.api_key`.
+# Secrets: with auth = "api_key", `api_key` accepts the same "cmd:" prefix as
+# `claude.api_key`.
 #   api_key = "cmd:op read op://Private/OpenAI/credential"
 #   api_key = "sk-proj-..."
 
@@ -125,8 +129,9 @@
 # [proxy.openai]                    # Codex. OpenAI keys are always Bearer.
 # credential = "cmd:op read op://Private/OpenAI/credential"
 # auth = "bearer"                   # OpenAI keys inject as Authorization: Bearer.
-#                                   # Codex subscription (auth.json) is not
-#                                   # supported in proxy mode — use an API key.
+#                                   # Cannot be combined with
+#                                   # [codex] auth = "chatgpt"; proxy mode uses
+#                                   # an API key.
 
 # [profiles.my-tools]
 # apt_packages = ["ripgrep", "fd-find", "jq"]

--- a/config.example.toml
+++ b/config.example.toml
@@ -81,11 +81,13 @@
 # [codex]
 # auth = "api_key"  # "api_key" (default) or "chatgpt" for ChatGPT account/workspace auth
 # config_dir = "~/.codex"  # path to copy AGENTS.md, prompts/, config.toml, auth.json from (false to disable)
-# auth = "chatgpt" stores Codex credentials in the guest Linux keyring and
-# does not copy auth.json or forward OPENAI_API_KEY.
 # env_forward = ["CUSTOM_TOKEN"]  # Extra env vars to forward to guest
 # marketplaces = ["trailofbits/codex-plugins"]  # owner/repo, git URL, or local path
 # plugins = ["my-lsp@codex-plugins"]  # plugin@marketplace to install
+#
+# Note: the "chatgpt" mode stores Codex credentials in the guest Linux
+# keyring, and neither copies auth.json nor forwards OPENAI_API_KEY.
+# Sign in once with `coop codex -- login --device-auth`.
 #
 # Secrets: with auth = "api_key", `api_key` accepts the same "cmd:" prefix as
 # `claude.api_key`.

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -12,16 +12,20 @@ This SSHes into the guest and runs the `codex` CLI. By default coop passes `--da
 
 When `[codex] auth = "chatgpt"` is enabled, `coop codex` launches a small
 guest wrapper (`/usr/local/bin/codex-account`) that starts a D-Bus session,
-unlocks GNOME Keyring when needed, and then runs the real Codex binary. The
-wrapper may prompt for the guest keyring password before Codex starts.
+unlocks GNOME Keyring, and then runs the real Codex binary. In keyring mode
+each launch gets a fresh private D-Bus session, so the wrapper asks for the
+guest keyring password every time before Codex starts.
 
 The in-guest `codex-yolo` shortcut routes through the same wrapper, so it works
 in either auth mode. Running the bare `codex` binary from `coop shell` does
 not: it has no D-Bus session, and `keyring` credential storage has no
 `auth.json` fallback, so Codex will not find its credentials. Inside the guest,
 run `codex-account` (or `codex-yolo`) instead of `codex`. The wrapper is a
-transparent passthrough when `auth = "chatgpt"` is not configured, so it is
-always safe to use.
+transparent passthrough unless the guest `~/.codex/config.toml` asks for
+keyring storage, so it is safe to use in either mode. It gates on the guest
+file rather than on coop's `auth` setting, which is what keeps `codex-yolo`
+working from inside the guest; coop keeps that file in step when you switch
+modes, rewriting it on the next `coop start` to drop the keyring setting.
 
 To keep Codex's sandbox and approval prompts for a single session, pass `--ask`. coop then launches `codex` with no bypass flag, so Codex applies its normal defaults:
 
@@ -99,8 +103,8 @@ coop codex -- login --device-auth
 Then open the shown URL in your browser, sign in to the intended ChatGPT
 workspace, and enter the one-time code. Later `coop codex` launches reuse the
 cached account credentials from the guest keyring. (`coop codex` launches
-`login` and `logout` without the sandbox-bypass flag, which Codex rejects on
-those subcommands, so no `--ask` is needed.)
+`login` and `logout` without the sandbox-bypass flag — they never start an
+agent session, so there is nothing to sandbox — and no `--ask` is needed.)
 
 #### The guest keyring password
 
@@ -130,6 +134,20 @@ Images built before this support existed need a rebuild:
 ```bash
 coop setup --rebuild
 ```
+
+A rebuild only changes the golden image. An existing VM keeps its own guest
+disk across `coop stop` / `coop start`, so it will not pick up the new guest
+packages. Swap the rebuilt image in without losing the instance:
+
+```bash
+coop stop my-project
+coop restore my-project --image default
+coop start my-project
+```
+
+[`restore`](commands.md#restore) keeps the instance's name, index, IP, and
+workspace association. Destroying and recreating the VM also works, but
+discards its guest disk.
 
 ### GitHub auth
 

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -11,9 +11,17 @@ coop codex [instance-name] [-- extra-args...]
 This SSHes into the guest and runs the `codex` CLI. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with how `coop claude` runs unrestricted. The VM is the isolation boundary, so Codex's own sandbox is redundant; it also does not work in the guest, which lacks a functioning bubblewrap, so leaving it enabled makes every shell command Codex runs fail.
 
 When `[codex] auth = "chatgpt"` is enabled, `coop codex` launches a small
-guest wrapper that starts a D-Bus session, unlocks GNOME Keyring when needed,
-and then runs the real Codex binary. The wrapper may prompt for the guest
-keyring password before Codex starts.
+guest wrapper (`/usr/local/bin/codex-account`) that starts a D-Bus session,
+unlocks GNOME Keyring when needed, and then runs the real Codex binary. The
+wrapper may prompt for the guest keyring password before Codex starts.
+
+The in-guest `codex-yolo` shortcut routes through the same wrapper, so it works
+in either auth mode. Running the bare `codex` binary from `coop shell` does
+not: it has no D-Bus session, and `keyring` credential storage has no
+`auth.json` fallback, so Codex will not find its credentials. Inside the guest,
+run `codex-account` (or `codex-yolo`) instead of `codex`. The wrapper is a
+transparent passthrough when `auth = "chatgpt"` is not configured, so it is
+always safe to use.
 
 To keep Codex's sandbox and approval prompts for a single session, pass `--ask`. coop then launches `codex` with no bypass flag, so Codex applies its normal defaults:
 
@@ -85,12 +93,27 @@ for the Codex credential-store setting and device-code login flow.
 The first login should use device-code auth from inside the guest:
 
 ```bash
-coop codex --ask -- login --device-auth
+coop codex -- login --device-auth
 ```
 
 Then open the shown URL in your browser, sign in to the intended ChatGPT
 workspace, and enter the one-time code. Later `coop codex` launches reuse the
-cached account credentials from the guest keyring.
+cached account credentials from the guest keyring. (`coop codex` launches
+`login` and `logout` without the sandbox-bypass flag, which Codex rejects on
+those subcommands, so no `--ask` is needed.)
+
+#### The guest keyring password
+
+A fresh VM has no keyring, so the first prompt is *choosing* a password, not
+entering one. The wrapper says so and asks for confirmation. That password
+encrypts the Codex account credentials at rest inside the guest and is
+requested again on later launches; it is unrelated to your ChatGPT or host
+credentials. Because it is per-guest, `coop destroy` discards it along with the
+cached login.
+
+The prompt needs a terminal. `coop codex` provides one; a non-interactive
+`coop exec` does not, and the wrapper fails with a clear message rather than
+hanging.
 
 Security and billing guardrails in this mode:
 

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -10,6 +10,11 @@ coop codex [instance-name] [-- extra-args...]
 
 This SSHes into the guest and runs the `codex` CLI. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with how `coop claude` runs unrestricted. The VM is the isolation boundary, so Codex's own sandbox is redundant; it also does not work in the guest, which lacks a functioning bubblewrap, so leaving it enabled makes every shell command Codex runs fail.
 
+When `[codex] auth = "chatgpt"` is enabled, `coop codex` launches a small
+guest wrapper that starts a D-Bus session, unlocks GNOME Keyring when needed,
+and then runs the real Codex binary. The wrapper may prompt for the guest
+keyring password before Codex starts.
+
 To keep Codex's sandbox and approval prompts for a single session, pass `--ask`. coop then launches `codex` with no bypass flag, so Codex applies its normal defaults:
 
 ```bash
@@ -32,6 +37,7 @@ Codex-related settings live under the `[codex]` section in `config.toml`, except
 github = "auto"
 
 [codex]
+auth = "api_key"
 api_key = "sk-proj-..."
 env_forward = ["MYORG_KEY"]
 config_dir = "~/.codex"
@@ -41,11 +47,14 @@ command = "npx"
 args = ["-y", "@playwright/mcp@latest"]
 ```
 
-Every field is optional. An empty `[codex]` section (or omitting it entirely) skips all Codex-specific bootstrap steps.
+Every field is optional. An empty `[codex]` section (or omitting it entirely) keeps the historical API-key mode and skips all Codex-specific bootstrap steps unless host config, MCP servers, plugins, or local-model routing need to be applied.
 
 ### API key forwarding
 
-coop forwards `OPENAI_API_KEY` to the guest via SSH `SendEnv` on every session: `coop codex`, `coop shell`, and `coop exec` alike. The key is never written to disk inside the guest.
+The default auth mode is `auth = "api_key"`. In this mode, coop forwards
+`OPENAI_API_KEY` to the guest via SSH `SendEnv` on every session: `coop codex`,
+`coop shell`, and `coop exec` alike. The key is never written to disk inside
+the guest.
 
 Resolution order:
 
@@ -53,6 +62,51 @@ Resolution order:
 2. `OPENAI_API_KEY` environment variable on the host
 
 If neither is set, the guest starts without an API key. You can authenticate interactively the first time you run `codex` inside the VM.
+
+### ChatGPT account auth
+
+Set `auth = "chatgpt"` to use a ChatGPT account or ChatGPT Business workspace
+with Codex instead of an OpenAI API key:
+
+```toml
+[codex]
+auth = "chatgpt"
+```
+
+This mode follows Codex's ChatGPT sign-in path, so usage is tied to the
+selected ChatGPT workspace rather than standard API billing. coop writes
+`cli_auth_credentials_store = "keyring"` into the guest `~/.codex/config.toml`
+so Codex uses Linux Secret Service storage, and it launches Codex through
+`/usr/local/bin/codex-account` so a headless guest has a D-Bus session and an
+unlocked GNOME Keyring. See OpenAI's
+[authentication documentation](https://learn.chatgpt.com/docs/auth#credential-storage)
+for the Codex credential-store setting and device-code login flow.
+
+The first login should use device-code auth from inside the guest:
+
+```bash
+coop codex --ask -- login --device-auth
+```
+
+Then open the shown URL in your browser, sign in to the intended ChatGPT
+workspace, and enter the one-time code. Later `coop codex` launches reuse the
+cached account credentials from the guest keyring.
+
+Security and billing guardrails in this mode:
+
+- `OPENAI_API_KEY` is not forwarded, even if it is configured, present in the
+  host environment, listed in `env_forward`, or persisted from `coop start
+  --env`.
+- `auth.json` from the host Codex config directory is not copied into the
+  guest. Account tokens are stored in the guest OS credential store instead.
+- `[proxy.openai]` is rejected with `auth = "chatgpt"`, because the proxy path
+  uses an OpenAI API key and would switch Codex back to API billing.
+
+Images built before this support existed need a rebuild:
+
+```bash
+coop setup --rebuild
+```
 
 ### GitHub auth
 
@@ -69,6 +123,10 @@ When a token is available, coop runs `gh auth setup-git` in the guest during boo
 ### Config directory
 
 `config_dir` specifies a host directory from which coop copies an allowlist of entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) into `~/.codex/` in the guest. This provides Codex's global instructions, prompt files, baseline user configuration, and local Codex authentication state.
+
+When `auth = "chatgpt"` or `[proxy.openai]` is active, `auth.json` is excluded
+from the copy. In ChatGPT account mode, coop stores cached account credentials
+through the guest keyring instead.
 
 ```toml
 [codex]
@@ -124,11 +182,17 @@ Codex stores marketplace registrations under `[marketplaces.*]` and per-plugin e
 When `coop up` creates/restarts a project VM or `coop start` restarts a stopped VM (without `--no-agents`), coop executes the following steps after the VM boots and SSH becomes available:
 
 1. **GitHub auth**: If a `GITHUB_TOKEN` is available, run `gh auth setup-git` in the guest.
-2. **User content**: Copy the allowlisted Codex entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from `config_dir` to `~/.codex/` in the guest, preserving the guest's installed `[marketplaces.*]`/`[plugins.*]` tables.
-3. **MCP servers**: Merge configured MCP server definitions into `~/.codex/config.toml`.
-4. **Marketplaces & plugins** (first boot only): Install the configured `marketplaces`/`plugins` not already baked into the golden image.
+2. **User content**: Copy the allowlisted Codex entries (`AGENTS.md`,
+   `prompts/`, `config.toml`, `auth.json`) from `config_dir` to `~/.codex/` in
+   the guest, preserving the guest's installed `[marketplaces.*]`/`[plugins.*]`
+   tables. `auth.json` is omitted when ChatGPT account auth or proxy mode is
+   active.
+3. **Auth storage**: In ChatGPT account mode, write
+   `cli_auth_credentials_store = "keyring"` into `~/.codex/config.toml`.
+4. **MCP servers**: Merge configured MCP server definitions into `~/.codex/config.toml`.
+5. **Marketplaces & plugins** (first boot only): Install the configured `marketplaces`/`plugins` not already baked into the golden image.
 
-On restart (`coop start` of a stopped instance), the same Codex config files are refreshed so host-side updates are reflected in the guest; marketplaces and plugins are not reinstalled, but the guest's installed plugin state is preserved (step 2).
+On restart (`coop start` of a stopped instance), the same Codex config files are refreshed so host-side updates are reflected in the guest; marketplaces and plugins are not reinstalled, but the guest's installed plugin state is preserved.
 
 ### Skipping bootstrap
 

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -115,8 +115,9 @@ requested again on later launches; it is unrelated to your ChatGPT or host
 credentials. Because it is per-guest, `coop destroy` discards it along with the
 cached login.
 
-The prompt needs a terminal. `coop codex` provides one; a non-interactive
-`coop exec` does not, and the wrapper fails with a clear message rather than
+The prompt needs a terminal. `coop codex` provides one. Anything that runs
+the wrapper without one — invoking `codex-account` yourself through
+`coop exec`, or a `post_start` script — fails with a clear message rather than
 hanging.
 
 Security and billing guardrails in this mode:
@@ -128,6 +129,12 @@ Security and billing guardrails in this mode:
   guest. Account tokens are stored in the guest OS credential store instead.
 - `[proxy.openai]` is rejected with `auth = "chatgpt"`, because the proxy path
   uses an OpenAI API key and would switch Codex back to API billing.
+
+Because coop must keep `cli_auth_credentials_store` in the guest
+`~/.codex/config.toml`, this mode rewrites that file on every start. Codex's
+own state in it — installed marketplaces and plugins, and the
+`[projects.*]` workspace-trust records — is read back and preserved across the
+rewrite, so you are not re-approving workspace trust after each restart.
 
 Images built before this support existed need a rebuild:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -332,7 +332,7 @@ coop ca my-project -- --cwd /workspace
 
 ### `codex`
 
-Launch Codex inside the VM. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with `coop claude`. The VM is the isolation boundary, and Codex's own Linux sandbox does not work in the guest (no functioning bubblewrap), so leaving it enabled makes every shell command Codex runs fail. Use `--ask` to keep Codex's sandbox and approval prompts for that session. With `[codex] auth = "chatgpt"`, `coop codex` launches through the guest keyring wrapper. The `login` and `logout` subcommands are always launched without the bypass flag, which Codex rejects on them.
+Launch Codex inside the VM. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with `coop claude`. The VM is the isolation boundary, and Codex's own Linux sandbox does not work in the guest (no functioning bubblewrap), so leaving it enabled makes every shell command Codex runs fail. Use `--ask` to keep Codex's sandbox and approval prompts for that session. With `[codex] auth = "chatgpt"`, `coop codex` launches through the guest keyring wrapper. The `login` and `logout` subcommands are always launched without the bypass flag: they never start an agent session, so there is nothing to sandbox.
 
 ```
 coop codex [NAME] [FLAGS] [ARGS...]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -332,7 +332,7 @@ coop ca my-project -- --cwd /workspace
 
 ### `codex`
 
-Launch Codex inside the VM. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with `coop claude`. The VM is the isolation boundary, and Codex's own Linux sandbox does not work in the guest (no functioning bubblewrap), so leaving it enabled makes every shell command Codex runs fail. Use `--ask` to keep Codex's sandbox and approval prompts for that session. With `[codex] auth = "chatgpt"`, `coop codex` launches through the guest keyring wrapper; use `--ask` when running login subcommands.
+Launch Codex inside the VM. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with `coop claude`. The VM is the isolation boundary, and Codex's own Linux sandbox does not work in the guest (no functioning bubblewrap), so leaving it enabled makes every shell command Codex runs fail. Use `--ask` to keep Codex's sandbox and approval prompts for that session. With `[codex] auth = "chatgpt"`, `coop codex` launches through the guest keyring wrapper. The `login` and `logout` subcommands are always launched without the bypass flag, which Codex rejects on them.
 
 ```
 coop codex [NAME] [FLAGS] [ARGS...]
@@ -348,7 +348,7 @@ coop codex [NAME] [FLAGS] [ARGS...]
 coop codex
 coop codex my-project --ask
 coop codex my-project -- --model gpt-5
-coop codex my-project --ask -- login --device-auth
+coop codex my-project -- login --device-auth
 ```
 
 ### `exec`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -332,7 +332,7 @@ coop ca my-project -- --cwd /workspace
 
 ### `codex`
 
-Launch Codex inside the VM. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with `coop claude`. The VM is the isolation boundary, and Codex's own Linux sandbox does not work in the guest (no functioning bubblewrap), so leaving it enabled makes every shell command Codex runs fail. Use `--ask` to keep Codex's sandbox and approval prompts for that session.
+Launch Codex inside the VM. By default coop passes `--dangerously-bypass-approvals-and-sandbox`, so Codex runs without its sandbox or approval prompts — parity with `coop claude`. The VM is the isolation boundary, and Codex's own Linux sandbox does not work in the guest (no functioning bubblewrap), so leaving it enabled makes every shell command Codex runs fail. Use `--ask` to keep Codex's sandbox and approval prompts for that session. With `[codex] auth = "chatgpt"`, `coop codex` launches through the guest keyring wrapper; use `--ask` when running login subcommands.
 
 ```
 coop codex [NAME] [FLAGS] [ARGS...]
@@ -348,6 +348,7 @@ coop codex [NAME] [FLAGS] [ARGS...]
 coop codex
 coop codex my-project --ask
 coop codex my-project -- --model gpt-5
+coop codex my-project --ask -- login --device-auth
 ```
 
 ### `exec`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -244,15 +244,16 @@ Codex configuration injected into the guest VM at start time. Every field is opt
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `api_key` | string | unset (reads `$OPENAI_API_KEY` from environment) | OpenAI API key. Forwarded to the guest via SSH `SendEnv`. Never written to disk inside the VM. |
-| `config_dir` | string (path) or `false` | `~/.codex` | Source directory for Codex config files. Copies an allowlist of entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from this directory to `~/.codex/` in the guest on start. Set to `false` to disable. Supports `~` expansion. |
+| `auth` | string | `"api_key"` | Codex auth mode: `"api_key"` forwards an OpenAI API key; `"chatgpt"` uses ChatGPT account or workspace login through the guest Linux keyring. |
+| `api_key` | string | unset (reads `$OPENAI_API_KEY` from environment) | OpenAI API key. Used only with `auth = "api_key"`. Forwarded to the guest via SSH `SendEnv`. Never written to disk inside the VM. |
+| `config_dir` | string (path) or `false` | `~/.codex` | Source directory for Codex config files. Copies an allowlist of entries (`AGENTS.md`, `prompts/`, `config.toml`, `auth.json`) from this directory to `~/.codex/` in the guest on start. `auth.json` is omitted when `auth = "chatgpt"` or `[proxy.openai]` is active. Set to `false` to disable. Supports `~` expansion. |
 | `env_forward` | array of strings | `[]` | Extra environment variable names to forward from host to guest via SSH `SendEnv`. `OPENAI_API_KEY` and `GITHUB_TOKEN` are forwarded automatically when set; list additional variables here. |
 | `marketplaces` | array of strings | `[]` | Codex plugin marketplace sources. Each entry is a `owner/repo`[`@ref`] shorthand, a git URL, or an absolute local directory path. Local directories are copied into the guest before registration. Baked into the golden image and delta-installed on first boot. |
 | `plugins` | array of strings | `[]` | Codex plugins to install from registered marketplaces. Format: `plugin-name@marketplace-name`. |
 | `mcp_servers` | table | `{}` | MCP servers to merge into the guest `~/.codex/config.toml`. Keys are server names; values are server definitions. See [MCP servers](#mcp-servers). |
 | `local_model` | table | unset | Host-side model endpoint to route Codex at when the VM is in local mode (`coop model <vm> local`). See [Local-model routing](#local-model-routing). |
 
-coop preserves any other settings already present in the staged `config.toml`, but the `mcp_servers` table is owned by coop when `codex.mcp_servers` is configured.
+coop preserves any other settings already present in the staged `config.toml`, but the `mcp_servers` table is owned by coop when `codex.mcp_servers` is configured. With `auth = "chatgpt"`, coop also writes `cli_auth_credentials_store = "keyring"` so Codex caches account credentials in the guest OS credential store instead of `auth.json`.
 
 ## Local-model routing
 
@@ -296,6 +297,10 @@ holds only a per-instance capability token, while the real credential stays on
 the host and is injected onto outbound requests the guest never sees. Absent
 config means no proxy — credentials are forwarded into the guest exactly as
 before.
+
+`[proxy.openai]` is API-key based and cannot be combined with
+`[codex] auth = "chatgpt"`. Use one Codex remote auth path per VM: the proxy
+for an OpenAI API key, or ChatGPT auth for account/workspace access.
 
 Proxy mode applies only in remote model mode
 ([`coop model <vm> remote`](commands.md#model)); local mode takes precedence.
@@ -446,6 +451,7 @@ args = ["--verbose"]
 env = { API_KEY = "MY_API_KEY" }
 
 [codex]
+auth = "api_key"
 config_dir = "~/.codex"
 env_forward = ["CUSTOM_TOKEN"]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,6 +298,12 @@ the host and is injected onto outbound requests the guest never sees. Absent
 config means no proxy — credentials are forwarded into the guest exactly as
 before.
 
+Every golden image installs the Secret Service packages this mode needs
+(`dbus-user-session`, `gnome-keyring`, `libsecret-tools`) regardless of the
+`auth` setting, because the image is built once and reused across configs —
+gating them would let a later `auth = "chatgpt"` edit meet an image that cannot
+serve it.
+
 `[proxy.openai]` is API-key based and cannot be combined with
 `[codex] auth = "chatgpt"`. Use one Codex remote auth path per VM: the proxy
 for an OpenAI API key, or ChatGPT auth for account/workspace access.

--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -32,6 +32,11 @@ for the lifetime of the VM:
   closes). Codex subscription is therefore out of scope in proxy mode; use an
   OpenAI API key.
 
+For Codex account or workspace access without API billing, use
+`[codex] auth = "chatgpt"` instead of `[proxy.openai]`. That mode stores Codex
+credentials in the guest Linux keyring and is rejected when an OpenAI proxy is
+also active.
+
 The capability token is worthless off the host — it only authorizes the local
 proxy, which holds the real key itself — so exfiltrating it gains a compromised
 guest nothing.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,6 +92,7 @@ mem_size_mib = 8192
 config_dir = "~/.claude"
 
 [codex]
+auth = "api_key"
 config_dir = "~/.codex"
 ```
 
@@ -104,7 +105,14 @@ The `github` field controls how coop resolves a GitHub token for the guest:
 
 GitHub auth is off by default. Set `github = "auto"` (or run `coop github setup-pat --repo owner/name` for a scoped PAT) to enable it. `coop up` offers to run the PAT wizard inline the first time you bring up a project backed by a GitHub repo without auth configured.
 
-coop picks up `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from your environment automatically. Setting them explicitly under `claude.api_key` or `codex.api_key` also works, but environment variables are preferred.
+coop picks up `ANTHROPIC_API_KEY` and, in the default Codex API-key mode,
+`OPENAI_API_KEY` from your environment automatically. Setting them explicitly
+under `claude.api_key` or `codex.api_key` also works, but environment variables
+are preferred.
+
+For Codex account or workspace access without OpenAI API billing, set
+`[codex] auth = "chatgpt"`, rebuild any old image with `coop setup --rebuild`,
+then run `coop codex --ask -- login --device-auth` once.
 
 ## First run
 
@@ -259,6 +267,12 @@ coop claude -- --model opus
 
 ```
 coop codex
+```
+
+With `[codex] auth = "chatgpt"`, first sign in from the guest:
+
+```
+coop codex --ask -- login --device-auth
 ```
 
 Pass extra arguments through to `codex`:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,8 +111,11 @@ under `claude.api_key` or `codex.api_key` also works, but environment variables
 are preferred.
 
 For Codex account or workspace access without OpenAI API billing, set
-`[codex] auth = "chatgpt"`, rebuild any old image with `coop setup --rebuild`,
-then run `coop codex --ask -- login --device-auth` once.
+`[codex] auth = "chatgpt"` and rebuild any old image with `coop setup
+--rebuild`. An existing VM keeps its own guest disk across a restart, so also
+run `coop restore <vm> --image <image>` (see
+[Codex integration](codex-integration.md)) to pick up the rebuilt image. Then
+run `coop codex -- login --device-auth` once.
 
 ## First run
 
@@ -272,7 +275,7 @@ coop codex
 With `[codex] auth = "chatgpt"`, first sign in from the guest:
 
 ```
-coop codex --ask -- login --device-auth
+coop codex -- login --device-auth
 ```
 
 Pass extra arguments through to `codex`:

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -18,7 +18,7 @@ coop stores the result under `~/.coop/images/<name>/`. When creating an instance
 
 Every template installs these packages regardless of profile selection.
 
-**Base packages:** `openssh-server`, `curl`, `wget`, `git`, `build-essential`, `ca-certificates`, `gnupg`, `lsb-release`, `sudo`, `iproute2`, `iptables`, `kmod`, `procps`, `jq`, `rsync`, `unzip`, `zip`, `file`, `less`
+**Base packages:** `openssh-server`, `dbus-user-session`, `curl`, `wget`, `git`, `build-essential`, `ca-certificates`, `gnupg`, `lsb-release`, `sudo`, `iproute2`, `iptables`, `kmod`, `procps`, `jq`, `rsync`, `unzip`, `zip`, `file`, `gnome-keyring`, `less`, `libsecret-tools`
 
 **Docker:** `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin`
 
@@ -27,6 +27,9 @@ Every template installs these packages regardless of profile selection.
 **Claude Code CLI:** installed via the native installer during the template build.
 
 **Codex CLI:** installed as a standalone binary during the template build.
+The image also installs `/usr/local/bin/codex-account`, a wrapper used by
+`[codex] auth = "chatgpt"` to run Codex with a D-Bus session and guest Linux
+Secret Service storage.
 
 Both agents are installed at whatever version was current when the template was built, and that version is not part of the staleness hash — a plain `coop setup` does not refresh them. There are two ways to get newer agents:
 

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -29,7 +29,12 @@ Every template installs these packages regardless of profile selection.
 **Codex CLI:** installed as a standalone binary during the template build.
 The image also installs `/usr/local/bin/codex-account`, a wrapper used by
 `[codex] auth = "chatgpt"` to run Codex with a D-Bus session and guest Linux
-Secret Service storage.
+Secret Service storage. The wrapper and its three supporting packages
+(`dbus-user-session`, `gnome-keyring`, `libsecret-tools`) are installed in every
+image, not gated on the `auth` setting: an image is built once and reused across
+configs, so gating them would let a later `auth = "chatgpt"` edit meet an image
+that cannot serve it. When that mode is not configured the wrapper simply execs
+Codex, so it costs nothing at run time.
 
 Both agents are installed at whatever version was current when the template was built, and that version is not part of the staleness hash — a plain `coop setup` does not refresh them. There are two ways to get newer agents:
 

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -107,6 +107,15 @@ user `env_forward` entries, and the VM SSH key. The invariants:
   credential for one VM — resolution is override → default → off — without
   changing the proxy binary or the capability token. See
   [`credential-proxy.md`](credential-proxy.md).
+- **Codex ChatGPT account auth is persistent guest state.** With
+  `[codex] auth = "chatgpt"`, coop suppresses `OPENAI_API_KEY` across config,
+  process env, `env_forward`, and persisted `--env` overlays, writes
+  `cli_auth_credentials_store = "keyring"` to guest `~/.codex/config.toml`, and
+  excludes host `auth.json` from the guest copy. Codex stores its cached account
+  credentials in the guest Linux Secret Service instead. This avoids API-key
+  billing and host `auth.json` copying, but it does **not** keep the ChatGPT
+  refresh token out of the guest. A compromised guest can use or extract any
+  credential its keyring session can unlock.
 
 ## SSH boundary
 

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -120,7 +120,13 @@ user `env_forward` entries, and the VM SSH key. The invariants:
   earlier boot wrote it, the wrapper then falls through to plain Codex and
   `codex login` writes a plaintext `~/.codex/auth.json` instead. coop warns in
   exactly that case; the setting lives on the guest disk, so once written it
-  survives a later `--no-agents` start.
+  survives a later `--no-agents` start. Two guardrails close the gaps that
+  leaves: each bootstrap in this mode deletes any guest `~/.codex/auth.json`
+  left by an earlier `api_key` boot or `--no-agents` login (dropping the file
+  from the staged set only stops coop *copying* one, it removes nothing), and
+  `coop codex` refuses to launch when the guest config does not actually
+  select the keyring store — otherwise the wrapper would pass through to plain
+  Codex and write the token in the clear.
 
 ## SSH boundary
 

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -115,7 +115,12 @@ user `env_forward` entries, and the VM SSH key. The invariants:
   credentials in the guest Linux Secret Service instead. This avoids API-key
   billing and host `auth.json` copying, but it does **not** keep the ChatGPT
   refresh token out of the guest. A compromised guest can use or extract any
-  credential its keyring session can unlock.
+  credential its keyring session can unlock. The keyring setting is written
+  during agent bootstrap, so `--no-agents` skips it. On a guest where no
+  earlier boot wrote it, the wrapper then falls through to plain Codex and
+  `codex login` writes a plaintext `~/.codex/auth.json` instead. coop warns in
+  exactly that case; the setting lives on the guest disk, so once written it
+  survives a later `--no-agents` start.
 
 ## SSH boundary
 

--- a/scripts/guest/codex-account.sh
+++ b/scripts/guest/codex-account.sh
@@ -98,7 +98,7 @@ unlock_keyring() {
     # its own fd 2, so this surfaces only its startup diagnostics — the probe
     # below is what reports a wrong password.
     output="$(printf '%s' "$password" \
-        | gnome-keyring-daemon --unlock --components=secrets)" \
+        | timeout 30 gnome-keyring-daemon --unlock --components=secrets)" \
         || die "failed to unlock the guest keyring"
 
     # The daemon prints its session env as `NAME=value` lines. Take only

--- a/scripts/guest/codex-account.sh
+++ b/scripts/guest/codex-account.sh
@@ -33,28 +33,20 @@ keyring_exists() {
     compgen -G "$KEYRING_DIR/*.keyring" >/dev/null 2>&1
 }
 
-eval_env_output() {
-    local output
-    output="$("$@" 2>/dev/null)" || return 1
-    if [ -n "$output" ]; then
-        eval "$output"
-    fi
-}
-
-start_keyring() {
-    eval_env_output gnome-keyring-daemon --start --components=secrets || true
-}
+# secret-tool's stderr from the last probe, so the failure path can report the
+# real cause instead of only guessing at the password.
+PROBE_ERROR=""
 
 # Writing proves the collection is both reachable and unlocked; a lookup can
 # succeed against a locked collection. The probe item is cleared again so
 # repeated launches do not accumulate junk in the user's keyring.
 probe_keyring() {
-    printf 'ok' \
+    PROBE_ERROR="$(printf 'ok' \
         | timeout 5 secret-tool store \
             --label="coop Codex keyring probe" \
             service "$PROBE_SERVICE" \
             account "$PROBE_ACCOUNT" \
-            >/dev/null 2>&1 || return 1
+            2>&1 >/dev/null)" || return 1
     timeout 5 secret-tool clear \
         service "$PROBE_SERVICE" \
         account "$PROBE_ACCOUNT" \
@@ -102,8 +94,11 @@ unlock_keyring() {
         fi
     fi
 
+    # Let the daemon's stderr reach the terminal. Once it forks it redirects
+    # its own fd 2, so this surfaces only its startup diagnostics — the probe
+    # below is what reports a wrong password.
     output="$(printf '%s' "$password" \
-        | gnome-keyring-daemon --unlock --components=secrets 2>/dev/null)" \
+        | gnome-keyring-daemon --unlock --components=secrets)" \
         || die "failed to unlock the guest keyring"
 
     if [ -n "$output" ]; then
@@ -133,13 +128,17 @@ for tool in gnome-keyring-daemon secret-tool timeout; do
         || die "$tool is missing; rebuild the coop image with Codex account-auth support"
 done
 
-start_keyring
-if ! probe_keyring; then
-    unlock_keyring
-    start_keyring
-    probe_keyring \
-        || die "guest Secret Service is still unavailable; check the keyring password"
-fi
+# Unlock before anything else touches the bus. `gnome-keyring-daemon --unlock`
+# only creates and unlocks the login collection when it is the process that
+# starts the daemon; once any daemon owns `org.freedesktop.secrets` it hands
+# the unlock to the graphical gcr-prompter, which cannot render on a headless
+# guest and exits immediately. That includes a daemon the probe itself would
+# D-Bus-activate, so there is no cheap "is it already unlocked?" check to make
+# first — `dbus-run-session` above mints a fresh private bus every time, so
+# there is never a pre-unlocked daemon to find anyway.
+unlock_keyring
+probe_keyring \
+    || die "guest Secret Service is unavailable${PROBE_ERROR:+: $PROBE_ERROR}; check the keyring password"
 
 exec "$CODEX_BIN" "$@"
 CODEXACCOUNTEOF

--- a/scripts/guest/codex-account.sh
+++ b/scripts/guest/codex-account.sh
@@ -101,9 +101,15 @@ unlock_keyring() {
         | gnome-keyring-daemon --unlock --components=secrets)" \
         || die "failed to unlock the guest keyring"
 
-    if [ -n "$output" ]; then
-        eval "$output"
-    fi
+    # The daemon prints its session env as `NAME=value` lines. Take only
+    # those, and export them: an unfiltered `eval` would execute any GLib
+    # diagnostic the daemon puts on stdout as a command, and a bare
+    # assignment would not reach Codex anyway.
+    while IFS= read -r line; do
+        case "$line" in
+            [A-Za-z_]*=*) export "${line%%=*}=${line#*=}" ;;
+        esac
+    done <<<"$output"
 }
 
 if [ ! -x "$CODEX_BIN" ]; then
@@ -128,17 +134,26 @@ for tool in gnome-keyring-daemon secret-tool timeout; do
         || die "$tool is missing; rebuild the coop image with Codex account-auth support"
 done
 
-# Unlock before anything else touches the bus. `gnome-keyring-daemon --unlock`
-# only creates and unlocks the login collection when it is the process that
-# starts the daemon; once any daemon owns `org.freedesktop.secrets` it hands
-# the unlock to the graphical gcr-prompter, which cannot render on a headless
-# guest and exits immediately. That includes a daemon the probe itself would
-# D-Bus-activate, so there is no cheap "is it already unlocked?" check to make
-# first — `dbus-run-session` above mints a fresh private bus every time, so
-# there is never a pre-unlocked daemon to find anyway.
-unlock_keyring
-probe_keyring \
-    || die "guest Secret Service is unavailable${PROBE_ERROR:+: $PROBE_ERROR}; check the keyring password"
+# A nested codex-account — an in-guest agent shelling out to `codex-account` or
+# `codex-yolo` — inherits this bus and its already-unlocked keyring. Unlocking
+# again there would fail, for the same reason the ordering below matters, so
+# reuse the session instead of prompting a second time.
+if [ "${COOP_CODEX_ACCOUNT_UNLOCKED:-0}" = "1" ]; then
+    probe_keyring \
+        || die "inherited guest Secret Service session is unusable${PROBE_ERROR:+: $PROBE_ERROR}"
+else
+    # Unlock before anything else touches the bus. `gnome-keyring-daemon
+    # --unlock` only creates and unlocks the login collection when it is the
+    # process that starts the daemon; once any daemon owns
+    # `org.freedesktop.secrets` it hands the unlock to the graphical
+    # gcr-prompter, which cannot render on a headless guest and exits
+    # immediately. That includes a daemon the probe itself would D-Bus-activate,
+    # so there is no cheap "is it already unlocked?" check to make first.
+    unlock_keyring
+    probe_keyring \
+        || die "guest Secret Service is unavailable${PROBE_ERROR:+: $PROBE_ERROR}; check the keyring password"
+    export COOP_CODEX_ACCOUNT_UNLOCKED=1
+fi
 
 exec "$CODEX_BIN" "$@"
 CODEXACCOUNTEOF

--- a/scripts/guest/codex-account.sh
+++ b/scripts/guest/codex-account.sh
@@ -1,0 +1,91 @@
+# shellcheck shell=bash
+set -euo pipefail
+
+echo '  [guest] Installing codex-account shortcut...'
+cat >/usr/local/bin/codex-account <<'CODEXACCOUNTEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODEX_BIN="/usr/local/bin/codex"
+PROBE_SERVICE="coop-codex"
+PROBE_ACCOUNT="keyring-probe"
+
+die() {
+    echo "codex-account: $*" >&2
+    exit 1
+}
+
+eval_env_output() {
+    local output
+    output="$("$@" 2>/dev/null)" || return 1
+    if [ -n "$output" ]; then
+        eval "$output"
+    fi
+}
+
+start_keyring() {
+    eval_env_output gnome-keyring-daemon --start --components=secrets || true
+}
+
+probe_keyring() {
+    printf 'ok' \
+        | timeout 5 secret-tool store \
+            --label="coop Codex keyring probe" \
+            service "$PROBE_SERVICE" \
+            account "$PROBE_ACCOUNT" \
+            >/dev/null 2>&1
+}
+
+unlock_keyring() {
+    if [ ! -t 0 ]; then
+        die "Codex ChatGPT auth needs an interactive TTY to unlock the guest keyring"
+    fi
+
+    local password output
+    password=""
+    if ! IFS= read -rsp "Codex keyring password: " password; then
+        echo >&2
+        die "failed to read keyring password"
+    fi
+    echo >&2
+
+    output="$(printf '%s' "$password" \
+        | gnome-keyring-daemon --unlock --components=secrets 2>/dev/null)" \
+        || {
+            unset password
+            die "failed to unlock the guest keyring"
+        }
+    unset password
+
+    if [ -n "$output" ]; then
+        eval "$output"
+    fi
+}
+
+if [ ! -x "$CODEX_BIN" ]; then
+    die "$CODEX_BIN is missing; rebuild the coop image"
+fi
+
+if [ "${COOP_CODEX_ACCOUNT_DBUS:-0}" != "1" ]; then
+    command -v dbus-run-session >/dev/null 2>&1 \
+        || die "dbus-run-session is missing; install dbus-user-session or rebuild the coop image"
+    export COOP_CODEX_ACCOUNT_DBUS=1
+    exec dbus-run-session -- "$0" "$@"
+fi
+
+for tool in gnome-keyring-daemon secret-tool timeout; do
+    command -v "$tool" >/dev/null 2>&1 \
+        || die "$tool is missing; rebuild the coop image with Codex account-auth support"
+done
+
+start_keyring
+if ! probe_keyring; then
+    unlock_keyring
+    start_keyring
+    probe_keyring \
+        || die "guest Secret Service is still unavailable; check the keyring password"
+fi
+
+exec "$CODEX_BIN" "$@"
+CODEXACCOUNTEOF
+chmod 755 /usr/local/bin/codex-account

--- a/scripts/guest/codex-account.sh
+++ b/scripts/guest/codex-account.sh
@@ -7,12 +7,30 @@ cat >/usr/local/bin/codex-account <<'CODEXACCOUNTEOF'
 set -euo pipefail
 
 CODEX_BIN="/usr/local/bin/codex"
+CODEX_CONFIG="${CODEX_HOME:-$HOME/.codex}/config.toml"
+KEYRING_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/keyrings"
 PROBE_SERVICE="coop-codex"
 PROBE_ACCOUNT="keyring-probe"
 
 die() {
     echo "codex-account: $*" >&2
     exit 1
+}
+
+# coop writes `cli_auth_credentials_store = "keyring"` into the guest Codex
+# config only under `[codex] auth = "chatgpt"`. Every other mode reads
+# credentials from auth.json, where the D-Bus/keyring session is pure overhead
+# (and its password prompt is an outright regression). Gating on the config the
+# guest actually has lets every Codex entry point route through this wrapper.
+keyring_mode() {
+    [ -r "$CODEX_CONFIG" ] \
+        && grep -Eq \
+            '^[[:space:]]*cli_auth_credentials_store[[:space:]]*=[[:space:]]*"keyring"' \
+            "$CODEX_CONFIG"
+}
+
+keyring_exists() {
+    compgen -G "$KEYRING_DIR/*.keyring" >/dev/null 2>&1
 }
 
 eval_env_output() {
@@ -27,35 +45,66 @@ start_keyring() {
     eval_env_output gnome-keyring-daemon --start --components=secrets || true
 }
 
+# Writing proves the collection is both reachable and unlocked; a lookup can
+# succeed against a locked collection. The probe item is cleared again so
+# repeated launches do not accumulate junk in the user's keyring.
 probe_keyring() {
     printf 'ok' \
         | timeout 5 secret-tool store \
             --label="coop Codex keyring probe" \
             service "$PROBE_SERVICE" \
             account "$PROBE_ACCOUNT" \
-            >/dev/null 2>&1
+            >/dev/null 2>&1 || return 1
+    timeout 5 secret-tool clear \
+        service "$PROBE_SERVICE" \
+        account "$PROBE_ACCOUNT" \
+        >/dev/null 2>&1 || true
 }
 
 unlock_keyring() {
+    local creating=0 password confirm output
+    keyring_exists || creating=1
+
     if [ ! -t 0 ]; then
         die "Codex ChatGPT auth needs an interactive TTY to unlock the guest keyring"
     fi
 
-    local password output
-    password=""
+    # On a fresh guest there is no keyring yet, so this prompt is choosing a
+    # password rather than entering one. Say so, and confirm it — an
+    # unnoticed typo would otherwise lock the credentials behind a password
+    # the user cannot reproduce on the next launch.
+    if [ "$creating" = 1 ]; then
+        printf '%s\n' \
+            'codex-account: this VM has no guest keyring yet.' \
+            'Choose a password to create one. It encrypts the Codex account' \
+            'credentials stored inside the guest, and later `coop codex` runs' \
+            'ask for it again. It is not your ChatGPT or host password.' >&2
+    fi
+
     if ! IFS= read -rsp "Codex keyring password: " password; then
         echo >&2
         die "failed to read keyring password"
     fi
     echo >&2
 
+    if [ -z "$password" ]; then
+        die "keyring password must not be empty"
+    fi
+
+    if [ "$creating" = 1 ]; then
+        if ! IFS= read -rsp "Confirm keyring password: " confirm; then
+            echo >&2
+            die "failed to read keyring password"
+        fi
+        echo >&2
+        if [ "$password" != "$confirm" ]; then
+            die "passwords did not match; no keyring was created"
+        fi
+    fi
+
     output="$(printf '%s' "$password" \
         | gnome-keyring-daemon --unlock --components=secrets 2>/dev/null)" \
-        || {
-            unset password
-            die "failed to unlock the guest keyring"
-        }
-    unset password
+        || die "failed to unlock the guest keyring"
 
     if [ -n "$output" ]; then
         eval "$output"
@@ -66,6 +115,12 @@ if [ ! -x "$CODEX_BIN" ]; then
     die "$CODEX_BIN is missing; rebuild the coop image"
 fi
 
+if ! keyring_mode; then
+    exec "$CODEX_BIN" "$@"
+fi
+
+# The keyring speaks D-Bus, and a headless SSH session has no session bus.
+# Re-exec under one, using the env guard to avoid recursing forever.
 if [ "${COOP_CODEX_ACCOUNT_DBUS:-0}" != "1" ]; then
     command -v dbus-run-session >/dev/null 2>&1 \
         || die "dbus-run-session is missing; install dbus-user-session or rebuild the coop image"

--- a/scripts/guest/guest-config.sh
+++ b/scripts/guest/guest-config.sh
@@ -128,7 +128,7 @@ chmod 755 /usr/local/bin/claude-yolo
 echo '  [guest] Installing codex-yolo shortcut...'
 cat > /usr/local/bin/codex-yolo <<'YOLOEOF'
 #!/bin/bash
-exec codex --dangerously-bypass-approvals-and-sandbox "$@"
+exec codex-account --dangerously-bypass-approvals-and-sandbox "$@"
 YOLOEOF
 chmod 755 /usr/local/bin/codex-yolo
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1363,14 +1363,12 @@ pub fn prepare_env_forwarding(
     let codex = &cfg.codex;
     let codex_account_auth = codex.auth.uses_chatgpt_account();
     let suppress_openai_key = suppress_openai_key || codex_account_auth;
-    let openai_suppression_reason = if suppress_openai_key {
-        if codex_account_auth {
-            "codex.auth = \"chatgpt\""
-        } else {
-            "proxy mode"
-        }
+    // Only ever read under `suppress_openai_key`, so there is no "not
+    // suppressed" case to name.
+    let openai_suppression_reason = if codex_account_auth {
+        "codex.auth = \"chatgpt\""
     } else {
-        ""
+        "proxy mode"
     };
     let mut env = EnvForward::default();
 
@@ -1648,7 +1646,8 @@ fn bootstrap_codex(
             &codex.mcp_servers,
             has_plugins,
             codex.auth,
-        ) || manages_local;
+        ) || manages_local
+            || model_state.codex_keyring_materialized;
 
         if !needs_codex {
             return Ok(());
@@ -1674,7 +1673,26 @@ fn bootstrap_codex(
             local.as_ref(),
             manages_local,
             proxy.is_some(),
+            model_state.codex_keyring_materialized,
         )?;
+
+        // Same reasoning as `codex_materialized` above, for the keyring
+        // credential-store key: remember that coop has written it so a later
+        // switch back to `api_key` still rewrites a clean file that drops it,
+        // even when nothing else would trigger a rewrite.
+        //
+        // Recorded only after `copy_codex_config` succeeded, unlike
+        // `codex_materialized` — that flag records a fact already settled on
+        // the host, this one a claim about the guest. Setting it earlier would
+        // survive a failed bootstrap (a guest without Secret Service support,
+        // a dropped scp) and then force a full config rewrite on every later
+        // boot of a VM the guest key never reached — including the
+        // `read_codex_plugin_state` round-trip, whose warn-and-continue on a
+        // failed read drops the guest's own plugin tables.
+        if codex.auth.uses_chatgpt_account() && !model_state.codex_keyring_materialized {
+            model_state.codex_keyring_materialized = true;
+            model_state.save(inst)?;
+        }
 
         // Marketplaces and plugins are persisted in the guest's config.toml and
         // plugin cache (and preserved across restarts by `copy_codex_config`), so
@@ -1759,9 +1777,13 @@ pub fn ensure_codex_account_guest_support(target: &SshTarget) -> Result<()> {
         "Codex ChatGPT account auth requires guest Secret Service support, \
          but this VM image does not have it.\n\
          Rebuild the image with `coop setup --rebuild` (or \
-         `coop setup --image <name> --rebuild` for a named image), then \
-         recreate or restart the VM. For an existing guest disk, install \
-         `dbus-user-session`, `gnome-keyring`, and `libsecret-tools` manually."
+         `coop setup --image <name> --rebuild` for a named image).\n\
+         A rebuild does not touch this VM's existing guest disk, and a \
+         restart reuses it. To pick up the rebuilt image, either \
+         `coop stop` then `coop restore <vm> --image <image>` (in place, \
+         keeping the instance), or destroy and recreate the VM. \
+         Alternatively, install `dbus-user-session`, `gnome-keyring`, and \
+         `libsecret-tools` in the running guest by hand."
     );
 }
 
@@ -2384,6 +2406,7 @@ fn copy_codex_config(
     local: Option<&toml::Table>,
     manages_local: bool,
     proxy_active: bool,
+    keyring_materialized: bool,
 ) -> Result<()> {
     // The guest's config.toml holds the Codex CLI's installed `[marketplaces.*]`
     // / `[plugins.*]` tables. We only need to carry them across a *rewrite* of
@@ -2396,6 +2419,7 @@ fn copy_codex_config(
         local,
         manages_local,
         codex.auth,
+        keyring_materialized,
     ) {
         read_codex_plugin_state(target)
     } else {
@@ -2410,6 +2434,7 @@ fn copy_codex_config(
         preserved.as_ref(),
         proxy_active,
         codex.auth,
+        keyring_materialized,
     )
     .context("Failed to stage Codex config files")?;
     copy_staged_to_guest(target, &staged, ".codex", "Codex")
@@ -2585,23 +2610,32 @@ const CODEX_CONFIG_FILE: &str = "config.toml";
 
 /// Whether coop will rewrite the guest `~/.codex/config.toml` on this boot:
 /// true when the host supplies a `config.toml` base, when managed
-/// `mcp_servers` must be merged, or when a local-model block is being written
-/// or dropped (`manages_local`). When false the guest file is left untouched,
-/// so its installed plugin tables survive without coop round-tripping them.
+/// `mcp_servers` must be merged, when a local-model block is being written or
+/// dropped (`manages_local`), when `auth = "chatgpt"` needs the keyring
+/// credential store written, or when a previous boot wrote that key and this
+/// one must drop it again (`keyring_materialized`). When false the guest file
+/// is left untouched, so its installed plugin tables survive without coop
+/// round-tripping them.
 fn codex_config_needs_rewrite(
     source_dir: Option<&Path>,
     mcp_servers: &std::collections::HashMap<String, McpServerDef>,
     local: Option<&toml::Table>,
     manages_local: bool,
     auth: CodexAuthMode,
+    keyring_materialized: bool,
 ) -> bool {
     source_dir.is_some_and(|path| path.join(CODEX_CONFIG_FILE).is_file())
         || !mcp_servers.is_empty()
         || local.is_some()
         || manages_local
         || auth.uses_chatgpt_account()
+        || keyring_materialized
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each parameter is an independent, caller-resolved fact about this boot"
+)]
 fn stage_codex_files(
     source_dir: Option<&Path>,
     mcp_servers: &std::collections::HashMap<String, McpServerDef>,
@@ -2610,6 +2644,7 @@ fn stage_codex_files(
     preserved: Option<&toml::Table>,
     proxy_active: bool,
     auth: CodexAuthMode,
+    keyring_materialized: bool,
 ) -> Result<tempfile::TempDir> {
     let staging = tempfile::TempDir::new().context("Failed to create staging directory")?;
     let allowed_files = codex_allowed_files(proxy_active, auth);
@@ -2699,8 +2734,14 @@ fn stage_codex_files(
     // survives without coop having to round-trip it. This must stay in sync
     // with the gate in `copy_codex_config` that decides whether to read the
     // guest config at all — hence the shared predicate.
-    let should_write_config =
-        codex_config_needs_rewrite(source_dir, mcp_servers, local, manages_local, auth);
+    let should_write_config = codex_config_needs_rewrite(
+        source_dir,
+        mcp_servers,
+        local,
+        manages_local,
+        auth,
+        keyring_materialized,
+    );
 
     if should_write_config {
         std::fs::write(
@@ -3791,6 +3832,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         assert!(staging.path().join("AGENTS.md").is_file());
@@ -3830,6 +3872,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3855,6 +3898,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         assert_eq!(
@@ -3879,6 +3923,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             true,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         assert!(
@@ -3902,6 +3947,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ChatGpt,
+            false,
         )
         .unwrap();
 
@@ -3923,11 +3969,66 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ChatGpt,
+            false,
         )
         .unwrap();
 
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
         assert_eq!(config.trim(), "cli_auth_credentials_store = \"keyring\"");
+    }
+
+    #[test]
+    fn stage_codex_files_drops_keyring_store_when_switching_back_to_api_key() {
+        // Switching a VM from `chatgpt` to `api_key` with nothing else
+        // configured used to leave `cli_auth_credentials_store = "keyring"`
+        // behind in the guest, so the wrapper kept asking for a keyring
+        // password that was no longer needed. `keyring_materialized` (from
+        // `ModelState`) forces the rewrite that drops it.
+        let staging = stage_codex_files(
+            None,
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            None,
+            false,
+            CodexAuthMode::ApiKey,
+            true,
+        )
+        .unwrap();
+
+        let path = staging.path().join("config.toml");
+        assert!(
+            path.is_file(),
+            "a previously materialized keyring store must force a rewrite",
+        );
+        let config = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !config.contains("cli_auth_credentials_store"),
+            "api_key mode must clear the keyring store, got: {config:?}",
+        );
+    }
+
+    #[test]
+    fn codex_config_needs_rewrite_on_switch_away_from_chatgpt() {
+        // The gate that lets the rewrite above happen at all: with no source,
+        // no MCP servers, no local model and `api_key` auth, only the
+        // materialized flag can force it.
+        assert!(!codex_config_needs_rewrite(
+            None,
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            CodexAuthMode::ApiKey,
+            false,
+        ));
+        assert!(codex_config_needs_rewrite(
+            None,
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            CodexAuthMode::ApiKey,
+            true,
+        ));
     }
 
     #[test]
@@ -3946,6 +4047,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3968,6 +4070,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3990,6 +4093,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -4102,6 +4206,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             Some(&preserved),
             false,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -4137,6 +4242,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             None,
             false,
             CodexAuthMode::ApiKey,
+            false,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -4499,6 +4605,125 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         assert!(
             !env.contains("OPENAI_API_KEY"),
             "ChatGPT account auth must not forward an OpenAI API key"
+        );
+    }
+
+    // ── ensure_codex_remote_auth_consistent ─────────────────
+
+    fn auth_check_cfg(auth: CodexAuthMode, openai: bool, anthropic: bool) -> CoopConfig {
+        let upstream = || crate::config::ProxyUpstream {
+            credential: crate::config::Secret::new("sk-upstream".to_string()),
+            auth: crate::config::ProxyAuthScheme::Bearer,
+        };
+        let mut cfg = CoopConfig::default();
+        cfg.codex.auth = auth;
+        cfg.proxy.openai = openai.then(upstream);
+        cfg.proxy.anthropic = anthropic.then(upstream);
+        cfg
+    }
+
+    #[test]
+    fn codex_remote_auth_rejects_chatgpt_with_openai_upstream() {
+        // The tempdir holds no `proxy.json`, so `effective_upstream` resolves
+        // purely from the `[proxy]` config these fixtures build — the same
+        // holds for the three tests below.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let inst = temp_instance(tmp.path());
+        let cfg = auth_check_cfg(CodexAuthMode::ChatGpt, true, false);
+        let state = crate::model_state::ModelState::default();
+        assert_eq!(state.mode, crate::model_state::ModelMode::Remote);
+
+        let err = ensure_codex_remote_auth_consistent(&cfg, &inst, &state).unwrap_err();
+        assert_eq!(err.to_string(), codex_chatgpt_proxy_conflict_message());
+    }
+
+    #[test]
+    fn codex_remote_auth_rejects_chatgpt_with_per_vm_openai_override() {
+        // The case this guard exists for, and the only one that reaches it in
+        // production: `CoopConfig::validate` already rejects a config-level
+        // `[proxy.openai]` alongside `auth = "chatgpt"`, so the pairing can
+        // only survive a validated parse when it comes from a per-VM `coop
+        // proxy --vm` override in `<inst.dir>/proxy.json`. Config `[proxy]` is
+        // empty here, so only the on-disk override can trip the bail.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let inst = temp_instance(tmp.path());
+        crate::proxy_state::ProxyState {
+            openai: Some(crate::config::ProxyUpstream {
+                credential: crate::config::Secret::new("sk-per-vm".to_string()),
+                auth: crate::config::ProxyAuthScheme::Bearer,
+            }),
+            ..Default::default()
+        }
+        .save(&inst)
+        .unwrap();
+
+        let cfg = auth_check_cfg(CodexAuthMode::ChatGpt, false, false);
+        assert!(
+            cfg.proxy.openai.is_none(),
+            "the override must be the source"
+        );
+
+        let err = ensure_codex_remote_auth_consistent(
+            &cfg,
+            &inst,
+            &crate::model_state::ModelState::default(),
+        )
+        .unwrap_err();
+        assert_eq!(err.to_string(), codex_chatgpt_proxy_conflict_message());
+    }
+
+    #[test]
+    fn codex_remote_auth_allows_chatgpt_with_openai_upstream_in_local_mode() {
+        // Local mode never starts the OpenAI proxy, so the pair is not a
+        // conflict — this is the `model_state` term of the guard.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let inst = temp_instance(tmp.path());
+        let cfg = auth_check_cfg(CodexAuthMode::ChatGpt, true, false);
+        let state = crate::model_state::ModelState {
+            mode: crate::model_state::ModelMode::Local,
+            ..Default::default()
+        };
+
+        assert!(
+            ensure_codex_remote_auth_consistent(&cfg, &inst, &state).is_ok(),
+            "local mode must not trip the proxy conflict",
+        );
+    }
+
+    #[test]
+    fn codex_remote_auth_allows_api_key_with_openai_upstream() {
+        // The `uses_chatgpt_account` term: API-key auth is exactly what the
+        // OpenAI proxy is for.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let inst = temp_instance(tmp.path());
+        let cfg = auth_check_cfg(CodexAuthMode::ApiKey, true, false);
+
+        assert!(
+            ensure_codex_remote_auth_consistent(
+                &cfg,
+                &inst,
+                &crate::model_state::ModelState::default(),
+            )
+            .is_ok(),
+            "api_key auth with an OpenAI upstream is the supported pairing",
+        );
+    }
+
+    #[test]
+    fn codex_remote_auth_allows_chatgpt_with_anthropic_only_upstream() {
+        // The provider argument: a Claude-only proxy says nothing about Codex.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let inst = temp_instance(tmp.path());
+        let cfg = auth_check_cfg(CodexAuthMode::ChatGpt, false, true);
+
+        assert!(
+            ensure_codex_remote_auth_consistent(
+                &cfg,
+                &inst,
+                &crate::model_state::ModelState::default(),
+            )
+            .is_ok(),
+            "an Anthropic-only proxy must not trip the Codex guard",
         );
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1689,9 +1689,18 @@ fn bootstrap_codex(
         // boot of a VM the guest key never reached — including the
         // `read_codex_plugin_state` round-trip, whose warn-and-continue on a
         // failed read drops the guest's own plugin tables.
-        if codex.auth.uses_chatgpt_account() && !model_state.codex_keyring_materialized {
-            model_state.codex_keyring_materialized = true;
+        // Cleared as well as set, so it mirrors the guest rather than
+        // latching: once the `api_key` rewrite above has actually dropped the
+        // key, a stale `true` would force the very every-boot rewrite (and
+        // `read_codex_plugin_state` round-trip) this comment warns about.
+        let wants_keyring = codex.auth.uses_chatgpt_account();
+        if wants_keyring != model_state.codex_keyring_materialized {
+            model_state.codex_keyring_materialized = wants_keyring;
             model_state.save(inst)?;
+        }
+
+        if wants_keyring {
+            remove_guest_codex_auth_json(&session.target);
         }
 
         // Marketplaces and plugins are persisted in the guest's config.toml and
@@ -1758,6 +1767,56 @@ pub fn ensure_codex_remote_auth_consistent(
         bail!("{}", codex_chatgpt_proxy_conflict_message());
     }
     Ok(())
+}
+
+/// Delete a guest `~/.codex/auth.json` left behind by an earlier `api_key`
+/// boot (or by a `codex login` run under `--no-agents`).
+///
+/// Dropping `auth.json` from the staged file set only stops coop *copying* a
+/// new one — `copy_staged_to_guest` is additive and deletes nothing — so a VM
+/// switched from `api_key` to `chatgpt` would keep a plaintext refresh token
+/// on its guest disk, which is precisely what this mode exists to avoid.
+///
+/// Best-effort: the credential store is already the keyring by this point, so
+/// a failure here leaves a stale file rather than breaking the boot. It is
+/// loud about it, because the file is a credential.
+fn remove_guest_codex_auth_json(target: &SshTarget) {
+    if let Err(e) = target.exec(RemoteCommand::new().literal("rm -f ~/.codex/auth.json")) {
+        tracing::warn!(
+            "Could not remove a possible stale plaintext ~/.codex/auth.json from the \
+             guest; Codex account auth stores credentials in the guest keyring, so any \
+             such file is unused but still readable: {e:#}"
+        );
+    }
+}
+
+pub fn codex_keyring_not_configured_message() -> &'static str {
+    "Codex ChatGPT account auth is configured, but this VM's guest \
+     ~/.codex/config.toml does not select the keyring credential store.\n\
+     coop writes that setting during agent bootstrap, so a VM started before \
+     `auth = \"chatgpt\"` was set (or started with `--no-agents`) has not got \
+     it yet, and Codex would write its account credentials to a plaintext \
+     ~/.codex/auth.json in the guest instead.\n\
+     Run `coop start` (without `--no-agents`) to bootstrap it."
+}
+
+/// Fail closed when the guest is not actually in keyring mode.
+///
+/// The guest wrapper gates on the guest's own `~/.codex/config.toml` — which
+/// is what lets in-guest `codex-yolo` work — so if that file lacks the
+/// setting the wrapper silently execs plain Codex and `codex login` writes a
+/// plaintext token. `ensure_codex_account_guest_support` only proves the
+/// *packages* are installed, and agent bootstrap only runs on start/up, so
+/// enabling the mode against a running VM reaches exactly this gap.
+pub fn ensure_codex_keyring_configured(target: &SshTarget) -> Result<()> {
+    let configured = target.exec_ok(RemoteCommand::new().literal(
+        "grep -Eq '^[[:space:]]*cli_auth_credentials_store[[:space:]]*=[[:space:]]*\"keyring\"' \
+         ~/.codex/config.toml",
+    ));
+    if configured {
+        return Ok(());
+    }
+    bail!("{}", codex_keyring_not_configured_message());
 }
 
 pub fn ensure_codex_account_guest_support(target: &SshTarget) -> Result<()> {
@@ -2478,14 +2537,26 @@ fn read_codex_plugin_state(target: &SshTarget) -> Option<toml::Table> {
     }
 }
 
-/// Extract the `marketplaces` and `plugins` tables from a guest
-/// `config.toml`. These hold the Codex CLI's installed marketplace
-/// registrations (`[marketplaces.*]`) and per-plugin enabled state
-/// (`[plugins.*]`); coop preserves them verbatim when it rewrites
-/// config.toml so a stop/start does not wipe installed plugins. Returns
-/// `Ok(None)` when the input is empty or carries neither table, and `Err`
-/// when it is present but not valid TOML — so the caller can warn rather than
-/// silently dropping the tables.
+/// Guest-owned tables in `~/.codex/config.toml` that coop carries across its
+/// own rewrite of that file.
+///
+/// `marketplaces`/`plugins` are the Codex CLI's installed marketplace
+/// registrations and per-plugin enabled state. `projects` holds its
+/// per-directory `trust_level` records — without it a user re-approves
+/// workspace trust after every `coop stop`/`coop start`, which
+/// `auth = "chatgpt"` would otherwise make the norm by forcing a rewrite on
+/// every boot.
+///
+/// Deliberately *not* here: `model` / `model_provider`. Local-model routing
+/// and proxy mode overwrite those on purpose, so preserving the guest's copy
+/// would fight `coop model`.
+const CODEX_PRESERVED_GUEST_TABLES: &[&str] = &["marketplaces", "plugins", "projects"];
+
+/// Extract the guest-owned tables listed in [`CODEX_PRESERVED_GUEST_TABLES`]
+/// from a guest `config.toml`, so coop can write them back verbatim when it
+/// rewrites the file. Returns `Ok(None)` when the input is empty or carries
+/// none of them, and `Err` when it is present but not valid TOML — so the
+/// caller can warn rather than silently dropping the tables.
 fn extract_codex_plugin_state(config_toml: &str) -> Result<Option<toml::Table>> {
     let parsed = toml::from_str::<TomlValue>(config_toml)
         .context("guest ~/.codex/config.toml is not valid TOML")?;
@@ -2493,9 +2564,9 @@ fn extract_codex_plugin_state(config_toml: &str) -> Result<Option<toml::Table>> 
         return Ok(None);
     };
     let mut preserved = toml::Table::new();
-    for key in ["marketplaces", "plugins"] {
-        if let Some(value) = table.get(key) {
-            preserved.insert(key.to_string(), value.clone());
+    for key in CODEX_PRESERVED_GUEST_TABLES {
+        if let Some(value) = table.get(*key) {
+            preserved.insert((*key).to_string(), value.clone());
         }
     }
     Ok((!preserved.is_empty()).then_some(preserved))
@@ -2696,14 +2767,22 @@ fn stage_codex_files(
         }
     }
 
-    if auth.uses_chatgpt_account() {
+    {
         let TomlValue::Table(root) = &mut config else {
             bail!("Codex {CODEX_CONFIG_FILE} must deserialize to a TOML table");
         };
-        root.insert(
-            "cli_auth_credentials_store".to_string(),
-            TomlValue::String("keyring".to_string()),
-        );
+        if auth.uses_chatgpt_account() {
+            root.insert(
+                "cli_auth_credentials_store".to_string(),
+                TomlValue::String("keyring".to_string()),
+            );
+        } else {
+            // Explicit, not incidental: the host's own config.toml may set
+            // this (the user may use keyring storage on the host too), and
+            // copying it into an `api_key` guest would make the wrapper
+            // demand a keyring password that mode does not need.
+            root.remove("cli_auth_credentials_store");
+        }
     }
 
     // The Codex CLI records installed marketplaces under `[marketplaces.*]`
@@ -2718,8 +2797,9 @@ fn stage_codex_files(
         let TomlValue::Table(root) = &mut config else {
             bail!("Codex {CODEX_CONFIG_FILE} must deserialize to a TOML table");
         };
-        root.remove("marketplaces");
-        root.remove("plugins");
+        for key in CODEX_PRESERVED_GUEST_TABLES {
+            root.remove(*key);
+        }
         if let Some(preserved) = preserved {
             for (key, value) in preserved {
                 root.insert(key.clone(), value.clone());
@@ -4009,6 +4089,107 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
     }
 
     #[test]
+    fn stage_codex_files_drops_a_host_supplied_keyring_store_in_api_key_mode() {
+        // A user may use keyring storage on their *host* Codex too. Copying
+        // that key into an `api_key` guest would make the wrapper demand a
+        // keyring password the mode does not need, so the api_key path must
+        // remove it rather than merely not add it.
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("config.toml"),
+            "cli_auth_credentials_store = \"keyring\"\nmodel = \"gpt-5\"\n",
+        )
+        .unwrap();
+
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            None,
+            false,
+            CodexAuthMode::ApiKey,
+            false,
+        )
+        .unwrap();
+
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert!(
+            !config.contains("cli_auth_credentials_store"),
+            "api_key mode must drop a host-supplied keyring store, got: {config:?}",
+        );
+        assert!(
+            config.contains("gpt-5"),
+            "the rest of the host config must survive, got: {config:?}",
+        );
+    }
+
+    #[test]
+    fn extract_codex_plugin_state_preserves_project_trust_records() {
+        // Codex writes `[projects."<dir>"] trust_level` when the user approves
+        // a workspace. ChatGPT mode rewrites config.toml on every boot, so
+        // without this the user re-approves trust after every restart.
+        let guest = r#"
+model = "gpt-5"
+
+[projects."/workspace"]
+trust_level = "trusted"
+
+[marketplaces.acme]
+url = "https://example.com/m"
+"#;
+        let preserved = extract_codex_plugin_state(guest).unwrap().unwrap();
+        assert!(
+            preserved.contains_key("projects"),
+            "project trust records must survive coop's rewrite: {preserved:?}",
+        );
+        assert!(preserved.contains_key("marketplaces"));
+        assert!(
+            !preserved.contains_key("model"),
+            "model is coop-managed (local/proxy routing overwrite it) and must not be preserved",
+        );
+    }
+
+    #[test]
+    fn stage_codex_files_drops_host_projects_but_keeps_guest_ones() {
+        // Host-side Codex state must not leak into the guest, but the guest's
+        // own trust records must come back — the same rule the marketplaces
+        // and plugins tables already follow.
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("config.toml"),
+            "[projects.\"/host/secret\"]\ntrust_level = \"trusted\"\n",
+        )
+        .unwrap();
+        let mut preserved = toml::Table::new();
+        let guest_projects =
+            toml::from_str::<toml::Table>("[\"/workspace\"]\ntrust_level = \"trusted\"\n").unwrap();
+        preserved.insert("projects".to_string(), toml::Value::Table(guest_projects));
+
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            Some(&preserved),
+            false,
+            CodexAuthMode::ApiKey,
+            false,
+        )
+        .unwrap();
+
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert!(
+            config.contains("/workspace"),
+            "the guest's own trust records must be written back: {config:?}",
+        );
+        assert!(
+            !config.contains("/host/secret"),
+            "host-side Codex project state must not reach the guest: {config:?}",
+        );
+    }
+
+    #[test]
     fn codex_config_needs_rewrite_on_switch_away_from_chatgpt() {
         // The gate that lets the rewrite above happen at all: with no source,
         // no MCP servers, no local model and `api_key` auth, only the
@@ -4322,6 +4503,21 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         assert!(msg.contains("--no-agents"));
         assert!(msg.contains("--no-claude"));
         assert!(msg.contains("coop setup --rebuild"));
+    }
+
+    #[test]
+    fn codex_keyring_not_configured_message_names_the_recovery() {
+        // This fires when the guest never got the keyring setting, so the
+        // message has to name the step that writes it — otherwise the user is
+        // told only that something is wrong.
+        let msg = codex_keyring_not_configured_message();
+        assert!(msg.contains("cli_auth_credentials_store") || msg.contains("keyring"));
+        assert!(msg.contains("coop start"));
+        assert!(msg.contains("--no-agents"));
+        assert!(
+            msg.contains("auth.json"),
+            "the consequence — a plaintext token — is the reason to act",
+        );
     }
 
     #[test]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1616,13 +1616,7 @@ fn bootstrap_codex(
     guest_host: &str,
 ) -> Result<()> {
     let mut model_state = ModelState::load_or_default(inst)?;
-    if cfg.codex.auth.uses_chatgpt_account()
-        && model_state.mode == crate::model_state::ModelMode::Remote
-        && crate::proxy_state::effective_upstream(inst, crate::proxy::Provider::Openai, &cfg.proxy)?
-            .is_some()
-    {
-        bail!("{}", codex_chatgpt_proxy_conflict_message());
-    }
+    ensure_codex_remote_auth_consistent(cfg, inst, &model_state)?;
     // Proxy mode (issue #411): in remote mode with `[proxy.openai]` (or a
     // per-VM override) configured, start the host-side injecting proxy and
     // point Codex at it. The guest holds only the capability token; the real
@@ -1727,6 +1721,25 @@ pub fn codex_chatgpt_proxy_conflict_message() -> &'static str {
     "codex.auth = \"chatgpt\" conflicts with the effective OpenAI proxy for \
      this VM; Codex account auth uses ChatGPT workspace credentials, while \
      the OpenAI proxy uses an API key"
+}
+
+/// Reject the one Codex remote-auth combination `CoopConfig::validate` cannot
+/// see: a per-VM `coop proxy` override that pairs an `OpenAI` upstream with
+/// `codex.auth = "chatgpt"`. Every Codex entry point calls this so the failure
+/// lands on Codex rather than on the whole session.
+pub fn ensure_codex_remote_auth_consistent(
+    cfg: &CoopConfig,
+    inst: &crate::config::Instance,
+    model_state: &ModelState,
+) -> Result<()> {
+    if cfg.codex.auth.uses_chatgpt_account()
+        && model_state.mode == crate::model_state::ModelMode::Remote
+        && crate::proxy_state::effective_upstream(inst, crate::proxy::Provider::Openai, &cfg.proxy)?
+            .is_some()
+    {
+        bail!("{}", codex_chatgpt_proxy_conflict_message());
+    }
+    Ok(())
 }
 
 pub fn ensure_codex_account_guest_support(target: &SshTarget) -> Result<()> {
@@ -2543,14 +2556,14 @@ fn stage_allowed_files(source_dir: &Path) -> Result<tempfile::TempDir> {
 }
 
 /// Allowlisted files copied verbatim from the host Codex config dir. In proxy
-/// mode or ChatGPT account-auth mode `auth.json` is dropped (see
+/// mode or `ChatGPT` account-auth mode `auth.json` is dropped (see
 /// [`codex_allowed_files`]) so refreshable account tokens do not land on the
 /// guest disk through a host-file copy.
 const CODEX_ALLOWED_FILES: &[&str] = &["AGENTS.md", "auth.json"];
 
 /// The Codex allowlist for this boot. In proxy mode `~/.codex/auth.json` is
 /// dropped because Codex authenticates to the proxy with a capability token.
-/// In ChatGPT account-auth mode it is dropped because Codex must use the guest
+/// In `ChatGPT` account-auth mode it is dropped because Codex must use the guest
 /// keyring instead of a host-copied file.
 fn codex_allowed_files(proxy_active: bool, auth: CodexAuthMode) -> Vec<&'static str> {
     if proxy_active || auth.uses_chatgpt_account() {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -12,8 +12,8 @@ use toml::Value as TomlValue;
 
 use crate::cmd::Cmd;
 use crate::config::{
-    ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, LocalModel, McpServerDef,
-    NetworkConfig, VmMemory,
+    CodexAuthMode, ConfigDir, CoopConfig, GitHubAuth, ImageName, Instance, LocalModel,
+    McpServerDef, NetworkConfig, VmMemory,
 };
 use crate::model_state::ModelState;
 use crate::paths::{GuestPath, HostPath};
@@ -1361,6 +1361,17 @@ pub fn prepare_env_forwarding(
 ) -> Result<EnvForward> {
     let claude = &cfg.claude;
     let codex = &cfg.codex;
+    let codex_account_auth = codex.auth.uses_chatgpt_account();
+    let suppress_openai_key = suppress_openai_key || codex_account_auth;
+    let openai_suppression_reason = if suppress_openai_key {
+        if codex_account_auth {
+            "codex.auth = \"chatgpt\""
+        } else {
+            "proxy mode"
+        }
+    } else {
+        ""
+    };
     let mut env = EnvForward::default();
 
     // ANTHROPIC_API_KEY: prefer config, fall back to process env.
@@ -1379,9 +1390,13 @@ pub fn prepare_env_forwarding(
 
     // OPENAI_API_KEY: prefer config, fall back to process env. In proxy mode
     // the raw key stays on the host (injected upstream); Codex authenticates
-    // to the proxy with the capability token via the provider `env_key`.
+    // to the proxy with the capability token via the provider `env_key`. In
+    // ChatGPT account mode, forwarding is suppressed so Codex cannot silently
+    // switch to API billing.
     if suppress_openai_key {
-        tracing::debug!("proxy mode: not forwarding OPENAI_API_KEY into the guest");
+        tracing::debug!(
+            "{openai_suppression_reason}: not forwarding OPENAI_API_KEY into the guest"
+        );
     } else if let Some(key) = &codex.api_key {
         let resolved = crate::config::resolve_cmd_value(key.expose())
             .context("Failed to resolve codex.api_key")?;
@@ -1408,13 +1423,19 @@ pub fn prepare_env_forwarding(
     if suppress_openai_key {
         suppressed.push("OPENAI_API_KEY");
     }
+    let suppression_reason = |name: &str| {
+        if name == "OPENAI_API_KEY" {
+            openai_suppression_reason
+        } else {
+            "proxy mode"
+        }
+    };
 
     // User-specified env_forward vars from process environment
     for name in claude.env_forward.iter().chain(codex.env_forward.iter()) {
         if suppressed.contains(&name.as_str()) {
-            tracing::warn!(
-                "proxy mode: ignoring env_forward entry '{name}' — the raw key stays on the host"
-            );
+            let reason = suppression_reason(name.as_str());
+            tracing::warn!("{reason}: ignoring env_forward entry '{name}'");
             continue;
         }
         if !env.contains(name.as_str())
@@ -1430,9 +1451,8 @@ pub fn prepare_env_forwarding(
     // values are not logged (they may be secrets).
     for (name, value) in &cfg.guest_env {
         if suppressed.contains(&name.as_str()) {
-            tracing::warn!(
-                "proxy mode: ignoring guest_env entry '{name}' — the raw key stays on the host"
-            );
+            let reason = suppression_reason(name.as_str());
+            tracing::warn!("{reason}: ignoring guest_env entry '{name}'");
             continue;
         }
         if env.contains(name.as_str()) {
@@ -1596,6 +1616,13 @@ fn bootstrap_codex(
     guest_host: &str,
 ) -> Result<()> {
     let mut model_state = ModelState::load_or_default(inst)?;
+    if cfg.codex.auth.uses_chatgpt_account()
+        && model_state.mode == crate::model_state::ModelMode::Remote
+        && crate::proxy_state::effective_upstream(inst, crate::proxy::Provider::Openai, &cfg.proxy)?
+            .is_some()
+    {
+        bail!("{}", codex_chatgpt_proxy_conflict_message());
+    }
     // Proxy mode (issue #411): in remote mode with `[proxy.openai]` (or a
     // per-VM override) configured, start the host-side injecting proxy and
     // point Codex at it. The guest holds only the capability token; the real
@@ -1622,12 +1649,19 @@ fn bootstrap_codex(
             || model_state.resolved_codex(codex).is_some()
             || model_state.codex_materialized;
         let has_plugins = !codex.marketplaces.is_empty() || !codex.plugins.is_empty();
-        let needs_codex =
-            codex_bootstrap_needed(source_dir.as_deref(), &codex.mcp_servers, has_plugins)
-                || manages_local;
+        let needs_codex = codex_bootstrap_needed(
+            source_dir.as_deref(),
+            &codex.mcp_servers,
+            has_plugins,
+            codex.auth,
+        ) || manages_local;
 
         if !needs_codex {
             return Ok(());
+        }
+
+        if codex.auth.uses_chatgpt_account() {
+            ensure_codex_account_guest_support(&session.target)?;
         }
 
         if !session.target.exec_ok(
@@ -1687,6 +1721,35 @@ fn codex_missing_guest_cli_message() -> &'static str {
      If you want to skip Codex bootstrap for now, retry with \
      `--no-agents` (the `--no-claude` alias is deprecated).\n\
      Otherwise run `coop setup --rebuild` to rebuild the image."
+}
+
+pub fn codex_chatgpt_proxy_conflict_message() -> &'static str {
+    "codex.auth = \"chatgpt\" conflicts with the effective OpenAI proxy for \
+     this VM; Codex account auth uses ChatGPT workspace credentials, while \
+     the OpenAI proxy uses an API key"
+}
+
+pub fn ensure_codex_account_guest_support(target: &SshTarget) -> Result<()> {
+    let supported = target.exec_ok(
+        RemoteCommand::new()
+            .literal("test -x ")
+            .arg(crate::guest::codex_account_bin())
+            .literal(" && command -v dbus-run-session >/dev/null 2>&1")
+            .literal(" && command -v gnome-keyring-daemon >/dev/null 2>&1")
+            .literal(" && command -v secret-tool >/dev/null 2>&1"),
+    );
+    if supported {
+        return Ok(());
+    }
+
+    bail!(
+        "Codex ChatGPT account auth requires guest Secret Service support, \
+         but this VM image does not have it.\n\
+         Rebuild the image with `coop setup --rebuild` (or \
+         `coop setup --image <name> --rebuild` for a named image), then \
+         recreate or restart the VM. For an existing guest disk, install \
+         `dbus-user-session`, `gnome-keyring`, and `libsecret-tools` manually."
+    );
 }
 
 /// Load the persisted guest user for an image, falling back to the
@@ -2314,12 +2377,17 @@ fn copy_codex_config(
     // that file, so read the guest config only when a rewrite will actually
     // happen — otherwise the file is left untouched and its state survives on
     // its own (and we skip a needless SSH round-trip).
-    let preserved =
-        if codex_config_needs_rewrite(source_dir, &codex.mcp_servers, local, manages_local) {
-            read_codex_plugin_state(target)
-        } else {
-            None
-        };
+    let preserved = if codex_config_needs_rewrite(
+        source_dir,
+        &codex.mcp_servers,
+        local,
+        manages_local,
+        codex.auth,
+    ) {
+        read_codex_plugin_state(target)
+    } else {
+        None
+    };
 
     let staged = stage_codex_files(
         source_dir,
@@ -2328,6 +2396,7 @@ fn copy_codex_config(
         manages_local,
         preserved.as_ref(),
         proxy_active,
+        codex.auth,
     )
     .context("Failed to stage Codex config files")?;
     copy_staged_to_guest(target, &staged, ".codex", "Codex")
@@ -2474,15 +2543,17 @@ fn stage_allowed_files(source_dir: &Path) -> Result<tempfile::TempDir> {
 }
 
 /// Allowlisted files copied verbatim from the host Codex config dir. In proxy
-/// mode `auth.json` is dropped (see [`codex_allowed_files`]) — the refreshable
-/// subscription token must not land on the guest disk (issue #411 §7).
+/// mode or ChatGPT account-auth mode `auth.json` is dropped (see
+/// [`codex_allowed_files`]) so refreshable account tokens do not land on the
+/// guest disk through a host-file copy.
 const CODEX_ALLOWED_FILES: &[&str] = &["AGENTS.md", "auth.json"];
 
 /// The Codex allowlist for this boot. In proxy mode `~/.codex/auth.json` is
-/// dropped so the at-rest `OpenAI` subscription token never reaches the guest;
-/// Codex authenticates to the proxy with the capability token instead.
-fn codex_allowed_files(proxy_active: bool) -> Vec<&'static str> {
-    if proxy_active {
+/// dropped because Codex authenticates to the proxy with a capability token.
+/// In ChatGPT account-auth mode it is dropped because Codex must use the guest
+/// keyring instead of a host-copied file.
+fn codex_allowed_files(proxy_active: bool, auth: CodexAuthMode) -> Vec<&'static str> {
+    if proxy_active || auth.uses_chatgpt_account() {
         CODEX_ALLOWED_FILES
             .iter()
             .copied()
@@ -2509,11 +2580,13 @@ fn codex_config_needs_rewrite(
     mcp_servers: &std::collections::HashMap<String, McpServerDef>,
     local: Option<&toml::Table>,
     manages_local: bool,
+    auth: CodexAuthMode,
 ) -> bool {
     source_dir.is_some_and(|path| path.join(CODEX_CONFIG_FILE).is_file())
         || !mcp_servers.is_empty()
         || local.is_some()
         || manages_local
+        || auth.uses_chatgpt_account()
 }
 
 fn stage_codex_files(
@@ -2523,9 +2596,10 @@ fn stage_codex_files(
     manages_local: bool,
     preserved: Option<&toml::Table>,
     proxy_active: bool,
+    auth: CodexAuthMode,
 ) -> Result<tempfile::TempDir> {
     let staging = tempfile::TempDir::new().context("Failed to create staging directory")?;
-    let allowed_files = codex_allowed_files(proxy_active);
+    let allowed_files = codex_allowed_files(proxy_active, auth);
 
     let mut config = match source_dir {
         Some(path) => {
@@ -2574,6 +2648,16 @@ fn stage_codex_files(
         }
     }
 
+    if auth.uses_chatgpt_account() {
+        let TomlValue::Table(root) = &mut config else {
+            bail!("Codex {CODEX_CONFIG_FILE} must deserialize to a TOML table");
+        };
+        root.insert(
+            "cli_auth_credentials_store".to_string(),
+            TomlValue::String("keyring".to_string()),
+        );
+    }
+
     // The Codex CLI records installed marketplaces under `[marketplaces.*]`
     // and per-plugin enabled state under `[plugins.*]` in config.toml. Since
     // this rewrite would otherwise clobber them on every stop/start, drop any
@@ -2603,7 +2687,7 @@ fn stage_codex_files(
     // with the gate in `copy_codex_config` that decides whether to read the
     // guest config at all — hence the shared predicate.
     let should_write_config =
-        codex_config_needs_rewrite(source_dir, mcp_servers, local, manages_local);
+        codex_config_needs_rewrite(source_dir, mcp_servers, local, manages_local, auth);
 
     if should_write_config {
         std::fs::write(
@@ -2629,8 +2713,12 @@ fn codex_bootstrap_needed(
     source_dir: Option<&Path>,
     mcp_servers: &std::collections::HashMap<String, McpServerDef>,
     has_plugins: bool,
+    auth: CodexAuthMode,
 ) -> bool {
-    codex_source_has_bootstrap_content(source_dir) || !mcp_servers.is_empty() || has_plugins
+    codex_source_has_bootstrap_content(source_dir)
+        || !mcp_servers.is_empty()
+        || has_plugins
+        || auth.uses_chatgpt_account()
 }
 
 fn resolve_codex_mcp_servers(
@@ -3682,8 +3770,16 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             },
         );
 
-        let staging =
-            stage_codex_files(Some(src.path()), &servers, None, false, None, false).unwrap();
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &servers,
+            None,
+            false,
+            None,
+            false,
+            CodexAuthMode::ApiKey,
+        )
+        .unwrap();
         assert!(staging.path().join("AGENTS.md").is_file());
 
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3713,8 +3809,16 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             },
         );
 
-        let staging =
-            stage_codex_files(Some(src.path()), &servers, None, false, None, false).unwrap();
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &servers,
+            None,
+            false,
+            None,
+            false,
+            CodexAuthMode::ApiKey,
+        )
+        .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
 
         assert!(config.contains("model = \"gpt-5\""));
@@ -3737,6 +3841,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             false,
             None,
             false,
+            CodexAuthMode::ApiKey,
         )
         .unwrap();
         assert_eq!(
@@ -3760,6 +3865,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             false,
             None,
             true,
+            CodexAuthMode::ApiKey,
         )
         .unwrap();
         assert!(
@@ -3768,6 +3874,47 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         );
         // Other allowlisted files are unaffected.
         assert!(staging.path().join("AGENTS.md").is_file());
+    }
+
+    #[test]
+    fn stage_codex_files_drops_auth_json_in_chatgpt_mode() {
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(src.path().join("auth.json"), "{\"access_token\":\"test\"}").unwrap();
+
+        let staging = stage_codex_files(
+            Some(src.path()),
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            None,
+            false,
+            CodexAuthMode::ChatGpt,
+        )
+        .unwrap();
+
+        assert!(
+            !staging.path().join("auth.json").exists(),
+            "ChatGPT account auth must store credentials in keyring, not auth.json"
+        );
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert!(config.contains("cli_auth_credentials_store = \"keyring\""));
+    }
+
+    #[test]
+    fn stage_codex_files_chatgpt_mode_writes_config_without_source() {
+        let staging = stage_codex_files(
+            None,
+            &std::collections::HashMap::new(),
+            None,
+            false,
+            None,
+            false,
+            CodexAuthMode::ChatGpt,
+        )
+        .unwrap();
+
+        let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
+        assert_eq!(config.trim(), "cli_auth_credentials_store = \"keyring\"");
     }
 
     #[test]
@@ -3785,6 +3932,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             true,
             None,
             false,
+            CodexAuthMode::ApiKey,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3806,6 +3954,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             true,
             None,
             false,
+            CodexAuthMode::ApiKey,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3827,6 +3976,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             true,
             None,
             false,
+            CodexAuthMode::ApiKey,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3842,12 +3992,14 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         assert!(!codex_bootstrap_needed(
             Some(src.path()),
             &std::collections::HashMap::new(),
-            false
+            false,
+            CodexAuthMode::ApiKey,
         ));
         assert!(!codex_bootstrap_needed(
             None,
             &std::collections::HashMap::new(),
-            false
+            false,
+            CodexAuthMode::ApiKey,
         ));
     }
 
@@ -3859,7 +4011,8 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         assert!(codex_bootstrap_needed(
             Some(src.path()),
             &std::collections::HashMap::new(),
-            false
+            false,
+            CodexAuthMode::ApiKey,
         ));
     }
 
@@ -3870,7 +4023,18 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         assert!(codex_bootstrap_needed(
             None,
             &std::collections::HashMap::new(),
-            true
+            true,
+            CodexAuthMode::ApiKey,
+        ));
+    }
+
+    #[test]
+    fn codex_bootstrap_needed_is_true_in_chatgpt_mode() {
+        assert!(codex_bootstrap_needed(
+            None,
+            &std::collections::HashMap::new(),
+            false,
+            CodexAuthMode::ChatGpt,
         ));
     }
 
@@ -3924,6 +4088,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             false,
             Some(&preserved),
             false,
+            CodexAuthMode::ApiKey,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -3958,6 +4123,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
             false,
             None,
             false,
+            CodexAuthMode::ApiKey,
         )
         .unwrap();
         let config = std::fs::read_to_string(staging.path().join("config.toml")).unwrap();
@@ -4309,6 +4475,20 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
         );
     }
 
+    #[test]
+    fn chatgpt_account_auth_suppresses_openai_key_forwarding() {
+        let mut cfg = CoopConfig::default();
+        cfg.codex.auth = CodexAuthMode::ChatGpt;
+        cfg.codex.api_key = Some(crate::config::Secret::new("sk-openai-realkey".to_string()));
+        cfg.github = None;
+
+        let env = prepare_env_forwarding(&cfg, None, false, false).unwrap();
+        assert!(
+            !env.contains("OPENAI_API_KEY"),
+            "ChatGPT account auth must not forward an OpenAI API key"
+        );
+    }
+
     // ── guest_env merge precedence ──────────────────────────
 
     /// Build a `CoopConfig` whose env-resolving inputs are all empty
@@ -4404,6 +4584,18 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
                 .get("OPENAI_API_KEY")
                 .map(String::as_str),
             Some("sk-openai-realkey")
+        );
+    }
+
+    #[test]
+    fn chatgpt_account_auth_suppresses_openai_key_from_guest_env() {
+        let mut cfg = cfg_with_guest_env(&[("OPENAI_API_KEY", "sk-openai-realkey")]);
+        cfg.codex.auth = CodexAuthMode::ChatGpt;
+
+        let env = prepare_env_forwarding(&cfg, None, false, false).unwrap();
+        assert!(
+            !env.contains("OPENAI_API_KEY"),
+            "guest_env must not re-inject an OpenAI API key in ChatGPT account mode"
         );
     }
 

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1640,9 +1640,12 @@ pub(crate) fn prepare_session_from_target(
     let suppress_openai_key = proxy_openai || codex_account_auth;
     // A per-VM proxy override can pair an OpenAI upstream with ChatGPT account
     // auth even though `CoopConfig::validate` rejects that combination in the
-    // config file. Only Codex is unusable then, so warn here and let the
-    // Codex entry points (`coop codex`, agent bootstrap) fail hard — a shell,
-    // exec, or `coop claude` session on the same VM is unaffected.
+    // config file. Warn here so the reason is visible on every session, and
+    // let the Codex entry points fail hard via
+    // `ensure_codex_remote_auth_consistent`. Note that agent bootstrap is one
+    // of those entry points, so `coop start` on such a VM aborts too — only
+    // `--no-agents` brings it up, and then shell/exec/`coop claude` work
+    // normally while Codex does not.
     if codex_account_auth && proxy_openai {
         tracing::warn!("{}", backend::codex_chatgpt_proxy_conflict_message());
     }

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1441,14 +1441,25 @@ pub(crate) fn prepend_binary(binary: &str, args: Vec<String>) -> Vec<String> {
 /// Codex's flag for running fully unrestricted (no sandbox, no approvals).
 const CODEX_BYPASS_FLAG: &str = "--dangerously-bypass-approvals-and-sandbox";
 
+/// Codex subcommands that manage credentials rather than start an agent
+/// session. They reject the sandbox-bypass flag, so it must not be prepended.
+const CODEX_AUTH_SUBCOMMANDS: &[&str] = &["login", "logout"];
+
 /// Prepend Codex's sandbox-bypass flag unless the user opted into approvals.
 ///
 /// The VM is the isolation boundary, so Codex's own sandbox is redundant — and
 /// broken in the guest, which lacks a working bubblewrap. Bypassing by default
 /// gives `coop codex` parity with `coop claude`'s `bypassPermissions`. `ask`
 /// (from `--ask`) keeps Codex's sandbox and approval prompts.
+///
+/// `codex login` / `codex logout` never start a session, and Codex rejects the
+/// bypass flag on them, so they are launched bare regardless of `ask` — this is
+/// what makes `coop codex -- login --device-auth` work without `--ask`.
 pub(crate) fn codex_launch_args(ask: bool, mut args: Vec<String>) -> Vec<String> {
-    if !ask {
+    let is_auth_subcommand = args
+        .first()
+        .is_some_and(|arg| CODEX_AUTH_SUBCOMMANDS.contains(&arg.as_str()));
+    if !ask && !is_auth_subcommand {
         args.insert(0, CODEX_BYPASS_FLAG.to_string());
     }
     args
@@ -1586,8 +1597,13 @@ pub(crate) fn prepare_session_from_target(
     };
     let codex_account_auth = cfg.codex.auth.uses_chatgpt_account();
     let suppress_openai_key = proxy_openai || codex_account_auth;
+    // A per-VM proxy override can pair an OpenAI upstream with ChatGPT account
+    // auth even though `CoopConfig::validate` rejects that combination in the
+    // config file. Only Codex is unusable then, so warn here and let the
+    // Codex entry points (`coop codex`, agent bootstrap) fail hard — a shell,
+    // exec, or `coop claude` session on the same VM is unaffected.
     if codex_account_auth && proxy_openai {
-        bail!("{}", backend::codex_chatgpt_proxy_conflict_message());
+        tracing::warn!("{}", backend::codex_chatgpt_proxy_conflict_message());
     }
 
     let mut env = backend::prepare_env_forwarding(cfg, repo, proxy_anthropic, suppress_openai_key)?;
@@ -2068,6 +2084,33 @@ mod tests {
     }
 
     #[test]
+    fn codex_launch_args_leaves_auth_subcommands_bare() {
+        // `coop codex -- login --device-auth` is the ChatGPT account sign-in
+        // path; Codex rejects the bypass flag on it, so `--ask` must not be
+        // required to get a working invocation.
+        for subcommand in ["login", "logout"] {
+            let args =
+                super::codex_launch_args(false, vec![subcommand.into(), "--device-auth".into()]);
+            assert_eq!(args, vec![subcommand, "--device-auth"]);
+        }
+    }
+
+    #[test]
+    fn codex_launch_args_still_bypasses_when_login_is_not_first() {
+        // Only the leading token selects a subcommand — a `login` appearing
+        // as a value must not disarm the bypass flag.
+        let args = super::codex_launch_args(false, vec!["--model".into(), "login".into()]);
+        assert_eq!(
+            args,
+            vec![
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--model",
+                "login"
+            ]
+        );
+    }
+
+    #[test]
     fn codex_launch_args_with_ask_keeps_sandbox() {
         let args = super::codex_launch_args(true, vec!["--model".into(), "gpt-5".into()]);
         assert_eq!(args, vec!["--model", "gpt-5"]);
@@ -2251,7 +2294,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_session_rejects_chatgpt_auth_with_openai_proxy() {
+    fn prepare_session_survives_chatgpt_auth_with_openai_proxy() {
         use std::num::NonZeroU16;
 
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -2277,11 +2320,16 @@ mod tests {
             key_path: tmp.path().join("id_test"),
         };
 
-        let err = super::prepare_session_from_target(&cfg, Some(&inst), target, None).unwrap_err();
+        // The conflict makes Codex unusable, not the VM: a shell/exec/claude
+        // session on the same instance must still come up. `coop codex` and
+        // the agent bootstrap are what fail hard, via
+        // `backend::ensure_codex_remote_auth_consistent`.
+        let session = super::prepare_session_from_target(&cfg, Some(&inst), target, None)
+            .expect("session must still be usable for non-Codex commands");
 
         assert!(
-            err.to_string().contains("effective OpenAI proxy"),
-            "expected ChatGPT/proxy conflict, got: {err}",
+            !session.env.as_envs().contains_key("OPENAI_API_KEY"),
+            "the raw key must stay on the host in both suppression modes",
         );
     }
 

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1442,7 +1442,7 @@ pub(crate) fn prepend_binary(binary: &str, args: Vec<String>) -> Vec<String> {
 const CODEX_BYPASS_FLAG: &str = "--dangerously-bypass-approvals-and-sandbox";
 
 /// Codex subcommands that manage credentials rather than start an agent
-/// session. They reject the sandbox-bypass flag, so it must not be prepended.
+/// session, so the sandbox-bypass flag is meaningless on them.
 const CODEX_AUTH_SUBCOMMANDS: &[&str] = &["login", "logout"];
 
 /// Prepend Codex's sandbox-bypass flag unless the user opted into approvals.
@@ -1452,9 +1452,12 @@ const CODEX_AUTH_SUBCOMMANDS: &[&str] = &["login", "logout"];
 /// gives `coop codex` parity with `coop claude`'s `bypassPermissions`. `ask`
 /// (from `--ask`) keeps Codex's sandbox and approval prompts.
 ///
-/// `codex login` / `codex logout` never start a session, and Codex rejects the
-/// bypass flag on them, so they are launched bare regardless of `ask` — this is
-/// what makes `coop codex -- login --device-auth` work without `--ask`.
+/// `codex login` / `codex logout` never start a session, so there is nothing
+/// to sandbox and the flag is dropped regardless of `ask`. Codex does accept it
+/// in the position this builds (root-level, before the subcommand); leaving it
+/// off keeps the argv for the `ChatGPT` sign-in path free of a flag that says
+/// nothing about it. Either way `coop codex -- login --device-auth` works
+/// without `--ask`.
 pub(crate) fn codex_launch_args(ask: bool, mut args: Vec<String>) -> Vec<String> {
     let is_auth_subcommand = args
         .first()
@@ -1533,6 +1536,13 @@ fn bootstrap_and_post_start(
              agents will not be able to authenticate in this VM"
         );
     }
+    if no_agents_skips_codex_keyring(
+        opts.no_agents,
+        cfg.codex.auth,
+        model_state::ModelState::load_or_default(inst)?.codex_keyring_materialized,
+    ) {
+        tracing::warn!("{}", NO_AGENTS_CHATGPT_WARNING);
+    }
     if opts.no_agents && post_start.is_none() {
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
         return Ok(());
@@ -1564,6 +1574,30 @@ fn bootstrap_and_post_start(
         backend::run_post_start(&session, cmd);
     }
     Ok(())
+}
+
+/// Warning for `--no-agents` on a VM that wants Codex `ChatGPT` account auth.
+pub(crate) const NO_AGENTS_CHATGPT_WARNING: &str = "codex.auth = \"chatgpt\" is configured but --no-agents skips agent bootstrap; \
+     the guest keyring credential store will not be set up, so `coop codex -- login` \
+     would store credentials in a plaintext ~/.codex/auth.json in the guest";
+
+/// Whether `--no-agents` leaves this VM's Codex writing plaintext credentials.
+///
+/// `cli_auth_credentials_store = "keyring"` is written during agent bootstrap,
+/// which `--no-agents` skips; without it the guest wrapper takes its
+/// passthrough branch and `codex login` writes `~/.codex/auth.json` in the
+/// clear instead of using the guest Secret Service — the one thing this mode
+/// exists to avoid.
+///
+/// `keyring_materialized` is what keeps this from crying wolf on a restart: the
+/// guest config lives on the guest disk and survives stop/start, so once an
+/// earlier boot has written the key, skipping bootstrap changes nothing.
+pub(crate) fn no_agents_skips_codex_keyring(
+    no_agents: bool,
+    auth: config::CodexAuthMode,
+    keyring_materialized: bool,
+) -> bool {
+    no_agents && auth.uses_chatgpt_account() && !keyring_materialized
 }
 
 pub(crate) fn prepare_session_from_target(
@@ -1610,9 +1644,12 @@ pub(crate) fn prepare_session_from_target(
     if let Some(inst) = inst {
         if let Some(state) = guest_env_state::GuestEnvState::try_load(inst)? {
             for (name, value) in &state.entries {
-                // In proxy mode a raw provider key snapshotted via `coop start
-                // --env` must not re-enter the guest — the host-side proxy
-                // holds it. Skip and warn, matching `prepare_env_forwarding`.
+                // A raw provider key snapshotted via `coop start --env` must
+                // not re-enter the guest under either suppression mode: in
+                // proxy mode the host-side proxy holds it, and under
+                // `codex.auth = "chatgpt"` forwarding it would let Codex
+                // silently fall back to API billing. Skip and warn, matching
+                // `prepare_env_forwarding`.
                 if (proxy_anthropic && name.as_str() == "ANTHROPIC_API_KEY")
                     || (suppress_openai_key && name.as_str() == "OPENAI_API_KEY")
                 {
@@ -2084,10 +2121,33 @@ mod tests {
     }
 
     #[test]
+    fn no_agents_warns_only_when_the_guest_keyring_was_never_set_up() {
+        use super::config::CodexAuthMode;
+        use super::no_agents_skips_codex_keyring as warns;
+
+        assert!(
+            warns(true, CodexAuthMode::ChatGpt, false),
+            "--no-agents on a guest that never got the keyring store must warn",
+        );
+        assert!(
+            !warns(false, CodexAuthMode::ChatGpt, false),
+            "a normal start bootstraps the keyring store, so there is nothing to warn about",
+        );
+        assert!(
+            !warns(true, CodexAuthMode::ApiKey, false),
+            "api_key auth does not use the guest keyring at all",
+        );
+        assert!(
+            !warns(true, CodexAuthMode::ChatGpt, true),
+            "an earlier boot already wrote the key; it survives on the guest disk",
+        );
+    }
+
+    #[test]
     fn codex_launch_args_leaves_auth_subcommands_bare() {
         // `coop codex -- login --device-auth` is the ChatGPT account sign-in
-        // path; Codex rejects the bypass flag on it, so `--ask` must not be
-        // required to get a working invocation.
+        // path. Nothing is sandboxed there, so the bypass flag is dropped and
+        // `--ask` is not required to get a working invocation.
         for subcommand in ["login", "logout"] {
             let args =
                 super::codex_launch_args(false, vec![subcommand.into(), "--device-auth".into()]);
@@ -2329,7 +2389,58 @@ mod tests {
 
         assert!(
             !session.env.as_envs().contains_key("OPENAI_API_KEY"),
-            "the raw key must stay on the host in both suppression modes",
+            "proxy mode must keep the raw key on the host",
+        );
+    }
+
+    #[test]
+    fn prepare_session_suppresses_openai_key_for_chatgpt_auth_without_proxy() {
+        use std::num::NonZeroU16;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inst = super::config::Instance {
+            name: super::config::InstanceName::new("test").expect("valid name"),
+            index: super::config::InstanceIndex::new(0).expect("0 is in range"),
+            dir: tmp.path().to_path_buf(),
+            image: super::config::ImageName::new(super::config::DEFAULT_IMAGE)
+                .expect("DEFAULT_IMAGE is valid"),
+        };
+
+        // No `[proxy.openai]`, so ChatGPT account auth is the *only* reason
+        // the key can be absent — unlike
+        // `prepare_session_survives_chatgpt_auth_with_openai_proxy`, where
+        // proxy-mode suppression would satisfy the assertion on its own.
+        let mut cfg = super::config::CoopConfig::default();
+        cfg.codex.auth = super::config::CodexAuthMode::ChatGpt;
+        cfg.codex.api_key = Some(super::config::Secret::new("sk-openai-realkey".to_string()));
+        cfg.github = None;
+        cfg.guest_env.insert(
+            super::guest_env_state::EnvVarName::new("COOP_TEST_PASSTHROUGH").expect("valid name"),
+            "kept".to_string(),
+        );
+        assert!(cfg.proxy.openai.is_none(), "fixture must have no proxy");
+
+        let target = super::backend::SshTarget {
+            host: super::backend::Hostname::new("127.0.0.1").expect("valid host"),
+            port: NonZeroU16::new(22).expect("non-zero"),
+            user: super::backend::SshUser::new("ubuntu").expect("valid user"),
+            key_path: tmp.path().join("id_test"),
+        };
+
+        let session = super::prepare_session_from_target(&cfg, Some(&inst), target, None)
+            .expect("ChatGPT account auth must not break session preparation");
+
+        let envs = session.env.as_envs();
+        assert!(
+            !envs.contains_key("OPENAI_API_KEY"),
+            "ChatGPT account auth must not forward an OpenAI API key",
+        );
+        // Positive control: proves the fixture can produce env at all, so the
+        // assertion above is about suppression and not an inert pipeline.
+        assert_eq!(
+            envs.get("COOP_TEST_PASSTHROUGH").map(String::as_str),
+            Some("kept"),
+            "non-suppressed entries must still flow through",
         );
     }
 

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1584,8 +1584,13 @@ pub(crate) fn prepare_session_from_target(
         ),
         _ => (false, false),
     };
+    let codex_account_auth = cfg.codex.auth.uses_chatgpt_account();
+    let suppress_openai_key = proxy_openai || codex_account_auth;
+    if codex_account_auth && proxy_openai {
+        bail!("{}", backend::codex_chatgpt_proxy_conflict_message());
+    }
 
-    let mut env = backend::prepare_env_forwarding(cfg, repo, proxy_anthropic, proxy_openai)?;
+    let mut env = backend::prepare_env_forwarding(cfg, repo, proxy_anthropic, suppress_openai_key)?;
     if let Some(inst) = inst {
         if let Some(state) = guest_env_state::GuestEnvState::try_load(inst)? {
             for (name, value) in &state.entries {
@@ -1593,12 +1598,14 @@ pub(crate) fn prepare_session_from_target(
                 // --env` must not re-enter the guest — the host-side proxy
                 // holds it. Skip and warn, matching `prepare_env_forwarding`.
                 if (proxy_anthropic && name.as_str() == "ANTHROPIC_API_KEY")
-                    || (proxy_openai && name.as_str() == "OPENAI_API_KEY")
+                    || (suppress_openai_key && name.as_str() == "OPENAI_API_KEY")
                 {
-                    tracing::warn!(
-                        "proxy mode: ignoring runtime --env entry '{}' — the raw key stays on the host",
-                        name.as_str()
-                    );
+                    let reason = if name.as_str() == "OPENAI_API_KEY" && codex_account_auth {
+                        "codex.auth = \"chatgpt\""
+                    } else {
+                        "proxy mode"
+                    };
+                    tracing::warn!("{reason}: ignoring runtime --env entry '{}'", name.as_str());
                     continue;
                 }
                 env.set(name.as_str(), value.as_str());
@@ -2192,6 +2199,89 @@ mod tests {
             envs.get("FROM_CLI").map(String::as_str),
             Some("saved-value"),
             "non-suppressed --env entries must still flow through",
+        );
+    }
+
+    #[test]
+    fn prepare_session_suppresses_persisted_openai_key_for_chatgpt_auth() {
+        use std::num::NonZeroU16;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inst = super::config::Instance {
+            name: super::config::InstanceName::new("test").expect("valid name"),
+            index: super::config::InstanceIndex::new(0).expect("0 is in range"),
+            dir: tmp.path().to_path_buf(),
+            image: super::config::ImageName::new(super::config::DEFAULT_IMAGE)
+                .expect("DEFAULT_IMAGE is valid"),
+        };
+        let mut state = super::guest_env_state::GuestEnvState::default();
+        state.entries.insert(
+            super::guest_env_state::EnvVarName::new("OPENAI_API_KEY").expect("valid env var"),
+            "sk-openai-realkey".to_string(),
+        );
+        state.entries.insert(
+            super::guest_env_state::EnvVarName::new("FROM_CLI").expect("valid env var"),
+            "saved-value".to_string(),
+        );
+        state.save(&inst).expect("save snapshot");
+
+        let mut cfg = super::config::CoopConfig::default();
+        cfg.codex.auth = super::config::CodexAuthMode::ChatGpt;
+
+        let target = super::backend::SshTarget {
+            host: super::backend::Hostname::new("127.0.0.1").expect("valid host"),
+            port: NonZeroU16::new(22).expect("non-zero"),
+            user: super::backend::SshUser::new("ubuntu").expect("valid user"),
+            key_path: tmp.path().join("id_test"),
+        };
+
+        let session =
+            super::prepare_session_from_target(&cfg, Some(&inst), target, None).expect("session");
+
+        let envs = session.env.as_envs();
+        assert!(
+            !envs.contains_key("OPENAI_API_KEY"),
+            "ChatGPT account auth re-injected the raw key from the persisted --env overlay",
+        );
+        assert_eq!(
+            envs.get("FROM_CLI").map(String::as_str),
+            Some("saved-value"),
+            "non-suppressed --env entries must still flow through",
+        );
+    }
+
+    #[test]
+    fn prepare_session_rejects_chatgpt_auth_with_openai_proxy() {
+        use std::num::NonZeroU16;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inst = super::config::Instance {
+            name: super::config::InstanceName::new("test").expect("valid name"),
+            index: super::config::InstanceIndex::new(0).expect("0 is in range"),
+            dir: tmp.path().to_path_buf(),
+            image: super::config::ImageName::new(super::config::DEFAULT_IMAGE)
+                .expect("DEFAULT_IMAGE is valid"),
+        };
+
+        let mut cfg = super::config::CoopConfig::default();
+        cfg.codex.auth = super::config::CodexAuthMode::ChatGpt;
+        cfg.proxy.openai = Some(super::config::ProxyUpstream {
+            credential: super::config::Secret::new("cmd:true".to_string()),
+            auth: super::config::ProxyAuthScheme::Bearer,
+        });
+
+        let target = super::backend::SshTarget {
+            host: super::backend::Hostname::new("127.0.0.1").expect("valid host"),
+            port: NonZeroU16::new(22).expect("non-zero"),
+            user: super::backend::SshUser::new("ubuntu").expect("valid user"),
+            key_path: tmp.path().join("id_test"),
+        };
+
+        let err = super::prepare_session_from_target(&cfg, Some(&inst), target, None).unwrap_err();
+
+        assert!(
+            err.to_string().contains("effective OpenAI proxy"),
+            "expected ChatGPT/proxy conflict, got: {err}",
         );
     }
 

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1536,11 +1536,15 @@ fn bootstrap_and_post_start(
              agents will not be able to authenticate in this VM"
         );
     }
-    if no_agents_skips_codex_keyring(
-        opts.no_agents,
-        cfg.codex.auth,
-        model_state::ModelState::load_or_default(inst)?.codex_keyring_materialized,
-    ) {
+    // A failed read degrades to "not materialized", which at worst warns when
+    // it need not. Aborting `--no-agents` — a path that otherwise never opens
+    // this file — over an unreadable model.json would be the worse trade.
+    if no_agents_skips_codex_keyring(opts.no_agents, cfg.codex.auth, || {
+        model_state::ModelState::try_load(inst)
+            .ok()
+            .flatten()
+            .is_some_and(|state| state.codex_keyring_materialized)
+    }) {
         tracing::warn!("{}", NO_AGENTS_CHATGPT_WARNING);
     }
     if opts.no_agents && post_start.is_none() {
@@ -1592,12 +1596,15 @@ pub(crate) const NO_AGENTS_CHATGPT_WARNING: &str = "codex.auth = \"chatgpt\" is 
 /// `keyring_materialized` is what keeps this from crying wolf on a restart: the
 /// guest config lives on the guest disk and survives stop/start, so once an
 /// earlier boot has written the key, skipping bootstrap changes nothing.
+///
+/// `keyring_materialized` is lazy: reading it costs an instance-state file
+/// read, and the cheap terms decide the answer for every VM not in this mode.
 pub(crate) fn no_agents_skips_codex_keyring(
     no_agents: bool,
     auth: config::CodexAuthMode,
-    keyring_materialized: bool,
+    keyring_materialized: impl FnOnce() -> bool,
 ) -> bool {
-    no_agents && auth.uses_chatgpt_account() && !keyring_materialized
+    no_agents && auth.uses_chatgpt_account() && !keyring_materialized()
 }
 
 pub(crate) fn prepare_session_from_target(
@@ -2126,21 +2133,38 @@ mod tests {
         use super::no_agents_skips_codex_keyring as warns;
 
         assert!(
-            warns(true, CodexAuthMode::ChatGpt, false),
+            warns(true, CodexAuthMode::ChatGpt, || false),
             "--no-agents on a guest that never got the keyring store must warn",
         );
         assert!(
-            !warns(false, CodexAuthMode::ChatGpt, false),
+            !warns(false, CodexAuthMode::ChatGpt, || false),
             "a normal start bootstraps the keyring store, so there is nothing to warn about",
         );
         assert!(
-            !warns(true, CodexAuthMode::ApiKey, false),
+            !warns(true, CodexAuthMode::ApiKey, || false),
             "api_key auth does not use the guest keyring at all",
         );
         assert!(
-            !warns(true, CodexAuthMode::ChatGpt, true),
+            !warns(true, CodexAuthMode::ChatGpt, || true),
             "an earlier boot already wrote the key; it survives on the guest disk",
         );
+
+        // The instance-state read is the expensive term, so it must not happen
+        // for the VMs that are not in this mode at all.
+        for (no_agents, auth) in [
+            (false, CodexAuthMode::ChatGpt),
+            (true, CodexAuthMode::ApiKey),
+        ] {
+            let read = std::cell::Cell::new(false);
+            assert!(!warns(no_agents, auth, || {
+                read.set(true);
+                false
+            }));
+            assert!(
+                !read.get(),
+                "the cheap terms must short-circuit before the state read",
+            );
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1489,7 +1489,7 @@ fn default_prompt_for_pat() -> bool {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CodexConfig {
-    /// How Codex should authenticate to OpenAI in remote cloud mode.
+    /// How Codex should authenticate to `OpenAI` in remote cloud mode.
     #[serde(default)]
     pub auth: CodexAuthMode,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1489,6 +1489,10 @@ fn default_prompt_for_pat() -> bool {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CodexConfig {
+    /// How Codex should authenticate to OpenAI in remote cloud mode.
+    #[serde(default)]
+    pub auth: CodexAuthMode,
+
     /// `OpenAI` API key (forwarded via `SendEnv`, never written to disk)
     pub api_key: Option<Secret<String>>,
 
@@ -1517,6 +1521,28 @@ pub struct CodexConfig {
     /// prompted interactively and saved in instance state.
     #[serde(default)]
     pub local_model: Option<LocalModel>,
+}
+
+/// Codex cloud authentication mode.
+///
+/// `ApiKey` preserves the historical behavior: coop forwards
+/// `OPENAI_API_KEY` when configured or present in the host environment.
+/// `ChatGpt` is account-level auth: coop suppresses API-key forwarding,
+/// writes Codex's credential store setting to `keyring`, and launches Codex
+/// through the guest Secret Service wrapper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum CodexAuthMode {
+    #[serde(rename = "api_key")]
+    #[default]
+    ApiKey,
+    #[serde(rename = "chatgpt")]
+    ChatGpt,
+}
+
+impl CodexAuthMode {
+    pub fn uses_chatgpt_account(self) -> bool {
+        matches!(self, Self::ChatGpt)
+    }
 }
 
 /// `[proxy]` — host-side credential-injecting proxy (issue #411).
@@ -2039,6 +2065,15 @@ impl CoopConfig {
             ));
         }
 
+        if self.codex.auth.uses_chatgpt_account() && self.proxy.openai.is_some() {
+            errors.push(
+                "codex.auth = \"chatgpt\" conflicts with [proxy.openai]; \
+                 Codex account auth uses ChatGPT workspace credentials, while \
+                 the OpenAI proxy uses an API key"
+                    .to_string(),
+            );
+        }
+
         check_local_marketplaces(
             "claude.marketplaces",
             &self.claude.marketplaces,
@@ -2377,6 +2412,7 @@ impl Default for ClaudeConfig {
 impl Default for CodexConfig {
     fn default() -> Self {
         Self {
+            auth: CodexAuthMode::ApiKey,
             api_key: std::env::var("OPENAI_API_KEY").ok().map(Secret::new),
             env_forward: Vec::new(),
             marketplaces: Vec::new(),
@@ -3448,6 +3484,7 @@ mod tests {
     #[test]
     fn codex_config_all_fields() {
         let json = r#"{
+            "auth": "chatgpt",
             "api_key": "sk-openai-test",
             "env_forward": ["MYORG_KEY"],
             "marketplaces": ["https://github.com/trailofbits/codex-plugins"],
@@ -3464,6 +3501,7 @@ mod tests {
             cfg.api_key.as_ref().map(|s| s.expose().as_str()),
             Some("sk-openai-test")
         );
+        assert_eq!(cfg.auth, CodexAuthMode::ChatGpt);
         assert_eq!(cfg.env_forward, vec![EnvVarName::new("MYORG_KEY").unwrap()]);
         assert_eq!(
             cfg.marketplaces,
@@ -3478,6 +3516,7 @@ mod tests {
     fn codex_config_all_defaults() {
         let json = "{}";
         let cfg: CodexConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.auth, CodexAuthMode::ApiKey);
         assert!(cfg.api_key.is_none());
         assert!(cfg.env_forward.is_empty());
         assert!(cfg.marketplaces.is_empty());
@@ -3485,6 +3524,12 @@ mod tests {
         assert!(cfg.mcp_servers.is_empty());
         assert_eq!(cfg.config_dir, ConfigDir::Default);
         assert!(cfg.local_model.is_none());
+    }
+
+    #[test]
+    fn codex_config_rejects_unknown_auth_mode() {
+        let json = r#"{"auth": "subscription"}"#;
+        assert!(serde_json::from_str::<CodexConfig>(json).is_err());
     }
 
     // ── LocalModel ───────────────────────────────────────────
@@ -3576,6 +3621,24 @@ auth = "bearer"
         let up = cfg.proxy.openai.unwrap();
         assert_eq!(up.credential.expose(), "cmd:op read op://x");
         assert_eq!(up.auth, ProxyAuthScheme::Bearer);
+    }
+
+    #[test]
+    fn validate_rejects_codex_chatgpt_with_openai_proxy() {
+        let toml_str = r#"
+[codex]
+auth = "chatgpt"
+
+[proxy.openai]
+credential = "cmd:op read op://x"
+auth = "bearer"
+"#;
+        let cfg: CoopConfig = toml::from_str(toml_str).unwrap();
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("conflicts with [proxy.openai]"),
+            "expected proxy conflict, got: {err}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3642,6 +3642,40 @@ auth = "bearer"
     }
 
     #[test]
+    fn validate_accepts_codex_chatgpt_without_a_proxy() {
+        // Pins the `proxy.openai.is_some()` half of the conflict check. With
+        // `&&` flipped to `||`, plain `auth = "chatgpt"` — the headline
+        // configuration for this mode — becomes a hard config error.
+        let toml_str = r#"
+[codex]
+auth = "chatgpt"
+"#;
+        let cfg: CoopConfig = toml::from_str(toml_str).unwrap();
+        assert!(
+            cfg.validate().is_ok(),
+            "chatgpt auth alone must be a valid config: {:?}",
+            cfg.validate().err(),
+        );
+    }
+
+    #[test]
+    fn validate_accepts_openai_proxy_with_default_api_key_auth() {
+        // Pins the `uses_chatgpt_account()` half. With `&&` flipped to `||`,
+        // an ordinary `[proxy.openai]` setup becomes a hard config error.
+        let toml_str = r#"
+[proxy.openai]
+credential = "cmd:op read op://x"
+auth = "bearer"
+"#;
+        let cfg: CoopConfig = toml::from_str(toml_str).unwrap();
+        assert!(
+            cfg.validate().is_ok(),
+            "an OpenAI proxy with default api_key auth must be valid: {:?}",
+            cfg.validate().err(),
+        );
+    }
+
+    #[test]
     fn proxy_anthropic_parses_bearer_scheme() {
         let toml_str = r#"
 [proxy.anthropic]

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -494,11 +494,14 @@ mod tests {
     #[test]
     fn codex_account_script_uses_secret_service() {
         assert!(
-            SCRIPT_CODEX_ACCOUNT.contains("/usr/local/bin/codex-account"),
+            SCRIPT_CODEX_ACCOUNT.contains("cat >/usr/local/bin/codex-account"),
             "Codex account wrapper should be installed in the guest image",
         );
         for expected in [
-            "dbus-run-session",
+            // Anchored on the re-exec itself: a bare "dbus-run-session" also
+            // matches the `command -v` guard and its die message, so it would
+            // pass even with the re-exec deleted.
+            "exec dbus-run-session -- ",
             "gnome-keyring-daemon --unlock",
             "secret-tool store",
             // The probe item must be removed again, not left in the keyring.
@@ -509,6 +512,48 @@ mod tests {
                 "Codex account wrapper is missing {expected:?}",
             );
         }
+    }
+
+    #[test]
+    fn codex_account_script_unlocks_before_touching_the_bus() {
+        // `gnome-keyring-daemon --unlock` only creates and unlocks the login
+        // collection when it is the process that starts the daemon. Once any
+        // daemon owns `org.freedesktop.secrets` — including one the probe's
+        // `secret-tool` would D-Bus-activate — the unlock is handed to the
+        // graphical gcr-prompter, which cannot run on a headless guest, and
+        // ChatGPT auth fails on every invocation. So the unlock must be the
+        // first thing the main flow does.
+        let unlock = SCRIPT_CODEX_ACCOUNT.find("\nunlock_keyring\n");
+        let probe = SCRIPT_CODEX_ACCOUNT.find("\nprobe_keyring \\");
+        assert!(
+            unlock.is_some() && probe.is_some(),
+            "the main flow must call both unlock_keyring and probe_keyring",
+        );
+        assert!(
+            unlock < probe,
+            "the main flow must unlock before probing, or the unlock is a no-op",
+        );
+        assert!(
+            !SCRIPT_CODEX_ACCOUNT.contains("gnome-keyring-daemon --start"),
+            "starting the daemon before the unlock is what breaks the unlock",
+        );
+    }
+
+    #[test]
+    fn codex_account_script_captures_probe_stderr() {
+        // The redirect order is load-bearing and easy to "correct" wrongly:
+        // `2>&1 >/dev/null` captures stderr because `2>&1` binds while stdout
+        // is still the substitution pipe. The tidier-looking `>/dev/null 2>&1`
+        // sends both to /dev/null, leaving PROBE_ERROR always empty and the
+        // die message back to guessing at the password.
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("2>&1 >/dev/null"),
+            "the probe must capture secret-tool's stderr, not discard it",
+        );
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("${PROBE_ERROR:+"),
+            "the die message must report the captured cause when there is one",
+        );
     }
 
     #[test]

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -578,6 +578,11 @@ mod tests {
             2,
             "both probe secret-tool calls must be time-bounded",
         );
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("timeout 30 gnome-keyring-daemon --unlock"),
+            "the unlock must be time-bounded too: it runs inside a command \
+             substitution, which waits for EOF rather than for exit",
+        );
     }
 
     #[test]

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -170,13 +170,19 @@ impl From<GuestUser> for String {
 /// build shell commands or inspect the chroot get path semantics for
 /// free (and the `/usr/bin/docker`/`/usr/bin/gh` entries can't be
 /// mistaken for host paths).
-pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 5] {
+pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 8] {
     [
         GuestPath::new("/usr/bin/docker"),
         GuestPath::new("/usr/bin/gh"),
         user.claude_bin(),
         codex_bin(),
         codex_account_bin(),
+        // The Secret Service stack `codex-account` drives. Checking the
+        // wrapper alone proves nothing — the provision script always writes
+        // it — so verify the three tools its BASE_PACKAGES entries install.
+        GuestPath::new("/usr/bin/dbus-run-session"),
+        GuestPath::new("/usr/bin/gnome-keyring-daemon"),
+        GuestPath::new("/usr/bin/secret-tool"),
     ]
 }
 
@@ -224,6 +230,17 @@ pub const SCRIPT_CLAUDE_CODE: &str = include_str!("../scripts/guest/claude-code.
 pub const SCRIPT_CODEX: &str = include_str!("../scripts/guest/codex.sh");
 pub const SCRIPT_CODEX_ACCOUNT: &str = include_str!("../scripts/guest/codex-account.sh");
 
+/// Packages installed into every golden image.
+///
+/// `dbus-user-session`, `gnome-keyring`, and `libsecret-tools` back the
+/// Secret Service that `codex-account` needs under `[codex] auth =
+/// "chatgpt"`. They are unconditional rather than gated on that config field
+/// on purpose: the golden image is built once by `coop setup` and reused
+/// across configs, so gating them would let a later `auth = "chatgpt"` edit
+/// meet an image that cannot serve it — a silent skew that surfaces only at
+/// `coop codex` time. The cost is the same for everyone (see
+/// `docs/images-and-profiles.md`); the wrapper stays a no-op passthrough
+/// unless the guest Codex config actually asks for the keyring.
 pub const BASE_PACKAGES: &[&str] = &[
     "openssh-server",
     "dbus-user-session",
@@ -484,12 +501,44 @@ mod tests {
             "dbus-run-session",
             "gnome-keyring-daemon --unlock",
             "secret-tool store",
+            // The probe item must be removed again, not left in the keyring.
+            "secret-tool clear",
         ] {
             assert!(
                 SCRIPT_CODEX_ACCOUNT.contains(expected),
                 "Codex account wrapper is missing {expected:?}",
             );
         }
+    }
+
+    #[test]
+    fn codex_account_script_passes_through_without_keyring_mode() {
+        // Every Codex entry point routes through the wrapper, so it must be a
+        // transparent exec unless the guest config asks for keyring storage.
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("cli_auth_credentials_store"),
+            "wrapper should gate on the guest Codex credential-store setting",
+        );
+        assert!(
+            SCRIPT_CODEX_ACCOUNT
+                .contains("if ! keyring_mode; then\n    exec \"$CODEX_BIN\" \"$@\""),
+            "wrapper should exec Codex directly when keyring mode is off",
+        );
+    }
+
+    #[test]
+    fn codex_account_script_confirms_a_newly_created_keyring_password() {
+        // A fresh guest has no keyring, so the prompt creates one; an
+        // unconfirmed typo would lock credentials behind an unreproducible
+        // password.
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("Confirm keyring password: "),
+            "wrapper should confirm the password when creating a keyring",
+        );
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("this VM has no guest keyring yet"),
+            "wrapper should explain that the first prompt chooses a password",
+        );
     }
 
     #[test]
@@ -654,6 +703,18 @@ mod tests {
                 .any(|b| b.to_string() == "/usr/local/bin/codex-account"),
             "guest image should include the Codex account-auth wrapper",
         );
+        // The wrapper is written unconditionally by the provision script, so
+        // verifying it alone cannot catch the packages failing to install.
+        for tool in [
+            "/usr/bin/dbus-run-session",
+            "/usr/bin/gnome-keyring-daemon",
+            "/usr/bin/secret-tool",
+        ] {
+            assert!(
+                bins.iter().any(|b| b.to_string() == tool),
+                "guest image should verify {tool} for Codex account auth",
+            );
+        }
     }
 
     #[test]

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -523,19 +523,71 @@ mod tests {
         // graphical gcr-prompter, which cannot run on a headless guest, and
         // ChatGPT auth fails on every invocation. So the unlock must be the
         // first thing the main flow does.
-        let unlock = SCRIPT_CODEX_ACCOUNT.find("\nunlock_keyring\n");
-        let probe = SCRIPT_CODEX_ACCOUNT.find("\nprobe_keyring \\");
         assert!(
-            unlock.is_some() && probe.is_some(),
-            "the main flow must call both unlock_keyring and probe_keyring",
-        );
-        assert!(
-            unlock < probe,
-            "the main flow must unlock before probing, or the unlock is a no-op",
+            SCRIPT_CODEX_ACCOUNT.contains("    unlock_keyring\n    probe_keyring \\"),
+            "on a bus this wrapper created, the unlock must precede the probe",
         );
         assert!(
             !SCRIPT_CODEX_ACCOUNT.contains("gnome-keyring-daemon --start"),
             "starting the daemon before the unlock is what breaks the unlock",
+        );
+    }
+
+    #[test]
+    fn codex_account_script_reuses_an_inherited_unlocked_session() {
+        // A nested codex-account (an in-guest agent shelling out to
+        // `codex-account` / `codex-yolo`) inherits the bus and its unlocked
+        // keyring. Unlocking again there hits the very gcr-prompter trap the
+        // ordering above exists to avoid, so the nested call must probe and
+        // reuse rather than re-unlock — and the outer call must publish the
+        // marker that says so.
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("export COOP_CODEX_ACCOUNT_UNLOCKED=1"),
+            "the unlocking call must mark the session as reusable",
+        );
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("\"${COOP_CODEX_ACCOUNT_UNLOCKED:-0}\" = \"1\""),
+            "a nested call must branch on the inherited-session marker",
+        );
+    }
+
+    #[test]
+    fn codex_account_script_guards_against_dbus_reexec_recursion() {
+        // `exec dbus-run-session -- "$0"` re-runs this same script. Without the
+        // env guard around it that is an unbounded fork loop inside the guest,
+        // and no other test would notice.
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("\"${COOP_CODEX_ACCOUNT_DBUS:-0}\" != \"1\""),
+            "the re-exec must be guarded, or it recurses forever",
+        );
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("export COOP_CODEX_ACCOUNT_DBUS=1"),
+            "the guard must be set before the re-exec, or it never takes effect",
+        );
+    }
+
+    #[test]
+    fn codex_account_script_bounds_its_secret_service_calls() {
+        // A wedged Secret Service must fail the launch, not hang it. The
+        // tool-presence loop checks for `timeout`; these pin that it is
+        // actually used on both probe calls.
+        assert_eq!(
+            SCRIPT_CODEX_ACCOUNT
+                .matches("timeout 5 secret-tool")
+                .count(),
+            2,
+            "both probe secret-tool calls must be time-bounded",
+        );
+    }
+
+    #[test]
+    fn codex_account_script_requires_a_tty_before_prompting() {
+        // Without this guard `read -rsp` blocks forever on a non-interactive
+        // session (agent bootstrap, `coop exec`), turning a clear failure into
+        // a hang.
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("[ ! -t 0 ]"),
+            "the wrapper must refuse to prompt without a TTY",
         );
     }
 

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -122,6 +122,11 @@ pub fn codex_bin() -> GuestPath {
     GuestPath::new("/usr/local/bin/codex")
 }
 
+/// Wrapper that runs Codex with a guest Linux Secret Service session.
+pub fn codex_account_bin() -> GuestPath {
+    GuestPath::new("/usr/local/bin/codex-account")
+}
+
 impl Default for GuestUser {
     fn default() -> Self {
         // Safe: DEFAULT_GUEST_USER ("ubuntu") satisfies the validator.
@@ -165,12 +170,13 @@ impl From<GuestUser> for String {
 /// build shell commands or inspect the chroot get path semantics for
 /// free (and the `/usr/bin/docker`/`/usr/bin/gh` entries can't be
 /// mistaken for host paths).
-pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 4] {
+pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 5] {
     [
         GuestPath::new("/usr/bin/docker"),
         GuestPath::new("/usr/bin/gh"),
         user.claude_bin(),
         codex_bin(),
+        codex_account_bin(),
     ]
 }
 
@@ -216,9 +222,11 @@ pub const SCRIPT_GH_REPO: &str = include_str!("../scripts/guest/gh-cli-repo.sh")
 pub const SCRIPT_DOCKER_REPO: &str = include_str!("../scripts/guest/docker-repo.sh");
 pub const SCRIPT_CLAUDE_CODE: &str = include_str!("../scripts/guest/claude-code.sh");
 pub const SCRIPT_CODEX: &str = include_str!("../scripts/guest/codex.sh");
+pub const SCRIPT_CODEX_ACCOUNT: &str = include_str!("../scripts/guest/codex-account.sh");
 
 pub const BASE_PACKAGES: &[&str] = &[
     "openssh-server",
+    "dbus-user-session",
     "curl",
     "wget",
     "git",
@@ -236,7 +244,9 @@ pub const BASE_PACKAGES: &[&str] = &[
     "unzip",
     "zip",
     "file",
+    "gnome-keyring",
     "less",
+    "libsecret-tools",
 ];
 
 pub const GH_PACKAGES: &[&str] = &["gh"];
@@ -465,6 +475,24 @@ mod tests {
     }
 
     #[test]
+    fn codex_account_script_uses_secret_service() {
+        assert!(
+            SCRIPT_CODEX_ACCOUNT.contains("/usr/local/bin/codex-account"),
+            "Codex account wrapper should be installed in the guest image",
+        );
+        for expected in [
+            "dbus-run-session",
+            "gnome-keyring-daemon --unlock",
+            "secret-tool store",
+        ] {
+            assert!(
+                SCRIPT_CODEX_ACCOUNT.contains(expected),
+                "Codex account wrapper is missing {expected:?}",
+            );
+        }
+    }
+
+    #[test]
     fn collect_codex_baked_lists_sorts_and_dedups() {
         let mut cfg = CoopConfig::default();
         cfg.codex.marketplaces = vec!["b".into(), "a".into(), "a".into()];
@@ -621,6 +649,21 @@ mod tests {
             bins.iter().any(|b| b.to_string() == "/usr/local/bin/codex"),
             "guest image should include codex in the default PATH",
         );
+        assert!(
+            bins.iter()
+                .any(|b| b.to_string() == "/usr/local/bin/codex-account"),
+            "guest image should include the Codex account-auth wrapper",
+        );
+    }
+
+    #[test]
+    fn base_packages_include_secret_service_support() {
+        for expected in ["dbus-user-session", "gnome-keyring", "libsecret-tools"] {
+            assert!(
+                BASE_PACKAGES.contains(&expected),
+                "base packages should include {expected}",
+            );
+        }
     }
 
     #[test]
@@ -672,7 +715,12 @@ mod tests {
         let user = GuestUser::default();
         let result = verify_required_binaries(&user, "install script", |_path| false, String::new);
         let err = result.unwrap_err().to_string();
-        for expected in ["/usr/bin/docker", "/usr/bin/gh", "/usr/local/bin/codex"] {
+        for expected in [
+            "/usr/bin/docker",
+            "/usr/bin/gh",
+            "/usr/local/bin/codex",
+            "/usr/local/bin/codex-account",
+        ] {
             assert!(err.contains(expected), "{expected} missing from: {err}");
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1242,6 +1242,9 @@ pub fn run() -> Result<()> {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
             let args = codex_launch_args(ask, args);
             let codex_bin = if cfg.codex.auth.uses_chatgpt_account() {
+                let inst = cfg.resolve_instance(name.as_ref())?;
+                let model_state = model_state::ModelState::load_or_default(&inst)?;
+                backend::ensure_codex_remote_auth_consistent(&cfg, &inst, &model_state)?;
                 backend::ensure_codex_account_guest_support(&sess.target)?;
                 guest::codex_account_bin()
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1241,7 +1241,13 @@ pub fn run() -> Result<()> {
         Commands::Codex { name, ask, args } => {
             let sess = open_ssh_session(&be, &cfg, name.as_ref())?;
             let args = codex_launch_args(ask, args);
-            ssh::run_interactive(&sess, &prepend_binary(guest::codex_bin().as_ref(), args))
+            let codex_bin = if cfg.codex.auth.uses_chatgpt_account() {
+                backend::ensure_codex_account_guest_support(&sess.target)?;
+                guest::codex_account_bin()
+            } else {
+                guest::codex_bin()
+            };
+            ssh::run_interactive(&sess, &prepend_binary(codex_bin.as_ref(), args))
         }
         Commands::Stop { name } => {
             let inst = cfg.resolve_instance(name.as_ref())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1246,6 +1246,10 @@ pub fn run() -> Result<()> {
                 let model_state = model_state::ModelState::load_or_default(&inst)?;
                 backend::ensure_codex_remote_auth_consistent(&cfg, &inst, &model_state)?;
                 backend::ensure_codex_account_guest_support(&sess.target)?;
+                // The wrapper gates on the guest's own config, so a guest that
+                // never got the keyring setting would silently pass through and
+                // write a plaintext token. Fail closed instead.
+                backend::ensure_codex_keyring_configured(&sess.target)?;
                 guest::codex_account_bin()
             } else {
                 guest::codex_bin()

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -12,7 +12,7 @@ use crate::config::{CoopConfig, GiB, ImageName, Instance, InstanceName, MiB};
 use crate::devcontainer_oci::{ResolvedFeature, installed_features};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
-    SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
+    SCRIPT_CODEX, SCRIPT_CODEX_ACCOUNT, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO,
 };
 use crate::remote_command::RemoteCommand;
 use crate::setup::{SetupOptions, TEMPLATE_VERSION, TemplateConfig, utc_timestamp};
@@ -1493,6 +1493,8 @@ fn compose_provision_script(
     // Codex CLI (standalone binary under /usr/local/bin)
     s.push_str(SCRIPT_CODEX);
     s.push('\n');
+    s.push_str(SCRIPT_CODEX_ACCOUNT);
+    s.push('\n');
 
     // Test hook: inject a provision failure to exercise error detection.
     // Only activates when COOP_TEST_INJECT_PROVISION_FAILURE is set.
@@ -2066,6 +2068,10 @@ mod tests {
         assert!(
             script.contains("Installing Codex CLI"),
             "Lima provision script should install Codex CLI",
+        );
+        assert!(
+            script.contains("Installing codex-account shortcut"),
+            "Lima provision script should install Codex account-auth wrapper",
         );
     }
 

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1585,7 +1585,7 @@ chmod 755 /usr/local/bin/claude-yolo
 echo '  [guest] Installing codex-yolo shortcut...'
 cat > /usr/local/bin/codex-yolo <<'YOLOEOF'
 #!/bin/bash
-exec codex --dangerously-bypass-approvals-and-sandbox "$@"
+exec codex-account --dangerously-bypass-approvals-and-sandbox "$@"
 YOLOEOF
 chmod 755 /usr/local/bin/codex-yolo
 
@@ -2072,6 +2072,11 @@ mod tests {
         assert!(
             script.contains("Installing codex-account shortcut"),
             "Lima provision script should install Codex account-auth wrapper",
+        );
+        assert!(
+            script.contains("exec codex-account --dangerously-bypass-approvals-and-sandbox"),
+            "codex-yolo should route through the account wrapper so keyring \
+             mode works from an in-guest shell",
         );
     }
 

--- a/src/model_state.rs
+++ b/src/model_state.rs
@@ -82,6 +82,16 @@ pub struct ModelState {
     /// if the configured endpoint has since been removed.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub codex_materialized: bool,
+
+    /// Set once coop has written `cli_auth_credentials_store = "keyring"`
+    /// into the guest Codex config for `[codex] auth = "chatgpt"`. Switching
+    /// back to `api_key` otherwise leaves that key behind — with no host
+    /// `config.toml`, MCP servers, plugins, or local model there is nothing
+    /// else to rewrite for, so the guest keeps asking for a keyring password
+    /// it no longer needs. This flag keeps the file in coop's hands across
+    /// that transition.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub codex_keyring_materialized: bool,
 }
 
 impl ModelState {
@@ -93,6 +103,7 @@ impl ModelState {
             && self.claude_endpoint.is_none()
             && self.codex_endpoint.is_none()
             && !self.codex_materialized
+            && !self.codex_keyring_materialized
     }
 
     pub fn save(&self, inst: &Instance) -> Result<()> {
@@ -346,6 +357,7 @@ mod tests {
             claude_endpoint: Some(endpoint("http://localhost:11434", "qwen", None)),
             codex_endpoint: None,
             codex_materialized: false,
+            codex_keyring_materialized: false,
         };
         state.save(&inst).unwrap();
 
@@ -431,6 +443,7 @@ mod tests {
             claude_endpoint: Some(endpoint("http://localhost:1234", "m", None)),
             codex_endpoint: None,
             codex_materialized: false,
+            codex_keyring_materialized: false,
         }
         .save(&inst)
         .unwrap();
@@ -451,6 +464,7 @@ mod tests {
             claude_endpoint: None,
             codex_endpoint: None,
             codex_materialized: true,
+            codex_keyring_materialized: false,
         }
         .save(&inst)
         .unwrap();
@@ -460,6 +474,33 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .codex_materialized
+        );
+    }
+
+    #[test]
+    fn remote_with_codex_keyring_materialized_is_persisted() {
+        // Otherwise this state looks like the default and `save` deletes the
+        // file — losing the fact that the guest still carries
+        // `cli_auth_credentials_store = "keyring"` from a previous
+        // `auth = "chatgpt"` boot, so a switch back to `api_key` would never
+        // rewrite the guest config to drop it.
+        let tmp = tempfile::tempdir().unwrap();
+        let inst = fake_instance(tmp.path().to_path_buf());
+        ModelState {
+            mode: ModelMode::Remote,
+            claude_endpoint: None,
+            codex_endpoint: None,
+            codex_materialized: false,
+            codex_keyring_materialized: true,
+        }
+        .save(&inst)
+        .unwrap();
+        assert!(inst.model_state_path().exists());
+        assert!(
+            ModelState::try_load(&inst)
+                .unwrap()
+                .unwrap()
+                .codex_keyring_materialized
         );
     }
 
@@ -484,6 +525,7 @@ mod tests {
             claude_endpoint: Some(endpoint("http://localhost:2/", "from-saved", None)),
             codex_endpoint: None,
             codex_materialized: false,
+            codex_keyring_materialized: false,
         };
         assert_eq!(
             state.resolved_claude(&claude).unwrap().model(),
@@ -499,6 +541,7 @@ mod tests {
             claude_endpoint: Some(endpoint("http://localhost:2/", "from-saved", None)),
             codex_endpoint: None,
             codex_materialized: false,
+            codex_keyring_materialized: false,
         };
         assert_eq!(
             state.resolved_claude(&claude).unwrap().model(),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1573,6 +1573,11 @@ mod tests {
             script.contains("Installing codex-account shortcut"),
             "base recipe should install Codex account-auth wrapper",
         );
+        assert!(
+            script.contains("exec codex-account --dangerously-bypass-approvals-and-sandbox"),
+            "codex-yolo should route through the account wrapper so keyring \
+             mode works from an in-guest shell",
+        );
         no_consecutive_concat(&script);
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -13,7 +13,7 @@ use crate::config::{CoopConfig, ImageName, Instance};
 use crate::devcontainer_oci::{InstalledFeature, ResolvedFeature, installed_features};
 use crate::guest::{
     BASE_PACKAGES, DOCKER_PACKAGES, GH_PACKAGES, GuestUser, ProfileDef, SCRIPT_CLAUDE_CODE,
-    SCRIPT_CODEX, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, resolve_profiles,
+    SCRIPT_CODEX, SCRIPT_CODEX_ACCOUNT, SCRIPT_DOCKER_REPO, SCRIPT_GH_REPO, resolve_profiles,
 };
 use crate::sha256_hash::Sha256Hash;
 
@@ -24,7 +24,7 @@ const GH_RELEASES: &str = "https://github.com/firecracker-microvm/firecracker/re
 
 /// Monotonic version bumped when the base install script changes
 /// in a way that requires rebuilding templates.
-pub const TEMPLATE_VERSION: u32 = 1;
+pub const TEMPLATE_VERSION: u32 = 2;
 
 // ── Public types ──────────────────────────────────────────────
 
@@ -732,6 +732,7 @@ fn compose_recipe(
     s.push_str(SCRIPT_CLAUDE_CODE);
     // Codex installs as a standalone binary under /usr/local/bin.
     s.push_str(SCRIPT_CODEX);
+    s.push_str(SCRIPT_CODEX_ACCOUNT);
 
     s
 }
@@ -1567,6 +1568,10 @@ mod tests {
         assert!(
             script.contains("Installing Codex CLI"),
             "base recipe should install Codex CLI",
+        );
+        assert!(
+            script.contains("Installing codex-account shortcut"),
+            "base recipe should install Codex account-auth wrapper",
         );
         no_consecutive_concat(&script);
     }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -238,6 +238,34 @@ test_validate() {
     else
         fail "validate reports OK" "got: $HARNESS_OUT"
     fi
+
+    # `[codex] auth = "chatgpt"` uses ChatGPT workspace credentials while the
+    # OpenAI proxy injects an API key, so the pair is rejected at parse time.
+    local conflict_dir conflict_cfg
+    conflict_dir=$(mktemp -d)
+    conflict_cfg="$conflict_dir/config.toml"
+    cat >"$conflict_cfg" <<'CONFLICTEOF'
+[codex]
+auth = "chatgpt"
+
+[proxy.openai]
+credential = "cmd:echo sk-test"
+auth = "bearer"
+CONFLICTEOF
+
+    if coop_fails --config "$conflict_cfg" validate; then
+        if grep -q "conflicts with \[proxy.openai\]" <<<"$HARNESS_ERR$HARNESS_OUT"; then
+            pass "validate rejects codex.auth=chatgpt with [proxy.openai]"
+        else
+            fail "validate rejects codex.auth=chatgpt with [proxy.openai]" \
+                "wrong error: $HARNESS_ERR$HARNESS_OUT"
+        fi
+    else
+        fail "validate rejects codex.auth=chatgpt with [proxy.openai]" \
+            "validate unexpectedly succeeded"
+    fi
+
+    rm -rf "$conflict_dir"
 }
 
 test_completions() {
@@ -1104,6 +1132,33 @@ test_codex_account_auth_support() {
         fail "codex-account passes through to codex without keyring mode" \
             "stderr: $(guest_stderr)"
     fi
+
+    # Drive the keyring branch without reconfiguring the VM: the wrapper reads
+    # $CODEX_HOME, so a scratch config selects keyring mode for one call. This
+    # is the only place the `cli_auth_credentials_store` grep, the D-Bus
+    # re-exec, the tool guards and the TTY guard actually execute — the
+    # assertions above all run on the passthrough branch.
+    #
+    # `coop exec` is not a TTY, so the wrapper must refuse rather than block on
+    # a password prompt. A hang here is the failure this asserts against.
+    guest_exec sh -c 'mkdir -p /tmp/coop-keyring-probe \
+        && printf "cli_auth_credentials_store = \"keyring\"\n" \
+            > /tmp/coop-keyring-probe/config.toml'
+
+    # </dev/null so the TTY guard is deterministic: run interactively, stdin
+    # could otherwise be a terminal and the wrapper would prompt and block.
+    if coop_exec env CODEX_HOME=/tmp/coop-keyring-probe \
+        /usr/local/bin/codex-account --version </dev/null; then
+        fail "codex-account enters keyring mode from the guest config" \
+            "expected a non-TTY refusal, but the wrapper passed through to codex"
+    elif guest_stderr | grep -q "interactive TTY"; then
+        pass "codex-account enters keyring mode and refuses a non-TTY session"
+    else
+        fail "codex-account enters keyring mode and refuses a non-TTY session" \
+            "stderr: $(guest_stderr)"
+    fi
+
+    guest_exec rm -rf /tmp/coop-keyring-probe
 }
 
 test_codex_sandbox_bypass() {

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1061,8 +1061,48 @@ test_codex_bin_path() {
             fail "codex-yolo includes dangerous full-access flag" \
                 "content: $yolo_content"
         fi
+        if echo "$yolo_content" | grep -q "codex-account"; then
+            pass "codex-yolo routes through the account wrapper"
+        else
+            fail "codex-yolo routes through the account wrapper" \
+                "content: $yolo_content"
+        fi
     else
         fail "codex-yolo includes dangerous full-access flag" "cat failed"
+    fi
+}
+
+test_codex_account_auth_support() {
+    echo ""
+    echo "=== Phase: codex account-auth (Secret Service) support ==="
+
+    if guest_exec test -x /usr/local/bin/codex-account; then
+        pass "codex-account wrapper exists"
+    else
+        fail "codex-account wrapper exists" "stderr: $(guest_stderr)"
+        return
+    fi
+
+    # The wrapper is written unconditionally by the provision script, so the
+    # packages behind it are what actually need asserting.
+    local tool
+    for tool in dbus-run-session gnome-keyring-daemon secret-tool; do
+        if guest_exec command -v "$tool"; then
+            pass "guest Secret Service tool present: $tool"
+        else
+            fail "guest Secret Service tool present: $tool" "stderr: $(guest_stderr)"
+        fi
+    done
+
+    # Default config is auth = "api_key", so the wrapper must be a transparent
+    # passthrough: no D-Bus session, no keyring, no password prompt. A hang
+    # here would mean it tried to unlock a keyring it should have skipped.
+    local version
+    if version=$(coop_exec /usr/local/bin/codex-account --version); then
+        pass "codex-account passes through to codex without keyring mode ($version)"
+    else
+        fail "codex-account passes through to codex without keyring mode" \
+            "stderr: $(guest_stderr)"
     fi
 }
 
@@ -5155,6 +5195,7 @@ main() {
     test_claude_settings_merge
     test_claude_onboarding_seed
     test_codex_bin_path
+    test_codex_account_auth_support
     test_codex_sandbox_bypass
     test_agent_update
     test_github_token_forwarding


### PR DESCRIPTION
## Summary
  - Add [codex] auth = \"chatgpt\" for Codex account/workspace authentication.
  - Install guest Secret Service support and a codex-account wrapper for D-Bus/GNOME Keyring.
  - Suppress OPENAI_API_KEY forwarding and auth.json copying in ChatGPT auth mode.
  - Document setup, billing behavior, and the proxy incompatibility.

  ## Validation
  - rustfmt --edition 2024 src/lib.rs src/backend.rs src/commands/lifecycle.rs src/config.rs src/guest.rs src/lima.rs src/setup.rs
  - shfmt -w scripts/guest/codex-account.sh
  - shellcheck scripts/guest/codex-account.sh
  - git diff --check

  Not run here:
  - cargo test --lib codex: blocked by crates.io DNS and missing cached anyhow 1.0.104
  - taplo format --check: taplo unavailable