### PR TITLE
network: isolate guest VMs from each other on the shared bridge

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -152,6 +152,16 @@ exclude_re = [
   # fs_util.rs — flock syscall wrapper; callers always target existing dirs.
   "\\block_sibling\\b",
 
+  # network.rs — the guest-to-guest isolation shell-outs. Each drives `bridge`
+  # or `iptables` against a live br0, so a `--lib` test cannot observe whether
+  # the flag stuck or the rule landed; tests/integration.sh asserts the behavior
+  # with two running instances. The decision logic they were carved around stays
+  # IN scope and is unit-tested — port_is_isolated (the readback predicate),
+  # guest_isolation_spec (subnet scoping + rule tag), and guest_subnet_cidr (the
+  # network-address mask) — so a survivor on one of those is a real gap.
+  "\\bisolate_tap_port\\b",
+  "\\bensure_guest_isolation_rule\\b",
+
   # ---- src/commands/ and the lib.rs/main.rs shims ----
   # The #321-#327 refactor split every command handler out of lib.rs into
   # src/commands/. Apply the SAME surgical treatment the flat shell-out

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -155,10 +155,9 @@ exclude_re = [
   # network.rs — the guest-to-guest isolation shell-outs. Each drives `bridge`
   # or `iptables` against a live br0, so a `--lib` test cannot observe whether
   # the flag stuck or the rule landed; tests/integration.sh asserts the behavior
-  # with two running instances. The decision logic they were carved around stays
-  # IN scope and is unit-tested — port_is_isolated (the readback predicate),
-  # guest_isolation_spec (subnet scoping + rule tag), and guest_subnet_cidr (the
-  # network-address mask) — so a survivor on one of those is a real gap.
+  # with two running instances. The pure readback predicates port_is_isolated
+  # and guest_isolation_rule_is_first remain in scope and are unit-tested.
+  # GUEST_ISOLATION_SPEC is a shared six-argument constant.
   "\\bisolate_tap_port\\b",
   "\\bensure_guest_isolation_rule\\b",
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Unit tests
         run: cargo test --workspace
 
+      - name: Install network test tools
+        run: sudo apt-get update && sudo apt-get install -y iproute2 iptables iputils-ping util-linux
+
+      - name: Integration test — bridge isolation
+        run: ./tests/integration-network.sh
+
       - name: Integration test — installer provenance
         run: ./tests/integration-install.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install network test tools
         run: sudo apt-get update && sudo apt-get install -y iproute2 iptables iputils-ping util-linux
 
+      - name: Integration probe regression tests
+        run: python3 tests/test-integration-probes.py
+
       - name: Integration test — bridge isolation
         run: ./tests/integration-network.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,20 @@
 
 ### Fixes
 
+- **Firecracker guests can no longer reach each other by IP** — Instances on the
+  same host share the `br0` bridge and a single subnet, so any guest could reach
+  any other guest's SSH and forwarded ports. coop now marks every TAP as an
+  isolated bridge port and inserts a `FORWARD -i br0 -o br0 -j DROP` rule; both are
+  needed, since the bridge flag alone leaves a guest able to route around it via
+  the host's bridge address. Guest→host and guest→internet are unaffected. A
+  host that cannot apply the flag fails the VM start instead of booting an
+  unisolated guest; this needs Linux ≥ 4.18 and iproute2 ≥ 4.19. **Restart any running VMs after
+  upgrading** — isolation applies per start, and because the kernel requires
+  both ports to be isolated, one pre-upgrade VM leaves the whole bridge
+  unisolated. This blocks reachability, not impersonation; see
+  [`docs/trust-model.md`](docs/trust-model.md) for the residuals. macOS is
+  unaffected — Lima gives each guest its own user-mode NAT.
+
 - **Install Codex's complete runtime package** (#442) — Recent Codex releases
   use a companion `codex-code-mode-host` executable, but coop installed only
   the raw `codex` binary, causing Code Mode to fail closed at startup. Image

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -98,8 +98,15 @@ The network is configured as follows:
 - A Linux bridge (`br0`) is created if it does not already exist, with the configured host IP (default `172.16.0.1/24`).
 - IP forwarding is enabled via `sysctl`.
 - iptables NAT masquerade and forwarding rules route guest traffic through the host's default network interface. The interface is auto-detected from the default route, or set explicitly via `network.host_iface` in the config.
-- Each instance's TAP device is created, attached to the bridge, and brought up.
+- A `FORWARD -i br0 -o br0 -j DROP` rule is inserted at the head of the chain.
+- Each instance's TAP device is created, attached to the bridge, marked as an isolated bridge port, and brought up.
 - Guest IPs are assigned statically: `172.16.0.{index + 2}`. Instance 0 gets `172.16.0.2`.
+
+**Instances cannot reach each other by IP.** Two controls enforce that and both are required: the isolated bridge-port flag blocks the direct L2 path, and the `FORWARD` rule blocks the L3 path a guest could otherwise take by routing through the host's bridge address. Each guest still reaches the host and the internet. The flag is read back after being set, so a host that cannot apply it fails the VM start rather than booting an unisolated guest; this needs Linux ≥ 4.18 and iproute2 ≥ 4.19.
+
+Isolation is applied per start. Because the kernel drops a frame only when both ports are isolated, a VM still running from before the upgrade leaves the *whole bridge* unisolated until it is stopped and started — not just itself.
+
+[`docs/trust-model.md`](trust-model.md) carries the full invariant and its known residuals (ARP/IP impersonation, IPv6, firewall reloads).
 
 On teardown, the TAP device is removed. If no TAP devices remain on the bridge, the bridge and all associated iptables rules are also removed.
 
@@ -113,7 +120,7 @@ The `network` section in `config.toml` controls Firecracker networking:
 | `subnet_mask` | `/24` | CIDR subnet mask for the bridge network |
 | `host_iface` | `auto` | Host interface for NAT. `auto` detects the default route interface. Set explicitly if auto-detection fails. |
 
-These settings are ignored on macOS. Lima handles its own networking.
+These settings are ignored on macOS. Lima handles its own networking. coop's generated Lima templates declare no `networks:` stanza, so each macOS guest gets its own user-mode NAT: instances are isolated from each other by construction there, with no shared bridge and nothing to enforce.
 
 ### Resize (disk, memory, vCPUs)
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -98,7 +98,7 @@ The network is configured as follows:
 - A Linux bridge (`br0`) is created if it does not already exist, with the configured host IP (default `172.16.0.1/24`).
 - IP forwarding is enabled via `sysctl`.
 - iptables NAT masquerade and forwarding rules route guest traffic through the host's default network interface. The interface is auto-detected from the default route, or set explicitly via `network.host_iface` in the config.
-- A `FORWARD -i br0 -o br0 -j DROP` rule is inserted at the head of the chain.
+- A `FORWARD -i br0 -o br0 -j DROP` rule is inserted at the head of the chain. If an existing rule has lost that precedence, startup fails until the host firewall configuration places it first.
 - Each instance's TAP device is created, attached to the bridge, marked as an isolated bridge port, and brought up.
 - Guest IPs are assigned statically: `172.16.0.{index + 2}`. Instance 0 gets `172.16.0.2`.
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -60,3 +60,12 @@ Only scp's SFTP mode has this issue.
 
 The coop binary's tracing output (INFO/DEBUG/WARN logs) goes to **stderr**, so
 stdout stays clean for machine-readable (`--json`) output and piped consumers.
+
+## Firecracker base-image networking
+
+The upstream Firecracker image may enable `fcnet.service`, which assigns an
+address derived from the guest MAC with a `/30` prefix. Coop uses a `/24`
+network managed by systemd-networkd. Provisioning disables and masks the
+inherited service so it cannot install a second prefix and make another
+instance's IP a broadcast destination. Rebuild older images with `coop setup`
+to apply this guest-only fix; it does not change host networking or Lima.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,28 @@ host-only `tests/integration-install.sh`, `tests/integration-update.sh`, and
 When adding new features, consider whether they should be covered here. New
 commands or guest-visible changes are good candidates for a new test phase.
 
+## Host-only bridge isolation test
+
+Run `./tests/integration-network.sh` on Linux to test bridge-port isolation
+without KVM or VM images. It builds a library test as the current user, then
+uses passwordless sudo to run it in disposable network, mount, UTS, and PID
+namespaces. Prerequisites are Rust/Cargo, Python 3, sudo, iproute2, iptables,
+iputils-ping, util-linux, hostname, and coreutils. Missing prerequisites fail
+the gate; macOS reports an explicit skip. Linux CI runs this gate.
+
+Two veth-backed endpoints first communicate through a bridge with no firewall
+rules. The test calls the production isolation helper on each bridge port:
+one isolated port still permits communication, while two block peer traffic
+in both directions and preserve gateway access. Removing isolation restores
+communication. Ping execution errors fail the test rather than counting as
+isolation. The runner bounds execution and destroys the namespace resources
+on success, failure, or timeout.
+
+This exercises the bridge mechanism shared by veths and TAPs. The existing
+Firecracker `--full` phase checks actual VM TAP flags and both direct and routed
+traffic; it also detects removal of the helper call from `setup_tap`. This
+host-only gate does not replace Firecracker or Lima VM integration.
+
 ## Mutation testing
 
 Mutation testing finds unit tests that pass even when the code is broken — real

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,11 +41,24 @@ host-only `tests/integration-install.sh`, `tests/integration-update.sh`, and
 When adding new features, consider whether they should be covered here. New
 commands or guest-visible changes are good candidates for a new test phase.
 
+Run `python3 tests/test-integration-probes.py` for host-only regression tests
+of address discovery, ping result handling, and bounded HTTP retries. These
+use a temporary loopback HTTP server and require Python 3, Bash, and curl;
+Linux CI runs them. The full VM suite additionally checks these probes against
+real guests. A host FORWARD policy other than ACCEPT still causes an explicit
+skip of the routed guest-isolation probe, since it would mask the coop rule.
+
 ## Host-only bridge isolation test
 
-Run `./tests/integration-network.sh` on Linux to test bridge-port isolation
-without KVM or VM images. It builds a library test as the current user, then
-uses passwordless sudo to run it in disposable network, mount, UTS, and PID
+`./tests/run-integration.sh --full` runs the bridge isolation gate before
+the VM suite, on the selected local or remote host. A failure stops the full
+run; macOS explicitly skips this Linux-only gate. `TEST_FULL=1` also enables
+both gates. Remote full runs copy the tracked working-tree source and require
+the build and namespace prerequisites below on the remote host.
+
+Run `./tests/integration-network.sh` directly on Linux to test bridge-port
+isolation without KVM or VM images. It builds a library test as the current
+user, then uses passwordless sudo to run it in disposable network, mount, UTS, and PID
 namespaces. Prerequisites are Rust/Cargo, Python 3, sudo, iproute2, iptables,
 iputils-ping, util-linux, hostname, and coreutils. Missing prerequisites fail
 the gate; macOS reports an explicit skip. Linux CI runs this gate.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -154,6 +154,54 @@ user `env_forward` entries, and the VM SSH key. The invariants:
   TAP, enables `ip_forward`, and adds a `MASQUERADE` + `FORWARD` ruleset so the
   guest reaches the internet through the host's default interface. A change
   that widens guest egress or adds inbound reachability is a finding.
+- **Guest VMs cannot reach each other by IP.** All Firecracker guests share
+  `br0` and a single subnet, so this is enforced, not structural, and it takes
+  **two** complementary controls — removing either one re-opens the path:
+  1. Every TAP is an isolated bridge port (`bridge link set … isolated on`),
+     which stops the bridge forwarding frames between two guest ports. This is
+     the only control that covers the L2 path, because bridged frames reach the
+     `FORWARD` chain only when `br_netfilter` is loaded.
+  2. An `iptables -I FORWARD 1 -i br0 -o br0 -j DROP` rule, which stops a
+     routed guest→guest packet. Port isolation cannot cover this path: a frame
+     addressed to the bridge is *local delivery*, not port-to-port forwarding,
+     so the isolated flag never applies, and `ip_forward` would otherwise send
+     it back out `br0` from the bridge device — which has no isolated source
+     port either. Without the rule this falls through to the host's `FORWARD`
+     policy, `ACCEPT` on a stock host.
+
+  Both are asserted on every `setup_tap` and fail closed. The rule is
+  idempotent because `ensure_guest_isolation_rule` probes with `iptables -C`
+  first; it is asserted per call rather than in `ensure_bridge` because that
+  returns early on a pre-existing bridge. The bridge flag is read back after
+  being set — a kernel older than 4.18 caps the bridge-port attribute policy
+  below `IFLA_BRPORT_ISOLATED` and silently drops it, so `bridge` exits 0 on a
+  port that is not isolated. Requires Linux ≥ 4.18 and iproute2 ≥ 4.19.
+
+  **Known residuals**, in scope for a follow-up, not closed here:
+  - *Isolation is pairwise.* The kernel drops a frame only when both ports are
+    isolated, so one non-isolated member of `br0` re-opens L2 for every guest.
+    A VM still running from before the upgrade therefore leaves the whole
+    bridge unisolated, not just itself, until it is restarted.
+  - *A guest can still impersonate a peer.* Neither control governs ARP or the
+    guest's own addressing, and coop reaches guests by IP with host-key
+    checking deliberately disabled — so a connection meant for a peer could
+    land on an impostor along with its `SendEnv` payload.
+  - *IPv6 and firewall reloads.* Only `iptables` is touched, and any
+    `iptables-restore` (`firewall-cmd --reload`, `ufw reload`) discards the
+    rule until the next `coop up` re-asserts it.
+  - *A pre-existing `br0`.* `ensure_bridge` adopts a bridge it did not create
+    without inspecting its members or installing its other rules; on such a
+    host the DROP also applies to that bridge's traffic.
+
+  **Accepted by design:** guests *can* reach the host — that path carries the
+  local-model gateway and the credential proxy's `ssh -R` tunnel. A change that
+  drops either control, or that stops asserting them per start, is a finding.
+
+  On Lima this holds structurally instead: the generated templates declare no
+  `networks:` stanza, so each guest gets its own per-instance gvisor usernet
+  stack (not Apple's shared-segment `VZNATNetworkDeviceAttachment`) and has no
+  L2 neighbor to reach. Adding a `networks:` stanza would put guests on a
+  shared segment and void this.
 - `rewrite_host_url` rewrites a loopback local-model endpoint to the
   guest-visible gateway address so the guest can reach a model server running
   on the host; non-loopback URLs pass through unchanged.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -171,7 +171,9 @@ user `env_forward` entries, and the VM SSH key. The invariants:
 
   Both are asserted on every `setup_tap` and fail closed. The rule is
   idempotent because `ensure_guest_isolation_rule` probes with `iptables -C`
-  first; it is asserted per call rather than in `ensure_bridge` because that
+  first, then checks that it is the first FORWARD rule. Startup fails if another
+  rule precedes it; move the DROP first in the host firewall configuration before
+  retrying. It is asserted per call rather than in `ensure_bridge` because that
   returns early on a pre-existing bridge. The bridge flag is read back after
   being set — a kernel older than 4.18 caps the bridge-port attribute policy
   below `IFLA_BRPORT_ISOLATED` and silently drops it, so `bridge` exits 0 on a

--- a/scripts/guest/guest-config.sh
+++ b/scripts/guest/guest-config.sh
@@ -1,5 +1,11 @@
 set -euo pipefail
 
+# Firecracker's base image may enable fcnet, which derives a /30 address from
+# the MAC. It conflicts with coop's /24 networkd configuration (the next VM
+# can become a broadcast destination). Mask even an existing local unit file.
+systemctl disable fcnet.service 2>/dev/null || true
+ln -sfnT /dev/null /etc/systemd/system/fcnet.service
+
 echo '  [guest] Configuring guest networking...'
 mkdir -p /etc/systemd/network
 cat > /etc/systemd/network/10-eth0.network <<'NETEOF'

--- a/src/network.rs
+++ b/src/network.rs
@@ -70,6 +70,16 @@ pub fn setup_tap(cfg: &NetworkConfig, inst: &Instance) -> Result<()> {
         .sudo()
         .run()
         .context("Failed to add TAP to bridge")?;
+    // The Linux bridge forwards guest-to-guest frames at L2. Those frames do
+    // not reliably traverse the host's iptables FORWARD chain, so firewall
+    // rules alone cannot establish VM isolation. Mark every TAP as an
+    // isolated bridge port: isolated ports may talk to the non-isolated host
+    // bridge port, but never to one another.
+    Cmd::new("bridge")
+        .args(["link", "set", "dev", &tap, "isolated", "on"])
+        .sudo()
+        .run()
+        .context("Failed to isolate TAP from peer guest ports")?;
     Cmd::new("ip")
         .args(["link", "set", &tap, "up"])
         .sudo()

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,11 +1,16 @@
 use std::process::Command;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::cmd::Cmd;
 use crate::config::{HostInterface, Instance, NetworkConfig};
 
 const BRIDGE_NAME: &str = "br0";
+
+/// Match spec for the rule that drops routed guest-to-guest traffic. Shared by
+/// the `-C` probe, the `-I` insert, and the `-D` teardown so the three cannot
+/// drift — a teardown that misses by one argument leaks the rule.
+const GUEST_ISOLATION_SPEC: [&str; 6] = ["-i", BRIDGE_NAME, "-o", BRIDGE_NAME, "-j", "DROP"];
 
 /// Rewrite a host-visible endpoint URL into one reachable from inside the
 /// guest.
@@ -49,6 +54,9 @@ pub fn setup_tap(cfg: &NetworkConfig, inst: &Instance) -> Result<()> {
     let tap = inst.tap_device();
 
     ensure_bridge(cfg, &host_iface)?;
+    // Outside ensure_bridge, which returns early on a pre-existing bridge —
+    // one left by a crashed teardown must still get the rule.
+    ensure_guest_isolation_rule()?;
 
     tracing::info!("Setting up TAP device {tap} on bridge {BRIDGE_NAME}");
 
@@ -70,16 +78,10 @@ pub fn setup_tap(cfg: &NetworkConfig, inst: &Instance) -> Result<()> {
         .sudo()
         .run()
         .context("Failed to add TAP to bridge")?;
-    // The Linux bridge forwards guest-to-guest frames at L2. Those frames do
-    // not reliably traverse the host's iptables FORWARD chain, so firewall
-    // rules alone cannot establish VM isolation. Mark every TAP as an
-    // isolated bridge port: isolated ports may talk to the non-isolated host
-    // bridge port, but never to one another.
-    Cmd::new("bridge")
-        .args(["link", "set", "dev", &tap, "isolated", "on"])
-        .sudo()
-        .run()
-        .context("Failed to isolate TAP from peer guest ports")?;
+    // The L2 half: the bridge never forwards between two isolated ports. Set
+    // before the TAP goes up, so the port is never live and unisolated. The
+    // routed path is closed separately, in ensure_guest_isolation_rule.
+    isolate_tap_port(&tap)?;
     Cmd::new("ip")
         .args(["link", "set", &tap, "up"])
         .sudo()
@@ -118,6 +120,70 @@ pub fn teardown_tap(cfg: &NetworkConfig, inst: &Instance) -> Result<()> {
 pub fn teardown_all(cfg: &NetworkConfig) {
     let host_iface = resolve_host_iface(&cfg.host_iface).unwrap_or_else(|_| "eth0".into());
     teardown_bridge(&host_iface);
+}
+
+// ── Guest-to-guest isolation ──────────────────────────────────
+
+/// Apply the L2 half to one TAP and confirm it took effect.
+fn isolate_tap_port(tap: &str) -> Result<()> {
+    Cmd::new("bridge")
+        .args(["link", "set", "dev", tap, "isolated", "on"])
+        .sudo()
+        .run()
+        .context("Failed to isolate TAP from peer guest ports")?;
+    let flags = Cmd::new("bridge")
+        .args(["-d", "link", "show", "dev", tap])
+        .sudo()
+        .capture()
+        .with_context(|| format!("Failed to read back bridge port flags for {tap}"))?;
+    if !port_is_isolated(&flags) {
+        bail!(
+            "Bridge port {tap} did not accept the isolated flag, so peer guest VMs would be \
+             reachable from this one. Guest-to-guest isolation needs Linux >= 4.18 and \
+             iproute2 >= 4.19."
+        );
+    }
+    Ok(())
+}
+
+/// Whether `bridge -d link show dev <tap>` output reports the port isolated.
+///
+/// The readback exists because the set can succeed while doing nothing:
+/// `IFLA_BRPORT_ISOLATED` is attribute 33, and a kernel below 4.18 caps the
+/// bridge-port policy at 32 and silently drops out-of-range attributes, so
+/// `bridge` exits 0 on a port that is not isolated. `-d` is required — the
+/// flag is printed only in the detailed section.
+fn port_is_isolated(flags: &str) -> bool {
+    flags.contains("isolated on")
+}
+
+/// The L3 half: drop guest-to-guest traffic the host would otherwise route.
+///
+/// Port isolation governs only port-to-port forwarding. A frame a guest
+/// addresses to the bridge is local delivery, so the flag never applies, and
+/// `ip_forward` then sends it back out `br0` from the bridge device — which
+/// has no isolated source port either. Nothing else in the ruleset matches
+/// that, so without this it falls through to the FORWARD policy, ACCEPT on a
+/// stock host.
+///
+/// Inserted at the head so it cannot lose to a pre-existing permissive
+/// `-A FORWARD -j ACCEPT` from libvirt or another tool.
+fn ensure_guest_isolation_rule() -> Result<()> {
+    let present = Cmd::new("iptables")
+        .args(["-C", "FORWARD"])
+        .args(GUEST_ISOLATION_SPEC)
+        .sudo()
+        .capture()
+        .is_ok();
+    if !present {
+        Cmd::new("iptables")
+            .args(["-I", "FORWARD", "1"])
+            .args(GUEST_ISOLATION_SPEC)
+            .sudo()
+            .run()
+            .context("Failed to deny inter-guest routing across the bridge")?;
+    }
+    Ok(())
 }
 
 // ── Bridge management ─────────────────────────────────────────
@@ -209,6 +275,14 @@ fn ensure_bridge(cfg: &NetworkConfig, host_iface: &str) -> Result<()> {
 fn teardown_bridge(host_iface: &str) {
     tracing::info!("Tearing down bridge {BRIDGE_NAME}");
 
+    if let Err(e) = Cmd::new("iptables")
+        .args(["-D", "FORWARD"])
+        .args(GUEST_ISOLATION_SPEC)
+        .sudo()
+        .run()
+    {
+        tracing::debug!("Failed to remove guest isolation rule (non-fatal): {e}");
+    }
     if let Err(e) = Cmd::new("iptables")
         .args([
             "-t",
@@ -388,6 +462,25 @@ mod tests {
             rewrite("https://localhost:9999/v1/chat?a=b", "10.0.0.1"),
             "https://10.0.0.1:9999/v1/chat?a=b"
         );
+    }
+
+    #[test]
+    fn port_is_isolated_reads_the_detailed_flag() {
+        // Real `bridge -d link show dev tap0` shapes: the flag is printed as
+        // `isolated on` / `isolated off`, and is absent entirely on a kernel
+        // that does not know the attribute — the silent-no-op case.
+        let isolated = "6: tap0: <BROADCAST,MULTICAST> mtu 1500 master br0 state disabled \
+             priority 32 cost 100 \n    hairpin off guard off root_block off fastleave off \
+             learning on flood on mcast_flood on neigh_suppress off vlan_tunnel off isolated on ";
+        let not_isolated = isolated.replace("isolated on", "isolated off");
+        let no_attribute = "6: tap0: <BROADCAST,MULTICAST> mtu 1500 master br0 state disabled \
+             priority 32 cost 100 \n    hairpin off guard off root_block off fastleave off \
+             learning on flood on mcast_flood on neigh_suppress off vlan_tunnel off ";
+
+        assert!(port_is_isolated(isolated));
+        assert!(!port_is_isolated(&not_isolated));
+        assert!(!port_is_isolated(no_attribute));
+        assert!(!port_is_isolated(""));
     }
 
     #[test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -543,3 +543,7 @@ mod tests {
         assert!(!host_is_loopback(None));
     }
 }
+
+#[cfg(all(test, target_os = "linux"))]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod isolation_tests;

--- a/src/network.rs
+++ b/src/network.rs
@@ -167,7 +167,8 @@ fn port_is_isolated(flags: &str) -> bool {
 /// stock host.
 ///
 /// Inserted at the head so it cannot lose to a pre-existing permissive
-/// `-A FORWARD -j ACCEPT` from libvirt or another tool.
+/// `-A FORWARD -j ACCEPT` from libvirt or another tool. Existing rules are
+/// checked for precedence too; refuse startup if the firewall has shadowed it.
 fn ensure_guest_isolation_rule() -> Result<()> {
     let present = Cmd::new("iptables")
         .args(["-C", "FORWARD"])
@@ -183,7 +184,29 @@ fn ensure_guest_isolation_rule() -> Result<()> {
             .run()
             .context("Failed to deny inter-guest routing across the bridge")?;
     }
+    let rules = Cmd::new("iptables")
+        .args(["-S", "FORWARD"])
+        .sudo()
+        .capture()
+        .context("Failed to verify guest isolation rule precedence")?;
+    if !guest_isolation_rule_is_first(&rules) {
+        bail!(
+            "Guest isolation DROP must be the first FORWARD rule; \
+             move it ahead of other rules in the host firewall configuration before starting a VM"
+        );
+    }
     Ok(())
+}
+
+/// Ignore the chain policy; the first rule must enforce guest isolation.
+fn guest_isolation_rule_is_first(rules: &str) -> bool {
+    rules
+        .lines()
+        .find(|line| line.starts_with("-A "))
+        .is_some_and(|line| {
+            line.split_whitespace()
+                .eq(["-A", "FORWARD"].into_iter().chain(GUEST_ISOLATION_SPEC))
+        })
 }
 
 // ── Bridge management ─────────────────────────────────────────
@@ -462,6 +485,23 @@ mod tests {
             rewrite("https://localhost:9999/v1/chat?a=b", "10.0.0.1"),
             "https://10.0.0.1:9999/v1/chat?a=b"
         );
+    }
+
+    #[test]
+    fn guest_isolation_requires_the_first_forward_rule() {
+        let drop = "-A FORWARD -i br0 -o br0 -j DROP";
+        let accept = "-A FORWARD -j ACCEPT";
+        assert!(guest_isolation_rule_is_first(&format!(
+            "-P FORWARD ACCEPT\n{drop}\n{accept}\n"
+        )));
+        assert!(!guest_isolation_rule_is_first(&format!(
+            "-P FORWARD ACCEPT\n{accept}\n{drop}\n"
+        )));
+        assert!(!guest_isolation_rule_is_first("-P FORWARD DROP\n"));
+        assert!(!guest_isolation_rule_is_first(""));
+        assert!(!guest_isolation_rule_is_first(
+            "-A FORWARD -i br0 -o eth0 -j DROP"
+        ));
     }
 
     #[test]

--- a/src/network/isolation_tests.rs
+++ b/src/network/isolation_tests.rs
@@ -1,0 +1,73 @@
+//! Run through tests/integration-network.sh, which supplies disposable namespaces.
+
+use std::fs;
+use std::process::Command;
+
+use crate::network::isolate_tap_port;
+
+fn ping(namespace: &str, address: &str) -> i32 {
+    let output = Command::new("ip")
+        .args([
+            "netns", "exec", namespace, "ping", "-n", "-c", "1", "-W", "2", "-w", "3", address,
+        ])
+        .output()
+        .unwrap();
+    let code = output.status.code().unwrap();
+    assert!(
+        code == 0 || code == 1,
+        "ping failed to execute normally: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    code
+}
+
+fn assert_peers_reachable() {
+    assert_eq!(ping("guest-a", "192.0.2.3"), 0, "A must reach B");
+    assert_eq!(ping("guest-b", "192.0.2.2"), 0, "B must reach A");
+}
+
+fn assert_gateway_reachable() {
+    for guest in ["guest-a", "guest-b"] {
+        assert_eq!(ping(guest, "192.0.2.1"), 0, "{guest} must reach gateway");
+    }
+}
+
+#[test]
+#[ignore = "requires disposable namespaces; run tests/integration-network.sh"]
+fn bridge_port_isolation_blocks_peers_without_firewall() {
+    let host_namespace = std::env::var("COOP_NETWORK_TEST_HOST_NS").unwrap();
+    assert_ne!(
+        fs::read_link("/proc/self/ns/net").unwrap().as_os_str(),
+        std::ffi::OsStr::new(&host_namespace),
+        "refusing to change bridge flags in the host network namespace"
+    );
+
+    // An empty ACCEPT ruleset prevents br_netfilter from masking a missing flag.
+    let rules = Command::new("iptables")
+        .args(["-S", "FORWARD"])
+        .output()
+        .unwrap();
+    assert!(rules.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&rules.stdout).trim(),
+        "-P FORWARD ACCEPT"
+    );
+
+    assert_peers_reachable();
+    assert_gateway_reachable();
+    isolate_tap_port("port-a").unwrap();
+    // Isolation is pairwise: marking just one port must leave peers reachable.
+    assert_peers_reachable();
+    isolate_tap_port("port-b").unwrap();
+    assert_eq!(ping("guest-a", "192.0.2.3"), 1, "A must not reach B");
+    assert_eq!(ping("guest-b", "192.0.2.2"), 1, "B must not reach A");
+    assert_gateway_reachable();
+
+    // Recovery rules out endpoint failure as the reason for the negative probes.
+    let status = Command::new("bridge")
+        .args(["link", "set", "dev", "port-a", "isolated", "off"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert_peers_reachable();
+}

--- a/tests/integration-network.sh
+++ b/tests/integration-network.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Host-only Linux bridge test. Build unprivileged; elevate only the disposable
+# network/mount/PID namespace. No KVM, VM images, or running coop instances needed.
+if [[ "$(uname -s)" != Linux ]]; then
+    echo "SKIP: bridge isolation requires Linux"
+    exit 0
+fi
+for tool in cargo python3 sudo unshare timeout mount ip bridge iptables ping readlink hostname; do
+    command -v "$tool" >/dev/null || { echo "Missing prerequisite: $tool" >&2; exit 1; }
+done
+cd "$(dirname "$0")/.."
+artifacts=$(mktemp)
+trap 'rm -f "$artifacts"' EXIT
+cargo test --locked --lib --no-run --message-format=json >"$artifacts"
+binary=$(python3 - "$artifacts" <<'PY'
+import json
+import sys
+with open(sys.argv[1]) as source:
+    tests = [item["executable"] for line in source
+             if (item := json.loads(line)).get("reason") == "compiler-artifact"
+             and item.get("executable") and item["target"]["name"] == "coop"
+             and item["profile"]["test"]]
+if len(tests) != 1:
+    raise SystemExit(f"Expected one coop library test executable, found {tests!r}")
+print(tests[0])
+PY
+)
+test_name=network::isolation_tests::bridge_port_isolation_blocks_peers_without_firewall
+# An exact filter matching zero tests otherwise exits successfully.
+"$binary" --list --ignored --exact "$test_name" | grep -Fx "$test_name: test"
+host_ns=$(readlink /proc/self/ns/net)
+sudo -n timeout --kill-after=5s 60s \
+    unshare --mount --net --uts --pid --fork --mount-proc --kill-child \
+    bash -s -- "$host_ns" "$binary" "$test_name" <<'INNER'
+set -euo pipefail
+export COOP_NETWORK_TEST_HOST_NS="$1"
+[[ "$(readlink /proc/self/ns/net)" != "$COOP_NETWORK_TEST_HOST_NS" ]]
+# Named namespaces and their bind mounts live only in this private mount tree.
+mount --make-rprivate /
+# sudo resolves the hostname even for root; no host DNS is reachable here.
+hostname localhost
+mount -t tmpfs tmpfs /run
+mkdir -p /run/netns
+ip link add br0 type bridge
+ip addr add 192.0.2.1/24 dev br0
+ip link set br0 up
+for endpoint in a b; do
+    ip netns add "guest-$endpoint"
+    ip link add "port-$endpoint" type veth peer name eth0 netns "guest-$endpoint"
+    ip link set "port-$endpoint" master br0
+    ip link set "port-$endpoint" up
+    ip -n "guest-$endpoint" link set lo up
+    ip -n "guest-$endpoint" link set eth0 up
+done
+ip -n guest-a addr add 192.0.2.2/24 dev eth0
+ip -n guest-b addr add 192.0.2.3/24 dev eth0
+# No routing or firewall rules: only the production bridge-port helper may
+# change peer reachability. Namespace exit removes all links and mounts.
+"$2" --ignored --exact "$3" --nocapture
+INNER

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3352,6 +3352,92 @@ test_appledouble_sidecars() {
 
 # ── Multi-instance tests (--full only) ────────────────────────
 
+# Read one guest's IPv4 address. The interface is eth0 on this backend —
+# src/setup.rs writes `[Match] Name=eth0` and src/vm.rs sets iface_id "eth0".
+guest_ip_of() {
+    GUEST_INSTANCE="$1"
+    guest_exec sh -c "ip -4 -o addr show dev eth0 | awk '{print \$4}' | cut -d/ -f1" \
+        2>/dev/null | tr -d '[:space:]'
+}
+
+# Install <dest>/32 via the gateway and confirm it took — a route that silently
+# failed to install would make the probe fall back to the on-link path that L2
+# isolation already blocks.
+guest_route_via() {
+    GUEST_INSTANCE="$1"
+    guest_exec sudo ip route replace "$2/32" via "$3" >/dev/null 2>&1 || return 1
+    guest_exec ip route get "$2" 2>/dev/null | grep -q "via $3"
+}
+
+# Two live instances must not reach each other by either path, without losing
+# guest->host. Firecracker-only; each Lima VM has its own user-mode NAT.
+# An unisolated guest boots and works exactly like an isolated one, so without
+# this a regression in either control is invisible.
+assert_guest_isolation() {
+    local inst_a="$1" inst_b="$2" ip_a ip_b gateway
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        skip "guest-to-guest isolation" "Firecracker-only (Lima VMs use per-VM NAT)"
+        return
+    fi
+
+    ip_a=$(guest_ip_of "$inst_a")
+    ip_b=$(guest_ip_of "$inst_b")
+    GUEST_INSTANCE="$inst_a"
+    gateway=$(guest_exec sh -c "ip -4 route show default | awk '{print \$3}' | head -1" \
+        2>/dev/null | tr -d '[:space:]')
+    if [[ -z "$ip_a" || -z "$ip_b" || "$ip_a" == "$ip_b" || -z "$gateway" ]]; then
+        unset GUEST_INSTANCE
+        fail "guest-to-guest isolation" "bad addressing: a='$ip_a' b='$ip_b' gw='$gateway'"
+        return
+    fi
+
+    # Positive control first: every assertion below reads a ping failure as
+    # success, so a guest with no working ping would manufacture green
+    # negatives. Doubles as the guest->host non-regression.
+    if ! guest_exec ping -c1 -W2 "$gateway" >/dev/null 2>&1; then
+        unset GUEST_INSTANCE
+        fail "guest A still reaches the host gateway" "ping $gateway failed"
+        return
+    fi
+    pass "guest A still reaches the host gateway"
+
+    # L2: direct on-link path, blocked by the isolated bridge port.
+    if guest_exec ping -c1 -W2 "$ip_b" >/dev/null 2>&1; then
+        fail "guest A cannot ping guest B directly" "ping $ip_b from $inst_a succeeded"
+    else
+        pass "guest A cannot ping guest B directly"
+    fi
+
+    # L3: routed path, blocked by the FORWARD DROP. Both guests need the /32 —
+    # with only A's route, B answers over its connected /24 (two isolated
+    # ports), so the reply dies at L2 and the ping fails whether or not the
+    # rule exists. Attributable only under an ACCEPT policy; a DROP policy
+    # (any host that has run dockerd) would fail the ping either way.
+    if ! sudo -n iptables -S FORWARD 2>/dev/null | grep -q '^-P FORWARD ACCEPT'; then
+        skip "guest A cannot reach guest B via the host gateway" \
+            "host FORWARD policy is not ACCEPT"
+    elif guest_route_via "$inst_a" "$ip_b" "$gateway" &&
+        guest_route_via "$inst_b" "$ip_a" "$gateway"; then
+        GUEST_INSTANCE="$inst_a"
+        if guest_exec ping -c1 -W2 "$ip_b" >/dev/null 2>&1; then
+            fail "guest A cannot reach guest B via the host gateway" \
+                "routed ping to $ip_b via $gateway succeeded"
+        else
+            pass "guest A cannot reach guest B via the host gateway"
+        fi
+        GUEST_INSTANCE="$inst_a"
+        guest_exec sudo ip route del "$ip_b/32" >/dev/null 2>&1 || true
+        GUEST_INSTANCE="$inst_b"
+        guest_exec sudo ip route del "$ip_a/32" >/dev/null 2>&1 || true
+    else
+        fail "guest A cannot reach guest B via the host gateway" \
+            "could not install the /32 routes the probe depends on"
+    fi
+
+    unset GUEST_INSTANCE
+}
+
 test_multi_instance() {
     echo ""
     echo "=== Phase: multi-instance ==="
@@ -3433,6 +3519,8 @@ test_multi_instance() {
     else
         fail "both instances reachable via SSH" "a='$hostname_a' b='$hostname_b'"
     fi
+
+    assert_guest_isolation "$inst_a" "$inst_b"
 
     # Clean up
     coop destroy "$inst_a" 2>/dev/null || true

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3374,7 +3374,7 @@ guest_route_via() {
 # An unisolated guest boots and works exactly like an isolated one, so without
 # this a regression in either control is invisible.
 assert_guest_isolation() {
-    local inst_a="$1" inst_b="$2" ip_a ip_b gateway
+    local inst_a="$1" inst_b="$2" ip_a ip_b gateway ip tap
 
     if [[ "$(uname -s)" == "Darwin" ]]; then
         skip "guest-to-guest isolation" "Firecracker-only (Lima VMs use per-VM NAT)"
@@ -3392,6 +3392,22 @@ assert_guest_isolation() {
         return
     fi
 
+    # Instance::guest_ip uses 172.16.0.(index + 2), and tap_device uses tap<index>.
+    # Read each flag directly: br_netfilter can make the FORWARD DROP mask a
+    # missing L2 control in the direct-ping assertion below.
+    for ip in "$ip_a" "$ip_b"; do
+        if [[ ! "$ip" =~ ^172\.16\.0\.([0-9]{1,3})$ ]]; then
+            fail "guest address identifies a TAP" "unexpected guest IPv4 address"
+            continue
+        fi
+        tap="tap$(( 10#${BASH_REMATCH[1]} - 2 ))"
+        if sudo -n bridge -d link show dev "$tap" 2>/dev/null | grep -q 'isolated on'; then
+            pass "$tap is an isolated bridge port"
+        else
+            fail "$tap is an isolated bridge port" "isolated on flag is absent"
+        fi
+    done
+
     # Positive control first: every assertion below reads a ping failure as
     # success, so a guest with no working ping would manufacture green
     # negatives. Doubles as the guest->host non-regression.
@@ -3402,7 +3418,8 @@ assert_guest_isolation() {
     fi
     pass "guest A still reaches the host gateway"
 
-    # L2: direct on-link path, blocked by the isolated bridge port.
+    # Direct on-link reachability (the FORWARD rule can also block this when
+    # br_netfilter is enabled; the flag assertions above independently check L2).
     if guest_exec ping -c1 -W2 "$ip_b" >/dev/null 2>&1; then
         fail "guest A cannot ping guest B directly" "ping $ip_b from $inst_a succeeded"
     else

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1981,16 +1981,35 @@ test_network() {
         fail "DNS resolution works" "all resolution methods failed; stderr: $(guest_stderr)"
     fi
 
-    # HTTP connectivity (use a reliable endpoint)
-    local http_code
-    if http_code=$(guest_exec curl -s -o /dev/null -w '%{http_code}' --max-time 10 https://api.github.com); then
+    if [[ "$(uname -s)" == Linux ]]; then
+        # shellcheck disable=SC2016 # Expand readlink inside the guest.
+        if guest_exec sh -c '[ "$(readlink /etc/systemd/system/fcnet.service)" = /dev/null ]'; then
+            pass "inherited fcnet service is masked"
+        else
+            fail "inherited fcnet service is masked" "the base image must not assign competing /30 addresses"
+        fi
+        local addresses expected_ip
+        expected_ip=$(guest_ip_of "$INSTANCE") || expected_ip=""
+        addresses=$(guest_exec sh -c "ip -4 -o addr show dev eth0 | awk '{print \$4}'") || addresses=""
+        if [[ -n "$expected_ip" && "$addresses" == "$expected_ip/24" ]]; then
+            pass "guest has exactly its configured /24 address"
+        else
+            fail "guest has exactly its configured /24 address" "addresses: $addresses"
+        fi
+    fi
+
+    # Retry transient HTTP failures, but keep persistent failures fatal and bounded.
+    local http_code rc
+    if http_code=$(guest_exec curl -sS --fail -o /dev/null -w '%{http_code}' \
+        --max-time 10 --retry 2 --retry-delay 1 --retry-max-time 30 https://api.github.com); then
         if [[ "$http_code" =~ ^[23] ]]; then
             pass "HTTPS connectivity works (HTTP $http_code)"
         else
             fail "HTTPS connectivity works" "HTTP $http_code"
         fi
     else
-        fail "HTTPS connectivity works" "curl failed"
+        rc=$?
+        fail "HTTPS connectivity works" "curl/transport exit $rc; HTTP $http_code; stderr: $(guest_stderr)"
     fi
 }
 
@@ -3898,9 +3917,69 @@ test_appledouble_sidecars() {
 # Read one guest's IPv4 address. The interface is eth0 on this backend —
 # src/setup.rs writes `[Match] Name=eth0` and src/vm.rs sets iface_id "eth0".
 guest_ip_of() {
+    local addresses
     GUEST_INSTANCE="$1"
-    guest_exec sh -c "ip -4 -o addr show dev eth0 | awk '{print \$4}' | cut -d/ -f1" \
-        2>/dev/null | tr -d '[:space:]'
+    if ! addresses=$(guest_exec ip -4 -o addr show dev eth0); then
+        echo "Cannot read guest IPv4 addresses: $(guest_stderr)" >&2
+        return 1
+    fi
+    # The kernel and systemd can install the same IP with different prefixes.
+    # Deduplicate addresses, not entire CIDRs; never concatenate separate IPs.
+    printf '%s\n' "$addresses" | awk '
+        NF {
+            split($4, cidr, "/")
+            n = split(cidr[1], octet, ".")
+            if ($3 != "inet" || n != 4) invalid = 1
+            for (i = 1; i <= n; i++)
+                if (octet[i] !~ /^[0-9]+$/ || octet[i] + 0 > 255) invalid = 1
+            if (!seen[cidr[1]]++) { count++; address = cidr[1] }
+        }
+        END {
+            if (invalid || count != 1) {
+                print "Expected one distinct valid guest IPv4 address; found " count > "/dev/stderr"
+                exit 1
+            }
+            print address
+        }
+    '
+}
+
+# coop shell collapses nonzero guest statuses to exit 1. Send a validated
+# result on stdout instead; keep ping diagnostics on stderr. Only the host
+# helper uses 42 for no reply, so sudo/SSH failures cannot manufacture a pass.
+guest_ping() {
+    local result
+    # shellcheck disable=SC2016 # Expanded by the guest shell, not the host.
+    if ! result=$(guest_exec sudo -n sh -c '
+        ping -n -c 1 -W 2 -w 3 "$1" >&2
+        rc=$?
+        case "$rc" in
+            0) printf "reachable\n" ;;
+            1) printf "no-reply\n" ;;
+            *) exit 1 ;;
+        esac
+    ' sh "$1"); then
+        return 43
+    fi
+    case "$result" in
+        reachable) return 0 ;;
+        no-reply) return 42 ;;
+        *) echo "Unexpected ping result: $result" >&2; return 43 ;;
+    esac
+}
+
+assert_guest_ping_blocked() {
+    local address="$1" label="$2" output rc
+    if output=$(guest_ping "$address"); then
+        fail "$label" "ping $address succeeded"
+    else
+        rc=$?
+        if [[ "$rc" == 42 ]]; then
+            pass "$label"
+        else
+            fail "$label" "ping probe failed (exit $rc): $output; stderr: $(guest_stderr)"
+        fi
+    fi
 }
 
 # Install <dest>/32 via the gateway and confirm it took — a route that silently
@@ -3917,15 +3996,17 @@ guest_route_via() {
 # An unisolated guest boots and works exactly like an isolated one, so without
 # this a regression in either control is invisible.
 assert_guest_isolation() {
-    local inst_a="$1" inst_b="$2" ip_a ip_b gateway ip tap
+    local inst_a="$1" inst_b="$2" ip_a ip_b gateway ip tap output rc rules
 
     if [[ "$(uname -s)" == "Darwin" ]]; then
         skip "guest-to-guest isolation" "Firecracker-only (Lima VMs use per-VM NAT)"
         return
     fi
 
-    ip_a=$(guest_ip_of "$inst_a")
-    ip_b=$(guest_ip_of "$inst_b")
+    if ! ip_a=$(guest_ip_of "$inst_a") || ! ip_b=$(guest_ip_of "$inst_b"); then
+        fail "guest-to-guest isolation" "cannot determine distinct guest IPv4 addresses"
+        return
+    fi
     GUEST_INSTANCE="$inst_a"
     gateway=$(guest_exec sh -c "ip -4 route show default | awk '{print \$3}' | head -1" \
         2>/dev/null | tr -d '[:space:]')
@@ -3940,8 +4021,14 @@ assert_guest_isolation() {
     # missing L2 control in the direct-ping assertion below.
     for ip in "$ip_a" "$ip_b"; do
         if [[ ! "$ip" =~ ^172\.16\.0\.([0-9]{1,3})$ ]]; then
-            fail "guest address identifies a TAP" "unexpected guest IPv4 address"
-            continue
+            fail "guest address identifies a TAP" "unexpected guest IPv4 address: $ip"
+            unset GUEST_INSTANCE
+            return
+        fi
+        if (( 10#${BASH_REMATCH[1]} < 2 || 10#${BASH_REMATCH[1]} > 254 )); then
+            fail "guest address identifies a TAP" "guest address outside instance range: $ip"
+            unset GUEST_INSTANCE
+            return
         fi
         tap="tap$(( 10#${BASH_REMATCH[1]} - 2 ))"
         if sudo -n bridge -d link show dev "$tap" 2>/dev/null | grep -q 'isolated on'; then
@@ -3951,48 +4038,48 @@ assert_guest_isolation() {
         fi
     done
 
-    # Positive control first: every assertion below reads a ping failure as
-    # success, so a guest with no working ping would manufacture green
-    # negatives. Doubles as the guest->host non-regression.
-    if ! guest_exec ping -c1 -W2 "$gateway" >/dev/null 2>&1; then
+    # A working gateway probe is the positive control for blocked-peer probes.
+    if output=$(guest_ping "$gateway"); then
+        pass "guest A still reaches the host gateway"
+    else
+        rc=$?
+        fail "guest A still reaches the host gateway" \
+            "ping probe exit $rc: $output; stderr: $(guest_stderr)"
         unset GUEST_INSTANCE
-        fail "guest A still reaches the host gateway" "ping $gateway failed"
         return
     fi
-    pass "guest A still reaches the host gateway"
 
-    # Direct on-link reachability (the FORWARD rule can also block this when
-    # br_netfilter is enabled; the flag assertions above independently check L2).
-    if guest_exec ping -c1 -W2 "$ip_b" >/dev/null 2>&1; then
-        fail "guest A cannot ping guest B directly" "ping $ip_b from $inst_a succeeded"
-    else
-        pass "guest A cannot ping guest B directly"
-    fi
+    # br_netfilter may also block this path; the TAP flags are checked above.
+    assert_guest_ping_blocked "$ip_b" "guest A cannot ping guest B directly"
 
     # L3: routed path, blocked by the FORWARD DROP. Both guests need the /32 —
     # with only A's route, B answers over its connected /24 (two isolated
     # ports), so the reply dies at L2 and the ping fails whether or not the
     # rule exists. Attributable only under an ACCEPT policy; a DROP policy
     # (any host that has run dockerd) would fail the ping either way.
-    if ! sudo -n iptables -S FORWARD 2>/dev/null | grep -q '^-P FORWARD ACCEPT'; then
+    if ! rules=$(sudo -n iptables -S FORWARD 2>"$tmpdir/firewall_stderr"); then
+        fail "guest A cannot reach guest B via the host gateway" \
+            "cannot inspect host FORWARD policy: $(cat "$tmpdir/firewall_stderr")"
+        unset GUEST_INSTANCE
+        return
+    fi
+    if ! printf '%s\n' "$rules" | grep -q '^-P FORWARD ACCEPT'; then
         skip "guest A cannot reach guest B via the host gateway" \
             "host FORWARD policy is not ACCEPT"
     elif guest_route_via "$inst_a" "$ip_b" "$gateway" &&
         guest_route_via "$inst_b" "$ip_a" "$gateway"; then
         GUEST_INSTANCE="$inst_a"
-        if guest_exec ping -c1 -W2 "$ip_b" >/dev/null 2>&1; then
-            fail "guest A cannot reach guest B via the host gateway" \
-                "routed ping to $ip_b via $gateway succeeded"
-        else
-            pass "guest A cannot reach guest B via the host gateway"
-        fi
-        GUEST_INSTANCE="$inst_a"
-        guest_exec sudo ip route del "$ip_b/32" >/dev/null 2>&1 || true
-        GUEST_INSTANCE="$inst_b"
-        guest_exec sudo ip route del "$ip_a/32" >/dev/null 2>&1 || true
+        assert_guest_ping_blocked "$ip_b" "guest A cannot reach guest B via the host gateway"
     else
         fail "guest A cannot reach guest B via the host gateway" \
             "could not install the /32 routes the probe depends on"
+    fi
+    # The first route may have been installed even when the second failed.
+    if printf '%s\n' "$rules" | grep -q '^-P FORWARD ACCEPT'; then
+        GUEST_INSTANCE="$inst_a"
+        guest_exec sudo -n ip route del "$ip_b/32" >/dev/null 2>&1 || true
+        GUEST_INSTANCE="$inst_b"
+        guest_exec sudo -n ip route del "$ip_a/32" >/dev/null 2>&1 || true
     fi
 
     unset GUEST_INSTANCE

--- a/tests/run-integration.sh
+++ b/tests/run-integration.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Remote mode detects the remote host's architecture, cross-compiles
 # the matching musl binary, copies it and the test script, and runs tests there.
 #
+# --full also runs integration-network.sh on the test host before the VM suite.
 # All flags other than --remote are forwarded to integration.sh.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -18,11 +19,13 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEST_SCRIPT="$SCRIPT_DIR/integration.sh"
 
 REMOTE_HOST=""
+FULL="${TEST_FULL:-0}"
 FORWARD_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --remote)  REMOTE_HOST="$2";  shift 2 ;;
+        --full)    FULL=1; FORWARD_ARGS+=("$1"); shift ;;
         *)         FORWARD_ARGS+=("$1"); shift ;;
     esac
 done
@@ -30,6 +33,11 @@ done
 # ── Local mode ───────────────────────────────────────────────────
 
 if [[ -z "$REMOTE_HOST" ]]; then
+    if [[ "$FULL" == "1" ]]; then
+        echo "Running bridge isolation integration test..."
+        "$SCRIPT_DIR/integration-network.sh"
+    fi
+
     echo "Building coop (release)..."
     cargo build --release --manifest-path "$PROJECT_DIR/Cargo.toml"
 
@@ -81,28 +89,47 @@ else
 fi
 
 REMOTE_DIR=$(ssh "$REMOTE_HOST" mktemp -d)
-trap 'ssh "$REMOTE_HOST" rm -rf "$REMOTE_DIR"' EXIT
+source_archive=""
+trap '[[ -z "$source_archive" ]] || rm -f "$source_archive"; ssh "$REMOTE_HOST" rm -rf "$REMOTE_DIR"' EXIT
 
 echo "Copying binary and test script to $REMOTE_HOST:$REMOTE_DIR..."
 scp -q "$LOCAL_BINARY" "$TEST_SCRIPT" "$REMOTE_HOST:$REMOTE_DIR/"
 
+# The full network gate builds on the remote, as does the proxy fallback.
+# Include tracked working-tree edits so the gate tests the same code as coop.
+if [[ "$FULL" == "1" || "$build_proxy_on_remote" == "1" ]]; then
+    source_archive=$(mktemp "${TMPDIR:-/tmp}/coop-integration-src.XXXXXX.tar.gz")
+    (
+        cd "$PROJECT_DIR"
+        git ls-files -z | tar --null -czf "$source_archive" -T -
+    )
+    scp -q "$source_archive" "$REMOTE_HOST:$REMOTE_DIR/coop-src.tar.gz"
+    rm -f "$source_archive"
+    source_archive=""
+    # shellcheck disable=SC2029 # $REMOTE_DIR is a mktemp path
+    ssh "$REMOTE_HOST" "mkdir -p '$REMOTE_DIR/src' && tar xzf '$REMOTE_DIR/coop-src.tar.gz' -C '$REMOTE_DIR/src'"
+fi
+
+if [[ "$FULL" == "1" ]]; then
+    echo "Running bridge isolation integration test on $REMOTE_HOST..."
+    # shellcheck disable=SC2029 # $REMOTE_DIR is a mktemp path
+    ssh "$REMOTE_HOST" "
+        set -e
+        . \"\$HOME/.cargo/env\" 2>/dev/null || true
+        cd '$REMOTE_DIR/src'
+        ./tests/integration-network.sh
+    "
+fi
+
 if [[ "$build_proxy_on_remote" == "0" ]]; then
     scp -q "$LOCAL_PROXY" "$REMOTE_HOST:$REMOTE_DIR/"
 else
-    # Native build on the remote from a clean source snapshot of the current
-    # commit. Best-effort: needs cargo + cmake + a C compiler on the remote; on
-    # any failure the proxy phase skips (a warning is printed, the suite runs).
+    # Best-effort: the proxy fallback requires cargo + cmake + a C compiler.
     echo "Building coop-proxy natively on $REMOTE_HOST..."
-    proxy_src=$(mktemp "${TMPDIR:-/tmp}/coop-proxy-src.XXXXXX.tar.gz")
-    git -C "$PROJECT_DIR" archive --format=tar.gz -o "$proxy_src" HEAD
-    scp -q "$proxy_src" "$REMOTE_HOST:$REMOTE_DIR/coop-src.tar.gz"
-    rm -f "$proxy_src"
     # shellcheck disable=SC2029 # $REMOTE_DIR is a mktemp path; expand client-side
     ssh "$REMOTE_HOST" "
         set -e
         . \"\$HOME/.cargo/env\" 2>/dev/null || true
-        mkdir -p '$REMOTE_DIR/src'
-        tar xzf '$REMOTE_DIR/coop-src.tar.gz' -C '$REMOTE_DIR/src'
         cd '$REMOTE_DIR/src'
         cargo build --release -p coop-proxy
         cp target/release/coop-proxy '$REMOTE_DIR/coop-proxy'
@@ -112,6 +139,9 @@ fi
 # Build the remote command as an array, then printf %q to safely quote for ssh.
 # ssh doesn't forward arbitrary env vars, so pass opt-in flags explicitly.
 REMOTE_CMD=()
+if [[ "$FULL" == "1" ]]; then
+    REMOTE_CMD+=("TEST_FULL=1")
+fi
 if [[ -n "${COOP_TEST_DESTRUCTIVE:-}" ]]; then
     REMOTE_CMD+=("COOP_TEST_DESTRUCTIVE=$COOP_TEST_DESTRUCTIVE")
 fi

--- a/tests/test-integration-probes.py
+++ b/tests/test-integration-probes.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Regression tests for VM integration probes, without booting a VM."""
+import http.server
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+
+SOURCE = (Path(__file__).parent / "integration.sh").read_text()
+
+
+def functions(*names):
+    return "\n".join(
+        re.search(r"^" + name + r"\(\) \{\n.*?^\}", SOURCE, re.M | re.S)[0]
+        for name in names
+    )
+
+
+def shell(script, **env):
+    return subprocess.run(
+        ["bash", "-c", script], env={**os.environ, **env},
+        capture_output=True, text=True, timeout=45,
+    )
+
+
+class ProbeTests(unittest.TestCase):
+    @unittest.skipUnless(sys.platform.startswith("linux"), "Linux guest provisioning")
+    def test_fcnet_mask_replaces_existing_unit(self):
+        setup = (Path(__file__).parent.parent / "scripts/guest/guest-config.sh").read_text()
+        fragment = setup[:setup.index("echo '  [guest] Configuring guest networking...'")]
+        with tempfile.TemporaryDirectory() as directory:
+            unit = Path(directory) / "fcnet.service"
+            unit.write_text("[Service]\nExecStart=/usr/local/bin/fcnet-setup.sh\n")
+            fragment = fragment.replace("/etc/systemd/system/fcnet.service", str(unit))
+            result = shell("systemctl() { return 1; }\n" + fragment)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(unit.is_symlink())
+            self.assertEqual(os.readlink(unit), "/dev/null")
+
+    def test_addresses(self):
+        for addresses, expected in [
+            ("2: eth0 inet 172.16.0.2/24\n2: eth0 inet 172.16.0.2/30", "172.16.0.2"),
+            ("2: eth0 inet 172.16.0.3/24", "172.16.0.3"),
+            ("", None),
+            ("2: eth0 inet 172.16.0.2/24\n2: eth0 inet 172.16.0.3/24", None),
+            ("2: eth0 inet 999.1.1.1/24", None),
+            ("garbage", None),
+        ]:
+            with self.subTest(addresses=addresses):
+                result = shell(functions("guest_ip_of") + '''
+                    guest_exec() { printf '%s\n' "$FIXTURE"; }
+                    guest_stderr() { echo transport-error; }
+                    guest_ip_of example
+                ''', FIXTURE=addresses)
+                self.assertEqual(result.returncode == 0, expected is not None)
+                if expected is not None:
+                    self.assertEqual(result.stdout.strip(), expected)
+        result = shell(functions("guest_ip_of") + '''
+            guest_exec() { echo '2: eth0 inet 172.16.0.2/24'; return 255; }
+            guest_stderr() { echo transport-error; }
+            guest_ip_of example
+        ''')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("transport-error", result.stderr)
+
+    def test_ping_status_and_sudo(self):
+        with tempfile.TemporaryDirectory() as directory:
+            ping = Path(directory) / "ping"
+            ping.write_text('#!/bin/sh\nexit "$PING_STATUS"\n')
+            ping.chmod(0o755)
+            for status, expected in [(0, 0), (1, 42), (2, 43), (127, 43)]:
+                with self.subTest(status=status):
+                    result = shell(functions("guest_ping") + '''
+                        guest_exec() {
+                            [[ "$1" == sudo && "$2" == -n ]] || return 99
+                            shift 2
+                            "$@" || return 1
+                        }
+                        guest_ping 172.16.0.3
+                    ''', PATH=directory + ":" + os.environ["PATH"], PING_STATUS=str(status))
+                    self.assertEqual(result.returncode, expected)
+
+    def test_ping_transport_errors_and_unexpected_output(self):
+        for status, output in [(1, ""), (255, ""), (0, "unexpected"),
+                               (0, "no-reply\nextra"), (1, "no-reply")]:
+            with self.subTest(status=status, output=output):
+                result = shell(functions("guest_ping") + '''
+                    guest_exec() { printf '%s\n' "$OUTPUT"; return "$STATUS"; }
+                    guest_ping 172.16.0.3
+                ''', STATUS=str(status), OUTPUT=output)
+                self.assertEqual(result.returncode, 43)
+
+    def test_only_ping_no_reply_counts_as_blocked(self):
+        for status in (0, 1, 42, 43, 127, 255):
+            with self.subTest(status=status):
+                result = shell(functions("assert_guest_ping_blocked") + '''
+                    guest_ping() { return "$PROBE_STATUS"; }
+                    guest_stderr() { echo probe-error; }
+                    pass() { echo PASS; }
+                    fail() { echo "FAIL $*"; }
+                    assert_guest_ping_blocked 172.16.0.3 blocked
+                ''', PROBE_STATUS=str(status))
+                self.assertEqual(result.stdout.startswith("PASS"), status == 42)
+                if status not in (0, 42):
+                    self.assertIn("probe-error", result.stdout)
+
+    def test_http_retry_and_persistent_failures(self):
+        for responses, expected, requests in [
+            ([504, 200], "PASS HTTPS", 2),
+            ([504], "FAIL HTTPS", 3),
+            ([404], "FAIL HTTPS", 1),
+        ]:
+            with self.subTest(responses=responses), tempfile.TemporaryDirectory() as directory:
+                seen = []
+
+                class Handler(http.server.BaseHTTPRequestHandler):
+                    def do_GET(self):
+                        code = responses[min(len(seen), len(responses) - 1)]
+                        seen.append(code)
+                        self.send_response(code)
+                        self.send_header("Content-Length", "0")
+                        self.end_headers()
+
+                    def log_message(self, *_args):
+                        pass
+
+                with http.server.HTTPServer(("127.0.0.1", 0), Handler) as server:
+                    thread = threading.Thread(target=server.serve_forever)
+                    thread.start()
+                    try:
+                        result = shell(functions("test_network") + '''
+                            guest_exec() {
+                                if [[ "$1" != curl ]]; then return 0; fi
+                                local args=("$@")
+                                args[${#args[@]}-1]="$TEST_URL"
+                                "${args[@]}" 2>"$TEST_ERR"
+                            }
+                            guest_stderr() { cat "$TEST_ERR"; }
+                            pass() { echo "PASS $*"; }
+                            fail() { echo "FAIL $*"; }
+                            test_network
+                        ''', TEST_URL=f"http://127.0.0.1:{server.server_port}",
+                            TEST_ERR=str(Path(directory) / "stderr"))
+                    finally:
+                        server.shutdown()
+                        thread.join()
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(expected, result.stdout)
+                self.assertEqual(len(seen), requests)
+                if expected.startswith("FAIL"):
+                    self.assertIn(f"HTTP {responses[-1]}", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Firecracker instances on one host share `br0` and a subnet, allowing guests to reach peer SSH and forwarded ports. This change isolates guest traffic at both the bridge and routed forwarding layers.

## Behavior

- Each TAP is marked an isolated bridge port. Startup reads back the flag and fails closed if it did not take effect.
- A `FORWARD -i br0 -o br0 -j DROP` rule blocks traffic routed between guests through the bridge gateway. Each TAP setup checks that the rule is first in FORWARD and fails with an actionable error if another rule shadows it. Bridge teardown removes the rule.
- Guest-to-host and guest-to-internet traffic do not match the bridge-to-bridge DROP.
- Linux guest provisioning masks the inherited `fcnet.service`, which otherwise derives an extra /30 address from the MAC and conflicts with coop's /24 configuration. Rebuild existing images with `coop setup`.

The minimum versions are Linux 4.18 and iproute2 4.19. Readback is required because an older kernel can silently ignore the isolation attribute even when the command succeeds.

## Tests

The full integration runner now runs the independent network namespace gate on the selected local or remote host before the VM suite. macOS explicitly skips the Linux-only gate. CI runs the namespace gate and Python probe regression tests.

The namespace test verifies L2 isolation without firewall masking and the routed control with positive witnesses. Live Firecracker assertions check both TAP isolation flags, gateway reachability, direct guest isolation, and reciprocal /32 routes through the gateway when the host FORWARD policy permits a discriminating test. Negative ping assertions accept only confirmed no-reply results; privilege, command, and transport errors fail. Reciprocal routes prevent L2 isolation of the return path from masking a missing L3 rule.

Probe regressions cover duplicate or invalid guest addresses, ping privilege and transport failures, transient and persistent HTTP failures, and replacement of an inherited fcnet unit. Rule and bridge readback predicates have unit coverage; shell wrappers are excluded from mutation testing.

## Verification

Validated on head `665d1ae` (the same code as the tested working tree):

- Full macOS/Lima: **435 passed, 0 failed, 13 skipped**.
- Full Linux/Firecracker: **445 passed, 1 failed, 8 skipped**. The failure was an HTTP 500 downloading the Codex checksum manifest after four attempts. Replaying that interrupted-setup recovery phase with unchanged code passed **4/4** assertions. The original full run remains recorded as failed.
- The independent namespace gate passed through the full runner. Actual VM isolation flags, gateway reachability, direct peer isolation, masked fcnet, and single /24 addressing passed. Routed VM isolation skipped because the remote host FORWARD policy is DROP.
- All six Python regressions passed on Linux, and twelve runner mock cases passed. Deliberate mutations removing address deduplication, sudo, HTTP retries, and the fcnet mask, or accepting probe errors as isolation, were caught.
- Format, clippy with all targets/features and zero warnings, shell syntax, and diff whitespace checks passed. The macOS unit run passed 1,149 tests and failed one unchanged main-branch test because the filesystem rejects its non-UTF-8 directory fixture. Linux CI passed the unit suite, Python regression tests, namespace isolation test, and its other integration steps on this head.

No macOS host network settings were changed during validation. Linux network operations ran on the remote host and in disposable namespaces/guests. Lima uses separate guest configuration and per-instance usernet stacks.

## Residuals

These remain documented follow-ups, not guarantees provided by this PR:

- **Legacy ports:** bridge isolation requires both ports to be isolated. Restart running VMs after upgrading so older unisolated ports cannot communicate with peers.
- **Impersonation:** neither control restricts ARP or guest-authored addresses. SSH uses IP addresses with host-key checking disabled, so an impostor could receive a connection and its forwarded environment. MAC/IP pinning is not implemented.
- **IPv6 and firewall reloads:** only iptables is covered; a firewall reload can discard the rule until another startup checks it.
- **Pre-existing br0:** coop adopts an existing bridge without inspecting its members or installing all other expected rules. The DROP affects that bridge's traffic too. Bridge ownership and idempotent assertion of all rules remain separate work.

This is partial progress toward #5, not completion of guest isolation or #2's egress restrictions. The new Linux host forwarding rule requires the repository's merge-time human confirmation.
