### PR TITLE
test: cover post-v0.5.4 integration gaps

### DIFF
--- a/.agents/skills/review/references/review-tests.md
+++ b/.agents/skills/review/references/review-tests.md
@@ -12,7 +12,7 @@ Only flag issues **introduced or materially changed by the diff**. Cross-referen
 ## coop's test layers
 
 - **Unit tests** live in the library crate (`src/lib.rs` target) as `#[cfg(test)] mod tests`. All logic is unit-testable there; `main.rs` is a thin shim.
-- **Integration tests** (`tests/integration.sh`, driven by `tests/run-integration.sh`) exercise the full VM lifecycle (setup → up → status → shell → guest env → docker → stop → destroy) on **both** backends (Firecracker/Linux and Lima/macOS). CI additionally runs `tests/integration-update.sh` and `tests/integration-uninstall.sh`.
+- **Integration tests** (`tests/integration.sh`, driven by `tests/run-integration.sh`) exercise the full VM lifecycle (setup → up → status → shell → guest env → docker → stop → destroy) on **both** backends (Firecracker/Linux and Lima/macOS). CI additionally runs `tests/integration-install.sh`, `tests/integration-update.sh`, and `tests/integration-uninstall.sh`.
 - **Mutation testing** scope is curated in `.cargo/mutants.toml`; the pure-logic helpers are kept in scope and expected to have unit tests that kill their mutants (AGENTS.md details this).
 
 ## What to flag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Unit tests
         run: cargo test --workspace
 
+      - name: Integration test — installer provenance
+        run: ./tests/integration-install.sh
+
       - name: Integration test — coop update
         run: ./tests/integration-update.sh
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,8 @@ How a `coop` release is cut, and what to check before cutting one.
 ## How the automation works
 
 - **`ci.yml`** runs on pushes to `main` and on every PR: `fmt --check`, `clippy -D warnings`,
-  `cargo test`, `integration-update.sh`, `integration-uninstall.sh`,
+  `cargo test`, `integration-install.sh`, `integration-update.sh`,
+  `integration-uninstall.sh`,
   `cargo deny check`, and `zizmor`.
 - **`release.yml`** runs when a `v*` tag is pushed. It **re-runs all of CI as a
   gate**, then cross-compiles the three target binaries
@@ -24,7 +25,7 @@ push succeeds and ships something correct.
 |-------|:---:|:---:|:---:|
 | fmt / clippy / unit tests | ✓ | ✓ | |
 | `cargo deny`, `zizmor` | ✓ | ✓ (if installed) | |
-| `integration-update` / `-uninstall` | ✓ | ✓ | |
+| Host-only integration suites | ✓ | ✓ | |
 | Version ↔ lock ↔ CHANGELOG ↔ tag agreement | | ✓ | |
 | Release builds (3 targets) | native only | ✓ (per installed toolchain) | |
 | Formal verification (`cargo kani`) | | ✓ (if installed) | |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@ three are manual, run when a change warrants them.
 
 ## Integration tests
 
-Two scripts:
+VM integration uses two scripts:
 
 - `tests/integration.sh` — the test suite. Runs locally, requires `--binary`.
 - `tests/run-integration.sh` — the runner. Builds, deploys (if remote), and
