### PR TITLE
Install complete Codex runtime package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,13 @@
 
 ### Fixes
 
+- **Install Codex's complete runtime package** (#442) — Recent Codex releases
+  use a companion `codex-code-mode-host` executable, but coop installed only
+  the raw `codex` binary, causing Code Mode to fail closed at startup. Image
+  builds and `coop agent update --codex` now install the upstream package with
+  its host and runtime resources intact, and atomically switch both public
+  entrypoints to the same release.
+
 - **`install.sh` and `coop update` verify provenance without a GitHub
   credential** (#421) — Verification ran `gh attestation verify --repo
   trailofbits/coop`, which reads the Sigstore bundle from the attestations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,9 @@
 - **Install Codex's complete runtime package** (#442) — Recent Codex releases
   use a companion `codex-code-mode-host` executable, but coop installed only
   the raw `codex` binary, causing Code Mode to fail closed at startup. Image
-  builds and `coop agent update --codex` now install the upstream package with
-  its host and runtime resources intact, and atomically switch both public
-  entrypoints to the same release.
+  builds and `coop agent update --codex` now verify and install the upstream
+  package with its host and runtime resources intact, root-owned and behind a
+  shared current-release link.
 
 - **`install.sh` and `coop update` verify provenance without a GitHub
   credential** (#421) — Verification ran `gh attestation verify --repo

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -262,7 +262,7 @@ coop agent update --codex          # update Codex to the latest release
 coop agent update --check          # report installed vs. latest, change nothing
 ```
 
-This re-runs coop's own Codex installer inside the guest as root and atomically switches the CLI and code-mode host to the same current package. To refresh the golden image so new VMs ship the latest Codex, rebuild it with `coop setup --rebuild`. See [`agent update`](commands.md#agent-update).
+This re-runs coop's own Codex installer inside the guest as root, verifies the published package checksums, and switches the CLI and code-mode host through the same current-package link. To refresh the golden image so new VMs ship the latest Codex, rebuild it with `coop setup --rebuild`. See [`agent update`](commands.md#agent-update).
 
 ## Local model support
 

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -255,14 +255,14 @@ This skips the guest bootstrap sequence entirely. The VM still includes both CLI
 
 ## Updating Codex
 
-Codex is installed "latest at build time" during `coop setup` and has no background updater, so it stays at that version until the image is rebuilt. Unlike Claude Code, it does not refresh itself. To update Codex in a running VM without rebuilding the image:
+Codex is installed "latest at build time" during `coop setup` and has no background updater, so it stays at that version until the image is rebuilt. Unlike Claude Code, it does not refresh itself. coop installs the complete upstream package, including the `codex-code-mode-host` companion and runtime resources, under `/usr/local/lib/codex`; stable entrypoints live in `/usr/local/bin`. To update Codex in a running VM without rebuilding the image:
 
 ```bash
 coop agent update --codex          # update Codex to the latest release
 coop agent update --check          # report installed vs. latest, change nothing
 ```
 
-This re-runs coop's own Codex installer inside the guest as root, overwriting `/usr/local/bin/codex` with the current release. To refresh the golden image so new VMs ship the latest Codex, rebuild it with `coop setup --rebuild`. See [`agent update`](commands.md#agent-update).
+This re-runs coop's own Codex installer inside the guest as root and atomically switches the CLI and code-mode host to the same current package. To refresh the golden image so new VMs ship the latest Codex, rebuild it with `coop setup --rebuild`. See [`agent update`](commands.md#agent-update).
 
 ## Local model support
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -483,7 +483,8 @@ With no agent flag, both agents are updated; passing both `--claude` and
 
 Codex has no background updater, so `coop agent update --codex` re-runs coop's
 own installer inside the guest as root. It installs the complete upstream
-package and atomically switches the CLI and code-mode host to the same release.
+package, verifies its published checksums, and switches the CLI and code-mode
+host through the same current-release link.
 Claude Code already auto-updates in the background;
 `coop agent update --claude` runs `claude update` now, synchronously — a
 convenience rather than a fix.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -482,8 +482,9 @@ With no agent flag, both agents are updated; passing both `--claude` and
 `--codex` is the same as passing neither. The VM must be running.
 
 Codex has no background updater, so `coop agent update --codex` re-runs coop's
-own installer inside the guest as root, overwriting `/usr/local/bin/codex` with
-the current release. Claude Code already auto-updates in the background;
+own installer inside the guest as root. It installs the complete upstream
+package and atomically switches the CLI and code-mode host to the same release.
+Claude Code already auto-updates in the background;
 `coop agent update --claude` runs `claude update` now, synchronously — a
 convenience rather than a fix.
 

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -26,7 +26,9 @@ Every template installs these packages regardless of profile selection.
 
 **Claude Code CLI:** installed via the native installer during the template build.
 
-**Codex CLI:** installed as a standalone binary during the template build.
+**Codex CLI:** installed as a complete package during the template build. The
+package contains the CLI, its code-mode host, and bundled runtime resources;
+stable entrypoints under `/usr/local/bin` switch together on update.
 The image also installs `/usr/local/bin/codex-account`, a wrapper used by
 `[codex] auth = "chatgpt"` to run Codex with a D-Bus session and guest Linux
 Secret Service storage. The wrapper and its three supporting packages

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -18,7 +18,7 @@ coop stores the result under `~/.coop/images/<name>/`. When creating an instance
 
 Every template installs these packages regardless of profile selection.
 
-**Base packages:** `openssh-server`, `dbus-user-session`, `curl`, `wget`, `git`, `build-essential`, `ca-certificates`, `gnupg`, `lsb-release`, `sudo`, `iproute2`, `iptables`, `kmod`, `procps`, `jq`, `rsync`, `unzip`, `zip`, `file`, `gnome-keyring`, `less`, `libsecret-tools`
+**Base packages:** `openssh-server`, `dbus-user-session`, `curl`, `wget`, `git`, `build-essential`, `ca-certificates`, `gnupg`, `lsb-release`, `sudo`, `iproute2`, `iptables`, `kmod`, `procps`, `util-linux`, `jq`, `rsync`, `unzip`, `zip`, `file`, `gnome-keyring`, `less`, `libsecret-tools`
 
 **Docker:** `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin`
 

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -28,7 +28,7 @@ Every template installs these packages regardless of profile selection.
 
 **Codex CLI:** installed as a complete package during the template build. The
 package contains the CLI, its code-mode host, and bundled runtime resources;
-stable entrypoints under `/usr/local/bin` switch together on update.
+stable entrypoints under `/usr/local/bin` share one current-package link.
 The image also installs `/usr/local/bin/codex-account`, a wrapper used by
 `[codex] auth = "chatgpt"` to run Codex with a D-Bus session and guest Linux
 Secret Service storage. The wrapper and its three supporting packages

--- a/scripts/guest/codex.sh
+++ b/scripts/guest/codex.sh
@@ -5,20 +5,21 @@ set -euo pipefail
 # exit would short-circuit anything appended after it.
 #
 # COOP_FORCE_INSTALL bypasses the "already installed" guard so `coop agent
-# update --codex` can re-run this same script to overwrite the root-owned
-# binary with the current release. Unset during normal setup, so the
-# skip-if-present behaviour is preserved there.
-if [ -z "${COOP_FORCE_INSTALL:-}" ] && [ -x /usr/local/bin/codex ]; then
-    echo '  [guest] Codex CLI already installed, skipping.'
+# update --codex` can re-run this same script. Unset during normal setup, so
+# the skip-if-present behaviour is preserved there.
+if [ -z "${COOP_FORCE_INSTALL:-}" ] \
+    && [ -x /usr/local/bin/codex ] \
+    && [ -x /usr/local/bin/codex-code-mode-host ]; then
+    echo '  [guest] Codex CLI package already installed, skipping.'
 else
-    echo '  [guest] Installing Codex CLI...'
+    echo '  [guest] Installing Codex CLI package...'
 
     case "$(uname -m)" in
         x86_64)
