### PR TITLE
Add `coop up --new-instance` for a second instance on one project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,14 @@
   `zed ssh://coop-<name>/<path>`, reusing the same `~/.ssh/config` alias
   block that VS Code's Remote-SSH uses.
 
+- **`coop up --new-instance` — a second instance for the same project** — `up`
+  normally reuses the instance recorded for a project directory or `--git-repo`
+  URL. `--new-instance` skips that lookup and creates a sibling instance
+  instead, so two agents can work from one source tree. It requires `--name`,
+  since the project-derived name is already taken. Once a project has siblings,
+  `coop up` reports the ambiguity rather than picking one, so address them by
+  name (`coop start <name>`, `coop shell <name>`).
+
 ### Fixes
 
 - **Install Codex's complete runtime package** (#442) — Recent Codex releases

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,7 +33,11 @@ the project identity for instance naming, devcontainer discovery, GitHub PAT
 lookup, and future `coop up DIR` affinity. If a matching instance is already
 running, `up` reports success without creating another VM. If a matching
 instance is stopped, `up` restarts it. If no matching instance exists, `up`
-creates one.
+creates one. Pass `--new-instance` with `--name` to skip the lookup and create
+a second, separately named instance for the same directory or `--git-repo`
+URL. That leaves the project with two matching instances, so later `coop up`
+runs report the ambiguity instead of choosing one — address the instances by
+name (`coop start <name>`, `coop shell <name>`) from then on.
 
 By default, `up` copies/syncs the project into `/workspace`. Pass `--mount`
 to use the mount transport for the project at `/workspace` instead. On
@@ -46,6 +50,7 @@ Use `--git-repo <url>` instead of `DIR` to clone a remote repository into
 |------|-------------|
 | `DIR` | Project directory (default: current directory) |
 | `--name <name>` | Instance name to use when creating the project environment |
+| `--new-instance` | Create a separate instance even when the project already has one (requires `--name`) |
 | `--copy` | Copy/sync `DIR` into `/workspace` (default) |
 | `--mount` | Mount `DIR` at `/workspace` instead of using `--copy` |
 | `--extra-mount <spec>` | Additional host directory to mount into the guest (`HOST_PATH[:GUEST_PATH]`, repeatable; specify a guest path other than `/workspace` when using `--copy`) |

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -16,6 +16,19 @@ coop up ./my-project --name my-project
 
 Named instances pay off when you have several running at once. The name appears in `coop list` / `coop status` output and targets commands at a specific instance.
 