@@ -34,8 +34,9 @@ You can also run the suite directly if you already have a binary:
 ```
 
 The test exercises the full VM lifecycle (setup → start → status → shell →
-guest environment → docker → stop → destroy). CI additionally runs
-`tests/integration-update.sh` and `tests/integration-uninstall.sh`.
+guest environment → docker → stop → destroy). CI additionally runs the fast,
+host-only `tests/integration-install.sh`, `tests/integration-update.sh`, and
+`tests/integration-uninstall.sh` suites.
 
 When adding new features, consider whether they should be covered here. New
 commands or guest-visible changes are good candidates for a new test phase.

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -274,6 +274,7 @@ step "Unit tests" cargo test
 step "Release target builds" build_release_targets
 step "Supply chain (cargo deny)" run_deny
 step "Workflow audit (zizmor)" run_zizmor
+step "Integration — installer provenance" ./tests/integration-install.sh
 step "Integration — coop update" ./tests/integration-update.sh
 step "Integration — coop uninstall" ./tests/integration-uninstall.sh
 step "Formal verification (kani)" run_kani

--- a/tests/integration-install.sh
+++ b/tests/integration-install.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end test for install.sh's release provenance path. GitHub transports
+# are stubbed, but the real installer performs checksum verification,
+# attestation dispatch, extraction, and installation.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REAL_PATH="$PATH"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64) TRIPLE="x86_64-unknown-linux-musl" ;;
+    Linux-aarch64) TRIPLE="aarch64-unknown-linux-musl" ;;
+    Darwin-arm64|Darwin-aarch64) TRIPLE="aarch64-apple-darwin" ;;
+    *) echo "Unsupported test platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+VERSION="v9.9.9"
+ARCHIVE_DIR="coop-${VERSION}-${TRIPLE}"
+TARBALL="${ARCHIVE_DIR}.tar.gz"
+FIXTURE="$TEST_ROOT/fixture"
+MOCK_BIN="$TEST_ROOT/mock-bin"
+INSTALL_DIR="$TEST_ROOT/install"
+GH_LOG="$TEST_ROOT/gh.log"
+CURL_LOG="$TEST_ROOT/curl.log"
+mkdir -p "$FIXTURE/$ARCHIVE_DIR" "$MOCK_BIN" "$INSTALL_DIR"
+
+cat >"$FIXTURE/$ARCHIVE_DIR/coop" <<'EOF'
+#!/bin/sh
+echo installed-coop
+EOF
+cat >"$FIXTURE/$ARCHIVE_DIR/coop-proxy" <<'EOF'
+#!/bin/sh
+echo installed-coop-proxy
+EOF
+chmod +x "$FIXTURE/$ARCHIVE_DIR/coop" "$FIXTURE/$ARCHIVE_DIR/coop-proxy"
+(cd "$FIXTURE" && tar -czf "$TARBALL" "$ARCHIVE_DIR")
+
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$FIXTURE" && sha256sum "$TARBALL" > SHA256SUMS)
+else
+    (cd "$FIXTURE" && shasum -a 256 "$TARBALL" > SHA256SUMS)
+fi
+printf '%s\n' '{"synthetic":"non-empty provenance bundle"}' \
+    >"$FIXTURE/attestations.jsonl"
+
+cat >"$MOCK_BIN/gh" <<'STUB'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"$COOP_TEST_GH_LOG"
+
+if [ "$1 $2" = "release download" ]; then
+    pattern=""
+    destination=""
+    shift 2
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --pattern) pattern="$2"; shift 2 ;;
+            --dir) destination="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    cp "$COOP_TEST_FIXTURE/$pattern" "$destination/$pattern"
+    exit 0
+fi
+
+if [ "$1 $2" = "attestation verify" ]; then
+    [ "${COOP_TEST_GH_VERIFY_FAIL:-0}" != "1" ] || exit 42
+    bundle=""
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--bundle" ]; then
+            bundle="$2"
+            break
+        fi
+        shift
+    done
+    if [ "${COOP_TEST_GH_REQUIRE_BUNDLE:-0}" = "1" ]; then
+        [ -n "$bundle" ] && [ -s "$bundle" ] || exit 43
+    fi
+    exit 0
+fi
+
+exit 44
+STUB
+
+cat >"$MOCK_BIN/curl" <<'STUB'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"$COOP_TEST_CURL_LOG"
+destination=""
+url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) destination="$2"; shift 2 ;;
+        http://*|https://*) url="$1"; shift ;;
+        *) shift ;;
+    esac
+done
+case "$url" in
+    */attestations.jsonl)
+        [ "${COOP_TEST_BUNDLE_FAIL:-0}" != "1" ] || exit 22
+        cp "$COOP_TEST_FIXTURE/attestations.jsonl" "$destination"
+        ;;
+    *) exit 45 ;;
+esac
+STUB
+chmod +x "$MOCK_BIN/gh" "$MOCK_BIN/curl"
+
+pass_count=0
+fail_count=0
+
+pass() {
+    pass_count=$((pass_count + 1))
+    echo "  PASS  $1"
+}
+
+fail() {
+    fail_count=$((fail_count + 1))
+    echo "  FAIL  $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "        $2"
+    fi
+}
+
+run_installer() {
+    env PATH="$MOCK_BIN:$REAL_PATH" \
+        VERSION="$VERSION" \
+        INSTALL_DIR="$INSTALL_DIR" \
+        GITHUB_TOKEN="restricted-token-must-not-reach-bundle-curl" \
+        COOP_TEST_FIXTURE="$FIXTURE" \
+        COOP_TEST_GH_LOG="$GH_LOG" \
+        COOP_TEST_CURL_LOG="$CURL_LOG" \
+        COOP_TEST_GH_REQUIRE_BUNDLE="${COOP_TEST_GH_REQUIRE_BUNDLE:-0}" \
+        COOP_TEST_GH_VERIFY_FAIL="${COOP_TEST_GH_VERIFY_FAIL:-0}" \
+        COOP_TEST_BUNDLE_FAIL="${COOP_TEST_BUNDLE_FAIL:-0}" \
+        bash "$PROJECT_DIR/install.sh"
+}
+
+echo "==> Test 1: published bundle is downloaded anonymously and verified"
+: >"$GH_LOG"
+: >"$CURL_LOG"
+COOP_TEST_GH_REQUIRE_BUNDLE=1
+export COOP_TEST_GH_REQUIRE_BUNDLE
+if run_installer >"$TEST_ROOT/t1.log" 2>&1; then
+    pass "install succeeds with a published attestation bundle"
+else
+    fail "install succeeds with a published attestation bundle" \
+        "$(tail -10 "$TEST_ROOT/t1.log")"
+fi
+unset COOP_TEST_GH_REQUIRE_BUNDLE
+
+if "$INSTALL_DIR/coop" | grep -q '^installed-coop$' \
+    && "$INSTALL_DIR/coop-proxy" | grep -q '^installed-coop-proxy$'; then
+    pass "installer extracts coop and coop-proxy"
+else
+    fail "installer extracts coop and coop-proxy"
+fi
+
+if grep -q 'attestation verify .* --repo trailofbits/coop --bundle ' "$GH_LOG"; then
+    pass "gh verifies the tarball with the downloaded bundle"
+else
+    fail "gh verifies the tarball with the downloaded bundle" "gh calls: $(cat "$GH_LOG")"
+fi
+
+if grep -Eq -- '-H|--header|restricted-token' "$CURL_LOG"; then
+    fail "bundle download carries no GitHub credential" "curl args: $(cat "$CURL_LOG")"
+else
+    pass "bundle download carries no GitHub credential"
+fi
+
+echo "==> Test 2: bundle verification failure is fail-closed"
+printf '%s\n' 'keep-existing-install' >"$INSTALL_DIR/coop"
+COOP_TEST_GH_VERIFY_FAIL=1
+export COOP_TEST_GH_VERIFY_FAIL
+if run_installer >"$TEST_ROOT/t2.log" 2>&1; then
+    fail "failed bundle verification aborts installation" "installer exited 0"
+elif [[ "$(cat "$INSTALL_DIR/coop")" == "keep-existing-install" ]]; then
+    pass "failed bundle verification leaves the installed binary unchanged"
+else
+    fail "failed bundle verification leaves the installed binary unchanged"
+fi
+unset COOP_TEST_GH_VERIFY_FAIL
+
+echo "==> Test 3: releases without a usable bundle retain API fallback"
+: >"$GH_LOG"
+COOP_TEST_BUNDLE_FAIL=1
+export COOP_TEST_BUNDLE_FAIL
+if run_installer >"$TEST_ROOT/t3.log" 2>&1; then
+    pass "installer falls back for a pre-bundle release"
+else
+    fail "installer falls back for a pre-bundle release" \
+        "$(tail -10 "$TEST_ROOT/t3.log")"
+fi
+unset COOP_TEST_BUNDLE_FAIL
+
+if grep -q 'attestation verify .* --repo trailofbits/coop$' "$GH_LOG" \
+    && ! grep -q -- '--bundle' "$GH_LOG"; then
+    pass "legacy fallback verifies through the attestations API"
+else
+    fail "legacy fallback verifies through the attestations API" "gh calls: $(cat "$GH_LOG")"
+fi
+
+echo
+echo "  $pass_count passed, $fail_count failed"
+[[ $fail_count -eq 0 ]]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -840,6 +840,101 @@ test_ssh_config() {
     fi
 }
 
+# Exercises the host-side half of `coop editor` against a live VM. Stub editor
+# CLIs make the phase hermetic (no GUI is opened) while still pinning the argv
+# contract, Zed URL encoding, the legacy `vscode` alias, and SSH-config setup.
+test_editor() {
+    echo ""
+    echo "=== Phase: editor launch ==="
+
+    local editor_dir="$tmpdir/editor-bin"
+    local editor_log="$tmpdir/editor-argv"
+    local marker="# coop START coop-$INSTANCE"
+    local ssh_cfg="$HOME/.ssh/config"
+    mkdir -p "$editor_dir"
+
+    cat >"$editor_dir/zed" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$@" > "$COOP_TEST_EDITOR_LOG"
+STUB
+    cat >"$editor_dir/code" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$@" > "$COOP_TEST_EDITOR_LOG"
+STUB
+    chmod +x "$editor_dir/zed" "$editor_dir/code"
+
+    local zed_project='/workspace/editor path#part%done?'
+    if COOP_TEST_EDITOR_LOG="$editor_log" PATH="$editor_dir:$PATH" \
+        coop editor "$INSTANCE" --editor zed --project "$zed_project"; then
+        pass "editor --editor zed exits 0"
+    else
+        fail "editor --editor zed exits 0" "stderr: $HARNESS_ERR"
+        coop editor "$INSTANCE" --clean >/dev/null 2>&1 || true
+        return
+    fi
+
+    local expected_zed="ssh://coop-$INSTANCE/workspace/editor%20path%23part%25done%3F"
+    if [[ "$(cat "$editor_log" 2>/dev/null)" == "$expected_zed" ]]; then
+        pass "editor passes Zed an encoded SSH URL"
+    else
+        fail "editor passes Zed an encoded SSH URL" \
+            "expected=$expected_zed got=$(cat "$editor_log" 2>/dev/null)"
+    fi
+
+    if grep -qF "$marker" "$ssh_cfg" 2>/dev/null; then
+        pass "editor installs the shared SSH alias"
+    else
+        fail "editor installs the shared SSH alias" "no marker in $ssh_cfg"
+    fi
+
+    : >"$editor_log"
+    if COOP_TEST_EDITOR_LOG="$editor_log" PATH="$editor_dir:$PATH" \
+        coop editor "$INSTANCE" --project /workspace/auto; then
+        pass "editor auto-detection exits 0"
+    else
+        fail "editor auto-detection exits 0" "stderr: $HARNESS_ERR"
+    fi
+
+    local editor_argv
+    editor_argv=$(cat "$editor_log" 2>/dev/null)
+    if [[ "$editor_argv" == $'--remote\nssh-remote+coop-'"$INSTANCE"$'\n/workspace/auto' ]]; then
+        pass "editor auto-detection tries VS Code first"
+    else
+        fail "editor auto-detection tries VS Code first" "got: $editor_argv"
+    fi
+
+    # `vscode` remains a public compatibility alias for `editor`. Pin the real
+    # dispatch path, not only clap parsing, and check the VS Code Remote-SSH
+    # argv shape expected by the extension.
+    : >"$editor_log"
+    if COOP_TEST_EDITOR_LOG="$editor_log" PATH="$editor_dir:$PATH" \
+        coop vscode "$INSTANCE" --editor code --project /workspace/legacy; then
+        pass "vscode compatibility alias exits 0"
+    else
+        fail "vscode compatibility alias exits 0" "stderr: $HARNESS_ERR"
+    fi
+
+    editor_argv=$(cat "$editor_log" 2>/dev/null)
+    if [[ "$editor_argv" == $'--remote\nssh-remote+coop-'"$INSTANCE"$'\n/workspace/legacy' ]]; then
+        pass "vscode alias passes the VS Code Remote-SSH arguments"
+    else
+        fail "vscode alias passes the VS Code Remote-SSH arguments" "got: $editor_argv"
+    fi
+
+    # Leave the SSH config in the same clean state this phase inherited from
+    # test_ssh_config, so later restart tests do not accidentally cover alias
+    # refresh merely because this test ran.
+    if coop editor "$INSTANCE" --clean; then
+        if grep -qF "$marker" "$ssh_cfg" 2>/dev/null; then
+            fail "editor --clean removes its SSH block" "marker still present"
+        else
+            pass "editor --clean removes its SSH block"
+        fi
+    else
+        fail "editor --clean exits 0" "stderr: $HARNESS_ERR"
+    fi
+}
+
 test_exec() {
     echo ""
     echo "=== Phase: exec ==="
@@ -1222,6 +1317,98 @@ test_codex_account_auth_support() {
     fi
 
     guest_exec rm -rf /tmp/coop-keyring-probe
+}
+
+# The wrapper/package checks above use a scratch CODEX_HOME, but they do not
+# prove that `[codex] auth = "chatgpt"` drives the real lifecycle wiring. This
+# phase restarts the primary VM in account mode, checks the guest boundary, and
+# restores the default configuration for all later phases.
+test_codex_chatgpt_mode() {
+    echo ""
+    echo "=== Phase: configured Codex ChatGPT auth ==="
+
+    local cfg_dir="$tmpdir/codex-chatgpt"
+    local cfg_file="$cfg_dir/config.toml"
+    local host_openai="sk-host-openai-chatgpt-sentinel-LEAK"
+    local overlay_openai="sk-runtime-openai-chatgpt-sentinel-LEAK"
+    mkdir -p "$cfg_dir"
+    cat >"$cfg_file" <<'CFGEOF'
+[claude]
+github = "off"
+
+[codex]
+auth = "chatgpt"
+CFGEOF
+
+    chatgpt() {
+        local rc=0
+        HARNESS_OUT=$(OPENAI_API_KEY="$host_openai" \
+            "$BINARY" --config "$cfg_file" "$@" 2>"$tmpdir/stderr") || rc=$?
+        HARNESS_ERR=$(cat "$tmpdir/stderr")
+        return $rc
+    }
+    chatgpt_exec() {
+        RUST_LOG=off OPENAI_API_KEY="$host_openai" \
+            "$BINARY" --config "$cfg_file" exec "$INSTANCE" -- "$@" \
+            2>"$tmpdir/guest_stderr"
+    }
+
+    # Seed the credential file that account mode promises never to stage. A
+    # passing removal assertion therefore proves active cleanup, even on a host
+    # that has no ~/.codex/auth.json of its own.
+    if ! guest_exec sh -c 'mkdir -p ~/.codex && printf stale > ~/.codex/auth.json'; then
+        fail "seed stale Codex auth.json" "stderr: $(guest_stderr)"
+        return
+    fi
+
+    coop stop "$INSTANCE" || true
+    if chatgpt start "$INSTANCE" --env "OPENAI_API_KEY=$overlay_openai" \
+        --env "COOP_TEST_CHATGPT_PASSTHROUGH=kept"; then
+        pass "start with codex auth=chatgpt exits 0"
+    else
+        fail "start with codex auth=chatgpt exits 0" "stderr: $HARNESS_ERR"
+        coop start "$INSTANCE" || true
+        return
+    fi
+
+    local codex_cfg
+    if codex_cfg=$(chatgpt_exec cat ./.codex/config.toml) \
+        && echo "$codex_cfg" | grep -q 'cli_auth_credentials_store = "keyring"'; then
+        pass "chatgpt mode selects the guest keyring credential store"
+    else
+        fail "chatgpt mode selects the guest keyring credential store" \
+            "config=$codex_cfg stderr: $(guest_stderr)"
+    fi
+
+    local guest_env
+    guest_env=$(chatgpt_exec env || true)
+    if echo "$guest_env" | grep -q '^OPENAI_API_KEY=' \
+        || echo "$guest_env" | grep -qF "$host_openai" \
+        || echo "$guest_env" | grep -qF "$overlay_openai"; then
+        fail "chatgpt mode suppresses OPENAI_API_KEY" "raw host key reached the guest"
+    else
+        pass "chatgpt mode suppresses OPENAI_API_KEY"
+    fi
+    if echo "$guest_env" | grep -q '^COOP_TEST_CHATGPT_PASSTHROUGH=kept$'; then
+        pass "chatgpt mode preserves non-secret runtime env"
+    else
+        fail "chatgpt mode preserves non-secret runtime env" \
+            "positive-control env entry is missing"
+    fi
+
+    if chatgpt_exec test -e ./.codex/auth.json; then
+        fail "chatgpt mode removes Codex auth.json" "stale auth.json remains in the guest"
+    else
+        pass "chatgpt mode removes Codex auth.json"
+    fi
+
+    chatgpt stop "$INSTANCE" || true
+    if coop start "$INSTANCE"; then
+        pass "restart after chatgpt-mode test restores default config"
+    else
+        fail "restart after chatgpt-mode test restores default config" \
+            "stderr: $HARNESS_ERR"
+    fi
 }
 
 test_codex_sandbox_bypass() {
@@ -4452,6 +4639,49 @@ CFGEOF
         return
     fi
 
+    # Pin the user-facing status contract against the same running instance.
+    # Literal credentials are deliberately used above, so this also proves the
+    # command redacts them rather than leaking either value to stdout.
+    if px proxy status --vm "$inst_name"; then
+        if echo "$HARNESS_OUT" | grep -q 'anthropic.*default.*bearer.*redacted' \
+            && echo "$HARNESS_OUT" | grep -q 'openai.*default.*bearer.*redacted' \
+            && ! echo "$HARNESS_OUT" | grep -qF "$anthropic_secret" \
+            && ! echo "$HARNESS_OUT" | grep -qF "$openai_secret"; then
+            pass "proxy status shows redacted provider defaults"
+        else
+            fail "proxy status shows redacted provider defaults" "out: $HARNESS_OUT"
+        fi
+    else
+        fail "proxy status --vm exits 0" "stderr: $HARNESS_ERR"
+    fi
+
+    # Exercise the persisted per-VM representation used by `proxy setup --vm`.
+    # The wizard itself is intentionally interactive; seeding proxy.json keeps
+    # the suite noninteractive while testing load, precedence, status, and
+    # redaction through the public command.
+    local override_secret="sk-ant-coop-it-override-FAKE-do-not-use"
+    local proxy_state="$HOME/.coop/instances/$inst_name/proxy.json"
+    cat >"$proxy_state" <<STATEEOF
+{
+  "anthropic": {
+    "credential": "$override_secret",
+    "auth": "api_key"
+  }
+}
+STATEEOF
+    chmod 600 "$proxy_state"
+    if px proxy status --vm "$inst_name"; then
+        if echo "$HARNESS_OUT" | grep -q 'anthropic.*override.*api_key.*redacted' \
+            && echo "$HARNESS_OUT" | grep -q 'openai.*default.*bearer.*redacted' \
+            && ! echo "$HARNESS_OUT" | grep -qF "$override_secret"; then
+            pass "proxy status resolves and redacts a per-VM override"
+        else
+            fail "proxy status resolves and redacts a per-VM override" "out: $HARNESS_OUT"
+        fi
+    else
+        fail "proxy status reads a per-VM override" "stderr: $HARNESS_ERR"
+    fi
+
     # ── Codex (OpenAI) guest wiring ──
     local codex_cfg
     if codex_cfg=$(px_exec cat ./.codex/config.toml); then
@@ -5416,12 +5646,14 @@ main() {
     test_shell_connectivity
     test_ssh_alias
     test_ssh_config
+    test_editor
     test_exec
     test_claude_bin_path
     test_claude_settings_merge
     test_claude_onboarding_seed
     test_codex_bin_path
     test_codex_account_auth_support
+    test_codex_chatgpt_mode
     test_codex_sandbox_bypass
     test_agent_update
     test_github_token_forwarding

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1280,11 +1280,22 @@ test_codex_account_auth_support() {
         fi
     done
 
-    # Default config is auth = "api_key", so the wrapper must be a transparent
-    # passthrough: no D-Bus session, no keyring, no password prompt. A hang
-    # here would mean it tried to unlock a keyring it should have skipped.
+    # The primary guest config may inherit the host's Codex credential-store
+    # setting. Use an explicit empty config so this assertion isolates the
+    # wrapper's non-keyring branch from the machine running the suite.
+    local account_probe_dir="/tmp/coop-codex-account-probe"
+    if ! guest_exec sh -c 'mkdir -p "$1" && : > "$1/config.toml"' \
+        sh "$account_probe_dir"; then
+        fail "prepare codex-account probe config" "stderr: $(guest_stderr)"
+        return
+    fi
+
+    # Without keyring mode the wrapper must be a transparent passthrough: no
+    # D-Bus session, keyring, or password prompt. A hang here would mean it
+    # tried to unlock a keyring it should have skipped.
     local version
-    if version=$(coop_exec /usr/local/bin/codex-account --version); then
+    if version=$(coop_exec env CODEX_HOME="$account_probe_dir" \
+        /usr/local/bin/codex-account --version); then
         pass "codex-account passes through to codex without keyring mode ($version)"
     else
         fail "codex-account passes through to codex without keyring mode" \
@@ -1299,13 +1310,12 @@ test_codex_account_auth_support() {
     #
     # `coop exec` is not a TTY, so the wrapper must refuse rather than block on
     # a password prompt. A hang here is the failure this asserts against.
-    guest_exec sh -c 'mkdir -p /tmp/coop-keyring-probe \
-        && printf "cli_auth_credentials_store = \"keyring\"\n" \
-            > /tmp/coop-keyring-probe/config.toml'
+    guest_exec sh -c 'printf "cli_auth_credentials_store = \"keyring\"\n" \
+        > "$1/config.toml"' sh "$account_probe_dir"
 
     # </dev/null so the TTY guard is deterministic: run interactively, stdin
     # could otherwise be a terminal and the wrapper would prompt and block.
-    if coop_exec env CODEX_HOME=/tmp/coop-keyring-probe \
+    if coop_exec env CODEX_HOME="$account_probe_dir" \
         /usr/local/bin/codex-account --version </dev/null; then
         fail "codex-account enters keyring mode from the guest config" \
             "expected a non-TTY refusal, but the wrapper passed through to codex"
@@ -1316,7 +1326,7 @@ test_codex_account_auth_support() {
             "stderr: $(guest_stderr)"
     fi
 
-    guest_exec rm -rf /tmp/coop-keyring-probe
+    guest_exec rm -rf "$account_probe_dir"
 }
 
 # The wrapper/package checks above use a scratch CODEX_HOME, but they do not


### PR DESCRIPTION
## Summary

This fills the integration gaps I found by comparing `v0.5.4` (`8e24729`) with `main` (`13b67be`). It adds no product behavior.

- exercise `coop editor` against a live VM with stub GUI CLIs: explicit Zed dispatch and URL escaping, default VS Code priority, the `vscode` compatibility alias, shared SSH-config creation, and cleanup
- restart a live VM with `[codex] auth = "chatgpt"` and prove the real lifecycle writes the keyring setting, removes stale `auth.json`, suppresses both host and persisted `OPENAI_API_KEY` values, and still forwards an unrelated runtime env value
- exercise `coop proxy status --vm` for configured defaults and a persisted per-VM override, including precedence, auth-scheme reporting, and literal-credential redaction
- add a host-only installer provenance suite covering anonymous `attestations.jsonl` download, `gh attestation verify --bundle`, fail-closed verification, legacy API fallback, and installation of both `coop` and `coop-proxy`
- wire the new host-only suite into CI, release preflight, and the testing/releasing workflow docs

## Why these are the gaps

The post-release feature audit found that several other changes already have good integration coverage:

- the complete Codex runtime package is checked after provisioning and after updater repair, including `codex-code-mode-host`, runtime resources, ownership, garbage collection, and a live-executable release
- the Firecracker PID fix is checked by asserting that status identifies the actual Firecracker process
- the credential proxy's guest wiring, raw-key non-exposure, capability gate, jail, and teardown are already covered in the full suite; provider allowlists/default-deny behavior are covered by `coop-proxy/tests/gate.rs`
- ChatGPT auth's guest packages and wrapper branches are already checked, but no test selected account auth through the actual VM lifecycle
- editor strategy construction was unit-tested, but no live command-dispatch test existed
- proxy resolution/redaction was unit-tested, but the public status command and persisted state were not exercised
- the updater's local-fixture mode deliberately disables attestation verification, so it cannot cover the new bundle transport. The installer suite tests that shared release contract without weakening the updater's production-only guard.

Interactive `coop proxy setup` and an actual ChatGPT device login remain intentionally out of scope: both require a TTY/user credential. The integration phase seeds the exact `proxy.json` representation written by the wizard, then tests it through the public command.

## Validation performed here

- `./tests/integration-install.sh` — 7 passed, 0 failed
- `bash -n tests/integration.sh tests/integration-install.sh scripts/preflight-release.sh`
- changed-file pre-commit hooks — YAML, whitespace, EOF, large-file, and merge-conflict checks passed
- `git diff --check`
- closeout review — clean at `872590d075589f9514ec77211ede658ff8861f31`
- adversarial check — removed the real installer's `--bundle` argument in a disposable worktree; the new suite failed 3 assertions and exited 1

Not run in this environment:

- `cargo fmt`, clippy, and Rust tests: `cargo` is not installed here. No Rust source changed, but CI should still run these normally.
- Lima integration
- Firecracker integration

## Instructions for the integration agent

Use unique names if the hosts are shared. Run the full suite on both platforms because all three VM additions are backend-shared and the proxy phase is behind `--full`:

```bash
# macOS / Lima
./tests/run-integration.sh --full --name pr-post-release-lima