-            ASSET="codex-x86_64-unknown-linux-musl.tar.gz"
+            CODEX_TARGET="x86_64-unknown-linux-musl"
             ;;
         aarch64|arm64)
-            ASSET="codex-aarch64-unknown-linux-musl.tar.gz"
+            CODEX_TARGET="aarch64-unknown-linux-musl"
             ;;
         *)
             echo "  [guest] ERROR: Unsupported architecture for Codex CLI: $(uname -m)" >&2
@@ -26,22 +27,24 @@ else
             ;;
     esac
 
-    TMPDIR=$(mktemp -d)
-    trap 'rm -rf "$TMPDIR"' EXIT
-    ARCHIVE="$TMPDIR/$ASSET"
-    BIN="$TMPDIR/${ASSET%.tar.gz}"
+    CODEX_ASSET="codex-package-$CODEX_TARGET.tar.gz"
+    CODEX_TMP_DIR=$(mktemp -d)
+    trap 'rm -rf "$CODEX_TMP_DIR"' EXIT
+    CODEX_ARCHIVE="$CODEX_TMP_DIR/$CODEX_ASSET"
+    CODEX_EXTRACTED="$CODEX_TMP_DIR/package"
+    mkdir -p "$CODEX_EXTRACTED"
 
     MAX_RETRIES=4
     RETRY_DELAY=5
-    URL="https://github.com/openai/codex/releases/latest/download/$ASSET"
+    CODEX_URL="https://github.com/openai/codex/releases/latest/download/$CODEX_ASSET"
     for attempt in $(seq 1 "$MAX_RETRIES"); do
-        if curl -fsSL -o "$ARCHIVE" "$URL" 2>/tmp/codex-curl-err; then
+        if curl -fsSL -o "$CODEX_ARCHIVE" "$CODEX_URL" 2>/tmp/codex-curl-err; then
             break
         fi
         CURL_EXIT=$?
         CURL_ERR=$(cat /tmp/codex-curl-err 2>/dev/null || true)
         if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-            echo "  [guest] ERROR: Failed to download Codex CLI archive after $MAX_RETRIES attempts." >&2
+            echo "  [guest] ERROR: Failed to download Codex CLI package after $MAX_RETRIES attempts." >&2
             echo "  [guest] curl exit code: $CURL_EXIT" >&2
             echo "  [guest] curl error: ${CURL_ERR:-none}" >&2
             exit 1
@@ -51,11 +54,45 @@ else
         RETRY_DELAY=$((RETRY_DELAY * 2))
     done
 
-    tar -xzf "$ARCHIVE" -C "$TMPDIR"
-    if [ ! -x "$BIN" ]; then
-        echo '  [guest] ERROR: Codex archive did not contain the expected binary.' >&2
+    tar -xzf "$CODEX_ARCHIVE" -C "$CODEX_EXTRACTED"
+    for executable in codex codex-code-mode-host; do
+        if [ ! -x "$CODEX_EXTRACTED/bin/$executable" ]; then
+            echo "  [guest] ERROR: Codex package did not contain executable bin/$executable." >&2
+            exit 1
+        fi
+    done
+    if [ ! -f "$CODEX_EXTRACTED/codex-package.json" ] \
+        || [ ! -d "$CODEX_EXTRACTED/codex-resources" ] \
+        || [ ! -d "$CODEX_EXTRACTED/codex-path" ]; then
+        echo '  [guest] ERROR: Codex package did not contain its manifest and runtime resources.' >&2
         exit 1
     fi
 
-    install -m 755 "$BIN" /usr/local/bin/codex
+    # Keep each upstream package intact so Codex can find its bundled runtime
+    # resources relative to bin/codex. The archive digest is a stable release
+    # directory name even though the `latest` download URL has no version in it.
+    CODEX_PACKAGE_SHA=$(sha256sum "$CODEX_ARCHIVE" | cut -d ' ' -f 1)
+    CODEX_INSTALL_ROOT="/usr/local/lib/codex"
+    CODEX_RELEASES_DIR="$CODEX_INSTALL_ROOT/releases"
+    CODEX_RELEASE_DIR="$CODEX_RELEASES_DIR/$CODEX_PACKAGE_SHA"
+    install -d -m 755 "$CODEX_RELEASES_DIR"
+
+    if [ ! -d "$CODEX_RELEASE_DIR" ]; then
+        CODEX_STAGING_DIR="$CODEX_RELEASES_DIR/.staging-$CODEX_PACKAGE_SHA-$$"
+        install -d -m 755 "$CODEX_STAGING_DIR"
+        cp -a "$CODEX_EXTRACTED/." "$CODEX_STAGING_DIR/"
+        mv -T "$CODEX_STAGING_DIR" "$CODEX_RELEASE_DIR"
+    fi
+
+    # Both public entrypoints resolve through one `current` link. Updating that
+    # link switches codex and its version-matched code-mode host atomically.
+    CODEX_NEXT_LINK="$CODEX_INSTALL_ROOT/.current-$$"
+    ln -s "releases/$CODEX_PACKAGE_SHA" "$CODEX_NEXT_LINK"
+    mv -Tf "$CODEX_NEXT_LINK" "$CODEX_INSTALL_ROOT/current"
+
+    for executable in codex codex-code-mode-host; do
+        CODEX_BIN_LINK="/usr/local/bin/.$executable-$$"
+        ln -s "$CODEX_INSTALL_ROOT/current/bin/$executable" "$CODEX_BIN_LINK"
+        mv -Tf "$CODEX_BIN_LINK" "/usr/local/bin/$executable"
+    done
 fi

--- a/scripts/guest/codex.sh
+++ b/scripts/guest/codex.sh
@@ -1,98 +1,188 @@
 set -euo pipefail
 
