### PR TITLE
test(proxy): distinguish local gate refusals

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -4758,31 +4758,47 @@ STATEEOF
     # ── The proxy is reachable on host loopback and enforces the gate ──
     # The proxy binds 127.0.0.1:<port> on the host and is reverse-tunnelled into
     # the guest, so the host exercises the same listener. A request without the
-    # token is refused locally ("capability token"). With the token, an
-    # allowlisted operation is forwarded upstream (which fails closed at the
-    # real host — 502 with no egress, or an upstream auth error — but never the
-    # local refusal), so the presence/absence of the "capability" refusal
-    # distinguishes the two without needing a working upstream.
+    # token is refused locally with 401. With the token, an allowlisted
+    # operation reaches the real host, yielding 502 with no egress or an
+    # upstream auth error. Status alone is ambiguous because upstream auth can
+    # also return 401/403, so the fixed local bodies identify gate refusals.
     local oai_port cap_token
     oai_port=$(echo "$codex_cfg" | grep -oE '127\.0\.0\.1:[0-9]+' | head -1 | cut -d: -f2 || true)
     cap_token=$(echo "$guest_env" | grep '^COOP_LOCAL_API_KEY=' | cut -d= -f2- || true)
     if [[ -n "$oai_port" ]]; then
-        local no_tok tok response_body
+        local no_tok tok no_tok_status tok_status response_body
+        local no_tok_body_file="$tmpdir/proxy-no-token-body"
+        local tok_body_file="$tmpdir/proxy-token-body"
         response_body='{"model":"gpt-4.1","input":"ping"}'
-        no_tok=$(curl -s --max-time 10 -X POST "http://127.0.0.1:$oai_port/v1/responses" \
-            -H "Content-Type: application/json" --data "$response_body" || true)
-        tok=$(curl -s --max-time 15 -X POST "http://127.0.0.1:$oai_port/v1/responses" \
+        no_tok_status=$(curl -s --max-time 10 -X POST \
+            "http://127.0.0.1:$oai_port/v1/responses" \
+            -H "Content-Type: application/json" --data "$response_body" \
+            --output "$no_tok_body_file" --write-out '%{http_code}' || true)
+        no_tok=$(cat "$no_tok_body_file" 2>/dev/null || true)
+        tok_status=$(curl -s --max-time 15 -X POST \
+            "http://127.0.0.1:$oai_port/v1/responses" \
             -H "Authorization: Bearer $cap_token" -H "Content-Type: application/json" \
-            --data "$response_body" || true)
-        if echo "$no_tok" | grep -qi "capability"; then
+            --data "$response_body" --output "$tok_body_file" \
+            --write-out '%{http_code}' || true)
+        tok=$(cat "$tok_body_file" 2>/dev/null || true)
+        if [[ "$no_tok_status" == "401" ]] \
+            && echo "$no_tok" | grep -Fqi "missing or invalid coop-proxy capability token"; then
             pass "openai proxy refuses a request missing the capability token"
         else
-            fail "openai proxy refuses a request missing the capability token" "body: $no_tok"
+            fail "openai proxy refuses a request missing the capability token" \
+                "status: $no_tok_status body: $no_tok"
         fi
-        if echo "$tok" | grep -qi "capability"; then
-            fail "valid capability token forwards an allowed operation" "still refused: $tok"
-        else
+        if echo "$tok" | grep -Fqi "missing or invalid coop-proxy capability token"; then
+            fail "valid capability token forwards an allowed operation" \
+                "local capability refusal (status $tok_status): $tok"
+        elif echo "$tok" | grep -Fqi "operation is not allowed by coop-proxy"; then
+            fail "valid capability token forwards an allowed operation" \
+                "local operation-policy refusal (status $tok_status): $tok"
+        elif [[ "$tok_status" =~ ^[1-5][0-9][0-9]$ ]]; then
             pass "valid capability token forwards an allowed operation"
+        else
+            fail "valid capability token forwards an allowed operation" \
+                "no HTTP response (status: $tok_status body: $tok)"
         fi
     else
         fail "locate openai proxy port" "no 127.0.0.1:<port> in codex config"


### PR DESCRIPTION
## Summary

- require the missing-token probe to return the proxy local 401 response
- reject both capability-token and operation-policy local refusal bodies for the valid-token probe
- reject transport failures while retaining upstream authentication errors and no-egress 502 as evidence that both local gates were traversed

Closes #445

## Testing

- `bash -n tests/integration.sh`
- response-classification matrix covering local 401, local 403, upstream authentication, no-egress 502, and transport failure
- macOS/Lima full integration suite passed (reported by the author)

Firecracker/Linux full integration was not run in this VM because `/dev/kvm` is unavailable.