# Linux / Firecracker
./tests/run-integration.sh --remote user@linux-host --full \
  --name pr-post-release-firecracker

# Fast host-only provenance suite (also runs in CI/preflight)
./tests/integration-install.sh
```

Please capture the complete runner output to files as required by the integration skill, report every phase's result, and remove the output files afterward.

### Failure triage

- **`editor launch`** uses `$tmpdir/editor-bin/{code,zed}` stubs and never opens a GUI. A mismatch usually means command dispatch or argv/URL shape changed. Check the phase's `got:` value and `HARNESS_ERR`; the expected Zed URL percent-encodes space, `#`, `%`, and `?`. The phase removes its `~/.ssh/config` marker before returning.
- **`configured Codex ChatGPT auth`** deliberately stops and starts the primary VM twice, restoring the default config before later phases. If the keyring/tooling assertions fail on an older golden image, rebuild it with `coop setup --rebuild` before deciding this is a code regression. Inspect guest `~/.codex/config.toml`, `env`, and `~/.codex/auth.json`. A failed start can cascade into later primary-instance phases, so restore/start the instance before rerunning.
- **`credential-injecting proxy (--full)` status additions** seed only `$HOME/.coop/instances/<test-name>/proxy.json`, mode `0600`, after the test-owned instance exists. `coop destroy` removes it. If the entire proxy phase skips, ensure `coop-proxy` was built next to `coop`; the runner needs `cmake`, a C compiler, and Cargo for its best-effort proxy build. Existing Landlock/Seatbelt requirements still apply.
- **installer provenance** is fully local: mocked `gh` supplies release assets/verification and mocked `curl` supplies only the bundle. No GitHub or model request is made. A failure in test 1 indicates the installer stopped using the bundle or attached a credential to bundle curl; test 2 pins fail-closed behavior; test 3 pins old-release fallback.

If a failure reveals a platform-specific expectation rather than a product regression, preserve the behavioral invariant and adjust only the platform-specific observation. In particular, do not weaken the API-key absence/redaction checks or allow the provenance test to fall back after a downloaded bundle fails verification.