-# Using if/else (not early `exit 0`) because this file is concatenated
-# with claude-code.sh into a single shell invocation; an unconditional
-# exit would short-circuit anything appended after it.
-#
-# COOP_FORCE_INSTALL bypasses the "already installed" guard so `coop agent
-# update --codex` can re-run this same script. Unset during normal setup, so
-# the skip-if-present behaviour is preserved there.
+# Using if/else (not early `exit 0`) because this file is concatenated with
+# other guest installers; an unconditional exit would skip everything after it.
+
+case "$(uname -m)" in
+    x86_64)
+        CODEX_TARGET="x86_64-unknown-linux-musl"
+        ;;
+    aarch64|arm64)
+        CODEX_TARGET="aarch64-unknown-linux-musl"
+        ;;
+    *)
+        echo "  [guest] ERROR: Unsupported architecture for Codex CLI: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+CODEX_ASSET="codex-package-$CODEX_TARGET.tar.gz"
+CODEX_SUMS_ASSET="codex-package_SHA256SUMS"
+CODEX_INSTALL_ROOT="/usr/local/lib/codex"
+CODEX_RELEASES_DIR="$CODEX_INSTALL_ROOT/releases"
+CODEX_BIN_LINK=""
+
+codex_package_is_complete() {
+    local package_dir="$1"
+    local manifest_version reported_version
+
+    [ -x "$package_dir/bin/codex" ] \
+        && [ -x "$package_dir/bin/codex-code-mode-host" ] \
+        && [ -x "$package_dir/codex-path/rg" ] \
+        && [ -x "$package_dir/codex-resources/bwrap" ] \
+        && [ -x "$package_dir/codex-resources/zsh/bin/zsh" ] \
+        && [ -f "$package_dir/codex-package.json" ] \
+        && jq -e --arg target "$CODEX_TARGET" \
+            '.layoutVersion == 1 and .target == $target and .entrypoint == "bin/codex"' \
+            "$package_dir/codex-package.json" >/dev/null \
+        || return 1
+
+    manifest_version=$(jq -er '.version | strings | select(length > 0)' \
+        "$package_dir/codex-package.json") || return 1
+    reported_version=$("$package_dir/bin/codex" --version) || return 1
+    [ "$reported_version" = "codex-cli $manifest_version" ] || return 1
+}
+
+codex_installed_package_is_safe() {
+    local package_dir="$1"
+    local resolved_dir
+
+    resolved_dir=$(readlink -f "$package_dir") || return 1
+
+    codex_package_is_complete "$package_dir" \
+        && [ -z "$(find "$resolved_dir" ! -type l ! -user root -print -quit)" ] \
+        && [ -z "$(find "$resolved_dir" ! -type l -perm /022 -print -quit)" ]
+}
+
+codex_reconcile_public_entrypoints() {
+    local executable
+
+    # Install the helper first and Codex last. On migration from coop's legacy
+    # single-binary layout, Codex becomes the commit point only after its helper
+    # is ready. Both links resolve through `current`, so later release switches
+    # update the pair together.
+    for executable in codex-code-mode-host codex; do
+        CODEX_BIN_LINK="/usr/local/bin/.$executable-$$"
+        rm -f -- "$CODEX_BIN_LINK"
+        ln -s "$CODEX_INSTALL_ROOT/current/bin/$executable" "$CODEX_BIN_LINK"
+        mv -Tf "$CODEX_BIN_LINK" "/usr/local/bin/$executable"
+        CODEX_BIN_LINK=""
+    done
+}
+
+# COOP_FORCE_INSTALL bypasses the installed-package guard so `coop agent
+# update --codex` always checks upstream. Normal setup skips only a complete,
+# root-owned package; two manually copied binaries are not enough.
 if [ -z "${COOP_FORCE_INSTALL:-}" ] \
-    && [ -x /usr/local/bin/codex ] \
-    && [ -x /usr/local/bin/codex-code-mode-host ]; then
+    && codex_installed_package_is_safe "$CODEX_INSTALL_ROOT/current"; then
+    codex_reconcile_public_entrypoints
+    /usr/local/bin/codex --version >/dev/null
     echo '  [guest] Codex CLI package already installed, skipping.'
 else
     echo '  [guest] Installing Codex CLI package...'
 
-    case "$(uname -m)" in
-        x86_64)
-            CODEX_TARGET="x86_64-unknown-linux-musl"
-            ;;
-        aarch64|arm64)
-            CODEX_TARGET="aarch64-unknown-linux-musl"
-            ;;
-        *)
-            echo "  [guest] ERROR: Unsupported architecture for Codex CLI: $(uname -m)" >&2
-            exit 1
-            ;;
-    esac
-
-    CODEX_ASSET="codex-package-$CODEX_TARGET.tar.gz"
     CODEX_TMP_DIR=$(mktemp -d)
-    trap 'rm -rf "$CODEX_TMP_DIR"' EXIT
-    CODEX_ARCHIVE="$CODEX_TMP_DIR/$CODEX_ASSET"
-    CODEX_EXTRACTED="$CODEX_TMP_DIR/package"
-    mkdir -p "$CODEX_EXTRACTED"
+    CODEX_STAGING_DIR=""
+    CODEX_NEXT_LINK=""
 
-    MAX_RETRIES=4
-    RETRY_DELAY=5
-    CODEX_URL="https://github.com/openai/codex/releases/latest/download/$CODEX_ASSET"
-    for attempt in $(seq 1 "$MAX_RETRIES"); do
-        if curl -fsSL -o "$CODEX_ARCHIVE" "$CODEX_URL" 2>/tmp/codex-curl-err; then
+    cleanup_codex_install() {
+        rm -rf "$CODEX_TMP_DIR"
+        [ -z "$CODEX_STAGING_DIR" ] || rm -rf -- "$CODEX_STAGING_DIR"
+        [ -z "$CODEX_NEXT_LINK" ] || rm -f -- "$CODEX_NEXT_LINK"
+        [ -z "$CODEX_BIN_LINK" ] || rm -f -- "$CODEX_BIN_LINK"
+    }
+    trap cleanup_codex_install EXIT
+
+    download_codex_file() {
+        local url="$1"
+        local output="$2"
+        local description="$3"
+        local attempt curl_exit curl_error
+        local retry_delay=5
+
+        for attempt in $(seq 1 4); do
+            if curl -fsSL -o "$output" "$url" 2>"$CODEX_TMP_DIR/curl.err"; then
+                return 0
+            else
+                curl_exit=$?
+            fi
+            curl_error=$(cat "$CODEX_TMP_DIR/curl.err" 2>/dev/null || true)
+            if [ "$attempt" -eq 4 ]; then
+                echo "  [guest] ERROR: Failed to download $description after 4 attempts." >&2
+                echo "  [guest] curl exit code: $curl_exit" >&2
+                echo "  [guest] curl error: ${curl_error:-none}" >&2
+                return 1
+            fi
+            echo "  [guest] Download failed (attempt $attempt/4, curl exit $curl_exit), retrying in ${retry_delay}s..."
+            sleep "$retry_delay"
+            retry_delay=$((retry_delay * 2))
+        done
+    }
+
+    CODEX_SUMS_FILE="$CODEX_TMP_DIR/$CODEX_SUMS_ASSET"
+    CODEX_ARCHIVE="$CODEX_TMP_DIR/$CODEX_ASSET"
+    CODEX_PACKAGE_SHA=""
+    CODEX_RELEASE_VERIFIED=0
+    for release_attempt in $(seq 1 4); do
+        download_codex_file \
+            "https://github.com/openai/codex/releases/latest/download/$CODEX_SUMS_ASSET" \
+            "$CODEX_SUMS_FILE" "Codex package checksum manifest"
+        CODEX_PACKAGE_SHA=$(awk -v asset="$CODEX_ASSET" \
+            '$2 == asset && length($1) == 64 && $1 !~ /[^0-9a-fA-F]/ { print tolower($1) }' \
+            "$CODEX_SUMS_FILE")
+
+        download_codex_file \
+            "https://github.com/openai/codex/releases/latest/download/$CODEX_ASSET" \
+            "$CODEX_ARCHIVE" "Codex CLI package"
+        if [[ "$CODEX_PACKAGE_SHA" =~ ^[0-9a-f]{64}$ ]] \
+            && printf '%s  %s\n' "$CODEX_PACKAGE_SHA" "$CODEX_ARCHIVE" \
+                | sha256sum -c - >/dev/null 2>&1; then
+            CODEX_RELEASE_VERIFIED=1
             break
         fi
-        CURL_EXIT=$?
-        CURL_ERR=$(cat /tmp/codex-curl-err 2>/dev/null || true)
-        if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-            echo "  [guest] ERROR: Failed to download Codex CLI package after $MAX_RETRIES attempts." >&2
-            echo "  [guest] curl exit code: $CURL_EXIT" >&2
-            echo "  [guest] curl error: ${CURL_ERR:-none}" >&2
-            exit 1
-        fi
-        echo "  [guest] Download failed (attempt $attempt/$MAX_RETRIES, curl exit $CURL_EXIT), retrying in ${RETRY_DELAY}s..."
-        sleep "$RETRY_DELAY"
-        RETRY_DELAY=$((RETRY_DELAY * 2))
-    done
 