+### Several instances for one project
+
+`coop up` normally reuses the instance already recorded for a project directory (or `--git-repo` URL). Add `--new-instance` to create another one alongside it — useful for running two agents against the same source tree. It requires `--name`, since the project-derived name is already taken.
+
+```
+coop up ./my-project                                  # first instance
+coop up ./my-project --new-instance --name worker-2   # sibling instance
+```
+
+Each sibling is an independent instance with its own disk and workspace copy; the project directory is not shared state between them unless you use `--mount`.
+
+Once a directory has more than one instance, `coop up ./my-project` can no longer pick one for you: it reports the ambiguity and lists the names. Address the instances by name from then on — `coop start worker-2`, `coop shell worker-2` — or destroy the extra one.
+
 ### Name validation rules
 
 Instance names must satisfy all of the following:

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -19,6 +19,7 @@ use crate::{
 pub(crate) struct UpOpts<'a> {
     pub(crate) dir: Option<&'a str>,
     pub(crate) name: Option<&'a config::InstanceName>,
+    pub(crate) new_instance: bool,
     pub(crate) transport: ProjectTransport,
     pub(crate) extra_mount: Vec<config::Mount>,
     pub(crate) git_repo: Option<&'a str>,
@@ -93,12 +94,13 @@ fn canonical_profile_list(profiles: &[String]) -> Vec<String> {
     names
 }
 
-/// Project-oriented start: ensure DIR has a single matching environment.
+/// Project-oriented start: ensure DIR has a matching environment.
 ///
 /// Unlike `start`, `up` treats the project directory as identity and keeps
 /// transport explicit. Existing instances are found by their recorded
-/// `workspace.json` host path; creation-only inputs are only applied when no
-/// matching instance exists.
+/// `workspace.json` host path unless `--new-instance` requests a separate,
+/// explicitly named environment for the same source tree; creation-only
+/// inputs are only applied when no matching instance exists.
 pub(crate) fn cmd_up(
     be: &backend::PlatformBackend,
     cfg: &mut config::CoopConfig,
@@ -138,7 +140,9 @@ pub(crate) fn cmd_up(
         );
     }
 
-    if let Some(inst) = find_workspace_instance(cfg, &project_dir)? {
+    if !opts.new_instance
+        && let Some(inst) = find_workspace_instance(cfg, &project_dir)?
+    {
         ensure_up_project_name_matches(&inst, &project_dir, opts)?;
         ensure_up_existing_inputs_are_compatible(&inst, transport, opts)?;
         if be.is_running(&inst) {
@@ -194,7 +198,9 @@ fn cmd_up_git_repo(
         );
     }
 
-    if let Some(inst) = find_git_repo_instance(cfg, repo_url)? {
+    if !opts.new_instance
+        && let Some(inst) = find_git_repo_instance(cfg, repo_url)?
+    {
         ensure_up_git_repo_name_matches(&inst, repo_url, opts)?;
         ensure_up_existing_inputs_are_compatible_for_git_repo(&inst, opts)?;
         if be.is_running(&inst) {
@@ -2071,6 +2077,7 @@ mod tests {
         super::UpOpts {
             dir,
             name: None,
+            new_instance: false,
             transport: super::ProjectTransport::Copy,
             extra_mount: Vec::new(),
             git_repo: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,9 @@ enum Commands {
         /// Instance name to use when creating the project environment
         #[arg(long, value_parser = config::InstanceName::new)]
         name: Option<config::InstanceName>,
+        /// Create a separate named instance even when DIR already has one
+        #[arg(long, requires = "name")]
+        new_instance: bool,
         /// Copy/sync DIR into the guest as /workspace (default)
         #[arg(long, conflicts_with = "mount")]
         copy: bool,
@@ -974,6 +977,7 @@ pub fn run() -> Result<()> {
         Commands::Up {
             dir,
             name,
+            new_instance,
             copy,
             mount,
             extra_mount,
@@ -1014,6 +1018,7 @@ pub fn run() -> Result<()> {
             let opts = UpOpts {
                 dir: dir.as_deref(),
                 name: name.as_ref(),
+                new_instance,
                 transport,
                 extra_mount,
                 git_repo: git_repo.as_deref(),
@@ -2131,6 +2136,28 @@ mod tests {
     fn up_copy_and_mount_conflict() {
         let err = parse_err(&["up", "--copy", "--mount"]);
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn up_new_instance_parses_with_explicit_name() {
+        let cli = parse(&["up", "--name", "worker-2", "--new-instance"]);
+        let super::Commands::Up {
+            name, new_instance, ..
+        } = cli.command
+        else {
+            panic!("expected Up variant");
+        };
+        assert_eq!(
+            name.as_ref().map(super::config::InstanceName::as_str),
+            Some("worker-2")
+        );
+        assert!(new_instance);
+    }
+
+    #[test]
+    fn up_new_instance_requires_explicit_name() {
+        let err = parse_err(&["up", "--new-instance"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3036,6 +3036,48 @@ test_up_project_workflow() {
     rm -rf "$mount_ws"
 }
 
+# Exercise both source lookup bypasses using the same assertions.
+# Arguments: original instance, sibling name, ambiguity message, source args.
+test_new_instance_sibling() {
+    local original="$1" sibling="$2" ambiguity="$3"
+    shift 3
+
+    STARTED_INSTANCES+=("$sibling")
+    if coop up "$@" --new-instance --name "$sibling" --no-agents --no-devcontainer; then
+        pass "--new-instance creates sibling $sibling"
+    else
+        fail "--new-instance creates sibling $sibling" "$HARNESS_ERR"
+        return 1
+    fi
+
+    # Distinct contents at the same guest-only path prove separate VM state.
+    local original_marker sibling_marker
+    if GUEST_INSTANCE="$original" guest_exec sh -c 'echo original > /tmp/coop-sibling-marker' &&
+            GUEST_INSTANCE="$sibling" guest_exec sh -c 'echo sibling > /tmp/coop-sibling-marker' &&
+            original_marker=$(GUEST_INSTANCE="$original" guest_exec cat /tmp/coop-sibling-marker) &&
+            sibling_marker=$(GUEST_INSTANCE="$sibling" guest_exec cat /tmp/coop-sibling-marker) &&
+            [[ "$original_marker" == original && "$sibling_marker" == sibling ]]; then
+        pass "$original and $sibling have independent guest state"
+    else
+        fail "$original and $sibling have independent guest state" "$(guest_stderr)"
+    fi
+
+    if coop_fails up "$@" --new-instance --name "$sibling" --no-agents --no-devcontainer &&
+            [[ "$HARNESS_ERR" == *"Instance '$sibling' already exists"* ]]; then
+        pass "--new-instance rejects duplicate name $sibling"
+    else
+        fail "--new-instance rejects duplicate name $sibling" "$HARNESS_ERR"
+    fi
+
+    if coop_fails up "$@" --no-agents --no-devcontainer &&
+            [[ "$HARNESS_ERR" == *"$ambiguity"* &&
+               "$HARNESS_ERR" == *"$original"* && "$HARNESS_ERR" == *"$sibling"* ]]; then
+        pass "plain up reports ambiguity between $original and $sibling"
+    else
+        fail "plain up reports ambiguity between $original and $sibling" "$HARNESS_ERR"
+    fi
+}
+
 # ── git-repo source (--full only) ─────────────────────────────
 
 # Exercise `coop up --git-repo`: the clone runs inside the guest, so this
@@ -3143,6 +3185,13 @@ test_git_repo() {
     else
         fail "up --git-repo reuses the running instance" \
             "list changed: $(diff <(echo "$pre_list") <(echo "$post_list"))"
+    fi
+
+    local gr_sibling="${gr_instance}-sibling"
+    test_new_instance_sibling "$gr_instance" "$gr_sibling" \
+        "Multiple instances share git repo" --git-repo "$repo_url" || true
+    if coop destroy "$gr_sibling"; then
+        untrack_instance "$gr_sibling"
     fi
 
     coop destroy "$gr_instance" 2>/dev/null || true
@@ -3359,10 +3408,9 @@ test_multi_instance() {
     local inst_a="${INSTANCE}-a"
     local inst_b="${INSTANCE}-b"
     local ws_a="$tmpdir/${inst_a}-ws"
-    local ws_b="$tmpdir/${inst_b}-ws"
-    mkdir -p "$ws_a" "$ws_b"
+    mkdir -p "$ws_a"
 
-    # Create two project instances
+    # Create two instances from the same project directory.
     if coop up "$ws_a" --name "$inst_a" --no-agents --no-devcontainer; then
         STARTED_INSTANCES+=("$inst_a")
         pass "up creates instance A ($inst_a)"
@@ -3371,14 +3419,8 @@ test_multi_instance() {
         return
     fi
 
-    if coop up "$ws_b" --name "$inst_b" --no-agents --no-devcontainer; then
-        STARTED_INSTANCES+=("$inst_b")
-        pass "up creates instance B ($inst_b)"
-    else
-        fail "up creates instance B ($inst_b)" "exit code: $?"
-        coop destroy "$inst_a" 2>/dev/null || true
-        return
-    fi
+    test_new_instance_sibling "$inst_a" "$inst_b" \
+        "Multiple instances share workspace" "$ws_a" || return
 
     # Status should list both
     if coop status; then


### PR DESCRIPTION
`coop up` treats the project directory (or `--git-repo` URL) as the instance
identity: it reuses the instance already recorded for that path and applies
creation-only inputs only when it creates one. There was no way to ask for a
second environment on the same source tree — the existing instance always won.

`--new-instance` skips the workspace/git-repo lookup and creates a separate
instance instead. It requires `--name`, since the project-derived name is
already taken by the first instance.

```
coop up ./my-project                                  # first instance
coop up ./my-project --new-instance --name worker-2   # sibling instance
```

## Behavior notes

- Re-running the same `--new-instance --name X` fails in `allocate_instance`
  with `Instance 'X' already exists`, so the flag is not idempotent the way
  plain `up` is.
- After the sibling exists the directory has two matching instances, so plain
  `coop up DIR` reports the existing "Multiple instances share workspace"
  ambiguity error instead of picking one, including when `--name` is given
  (`up` bails during the lookup, before the name is considered). Instances are
  addressed by name from then on: `coop start <name>`, `coop shell <name>`.
  Whether `up --name` should instead select the named sibling is a separate
  decision — flagging it here rather than changing `up`'s semantics in this PR.

## Tests / gates

- New unit tests cover the clap contract: `--new-instance` parses with
  `--name`, and errors with `MissingRequiredArgument` without it.
- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -D
  warnings`, `cargo test` (1113 passed) — all green.
- Not run: the integration suite on either backend. The flag's runtime effect
  (bypassing the lookup and booting a sibling VM) has no `tests/integration.sh`
  phase; `cmd_up`/`cmd_up_git_repo` are excluded from the mutation sweep by the
  existing `\bcmd_[a-z_]+\b` rule, so the guard has no unit-level coverage
  either. An integration phase next to the existing two-instance phase is the
  gap to close before merge.
