### PR TITLE
fix(proxy): default deny provider operations

### DIFF
--- a/coop-proxy/src/proxy.rs
+++ b/coop-proxy/src/proxy.rs
@@ -241,7 +241,11 @@ async fn proxy(req: Request<Incoming>, ctx: &Ctx) -> Result<Response<ProxyBody>,
 /// Provider operations are deliberately default-deny: the coding agents only
 /// need response/message creation and Anthropic token counting, so
 /// administrative APIs and stored-resource reads must never inherit the host
-/// credential's broader authority.
+/// credential's broader authority. Agent upgrades that require another route
+/// must fail with 403 until this policy, its tests, and the documentation are
+/// deliberately updated. Codex currently identifies this custom provider as
+/// `coop credential proxy`, not `OpenAI`, so its OpenAI-specific
+/// `POST /v1/responses/compact` behavior does not apply.
 fn operation_allowed(method: &Method, uri: &Uri, upstream_host: &str) -> bool {
     if method != Method::POST {
         return false;

--- a/coop-proxy/src/proxy.rs
+++ b/coop-proxy/src/proxy.rs
@@ -14,6 +14,9 @@
 //! - The guest's own `authorization` / `x-api-key` (the capability token) is
 //!   stripped and replaced with the real credential — it never reaches the
 //!   upstream, and the real credential never reaches the guest.
+//! - Only the provider-specific method/path operations required by the coding
+//!   agents are forwarded; all other authenticated requests are refused
+//!   locally before any upstream connection is made.
 
 use std::convert::Infallible;
 use std::pin::Pin;
@@ -233,7 +236,7 @@ async fn proxy(req: Request<Incoming>, ctx: &Ctx) -> Result<Response<ProxyBody>,
     forward(upstream_req, ctx, permit).await
 }
 
-/// Whether the fixed upstream permits this method/path pair.
+/// Whether coop-proxy allows this method/path pair for the fixed upstream.
 ///
 /// Provider operations are deliberately default-deny: the coding agents only
 /// need response/message creation and Anthropic token counting, so

--- a/coop-proxy/src/proxy.rs
+++ b/coop-proxy/src/proxy.rs
@@ -506,7 +506,7 @@ mod tests {
         assert!(!authorized(&HeaderMap::new(), "right"));
     }
 
-    // ── OpenAI operation policy ────────────────────────────────
+    // ── Provider operation policy ──────────────────────────────
 
     #[test]
     fn openai_allows_only_response_creation() {
@@ -539,6 +539,7 @@ mod tests {
             (Method::GET, "/v1/responses"),
             (Method::DELETE, "/v1/responses/resp_123"),
             (Method::POST, "/v1/files"),
+            (Method::POST, "/v1/responses/"),
             (Method::TRACE, "/v1/responses"),
         ] {
             let uri: Uri = path.parse().unwrap();
@@ -564,6 +565,7 @@ mod tests {
             (Method::POST, "/v1/messages/batches"),
             (Method::GET, "/v1/messages/batches/msgbatch_123/results"),
             (Method::POST, "/v1/organizations/invites"),
+            (Method::POST, "/v1/messages/"),
         ] {
             let uri: Uri = path.parse().unwrap();
             assert!(
@@ -571,6 +573,23 @@ mod tests {
                 "unexpectedly allowed {method} {path}"
             );
         }
+    }
+
+    #[test]
+    fn provider_operations_cannot_cross_provider_boundaries() {
+        let openai_path: Uri = "/v1/responses".parse().unwrap();
+        let anthropic_path: Uri = "/v1/messages".parse().unwrap();
+
+        assert!(!operation_allowed(
+            &Method::POST,
+            &anthropic_path,
+            "api.openai.com"
+        ));
+        assert!(!operation_allowed(
+            &Method::POST,
+            &openai_path,
+            "api.anthropic.com"
+        ));
     }
 
     #[test]

--- a/coop-proxy/src/proxy.rs
+++ b/coop-proxy/src/proxy.rs
@@ -25,7 +25,7 @@ use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::body::{Body, Bytes, Frame, Incoming, SizeHint};
 use hyper::header::{AUTHORIZATION, HOST, HeaderMap, HeaderName, HeaderValue};
 use hyper::service::service_fn;
-use hyper::{Request, Response, StatusCode, Uri};
+use hyper::{Method, Request, Response, StatusCode, Uri};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as ServerBuilder;
 use rustls::pki_types::ServerName;
@@ -199,6 +199,13 @@ async fn proxy(req: Request<Incoming>, ctx: &Ctx) -> Result<Response<ProxyBody>,
         });
     }
 