-    tar -xzf "$CODEX_ARCHIVE" -C "$CODEX_EXTRACTED"
-    for executable in codex codex-code-mode-host; do
-        if [ ! -x "$CODEX_EXTRACTED/bin/$executable" ]; then
-            echo "  [guest] ERROR: Codex package did not contain executable bin/$executable." >&2
-            exit 1
+        if [ "$release_attempt" -lt 4 ]; then
+            echo "  [guest] Codex release changed during download; retrying the package and checksums..."
+            sleep 2
         fi
     done
-    if [ ! -f "$CODEX_EXTRACTED/codex-package.json" ] \
-        || [ ! -d "$CODEX_EXTRACTED/codex-resources" ] \
-        || [ ! -d "$CODEX_EXTRACTED/codex-path" ]; then
-        echo '  [guest] ERROR: Codex package did not contain its manifest and runtime resources.' >&2
+    if [ "$CODEX_RELEASE_VERIFIED" -ne 1 ]; then
+        echo "  [guest] ERROR: Codex package did not match its published checksum after 4 attempts." >&2
         exit 1
     fi
 
-    # Keep each upstream package intact so Codex can find its bundled runtime
-    # resources relative to bin/codex. The archive digest is a stable release
-    # directory name even though the `latest` download URL has no version in it.
-    CODEX_PACKAGE_SHA=$(sha256sum "$CODEX_ARCHIVE" | cut -d ' ' -f 1)
-    CODEX_INSTALL_ROOT="/usr/local/lib/codex"
-    CODEX_RELEASES_DIR="$CODEX_INSTALL_ROOT/releases"
-    CODEX_RELEASE_DIR="$CODEX_RELEASES_DIR/$CODEX_PACKAGE_SHA"
     install -d -m 755 "$CODEX_RELEASES_DIR"
+    exec 9>"$CODEX_INSTALL_ROOT/install.lock"
+    flock 9
+    find "$CODEX_RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d \
+        -name '.staging-*' -exec rm -rf -- {} +
 
-    if [ ! -d "$CODEX_RELEASE_DIR" ]; then
+    CODEX_RELEASE_DIR="$CODEX_RELEASES_DIR/$CODEX_PACKAGE_SHA"
+    if ! codex_installed_package_is_safe "$CODEX_RELEASE_DIR"; then
         CODEX_STAGING_DIR="$CODEX_RELEASES_DIR/.staging-$CODEX_PACKAGE_SHA-$$"
         install -d -m 755 "$CODEX_STAGING_DIR"
-        cp -a "$CODEX_EXTRACTED/." "$CODEX_STAGING_DIR/"
+        tar --no-same-owner --no-same-permissions -xzf "$CODEX_ARCHIVE" \
+            -C "$CODEX_STAGING_DIR"
+        chown -R root:root "$CODEX_STAGING_DIR"
+        chmod -R go-w "$CODEX_STAGING_DIR"
+        codex_installed_package_is_safe "$CODEX_STAGING_DIR" || {
+            echo '  [guest] ERROR: Staged Codex package failed validation.' >&2
+            exit 1
+        }
+        if [ -e "$CODEX_RELEASE_DIR" ] || [ -L "$CODEX_RELEASE_DIR" ]; then
+            rm -rf -- "$CODEX_RELEASE_DIR"
+        fi
         mv -T "$CODEX_STAGING_DIR" "$CODEX_RELEASE_DIR"
+        CODEX_STAGING_DIR=""
     fi
 
-    # Both public entrypoints resolve through one `current` link. Updating that
-    # link switches codex and its version-matched code-mode host atomically.
+    # Once installed, both entrypoints resolve through this one link. Updating
+    # it switches Codex and its version-matched code-mode host atomically.
     CODEX_NEXT_LINK="$CODEX_INSTALL_ROOT/.current-$$"
     ln -s "releases/$CODEX_PACKAGE_SHA" "$CODEX_NEXT_LINK"
     mv -Tf "$CODEX_NEXT_LINK" "$CODEX_INSTALL_ROOT/current"
+    CODEX_NEXT_LINK=""
 
-    for executable in codex codex-code-mode-host; do
-        CODEX_BIN_LINK="/usr/local/bin/.$executable-$$"
-        ln -s "$CODEX_INSTALL_ROOT/current/bin/$executable" "$CODEX_BIN_LINK"
-        mv -Tf "$CODEX_BIN_LINK" "/usr/local/bin/$executable"
-    done
+    codex_reconcile_public_entrypoints
+    /usr/local/bin/codex --version >/dev/null
 fi

--- a/scripts/guest/codex.sh
+++ b/scripts/guest/codex.sh
@@ -70,6 +70,53 @@ codex_reconcile_public_entrypoints() {
     done
 }
 