+    if !operation_allowed(req.method(), req.uri(), &ctx.cfg.upstream_host) {
+        return Err(Refusal {
+            status: StatusCode::FORBIDDEN,
+            msg: "operation is not allowed by coop-proxy",
+        });
+    }
+
     // Held until the response body finishes streaming (see `GuardedBody`), so
     // the concurrency cap bounds a request for its whole lifetime.
     let permit = ctx
@@ -224,6 +231,29 @@ async fn proxy(req: Request<Incoming>, ctx: &Ctx) -> Result<Response<ProxyBody>,
     let upstream_req = Request::from_parts(parts, body);
 
     forward(upstream_req, ctx, permit).await
+}
+
+/// Whether the fixed upstream permits this method/path pair.
+///
+/// Provider operations are deliberately default-deny: the coding agents only
+/// need response/message creation and input-token counting, so administrative
+/// APIs and stored-resource reads must never inherit the host credential's
+/// broader authority.
+fn operation_allowed(method: &Method, uri: &Uri, upstream_host: &str) -> bool {
+    if method != Method::POST {
+        return false;
+    }
+
+    matches!(
+        (upstream_host, uri.path()),
+        (
+            "api.openai.com",
+            "/v1/responses" | "/v1/responses/input_tokens"
+        ) | (
+            "api.anthropic.com",
+            "/v1/messages" | "/v1/messages/count_tokens"
+        )
+    )
 }
 
 async fn forward(
@@ -473,6 +503,89 @@ mod tests {
         assert!(authorized(&h, "right"));
         assert!(!authorized(&h, "wrong"));
         assert!(!authorized(&HeaderMap::new(), "right"));
+    }
+
+    // ── OpenAI operation policy ────────────────────────────────
+
+    #[test]
+    fn openai_allows_response_creation_and_token_counting() {
+        let create: Uri = "/v1/responses".parse().unwrap();
+        let count_tokens: Uri = "/v1/responses/input_tokens".parse().unwrap();
+        let create_with_query: Uri = "/v1/responses?foo=bar".parse().unwrap();
+
+        assert!(operation_allowed(&Method::POST, &create, "api.openai.com"));
+        assert!(operation_allowed(
+            &Method::POST,
+            &count_tokens,
+            "api.openai.com"
+        ));
+        assert!(operation_allowed(
+            &Method::POST,
+            &create_with_query,
+            "api.openai.com"
+        ));
+    }
+
+    #[test]
+    fn openai_denies_admin_key_creation() {
+        let uri: Uri = "/v1/organization/admin_api_keys".parse().unwrap();
+        assert!(!operation_allowed(&Method::POST, &uri, "api.openai.com"));
+    }
+
+    #[test]
+    fn openai_denies_stored_response_reads() {
+        let uri: Uri = "/v1/responses/resp_123".parse().unwrap();
+        assert!(!operation_allowed(&Method::GET, &uri, "api.openai.com"));
+    }
+
+    #[test]
+    fn openai_policy_is_default_deny() {
+        for (method, path) in [
+            (Method::GET, "/v1/responses"),
+            (Method::DELETE, "/v1/responses/resp_123"),
+            (Method::POST, "/v1/files"),
+            (Method::TRACE, "/v1/responses"),
+        ] {
+            let uri: Uri = path.parse().unwrap();
+            assert!(
+                !operation_allowed(&method, &uri, "api.openai.com"),
+                "unexpectedly allowed {method} {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn anthropic_allows_message_creation_and_token_counting() {
+        for path in ["/v1/messages", "/v1/messages/count_tokens"] {
+            let uri: Uri = path.parse().unwrap();
+            assert!(operation_allowed(&Method::POST, &uri, "api.anthropic.com"));
+        }
+    }
+
+    #[test]
+    fn anthropic_policy_is_default_deny() {
+        for (method, path) in [
+            (Method::GET, "/v1/messages"),
+            (Method::POST, "/v1/messages/batches"),
+            (Method::GET, "/v1/messages/batches/msgbatch_123/results"),
+            (Method::POST, "/v1/organizations/invites"),
+        ] {
+            let uri: Uri = path.parse().unwrap();
+            assert!(
+                !operation_allowed(&method, &uri, "api.anthropic.com"),
+                "unexpectedly allowed {method} {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_upstream_has_no_allowed_operations() {
+        let uri: Uri = "/v1/messages".parse().unwrap();
+        assert!(!operation_allowed(
+            &Method::POST,
+            &uri,
+            "proxy-test.invalid"
+        ));
     }
 
     // ── header rewrite ───────────────────────────────────────

--- a/coop-proxy/src/proxy.rs
+++ b/coop-proxy/src/proxy.rs
@@ -236,9 +236,9 @@ async fn proxy(req: Request<Incoming>, ctx: &Ctx) -> Result<Response<ProxyBody>,
 /// Whether the fixed upstream permits this method/path pair.
 ///
 /// Provider operations are deliberately default-deny: the coding agents only
-/// need response/message creation and input-token counting, so administrative
-/// APIs and stored-resource reads must never inherit the host credential's
-/// broader authority.
+/// need response/message creation and Anthropic token counting, so
+/// administrative APIs and stored-resource reads must never inherit the host
+/// credential's broader authority.
 fn operation_allowed(method: &Method, uri: &Uri, upstream_host: &str) -> bool {
     if method != Method::POST {
         return false;
@@ -246,13 +246,11 @@ fn operation_allowed(method: &Method, uri: &Uri, upstream_host: &str) -> bool {
 
     matches!(
         (upstream_host, uri.path()),
-        (
-            "api.openai.com",
-            "/v1/responses" | "/v1/responses/input_tokens"
-        ) | (
-            "api.anthropic.com",
-            "/v1/messages" | "/v1/messages/count_tokens"
-        )
+        ("api.openai.com", "/v1/responses")
+            | (
+                "api.anthropic.com",
+                "/v1/messages" | "/v1/messages/count_tokens"
+            )
     )
 }
 
@@ -508,17 +506,11 @@ mod tests {
     // ── OpenAI operation policy ────────────────────────────────
 
     #[test]
-    fn openai_allows_response_creation_and_token_counting() {
+    fn openai_allows_only_response_creation() {
         let create: Uri = "/v1/responses".parse().unwrap();
-        let count_tokens: Uri = "/v1/responses/input_tokens".parse().unwrap();
         let create_with_query: Uri = "/v1/responses?foo=bar".parse().unwrap();
 
         assert!(operation_allowed(&Method::POST, &create, "api.openai.com"));
-        assert!(operation_allowed(
-            &Method::POST,
-            &count_tokens,
-            "api.openai.com"
-        ));
         assert!(operation_allowed(
             &Method::POST,
             &create_with_query,

--- a/coop-proxy/tests/gate.rs
+++ b/coop-proxy/tests/gate.rs
@@ -4,11 +4,12 @@
 //!
 //! These assert the security-critical refusal path without a live upstream: a
 //! request that fails the capability check is rejected with 401 and the
-//! upstream is never contacted; a request that passes fails closed at the
-//! (unresolvable) upstream with 502, proving the gate opened without any real
-//! credential reaching a real service. The authorized header-rewrite/injection
-//! logic is covered by the unit tests in `src/proxy.rs`, and end-to-end against
-//! a mock upstream by coop's VM integration suite.
+//! upstream is never contacted; a request with a valid token reaches the
+//! operation policy and is denied with 403 for the test-only unknown upstream,
+//! proving the authentication gate opened without any credential reaching a
+//! real service. The authorized header-rewrite/injection logic is covered by
+//! the unit tests in `src/proxy.rs`, and end-to-end against a mock upstream by
+//! coop's VM integration suite.
 //!
 //! The `readiness_probe_*` and `spawned_proxy_*` tests are the exception: they
 //! assert nothing about the gate, but pin the harness that reaches it — the
@@ -362,10 +363,10 @@ async fn rejects_wrong_token_with_401() {
 }
 
 #[tokio::test]
-async fn valid_token_passes_gate_and_fails_closed_at_upstream() {
+async fn valid_token_passes_auth_gate_and_reaches_operation_policy() {
     let (addr, _child) = spawn_serving().await;
     let status = request_status(addr, Some("Authorization: Bearer the-right-token")).await;
-    assert!(status.contains("502"), "expected 502, got: {status:?}");
+    assert!(status.contains("403"), "expected 403, got: {status:?}");
 }
 
 #[tokio::test]

--- a/coop-proxy/tests/gate.rs
+++ b/coop-proxy/tests/gate.rs
@@ -9,7 +9,9 @@
 //! proving the authentication gate opened without any credential reaching a
 //! real service. The authorized header-rewrite/injection logic is covered by
 //! the unit tests in `src/proxy.rs`, and end-to-end against a mock upstream by
-//! coop's VM integration suite.
+//! coop's VM integration suite. Because the unknown-upstream policy denies
+//! before forwarding, this harness does not exercise `forward`, `bad_gateway`,
+//! or the `GuardedBody` permit wiring.
 //!
 //! The `readiness_probe_*` and `spawned_proxy_*` tests are the exception: they
 //! assert nothing about the gate, but pin the harness that reaches it — the
@@ -43,7 +45,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// the loop keeps checking whether the child died.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
-/// Read budget for a test's own request, which waits on the real upstream path.
+/// Read budget for a test's own HTTP request to the proxy.
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// How long a proxy that refuses its config gets to exit. It never binds, so
@@ -59,8 +61,8 @@ const PORT_ATTEMPTS: usize = 10;
 /// once its socket already holds it, never before.
 static HANDED_OUT: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
 
-/// A config whose upstream can never resolve, so any request that passes the
-/// gate fails closed rather than reaching a real service.
+/// A config with an unknown upstream profile, so valid requests reach the
+/// operation policy but never reach a real service.
 fn config_json(listen: &str) -> String {
     format!(
         r#"{{

--- a/coop-proxy/tests/gate.rs
+++ b/coop-proxy/tests/gate.rs
@@ -232,10 +232,23 @@ async fn probe_reply(stream: TcpStream) -> bool {
 }
 
 async fn request_status(addr: SocketAddr, auth_header: Option<&str>) -> String {
-    let stream = TcpStream::connect(addr).await.unwrap();
-    status_line(stream, auth_header, RESPONSE_TIMEOUT)
-        .await
-        .expect("request to the proxy failed at the socket level")
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let mut req =
+        String::from("POST /v1/messages HTTP/1.1\r\nHost: proxy\r\nContent-Length: 0\r\n");
+    if let Some(h) = auth_header {
+        req.push_str(h);
+        req.push_str("\r\n");
+    }
+    req.push_str("Connection: close\r\n\r\n");
+    stream.write_all(req.as_bytes()).await.unwrap();
+
+    let mut buf = Vec::new();
+    let _ = tokio::time::timeout(RESPONSE_TIMEOUT, stream.read_to_end(&mut buf)).await;
+    String::from_utf8_lossy(&buf)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_string()
 }
 
 /// Send a minimal HTTP/1.1 request over `stream` and return the status line, or

--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -36,6 +36,29 @@ The capability token is worthless off the host — it only authorizes the local
 proxy, which holds the real key itself — so exfiltrating it gains a compromised
 guest nothing.
 
+## Operation policy
+
+After authenticating the capability token, the proxy default-denies operations
+before connecting upstream. The only allowed method/path pairs are:
+
+| Provider | Allowed operation |
+| --- | --- |
+| OpenAI | `POST /v1/responses` |
+| Anthropic | `POST /v1/messages` |
+| Anthropic | `POST /v1/messages/count_tokens` |
+
+All other methods, paths, and unknown upstream profiles receive a local `403`.
+This limits a compromised guest to the model calls its configured coding agent
+needs, and prevents it from using the injected key for account, model, admin,
+or arbitrary retrieval APIs. Widening this list requires security review and
+tests for the new agent operation.
+
+The request bodies are intentionally opaque and streamed. In particular, an
+allowed `POST /v1/responses` can still reference OpenAI objects by ID (such as
+existing conversations, responses, prompts, or files) when the injected key is
+authorized for them. The allowlist is defense in depth against broad API use,
+not object-level tenant isolation.
+
 ## Enabling it
 
 The easiest path is `coop proxy setup`: it takes a pasted credential, stores it

--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -59,6 +59,16 @@ existing conversations, responses, prompts, or files) when the injected key is
 authorized for them. The allowlist is defense in depth against broad API use,
 not object-level tenant isolation.
 
+The policy is intentionally closed: if a future agent version needs another
+endpoint, it fails locally with `403` until coop adds and reviews that route.
+Claude Code may issue `HEAD /api/hello` and `GET /v1/models?limit=1000` for
+warmup or discovery; proxy mode intentionally refuses both because its normal
+message and token-count operations do not require gateway discovery. Codex's
+proxy provider is named `coop credential proxy`, not `OpenAI`, so Codex does
+not currently enable its OpenAI-specific `POST /v1/responses/compact` behavior.
+If either client changes this behavior, add the route only with an explicit
+policy, test, and documentation update.
+
 ## Enabling it
 
 The easiest path is `coop proxy setup`: it takes a pasted credential, stores it

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -142,11 +142,15 @@ user `env_forward` entries, and the VM SSH key. The invariants:
   per-instance `ssh -R` reverse tunnel (`proxy.rs:spawn_reverse_forward`), so —
   like the port-forwards above — it never binds a non-loopback interface and is
   reachable by exactly one guest, identically on both backends. It is guarded
-  by a per-instance capability token and forwards only to a fixed per-provider
-  upstream (`api.anthropic.com` / `api.openai.com`), never a guest-supplied host
-  — one proxy process and one tunnel per (VM, provider). Its own TLS-verifying
+  by a per-instance capability token and forwards only its documented
+  provider-specific operations to a fixed per-provider upstream
+  (`api.anthropic.com` / `api.openai.com`), never a guest-supplied host — one
+  proxy process and one tunnel per (VM, provider). Its own TLS-verifying
   outbound HTTPS is the intended egress; a change that lets the guest influence
-  the upstream host, or that binds anything wider than loopback, is a finding.
+  the upstream host, widens the operation policy without security review, or
+  binds anything wider than loopback, is a finding. The proxy streams allowed
+  request bodies opaquely, so this does not isolate provider objects referenced
+  by ID within an allowed request.
 
 - **The credential proxy is jailed (issue #411, slice 3).** `coop-proxy` holds
   the real credential and terminates connections the untrusted guest

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -7,10 +7,11 @@
 //! per-instance `ssh -R` reverse tunnel — both tracked by PID files.
 //!
 //! One `coop-proxy` process (and one reverse tunnel) runs per (VM, provider):
-//! Anthropic for Claude Code, `OpenAI` for Codex. The binary is
-//! provider-agnostic — it injects one configured header to one fixed upstream
-//! — so a provider is just a different upstream host, port, and auth scheme
-//! resolved on the host. See [`docs/design/issue-411-injecting-proxy.md`].
+//! Anthropic for Claude Code, `OpenAI` for Codex. The host lifecycle is shared,
+//! but `coop-proxy` applies a provider-specific operation profile as well as a
+//! fixed upstream and authentication scheme. Adding a provider therefore
+//! requires an explicit proxy policy change, not just a host, port, and auth
+//! configuration. See [`docs/design/issue-411-injecting-proxy.md`].
 //!
 //! Binding host loopback + reverse-tunnelling works identically on both
 //! backends (Firecracker and Lima), keeps the listener off every non-loopback
@@ -54,9 +55,9 @@ const TUNNEL_READY_GRACE: Duration = Duration::from_secs(2);
 /// integration suite, not by liveness here.
 const PROXY_READY_GRACE: Duration = Duration::from_secs(5);
 
-/// A proxied upstream. The binary is provider-agnostic; this enum carries the
-/// host-side per-provider constants (upstream host, base port, file/tunnel
-/// name) so one code path serves both.
+/// A proxied upstream. This enum carries the host-side per-provider constants
+/// (upstream host, base port, file/tunnel name); `coop-proxy` separately owns
+/// the per-provider operation policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Provider {
     /// Anthropic (Claude Code) → `api.anthropic.com`.

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -4237,28 +4237,31 @@ CFGEOF
     # ── The proxy is reachable on host loopback and enforces the gate ──
     # The proxy binds 127.0.0.1:<port> on the host and is reverse-tunnelled into
     # the guest, so the host exercises the same listener. A request without the
-    # token is refused locally ("capability token"); with the token it passes
-    # the gate and is forwarded upstream (which fails closed at the real host —
-    # 502 with no egress, or an upstream auth error — but never the local
-    # refusal), so the presence/absence of the "capability" refusal distinguishes
-    # the two without needing a working upstream.
+    # token is refused locally ("capability token"). With the token, an
+    # allowlisted operation is forwarded upstream (which fails closed at the
+    # real host — 502 with no egress, or an upstream auth error — but never the
+    # local refusal), so the presence/absence of the "capability" refusal
+    # distinguishes the two without needing a working upstream.
     local oai_port cap_token
     oai_port=$(echo "$codex_cfg" | grep -oE '127\.0\.0\.1:[0-9]+' | head -1 | cut -d: -f2 || true)
     cap_token=$(echo "$guest_env" | grep '^COOP_LOCAL_API_KEY=' | cut -d= -f2- || true)
     if [[ -n "$oai_port" ]]; then
-        local no_tok tok
-        no_tok=$(curl -s --max-time 10 "http://127.0.0.1:$oai_port/v1/models" || true)
-        tok=$(curl -s --max-time 15 "http://127.0.0.1:$oai_port/v1/models" \
-            -H "Authorization: Bearer $cap_token" || true)
+        local no_tok tok response_body
+        response_body='{"model":"gpt-4.1","input":"ping"}'
+        no_tok=$(curl -s --max-time 10 -X POST "http://127.0.0.1:$oai_port/v1/responses" \
+            -H "Content-Type: application/json" --data "$response_body" || true)
+        tok=$(curl -s --max-time 15 -X POST "http://127.0.0.1:$oai_port/v1/responses" \
+            -H "Authorization: Bearer $cap_token" -H "Content-Type: application/json" \
+            --data "$response_body" || true)
         if echo "$no_tok" | grep -qi "capability"; then
             pass "openai proxy refuses a request missing the capability token"
         else
             fail "openai proxy refuses a request missing the capability token" "body: $no_tok"
         fi
         if echo "$tok" | grep -qi "capability"; then
-            fail "valid capability token passes the gate" "still refused: $tok"
+            fail "valid capability token forwards an allowed operation" "still refused: $tok"
         else
-            pass "valid capability token passes the gate (forwarded upstream)"
+            pass "valid capability token forwards an allowed operation"
         fi
     else
         fail "locate openai proxy port" "no 127.0.0.1:<port> in codex config"


### PR DESCRIPTION
## Summary

- default-deny credential-proxy operations after capability-token authentication and before any upstream connection
- allow only `POST /v1/responses` for OpenAI
- allow only `POST /v1/messages` and `POST /v1/messages/count_tokens` for Anthropic
- reject every other method, path, cross-provider route, trailing-slash variant, and unknown upstream profile locally with `403`

## Why

This is defense in depth against a compromised guest using the host credential for provider administrative, account/model-discovery, or direct resource-retrieval APIs. It prevents operations such as minting an OpenAI admin key, creating an Anthropic organization invite, retrieving a stored OpenAI response directly, and retrieving Anthropic batch results.

The policy is matched against the pinned upstream host as well as the request method and path, so an operation allowed for one provider cannot be replayed through the other provider profile. It does not replace tenant or object-level authorization: the proxy deliberately streams bodies without parsing them, and an allowed OpenAI Responses request can still reference provider objects by ID when the injected credential is authorized for them.

The route set is intentionally closed. Future agent versions that need a new endpoint fail locally until a deliberate policy, test, and documentation change is reviewed. Current Codex proxy configuration is named `coop credential proxy`, not `OpenAI`; therefore Codex does not currently use its OpenAI-specific `POST /v1/responses/compact` behavior.

## Review follow-ups

- removed the unneeded OpenAI token-count endpoint rather than creating a stored-object token-count oracle
- corrected the VM integration probe to use the allowed Responses operation instead of the now-denied `GET /v1/models`
- added exact-path, cross-provider, unknown-profile, and authentication-to-policy coverage
- documented the allowlist, body-reference limitation, and agent compatibility boundary

## Testing

- `cargo +1.94.1 fmt --all -- --check`
- `cargo +1.94.1 test -p coop-proxy`
- `cargo +1.94.1 clippy -p coop-proxy --all-targets -- -D warnings`
- `bash -n tests/integration.sh`