+codex_current_release_sha() {
+    local current_target current_sha
+
+    current_target=$(readlink -f "$CODEX_INSTALL_ROOT/current" 2>/dev/null) || return 1
+    [ "$(dirname "$current_target")" = "$CODEX_RELEASES_DIR" ] || return 1
+    current_sha=$(basename "$current_target")
+    [[ "$current_sha" =~ ^[0-9a-f]{64}$ ]] || return 1
+    printf '%s\n' "$current_sha"
+}
+
+codex_release_has_live_executable() {
+    local release_dir="$1"
+    local proc_exe executable
+
+    # Processes can disappear, or become unreadable, between glob expansion
+    # and readlink. Those ordinary /proc races must not abort an update under
+    # `set -e`.
+    for proc_exe in /proc/[0-9]*/exe; do
+        [ -L "$proc_exe" ] || continue
+        executable=$(readlink "$proc_exe" 2>/dev/null) || continue
+        case "$executable" in
+            "$release_dir"/*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+codex_gc_releases() {
+    local current_sha="$1"
+    local previous_sha="$2"
+    local release_dir release_sha
+
+    for release_dir in "$CODEX_RELEASES_DIR"/*; do
+        # Never follow or remove a symlink. Release directories created by
+        # this installer have strict lowercase SHA-256 names.
+        [ -d "$release_dir" ] && [ ! -L "$release_dir" ] || continue
+        release_sha=$(basename "$release_dir")
+        [[ "$release_sha" =~ ^[0-9a-f]{64}$ ]] || continue
+        [ "$release_sha" = "$current_sha" ] && continue
+        [ -n "$previous_sha" ] && [ "$release_sha" = "$previous_sha" ] && continue
+        if codex_release_has_live_executable "$release_dir"; then
+            continue
+        fi
+        rm -rf -- "$release_dir"
+    done
+}
+
 # COOP_FORCE_INSTALL bypasses the installed-package guard so `coop agent
 # update --codex` always checks upstream. Normal setup skips only a complete,
 # root-owned package; two manually copied binaries are not enough.
@@ -80,6 +127,13 @@ if [ -z "${COOP_FORCE_INSTALL:-}" ] \
     echo '  [guest] Codex CLI package already installed, skipping.'
 else
     echo '  [guest] Installing Codex CLI package...'
+
+    # Serialize the complete update, including resolving the moving `latest`
+    # release. Otherwise a slower updater can download an older release, wait
+    # for a newer updater to activate, and then roll `current` backward.
+    install -d -m 755 "$CODEX_RELEASES_DIR"
+    exec 9>"$CODEX_INSTALL_ROOT/install.lock"
+    flock 9
 
     CODEX_TMP_DIR=$(mktemp -d)
     CODEX_STAGING_DIR=""
@@ -151,11 +205,13 @@ else
         exit 1
     fi
 
-    install -d -m 755 "$CODEX_RELEASES_DIR"
-    exec 9>"$CODEX_INSTALL_ROOT/install.lock"
-    flock 9
     find "$CODEX_RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d \
         -name '.staging-*' -exec rm -rf -- {} +
+
+    CODEX_PREVIOUS_RELEASE_SHA=""
+    if previous_release_sha=$(codex_current_release_sha); then
+        CODEX_PREVIOUS_RELEASE_SHA="$previous_release_sha"
+    fi
 
     CODEX_RELEASE_DIR="$CODEX_RELEASES_DIR/$CODEX_PACKAGE_SHA"
     if ! codex_installed_package_is_safe "$CODEX_RELEASE_DIR"; then
@@ -184,7 +240,9 @@ else
     CODEX_NEXT_LINK=""
 
     codex_reconcile_public_entrypoints
+    codex_installed_package_is_safe "$CODEX_INSTALL_ROOT/current"
     /usr/local/bin/codex --version >/dev/null
+    codex_gc_releases "$CODEX_PACKAGE_SHA" "$CODEX_PREVIOUS_RELEASE_SHA"
     flock -u 9
     exec 9>&-
 fi

--- a/scripts/guest/codex.sh
+++ b/scripts/guest/codex.sh
@@ -185,4 +185,6 @@ else
 
     codex_reconcile_public_entrypoints
     /usr/local/bin/codex --version >/dev/null
+    flock -u 9
+    exec 9>&-
 fi

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -9,10 +9,10 @@
 //! The two agents differ in how they update, and the difference is encoded in
 //! [`UpdateStrategy`] so no caller can run the wrong one:
 //!
-//! - **Codex** lives at root-owned `/usr/local/bin/codex` and has no
-//!   background updater. coop re-runs its own installer ([`guest::SCRIPT_CODEX`])
-//!   as root with `COOP_FORCE_INSTALL=1` to overwrite the binary with the
-//!   current release.
+//! - **Codex** is a root-owned package exposed through `/usr/local/bin` and has
+//!   no background updater. coop re-runs its own installer
+//!   ([`guest::SCRIPT_CODEX`]) as root with `COOP_FORCE_INSTALL=1` to install
+//!   the current release and atomically switch its entrypoints.
 //! - **Claude Code** lives in the guest user's `~/.local/bin` and already
 //!   auto-updates in the background. `coop agent update --claude` just runs
 //!   `claude update` synchronously as the guest user — a convenience, not a

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -73,8 +73,8 @@ impl Agent {
 
 /// How an agent's binary is refreshed in the guest.
 enum UpdateStrategy {
-    /// Re-run coop's own installer as root, forcing overwrite of the
-    /// root-owned binary. Carries the embedded installer script.
+    /// Re-run coop's installer as root and activate its package. Carries the
+    /// embedded installer script.
     ReinstallAsRoot { script: &'static str },
     /// Invoke the agent's own updater as the guest user (no sudo).
     SelfUpdate,

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -520,6 +520,57 @@ mod tests {
     }
 
     #[test]
+    fn codex_script_locks_before_resolving_latest_release() {
+        let lock = SCRIPT_CODEX.find("flock 9").unwrap();
+        let first_fetch = SCRIPT_CODEX.find("releases/latest/download").unwrap();
+        let final_validation = SCRIPT_CODEX
+            .rfind("codex_installed_package_is_safe \"$CODEX_INSTALL_ROOT/current\"")
+            .unwrap();
+        let unlock = SCRIPT_CODEX.find("flock -u 9").unwrap();
+
+        assert!(
+            lock < first_fetch,
+            "update lock must precede the first fetch"
+        );
+        assert!(
+            final_validation < unlock,
+            "activation must be validated before releasing the update lock",
+        );
+    }
+
+    #[test]
+    fn codex_script_garbage_collects_only_safe_inactive_releases() {
+        let final_validation = SCRIPT_CODEX
+            .rfind("codex_installed_package_is_safe \"$CODEX_INSTALL_ROOT/current\"")
+            .unwrap();
+        let garbage_collection = SCRIPT_CODEX
+            .find("codex_gc_releases \"$CODEX_PACKAGE_SHA\" \"$CODEX_PREVIOUS_RELEASE_SHA\"")
+            .unwrap();
+        let unlock = SCRIPT_CODEX.find("flock -u 9").unwrap();
+
+        assert!(
+            final_validation < garbage_collection && garbage_collection < unlock,
+            "release collection should run after validation and while holding the update lock",
+        );
+
+        for expected in [
+            "codex_gc_releases \"$CODEX_PACKAGE_SHA\" \"$CODEX_PREVIOUS_RELEASE_SHA\"",
+            "[[ \"$release_sha\" =~ ^[0-9a-f]{64}$ ]] || continue",
+            "[ ! -L \"$release_dir\" ]",
+            "[ \"$release_sha\" = \"$current_sha\" ] && continue",
+            "[ \"$release_sha\" = \"$previous_sha\" ] && continue",
+            "for proc_exe in /proc/[0-9]*/exe",
+            "executable=$(readlink \"$proc_exe\" 2>/dev/null) || continue",
+            "codex_release_has_live_executable \"$release_dir\"",
+        ] {
+            assert!(
+                SCRIPT_CODEX.contains(expected),
+                "Codex release retention is missing {expected:?}",
+            );
+        }
+    }
+
+    #[test]
     fn codex_account_script_uses_secret_service() {
         assert!(
             SCRIPT_CODEX_ACCOUNT.contains("cat >/usr/local/bin/codex-account"),

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -122,6 +122,11 @@ pub fn codex_bin() -> GuestPath {
     GuestPath::new("/usr/local/bin/codex")
 }
 
+/// Companion process used by Codex for Code Mode execution.
+pub fn codex_code_mode_host_bin() -> GuestPath {
+    GuestPath::new("/usr/local/bin/codex-code-mode-host")
+}
+
 /// Wrapper that runs Codex with a guest Linux Secret Service session.
 pub fn codex_account_bin() -> GuestPath {
     GuestPath::new("/usr/local/bin/codex-account")
@@ -170,12 +175,13 @@ impl From<GuestUser> for String {
 /// build shell commands or inspect the chroot get path semantics for
 /// free (and the `/usr/bin/docker`/`/usr/bin/gh` entries can't be
 /// mistaken for host paths).
-pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 8] {
+pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 9] {
     [
         GuestPath::new("/usr/bin/docker"),
         GuestPath::new("/usr/bin/gh"),
         user.claude_bin(),
         codex_bin(),
+        codex_code_mode_host_bin(),
         codex_account_bin(),
         // The Secret Service stack `codex-account` drives. Checking the
         // wrapper alone proves nothing — the provision script always writes
@@ -484,11 +490,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn codex_script_installs_extracted_binary_not_archive() {
+    fn codex_script_installs_complete_package_atomically() {
         assert!(
-            SCRIPT_CODEX.contains("BIN=\"$TMPDIR/${ASSET%.tar.gz}\""),
-            "Codex installer should target the extracted binary path directly",
+            SCRIPT_CODEX.contains("codex-package-$CODEX_TARGET.tar.gz"),
+            "Codex installer should download the complete upstream package",
         );
+        for expected in [
+            "bin/codex-code-mode-host",
+            "codex-package.json",
+            "codex-resources",
+            "codex-path",
+            "mv -Tf \"$CODEX_NEXT_LINK\" \"$CODEX_INSTALL_ROOT/current\"",
+        ] {
+            assert!(
+                SCRIPT_CODEX.contains(expected),
+                "Codex package installer is missing {expected:?}",
+            );
+        }
     }
 
     #[test]
@@ -802,6 +820,11 @@ mod tests {
         );
         assert!(
             bins.iter()
+                .any(|b| b.to_string() == "/usr/local/bin/codex-code-mode-host"),
+            "guest image should include Codex's code-mode host",
+        );
+        assert!(
+            bins.iter()
                 .any(|b| b.to_string() == "/usr/local/bin/codex-account"),
             "guest image should include the Codex account-auth wrapper",
         );
@@ -882,6 +905,7 @@ mod tests {
             "/usr/bin/docker",
             "/usr/bin/gh",
             "/usr/local/bin/codex",
+            "/usr/local/bin/codex-code-mode-host",
             "/usr/local/bin/codex-account",
         ] {
             assert!(err.contains(expected), "{expected} missing from: {err}");

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -262,6 +262,7 @@ pub const BASE_PACKAGES: &[&str] = &[
     "iptables",
     "kmod",
     "procps",
+    "util-linux",
     "jq",
     "rsync",
     "unzip",
@@ -500,6 +501,13 @@ mod tests {
             "codex-package.json",
             "codex-resources",
             "codex-path",
+            "codex-package_SHA256SUMS",
+            "sha256sum -c -",
+            "tar --no-same-owner --no-same-permissions",
+            "flock 9",
+            "chown -R root:root",
+            "for executable in codex-code-mode-host codex",
+            "codex_reconcile_public_entrypoints",
             "mv -Tf \"$CODEX_NEXT_LINK\" \"$CODEX_INSTALL_ROOT/current\"",
         ] {
             assert!(
@@ -844,7 +852,12 @@ mod tests {
 
     #[test]
     fn base_packages_include_secret_service_support() {
-        for expected in ["dbus-user-session", "gnome-keyring", "libsecret-tools"] {
+        for expected in [
+            "dbus-user-session",
+            "gnome-keyring",
+            "libsecret-tools",
+            "util-linux",
+        ] {
             assert!(
                 BASE_PACKAGES.contains(&expected),
                 "base packages should include {expected}",

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -196,8 +196,8 @@ pub fn required_guest_binaries(user: &GuestUser) -> [GuestPath; 9] {
 /// uniform error if any are missing.
 ///
 /// `probe` answers "does this binary exist in the image?" — its mechanism
-/// differs per backend (a chroot `symlink_metadata` for Firecracker, a
-/// `test -x` over `limactl shell` for Lima). `source_label` names what
+/// differs per backend (`test -x` inside the chroot for Firecracker, or over
+/// `limactl shell` for Lima). `source_label` names what
 /// produced the image ("install script" vs "provision script"), and
 /// `diagnostics` supplies any trailing detail (e.g. a build-log tail),
 /// evaluated lazily only when something is missing.
@@ -505,6 +505,8 @@ mod tests {
             "sha256sum -c -",
             "tar --no-same-owner --no-same-permissions",
             "flock 9",
+            "flock -u 9",
+            "exec 9>&-",
             "chown -R root:root",
             "for executable in codex-code-mode-host codex",
             "codex_reconcile_public_entrypoints",

--- a/src/lima.rs
+++ b/src/lima.rs
@@ -1490,7 +1490,7 @@ fn compose_provision_script(
     s.push_str(SCRIPT_CLAUDE_CODE);
     s.push('\n');
 
-    // Codex CLI (standalone binary under /usr/local/bin)
+    // Codex CLI package (stable entrypoints under /usr/local/bin)
     s.push_str(SCRIPT_CODEX);
     s.push('\n');
     s.push_str(SCRIPT_CODEX_ACCOUNT);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1313,17 +1313,21 @@ fn install_guest_packages(
 
 /// Verify critical binaries exist in the chroot after provisioning.
 ///
-/// Uses `symlink_metadata` (lstat) instead of `exists` (stat) because
-/// the Claude binary is a symlink with an absolute target
-/// (`/home/<user>/.local/share/claude/versions/X.Y.Z`). When checked
-/// from outside the chroot, `exists()` follows the symlink to the
-/// host filesystem where the target doesn't exist. A symlink being
-/// present is sufficient — it will resolve correctly inside the guest.
+/// Runs `test -x` inside the chroot so absolute symlink targets resolve against
+/// the guest root. Checking from the host with either `exists` or `lstat` would
+/// respectively reject valid absolute guest symlinks or accept dangling ones.
 fn verify_chroot_binaries(mount_str: &str, guest_user: &GuestUser) -> Result<()> {
     crate::guest::verify_required_binaries(
         guest_user,
         "install script",
-        |path| std::fs::symlink_metadata(format!("{mount_str}{path}")).is_ok(),
+        |path| {
+            let path = path.to_string();
+            Cmd::new("chroot")
+                .args([mount_str, "/usr/bin/test", "-x", path.as_str()])
+                .sudo()
+                .run()
+                .is_ok()
+        },
         String::new,
     )
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -730,7 +730,7 @@ fn compose_recipe(
     }
     // Direct binary download (runs as root in chroot, installs for guest user).
     s.push_str(SCRIPT_CLAUDE_CODE);
-    // Codex installs as a standalone binary under /usr/local/bin.
+    // Codex installs as a package with stable entrypoints under /usr/local/bin.
     s.push_str(SCRIPT_CODEX);
     s.push_str(SCRIPT_CODEX_ACCOUNT);
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -459,6 +459,11 @@ test_setup() {
     echo "=== Phase: setup ==="
 
     local args=(setup -y)
+    # The full suite exercises `agent update --codex`; force the initial image
+    # build so that test cannot silently reuse a pre-fix local template.
+    if [[ "$FULL" == "1" ]]; then
+        args+=(--rebuild)
+    fi
     if [[ -n "$PROFILES" ]]; then
         args+=(--profile "$PROFILES")
     fi
@@ -1082,15 +1087,35 @@ test_codex_bin_path() {
             "stderr: $(guest_stderr)"
     fi
 
-    local codex_release code_mode_release
-    codex_release=$(guest_exec readlink -f /usr/local/bin/codex | sed 's|/bin/codex$||')
-    code_mode_release=$(guest_exec readlink -f /usr/local/bin/codex-code-mode-host \
-        | sed 's|/bin/codex-code-mode-host$||')
-    if [[ -n "$codex_release" && "$codex_release" == "$code_mode_release" ]]; then
+    local codex_path code_mode_path codex_release
+    codex_path=$(guest_exec readlink -f /usr/local/bin/codex)
+    code_mode_path=$(guest_exec readlink -f /usr/local/bin/codex-code-mode-host)
+    if [[ "$codex_path" =~ ^(/usr/local/lib/codex/releases/[0-9a-f]{64})/bin/codex$ ]] \
+        && [[ "$code_mode_path" == "${BASH_REMATCH[1]}/bin/codex-code-mode-host" ]]; then
+        codex_release="${BASH_REMATCH[1]}"
         pass "codex and code-mode host come from the same package"
     else
         fail "codex and code-mode host come from the same package" \
-            "codex=$codex_release host=$code_mode_release"
+            "codex=$codex_path host=$code_mode_path"
+        return
+    fi
+
+    if guest_exec test -x "$codex_release/codex-path/rg" \
+        -a -x "$codex_release/codex-resources/bwrap" \
+        -a -x "$codex_release/codex-resources/zsh/bin/zsh" \
+        -a -f "$codex_release/codex-package.json"; then
+        pass "codex package runtime resources are installed"
+    else
+        fail "codex package runtime resources are installed" \
+            "release=$codex_release stderr: $(guest_stderr)"
+    fi
+
+    if guest_exec test ! -w "$codex_release/bin/codex" \
+        -a ! -w "$codex_release/bin/codex-code-mode-host"; then
+        pass "codex package executables are not guest-writable"
+    else
+        fail "codex package executables are not guest-writable" \
+            "release=$codex_release stderr: $(guest_stderr)"
     fi
 
     if guest_exec test -x /usr/local/bin/codex-yolo; then
@@ -1225,6 +1250,19 @@ test_agent_update() {
     fi
 
     if [[ "$FULL" == "1" ]]; then
+        # Model the broken legacy/corrupt-package state from #442. The forced
+        # updater must rebuild an incomplete same-SHA release, not merely keep
+        # an already healthy host executable in place.
+        local installed_host
+        installed_host=$(guest_exec readlink -f /usr/local/bin/codex-code-mode-host)
+        if guest_exec sudo rm -f "$installed_host" \
+            && guest_exec test ! -e /usr/local/bin/codex-code-mode-host; then
+            pass "removed code-mode host before updater repair test"
+        else
+            fail "removed code-mode host before updater repair test" \
+                "host=$installed_host stderr: $(guest_stderr)"
+        fi
+
         if coop agent update "$INSTANCE" --codex -y; then
             pass "agent update --codex exits 0"
         else
@@ -1242,9 +1280,9 @@ test_agent_update() {
         fi
 
         if guest_exec test -x /usr/local/bin/codex-code-mode-host; then
-            pass "codex update preserves executable code-mode host"
+            pass "codex update repairs missing code-mode host"
         else
-            fail "codex update preserves executable code-mode host" \
+            fail "codex update repairs missing code-mode host" \
                 "stderr: $(guest_stderr)"
         fi
     else

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1063,27 +1063,40 @@ test_claude_onboarding_seed() {
     fi
 }
 
-test_codex_bin_path() {
-    echo ""
-    echo "=== Phase: codex binary path ==="
+validate_codex_package() {
+    local context="$1"
 
     if guest_exec test -x /usr/local/bin/codex; then
-        pass "codex binary exists at /usr/local/bin/codex"
+        pass "codex binary exists at /usr/local/bin/codex ($context)"
     else
-        fail "codex binary exists at /usr/local/bin/codex" "stderr: $(guest_stderr)"
+        fail "codex binary exists at /usr/local/bin/codex ($context)" \
+            "stderr: $(guest_stderr)"
         return
     fi
 
     if coop_exec /usr/local/bin/codex --version >/dev/null; then
-        pass "codex binary invocable via full path"
+        pass "codex binary invocable via full path ($context)"
     else
-        fail "codex binary invocable via full path" "stderr: $(guest_stderr)"
+        fail "codex binary invocable via full path ($context)" \
+            "stderr: $(guest_stderr)"
     fi
 
     if guest_exec test -x /usr/local/bin/codex-code-mode-host; then
-        pass "codex code-mode host exists and is executable"
+        pass "codex code-mode host exists and is executable ($context)"
     else
-        fail "codex code-mode host exists and is executable" \
+        fail "codex code-mode host exists and is executable ($context)" \
+            "stderr: $(guest_stderr)"
+        return
+    fi
+
+    # `--help` exits before the host initializes its transport. Stdio with EOF
+    # exercises the real entrypoint without starting a persistent service; the
+    # timeout makes a regression fail instead of hanging the integration run.
+    if coop_exec sh -c \
+        'timeout 10 /usr/local/bin/codex-code-mode-host --listen stdio </dev/null >/dev/null'; then
+        pass "codex code-mode host accepts stdio transport ($context)"
+    else
+        fail "codex code-mode host accepts stdio transport ($context)" \
             "stderr: $(guest_stderr)"
     fi
 
@@ -1093,9 +1106,9 @@ test_codex_bin_path() {
     if [[ "$codex_path" =~ ^(/usr/local/lib/codex/releases/[0-9a-f]{64})/bin/codex$ ]] \
         && [[ "$code_mode_path" == "${BASH_REMATCH[1]}/bin/codex-code-mode-host" ]]; then
         codex_release="${BASH_REMATCH[1]}"
-        pass "codex and code-mode host come from the same package"
+        pass "codex and code-mode host come from the same package ($context)"
     else
-        fail "codex and code-mode host come from the same package" \
+        fail "codex and code-mode host come from the same package ($context)" \
             "codex=$codex_path host=$code_mode_path"
         return
     fi
@@ -1104,19 +1117,26 @@ test_codex_bin_path() {
         -a -x "$codex_release/codex-resources/bwrap" \
         -a -x "$codex_release/codex-resources/zsh/bin/zsh" \
         -a -f "$codex_release/codex-package.json"; then
-        pass "codex package runtime resources are installed"
+        pass "codex package runtime resources are installed ($context)"
     else
-        fail "codex package runtime resources are installed" \
+        fail "codex package runtime resources are installed ($context)" \
             "release=$codex_release stderr: $(guest_stderr)"
     fi
 
     if guest_exec test ! -w "$codex_release/bin/codex" \
         -a ! -w "$codex_release/bin/codex-code-mode-host"; then
-        pass "codex package executables are not guest-writable"
+        pass "codex package executables are not guest-writable ($context)"
     else
-        fail "codex package executables are not guest-writable" \
+        fail "codex package executables are not guest-writable ($context)" \
             "release=$codex_release stderr: $(guest_stderr)"
     fi
+}
+
+test_codex_bin_path() {
+    echo ""
+    echo "=== Phase: codex binary path ==="
+
+    validate_codex_package "after provisioning"
 
     if guest_exec test -x /usr/local/bin/codex-yolo; then
         pass "codex-yolo shortcut exists"
@@ -1254,6 +1274,53 @@ test_agent_update() {
         # updater must rebuild an incomplete same-SHA release, not merely keep
         # an already healthy host executable in place.
         local installed_host installed_codex_version
+        local inactive_sha active_sha inactive_release active_release active_pid active_exe
+        inactive_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        active_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        inactive_release="/usr/local/lib/codex/releases/$inactive_sha"
+        active_release="/usr/local/lib/codex/releases/$active_sha"
+        active_pid=""
+
+        # Seed one collectable release and one whose executable is live. The
+        # updater should bound disk growth without breaking an in-flight Codex
+        # session that still needs files from its package directory.
+        # shellcheck disable=SC2016 # Variables expand in the guest's sh, not here.
+        if guest_exec sudo sh -c '
+            set -eu
+            inactive_release=$1
+            active_release=$2
+            install -d -m 755 "$inactive_release" "$active_release/bin"
+            cp /bin/sleep "$active_release/bin/hold"
+            chmod 755 "$active_release/bin/hold"
+            nohup "$active_release/bin/hold" 300 </dev/null >/dev/null 2>&1 &
+            active_pid=$!
+            echo "$active_pid" >/tmp/coop-codex-active-release.pid
+            attempt=0
+            while [ "$attempt" -lt 50 ]; do
+                executable=$(readlink -f "/proc/$active_pid/exe" 2>/dev/null || true)
+                [ "$executable" = "$active_release/bin/hold" ] && exit 0
+                attempt=$((attempt + 1))
+                sleep 0.1
+            done
+            exit 1
+        ' sh "$inactive_release" "$active_release"; then
+            active_pid=$(guest_exec cat /tmp/coop-codex-active-release.pid) \
+                || active_pid=""
+            active_exe=$(guest_exec sudo readlink -f "/proc/$active_pid/exe") \
+                || active_exe=""
+            if [[ "$active_exe" == "$active_release/bin/hold" ]]; then
+                pass "seeded inactive and live Codex releases for garbage collection"
+            else
+                fail "seeded inactive and live Codex releases for garbage collection" \
+                    "pid=${active_pid:-unknown} exe=${active_exe:-unknown} stderr: $(guest_stderr)"
+            fi
+        else
+            active_pid=$(guest_exec cat /tmp/coop-codex-active-release.pid) \
+                || active_pid=""
+            fail "seeded inactive and live Codex releases for garbage collection" \
+                "stderr: $(guest_stderr)"
+        fi
+
         installed_host=$(guest_exec readlink -f /usr/local/bin/codex-code-mode-host)
         installed_codex_version=$(guest_exec codex --version)
         if guest_exec sudo rm -f "$installed_host" \
@@ -1291,6 +1358,38 @@ test_agent_update() {
             fail "codex update repairs missing code-mode host" \
                 "before=$installed_host ($installed_codex_version) after=$repaired_host ($repaired_codex_version) stderr: $(guest_stderr)"
         fi
+
+        validate_codex_package "after updater repair"
+
+        if guest_exec test ! -e "$inactive_release"; then
+            pass "codex update prunes an inactive release"
+        else
+            fail "codex update prunes an inactive release" \
+                "release still exists: $inactive_release"
+        fi
+        active_exe=""
+        if [[ -n "$active_pid" ]]; then
+            active_exe=$(guest_exec sudo readlink -f "/proc/$active_pid/exe") \
+                || active_exe=""
+        fi
+        if [[ "$active_exe" == "$active_release/bin/hold" ]] \
+            && guest_exec test -d "$active_release" \
+            && guest_exec sudo kill -0 "$active_pid"; then
+            pass "codex update preserves a release with a live executable"
+        else
+            fail "codex update preserves a release with a live executable" \
+                "release=$active_release pid=${active_pid:-unknown} exe=${active_exe:-unknown} stderr: $(guest_stderr)"
+        fi
+
+        if [[ -n "$active_pid" ]]; then
+            active_exe=$(guest_exec sudo readlink -f "/proc/$active_pid/exe") \
+                || active_exe=""
+            if [[ "$active_exe" == "$active_release/bin/hold" ]]; then
+                guest_exec sudo kill "$active_pid" 2>/dev/null || true
+            fi
+        fi
+        guest_exec sudo rm -rf -- "$active_release" "$inactive_release" \
+            /tmp/coop-codex-active-release.pid || true
     else
         skip "agent update --codex" "use --full; downloads the release in-guest"
     fi

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1279,11 +1279,14 @@ test_agent_update() {
                 "got: $ver stderr: $(guest_stderr)"
         fi
 
-        if guest_exec test -x /usr/local/bin/codex-code-mode-host; then
-            pass "codex update repairs missing code-mode host"
+        local repaired_host
+        repaired_host=$(guest_exec readlink -f /usr/local/bin/codex-code-mode-host)
+        if guest_exec test -x /usr/local/bin/codex-code-mode-host \
+            && [[ "$repaired_host" == "$installed_host" ]]; then
+            pass "codex update repairs code-mode host in the same release"
         else
-            fail "codex update repairs missing code-mode host" \
-                "stderr: $(guest_stderr)"
+            fail "codex update repairs code-mode host in the same release" \
+                "before=$installed_host after=$repaired_host stderr: $(guest_stderr)"
         fi
     else
         skip "agent update --codex" "use --full; downloads the release in-guest"

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1075,6 +1075,24 @@ test_codex_bin_path() {
         fail "codex binary invocable via full path" "stderr: $(guest_stderr)"
     fi
 
+    if guest_exec test -x /usr/local/bin/codex-code-mode-host; then
+        pass "codex code-mode host exists and is executable"
+    else
+        fail "codex code-mode host exists and is executable" \
+            "stderr: $(guest_stderr)"
+    fi
+
+    local codex_release code_mode_release
+    codex_release=$(guest_exec readlink -f /usr/local/bin/codex | sed 's|/bin/codex$||')
+    code_mode_release=$(guest_exec readlink -f /usr/local/bin/codex-code-mode-host \
+        | sed 's|/bin/codex-code-mode-host$||')
+    if [[ -n "$codex_release" && "$codex_release" == "$code_mode_release" ]]; then
+        pass "codex and code-mode host come from the same package"
+    else
+        fail "codex and code-mode host come from the same package" \
+            "codex=$codex_release host=$code_mode_release"
+    fi
+
     if guest_exec test -x /usr/local/bin/codex-yolo; then
         pass "codex-yolo shortcut exists"
     else
@@ -1221,6 +1239,13 @@ test_agent_update() {
         else
             fail "codex is executable and versioned after update" \
                 "got: $ver stderr: $(guest_stderr)"
+        fi
+
+        if guest_exec test -x /usr/local/bin/codex-code-mode-host; then
+            pass "codex update preserves executable code-mode host"
+        else
+            fail "codex update preserves executable code-mode host" \
+                "stderr: $(guest_stderr)"
         fi
     else
         skip "agent update --codex" "use --full; downloads the release in-guest"

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1253,8 +1253,9 @@ test_agent_update() {
         # Model the broken legacy/corrupt-package state from #442. The forced
         # updater must rebuild an incomplete same-SHA release, not merely keep
         # an already healthy host executable in place.
-        local installed_host
+        local installed_host installed_codex_version
         installed_host=$(guest_exec readlink -f /usr/local/bin/codex-code-mode-host)
+        installed_codex_version=$(guest_exec codex --version)
         if guest_exec sudo rm -f "$installed_host" \
             && guest_exec test ! -e /usr/local/bin/codex-code-mode-host; then
             pass "removed code-mode host before updater repair test"
@@ -1279,14 +1280,16 @@ test_agent_update() {
                 "got: $ver stderr: $(guest_stderr)"
         fi
 
-        local repaired_host
+        local repaired_host repaired_codex_version
         repaired_host=$(guest_exec readlink -f /usr/local/bin/codex-code-mode-host)
+        repaired_codex_version=$(guest_exec codex --version)
         if guest_exec test -x /usr/local/bin/codex-code-mode-host \
-            && [[ "$repaired_host" == "$installed_host" ]]; then
-            pass "codex update repairs code-mode host in the same release"
+            && { [[ "$repaired_codex_version" != "$installed_codex_version" ]] \
+                || [[ "$repaired_host" == "$installed_host" ]]; }; then
+            pass "codex update repairs missing code-mode host"
         else
-            fail "codex update repairs code-mode host in the same release" \
-                "before=$installed_host after=$repaired_host stderr: $(guest_stderr)"
+            fail "codex update repairs missing code-mode host" \
+                "before=$installed_host ($installed_codex_version) after=$repaired_host ($repaired_codex_version) stderr: $(guest_stderr)"
         fi
     else
         skip "agent update --codex" "use --full; downloads the release in-guest"


### PR DESCRIPTION
## Summary

- install the complete upstream Codex package so the CLI, code-mode host, and bundled runtime resources stay together
- verify published checksums, package metadata, ownership, permissions, and required executables before activation
- serialize updates, repair incomplete cached releases and missing public entrypoints, and switch version-matched binaries through one current-release link
- strengthen setup and integration verification across Lima and Firecracker paths
- update Codex image and updater documentation

Closes #442

## Review

The repository closeout review ran correctness, security, design, conventions, comments, tests, and docs lenses. Findings fixed included installer lock lifetime, stale backend/update comments, and release-rollover handling in the updater repair assertion. Final re-review was clean.

## Tests

- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test (1,099 passed)
- bash -n scripts/guest/codex.sh
- bash -n tests/integration.sh
- git diff --check
- disposable Ubuntu ARM64 package install and corrupt-release/public-link repair
- local macOS/Lima named-image rebuild, VM boot, package/resource verification, Codex pseudo-terminal startup, direct code-mode-host execution, and coop agent update --codex

The disposable VM and named test image were removed after validation. The full remote Firecracker integration suite was not run locally.