### PR TITLE
Prepare release: fix proxy and lifecycle failures, strengthen release checks

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -357,6 +357,8 @@ exclude_re = [
   "src/proxy\\.rs:.*\\bkill_pid_file\\b",
   "src/proxy\\.rs:.*\\bspawn_proxy\\b",
   "src/proxy\\.rs:.*\\bspawn_reverse_forward\\b",
+  "src/proxy\\.rs:.*\\bawait_forwarding_ack\\b",
+  "src/proxy\\.rs:.*\\bcreate_tunnel_control_dir\\b",
   # slice-3 jail: liveness poll of a spawned process + TCP probe (fail-closed)
   # and the platform spawn-command builder (macOS `sandbox-exec` wrap / Linux
   # bare binary) — IO/spawn wrappers, not `--lib`-observable. `await_proxy_ready`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,16 @@ jobs:
         run: cargo test --workspace
 
       - name: Install network test tools
-        run: sudo apt-get update && sudo apt-get install -y iproute2 iptables iputils-ping util-linux
+        run: sudo apt-get update && sudo apt-get install -y iproute2 iptables iputils-ping util-linux openssh-client openssh-server
 
       - name: Release preflight regression tests
         run: python3 tests/test-preflight-release.py
 
       - name: Integration probe regression tests
         run: python3 tests/test-integration-probes.py
+
+      - name: Integration test — proxy reverse forwarding
+        run: ./tests/integration-proxy-forward.sh
 
       - name: Integration test — bridge isolation
         run: ./tests/integration-network.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install network test tools
         run: sudo apt-get update && sudo apt-get install -y iproute2 iptables iputils-ping util-linux
 
+      - name: Release preflight regression tests
+        run: python3 tests/test-preflight-release.py
+
       - name: Integration probe regression tests
         run: python3 tests/test-integration-probes.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,20 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
         run: cargo build --release --workspace --target ${{ matrix.target }}
 
+      - name: Verify release binaries
+        env:
+          TAG: ${{ github.ref_name }}
+          TARGET: ${{ matrix.target }}
+        shell: bash
+        run: |
+          expected="coop ${TAG#v} ($(git rev-parse --short HEAD))"
+          actual="$("target/${TARGET}/release/coop" --version)"
+          if [[ "$actual" != "$expected" ]]; then
+            printf 'Expected release version %s, got %s\n' "$expected" "$actual" >&2
+            exit 1
+          fi
+          test -x "target/${TARGET}/release/coop-proxy"
+
       - name: Package
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,14 +51,18 @@ traces tainted/secret content; or softens the `coop update` verification chain.
 Runtime: Rust `1.94.0` (see `rust-toolchain.toml`), edition 2024.
 
 ```bash
-cargo build
+cargo build --workspace
 cargo fmt -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test
-cargo deny check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+cargo deny --workspace check
 taplo format --check
 prek run
 ```
+
+Workspace builds include `coop-proxy` and require CMake. Plain `cargo build`
+and the local clippy/test hooks cover only `coop`; run the workspace commands
+above before submitting.
 
 Install pinned local dev tools (prek, taplo, cargo-deny, cargo-mutants,
 cargo-fuzz, kani) with `./scripts/install-dev-tools.sh --all`, then `prek

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Upgrading from v0.5.4
+
+- Rerun the [installer](docs/getting-started.md#install) to install both `coop`
+  and the new `coop-proxy` companion in the same directory. The v0.5.4 updater
+  replaces only `coop`, so its first upgrade does not install the companion
+  required for proxy mode. Preserve your `INSTALL_DIR` if you used a custom
+  installation directory.
+- The published v0.5.4 Linux ARM64 binary reports
+  `coop 0.5.4-dev (8e24729+dirty)` and refuses self-update as a development
+  build. Use the installer to upgrade it.
+- Save guest-only work before `restore --reprovision`: it replaces the guest
+  disk, including any guest keyring and cached account login. Rebuilding an
+  image alone does not update existing VM disks.
+
 ### New features
 
 - **Codex ChatGPT account auth** — New `[codex] auth = "chatgpt"` mode for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,10 @@ cd coop
 cargo build --release
 ```
 
-The binary lands at `target/release/coop`.
+The binary lands at `target/release/coop`. This default build excludes the
+credential proxy. To build both release binaries, install CMake and run
+`cargo build --workspace --release`; keep `coop-proxy` next to `coop` when
+installing them.
 
 ## Pre-commit hooks
 
@@ -62,6 +65,10 @@ YAML, large files, merge conflicts). Run them by hand at any time with:
 prek run --all-files
 ```
 
+The local clippy and test hooks cover only `coop`. Before submitting, also
+run `cargo clippy --workspace --all-targets --all-features -- -D warnings` and
+`cargo test --workspace` to cover `coop-proxy`, as CI does.
+
 Fix every warning before committing. coop has a zero-warnings policy — clippy
 runs with `-D warnings`, so a warning fails the build.
 
@@ -70,10 +77,11 @@ runs with `-D warnings`, so a warning fails the build.
 ### Unit tests
 
 ```bash
-cargo test
+cargo test --workspace
 ```
 
-Unit tests live in the library crate and cover the pure logic: config parsing
+The workspace command also runs `coop-proxy` tests and requires CMake.
+The main CLI library tests cover the pure logic: config parsing
 and validation, workspace sync argument construction, env merging, secret
 routing, and the helpers the command handlers are built from. Test behavior,
 not implementation — a test that breaks under a refactor but not a behavior
@@ -109,7 +117,7 @@ parsing, the JSONC reader, the arithmetic kernels — see
 
 ## Code style
 
-- Format with `cargo fmt`; lint with `cargo clippy --all-targets
+- Format with `cargo fmt`; lint with `cargo clippy --workspace --all-targets
   --all-features -- -D warnings`. Both are enforced in CI.
 - Lean on the type system to make illegal states unrepresentable rather than
   validating at runtime: parse untrusted input into strong types at the
@@ -145,11 +153,15 @@ CI must pass before a pull request can merge. The
 [CI workflow](.github/workflows/ci.yml) runs:
 
 - **`cargo fmt -- --check`** — formatting.
-- **`cargo clippy --all-targets --all-features -- -D warnings`** — lints.
-- **`cargo test`** — unit tests.
-- **`./tests/integration-update.sh`** and
-  **`./tests/integration-uninstall.sh`** — the update and uninstall flows.
-- **`cargo deny check`** — advisories, licenses, bans, and sources.
+- **`cargo clippy --workspace --all-targets --all-features -- -D warnings`** — lints.
+- **`cargo test --workspace`** — tests for both crates.
+- **`./tests/integration-install.sh`**, **`./tests/integration-update.sh`**,
+  and **`./tests/integration-uninstall.sh`** — installer provenance, update,
+  and uninstall flows.
+- **`./tests/integration-network.sh`** — Linux bridge isolation.
+- **`python3 tests/test-integration-probes.py`** — regression checks for
+  integration probes.
+- **`cargo deny --workspace check`** — advisories, licenses, bans, and sources.
 - **[zizmor](https://github.com/zizmorcore/zizmor)** — GitHub Actions security
   audit.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,9 @@ CI must pass before a pull request can merge. The
   and **`./tests/integration-uninstall.sh`** — installer provenance, update,
   and uninstall flows.
 - **`./tests/integration-network.sh`** — Linux bridge isolation.
+- **`./tests/integration-proxy-forward.sh`** — authenticated SSH reverse
+  forwarding and rejected-bind cleanup on Linux.
+- **`python3 tests/test-preflight-release.py`** — release gate regression checks.
 - **`python3 tests/test-integration-probes.py`** — regression checks for
   integration probes.
 - **`cargo deny --workspace check`** — advisories, licenses, bans, and sources.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Install the latest release:
 curl -fsSL https://raw.githubusercontent.com/trailofbits/coop/main/install.sh | bash
 ```
 
-Or build from source (requires [Rust](https://rustup.rs/)):
+Or build from source (requires [Rust](https://rustup.rs/) and CMake):
 
 ```shell
-cargo build --release
-cp target/release/coop /usr/local/bin/
+cargo build --workspace --release
+cp target/release/coop target/release/coop-proxy /usr/local/bin/
 ```
 
 Then build the VM template image:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ How a `coop` release is cut, and what to check before cutting one.
 
 - **`ci.yml`** runs on pushes to `main` and on every PR: `fmt --check`, `clippy -D warnings`,
   `cargo test --workspace`, the preflight/probe regression tests, Linux bridge
-  isolation, `integration-install.sh`, `integration-update.sh`,
+  isolation, `integration-proxy-forward.sh`, `integration-install.sh`, `integration-update.sh`,
   `integration-uninstall.sh`,
   `cargo deny --workspace check`, `taplo format --check`, and `zizmor`.
 - **`release.yml`** runs when a `v*` tag is pushed. It **re-runs all of CI as a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,14 +5,17 @@ How a `coop` release is cut, and what to check before cutting one.
 ## How the automation works
 
 - **`ci.yml`** runs on pushes to `main` and on every PR: `fmt --check`, `clippy -D warnings`,
-  `cargo test`, `integration-install.sh`, `integration-update.sh`,
+  `cargo test --workspace`, the preflight/probe regression tests, Linux bridge
+  isolation, `integration-install.sh`, `integration-update.sh`,
   `integration-uninstall.sh`,
-  `cargo deny check`, and `zizmor`.
+  `cargo deny --workspace check`, `taplo format --check`, and `zizmor`.
 - **`release.yml`** runs when a `v*` tag is pushed. It **re-runs all of CI as a
-  gate**, then cross-compiles the three target binaries
+  gate**, then builds both `coop` and `coop-proxy` on native runners for three
+  targets
   (`aarch64-apple-darwin`, `x86_64-unknown-linux-musl`,
-  `aarch64-unknown-linux-musl`), generates `SHA256SUMS`, attests build
-  provenance, extracts the `## vX.Y.Z` section from `CHANGELOG.md` as the
+  `aarch64-unknown-linux-musl`), checks the built CLI reports the tagged release
+  version, packages both binaries per target, generates `SHA256SUMS`, attests
+  build provenance, extracts the `## vX.Y.Z` section from `CHANGELOG.md` as the
   release notes, and publishes the GitHub release. **It fails if there is no
   matching CHANGELOG section.**
 
@@ -24,8 +27,8 @@ push succeeds and ships something correct.
 | Check | CI (on PR + on tag) | `preflight-release.sh` | Manual judgement |
 |-------|:---:|:---:|:---:|
 | fmt / clippy / unit tests | ✓ | ✓ | |
-| `cargo deny`, `zizmor` | ✓ | ✓ (if installed) | |
-| Host-only integration suites | ✓ | ✓ | |
+| `cargo deny --workspace`, `zizmor`, `taplo` | ✓ | ✓ (if installed) | |
+| Host-only integration and preflight/probe regression suites | ✓ | ✓ | |
 | Version ↔ lock ↔ CHANGELOG ↔ tag agreement | | ✓ | |
 | Release builds (3 targets) | native only | ✓ (per installed toolchain) | |
 | Formal verification (`cargo kani`) | | ✓ (if installed) | |
@@ -45,8 +48,8 @@ CI can't run the full VM integration suite or the extra-toolchain checks
    `CHANGELOG.md` to judge.
 
 3. **Bump the version.**
-   - Edit `version` in `Cargo.toml`.
-   - Run `cargo build` so `Cargo.lock` picks up the new `coop` version.
+   - Edit `[workspace.package].version` in `Cargo.toml`; both packages inherit it.
+   - Run `cargo build --workspace` so `Cargo.lock` picks up both package versions.
 
 4. **Promote the changelog.** Rename `## Unreleased` to `## vX.Y.Z` in
    `CHANGELOG.md`. The text under it becomes the GitHub release notes verbatim,
@@ -58,6 +61,9 @@ CI can't run the full VM integration suite or the extra-toolchain checks
    ```bash
    ./scripts/preflight-release.sh
    ```
+
+   A successful exit with warnings is incomplete validation: resolve skipped
+   tools, targets, and platform gates before tagging.
 
    The full VM suite runs on **this machine** (one platform) plus **one remote
    host** you give for the other platform — so run the preflight from a
@@ -93,8 +99,8 @@ CI can't run the full VM integration suite or the extra-toolchain checks
    This triggers `release.yml`.
 
 9. **Verify the published release.** On the GitHub release page confirm:
-   - three `coop-vX.Y.Z-<target>.tar.gz` artifacts plus `SHA256SUMS` and
-     `attestations.jsonl`,
+   - three `coop-vX.Y.Z-<target>.tar.gz` artifacts, each containing both `coop`
+     and `coop-proxy`, plus `SHA256SUMS` and `attestations.jsonl`,
    - the build-provenance attestation is attached,
    - the notes match the `## vX.Y.Z` CHANGELOG section.
 
@@ -122,13 +128,18 @@ re-run the release. A red `release.yml` run means you **bump to the next patch
 version and cut a fresh release** — go back to step 2 with `vX.Y.(Z+1)`.
 
 This is why the preflight matters: `release.yml` re-runs CI and then builds the
-three target binaries, and a failure in *either* burns the version. Run
+workspace for three targets, and a failure in *either* burns the version. Run
 `./scripts/preflight-release.sh` before every tag — it mirrors the CI checks
-**and** builds the three release targets locally (for each rustup toolchain you
-have installed; pass `--install-targets` to `rustup target add` any that are
-missing — the cross-linker tools must already be installed), so the
-cross-compile matrix is exercised before the tag rather than after. Run it from
-a macOS/Lima box with `musl-cross` set up to cover all three targets at once.
+**and** builds both workspace binaries for release targets locally (for each
+rustup target you have installed; pass `--install-targets` to `rustup target add` any that are
+missing — the cross-linker tools must already be installed), so build failures
+can be caught before the tag. The release workflow uses
+native macOS ARM64, Linux x86_64, and Linux ARM64 runners; Linux needs
+`musl-tools` and `cmake` for the proxy's `aws-lc-sys` dependency, with `musl-gcc`
+as its C compiler and Rust linker (see `release.yml`). Cross-building locally
+also needs a C toolchain and linker configured for each target; installing the
+Rust target alone is insufficient. Check any targets skipped by the preflight
+on matching hosts before tagging.
 
 Do **not** attempt `git push origin :refs/tags/vX.Y.Z` to delete and reuse a
 tag — immutable releases reject it, and reusing a spent version is not allowed.

--- a/coop-proxy/src/proxy.rs
+++ b/coop-proxy/src/proxy.rs
@@ -52,6 +52,10 @@ const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(30);
 /// exhaust host CPU/memory by opening unbounded upstream connections.
 const MAX_CONCURRENT_REQUESTS: usize = 256;
 
+/// Bound guest sockets separately: idle connections never reach the request
+/// semaphore, but still consume a host file descriptor and an HTTP task.
+const MAX_CONCURRENT_CONNECTIONS: usize = 256;
+
 /// The unified response body: either an upstream stream or a small local
 /// error page, both boxed to one type.
 type ProxyBody = BoxBody<Bytes, hyper::Error>;
@@ -98,6 +102,7 @@ struct Ctx {
     cfg: Arc<ProxyConfig>,
     connector: TlsConnector,
     permits: Arc<Semaphore>,
+    connections: Arc<Semaphore>,
 }
 
 impl Ctx {
@@ -107,6 +112,7 @@ impl Ctx {
             cfg: Arc::new(cfg),
             connector,
             permits: Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS)),
+            connections: Arc::new(Semaphore::new(MAX_CONCURRENT_CONNECTIONS)),
         })
     }
 }
@@ -159,11 +165,19 @@ async fn accept_loop(
                     Ok((stream, _peer)) => stream,
                     Err(e) => {
                         tracing::warn!("accept failed: {e}");
+                        // Resource exhaustion can make accept fail immediately;
+                        // avoid spinning and filling the host log in that case.
+                        tokio::time::sleep(Duration::from_millis(100)).await;
                         continue;
                     }
                 };
+                let Ok(permit) = ctx.connections.clone().try_acquire_owned() else {
+                    drop(stream);
+                    continue;
+                };
                 let ctx = ctx.clone();
                 tokio::spawn(async move {
+                    let _permit = permit;
                     let io = TokioIo::new(stream);
                     let service = service_fn(move |req| {
                         let ctx = ctx.clone();
@@ -458,6 +472,88 @@ mod tests {
     fn bearer_injection(secret: &str) -> Injection {
         let json = format!(r#"{{ "scheme": "bearer", "credential": "{secret}" }}"#);
         serde_json::from_str(&json).unwrap()
+    }
+
+    #[tokio::test]
+    #[expect(
+        clippy::expect_used,
+        reason = "test deadlines describe the missing behavior"
+    )]
+    async fn idle_connections_are_bounded_and_released_on_disconnect() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let cfg = ProxyConfig::from_json(
+            r#"{
+                "listen": "127.0.0.1:0",
+                "capability_token": "test-token",
+                "upstream_host": "proxy-test.invalid",
+                "injection": { "scheme": "x_api_key", "credential": "fake" }
+            }"#,
+        )
+        .unwrap();
+        let mut ctx = Ctx::new(cfg).unwrap();
+        ctx.connections = Arc::new(Semaphore::new(2));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (stop, stopped) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(accept_loop(ctx, listener, async {
+            let _ = stopped.await;
+        }));
+        let budget = Duration::from_secs(5);
+        let mut held = Vec::new();
+        // A response proves each socket was accepted and entered HTTP serving.
+        // Keep it open afterward: these idle sockets hold no request permits.
+        for _ in 0..2 {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream
+                .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                .await
+                .unwrap();
+            let mut response = Vec::new();
+            timeout(budget, async {
+                while !response.windows(2).any(|pair| pair == b"\r\n") {
+                    assert_ne!(stream.read_buf(&mut response).await.unwrap(), 0);
+                }
+            })
+            .await
+            .unwrap();
+            assert!(response.starts_with(b"HTTP/1.1 401 "));
+            held.push(stream);
+        }
+
+        let mut excess = TcpStream::connect(addr).await.unwrap();
+        let mut byte = [0];
+        let n = timeout(budget, excess.read(&mut byte))
+            .await
+            .expect("excess idle connection must be closed without HTTP input")
+            .unwrap();
+        assert_eq!(n, 0);
+
+        drop(held);
+        // Disconnect releases capacity; wait for a real HTTP response, since
+        // connect alone can succeed even while the accept loop refuses sockets.
+        timeout(budget, async {
+            loop {
+                let mut stream = TcpStream::connect(addr).await.unwrap();
+                if stream
+                    .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                    .await
+                    .is_ok()
+                {
+                    let mut response = String::new();
+                    if stream.read_to_string(&mut response).await.is_ok()
+                        && response.contains("401")
+                    {
+                        break;
+                    }
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("disconnect must release connection capacity");
+        let _ = stop.send(());
+        server.await.unwrap();
     }
 
     // ── capability token ─────────────────────────────────────

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,8 @@ coop/
 │   ├── git_repo_devcontainer.rs # fetch devcontainer.json from a remote repo
 │   ├── guest.rs            # guest profiles, required binaries, baked package lists
 │   ├── guest_env_state.rs  # persisted guest env vars
+│   ├── proxy.rs            # host proxy processes and per-provider SSH reverse tunnels
+│   ├── proxy_state.rs      # persisted per-instance credential overrides
 │   ├── model_state.rs      # per-instance local/remote model routing
 │   ├── secret_store.rs     # pluggable secret backends (keychain/op/secret-tool/file)
 │   ├── github_pat.rs       # `coop github` PAT wizard (setup/rotate/status/forget)
@@ -51,6 +53,7 @@ coop/
 │   ├── prompt.rs           # TTY prompts
 │   ├── update.rs           # `coop update` self-update + background notifier
 │   └── commands/           # one module per command domain (see below)
+├── coop-proxy/             # separate binary crate: credential injection, policy, TLS, jail
 ├── scripts/guest/          # guest-image provisioning scripts (embedded at build)
 ├── guest/init.sh           # guest first-boot init
 ├── tests/                  # integration test scripts (see AGENTS.md "Before committing")
@@ -58,9 +61,11 @@ coop/
 └── docs/                   # this tree
 ```
 
-All application logic lives in the **library crate** (`src/lib.rs`); `main.rs`
-is a six-line shim calling `coop::run()`. This is why unit and mutation tests
-run against `--lib`.
+The main CLI logic lives in the **library crate** (`src/lib.rs`); `main.rs`
+is a thin shim calling `coop::run()`. Its unit and mutation tests target the
+library. The credential proxy is a separate binary crate in the same Cargo
+workspace; `--workspace` builds and tests both crates. Plain `cargo build`
+and `cargo test` select only the root `coop` package.
 
 ## The two-backend design
 
@@ -125,7 +130,8 @@ flags — this is a load-bearing design choice (see
 The `commands/` submodules own the domains: `lifecycle.rs` (up/start/shell/
 exec/stop/destroy/status/list/resize/commit/restore), `quickstart.rs`,
 `devcontainer.rs`, `profiles.rs` (+ images), `agent.rs` (`coop agent update`),
-`model.rs` (`coop model`), `github.rs`, `admin.rs` (init/validate/uninstall),
+`model.rs` (`coop model`), `proxy.rs` (`coop proxy`), `github.rs`,
+`admin.rs` (init/validate/uninstall),
 and `json.rs` (machine-readable `--json` output types). `commands/mod.rs`
 re-exports the dispatch surface and holds cross-domain helpers
 (`merge_runtime_guest_env`, `purge_all_data`).
@@ -169,19 +175,20 @@ retrieval commands and resolved at VM-start by `resolve_cmd_value`.
 
 Per-instance runtime state is a set of JSON sidecar files under the instance
 dir: `instance.json`, `vm_config.json`, `workspace.json`, `forwards.json`,
-`guest_env.json`, `model.json`, `devcontainer_state.json`, plus the Firecracker
-`.pid`/`.socket`/`.log`/vsock files.
+`guest_env.json`, `model.json`, `proxy.json`, `devcontainer_state.json`, plus
+the Firecracker `.pid`/`.socket`/`.log`/vsock files.
 
 ## `coop update`
 
-`update.rs` self-updates the binary: fetch release metadata from the pinned
-`trailofbits/coop` repo, download the platform tarball + `SHA256SUMS` +
+`update.rs` self-updates the CLI and its proxy companion: fetch release metadata
+from the pinned `trailofbits/coop` repo, download the platform tarball + `SHA256SUMS` +
 `attestations.jsonl`, verify the checksum (mandatory), verify the Sigstore
 attestation via `gh` against that bundle, falling back to the attestations API
 when the release publishes no usable one (best-effort),
 extract with path-escape-safe `tar` flags, and atomically `rename` the new
-binary over the running one. A background notifier checks for new versions on a
-24-hour interval (disabled in dev/CI/non-TTY). The full verification chain and
+`coop-proxy` beside the CLI before replacing `coop`. Each replacement is
+atomic; the pair is not a single transaction. A background notifier checks for
+new versions on a 24-hour interval (disabled in dev/CI/non-TTY). The full verification chain and
 its trust properties are documented in [`trust-model.md`](trust-model.md#coop-update-trust-chain).
 
 ## Guest image
@@ -193,7 +200,7 @@ embedded provisioning scripts in `scripts/guest/` (`preamble.sh`,
 from `guest.rs`. Firecracker uses a minimal CI kernel that is missing several
 netfilter modules; the resulting workarounds (iptables-legacy, static
 `resolv.conf`, `DOCKER_INSECURE_NO_IPTABLES_RAW=1`) are applied in
-`guest-config.sh` and explained in [`AGENTS.md`](../AGENTS.md) and
+`guest-config.sh` and explained in [`platform-notes.md`](platform-notes.md) and
 [`trust-model.md`](trust-model.md#documented-accepted-trade-offs).
 
 ## Architectural invariants

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -159,8 +159,10 @@ coop restore my-project --image default --reprovision
 IP, and workspace association, accepts a running instance, and leaves it
 running. It provisions the replaced disk as a first boot, so `/workspace` is
 restored and the agent plugins are reinstalled — a plain `restore` here would
-leave both empty, because the base image carries neither. Destroying and
-recreating the VM also works, but discards its guest disk.
+leave both empty, because the base image carries neither. Both reprovisioning
+and destroying/recreating replace the guest disk. Save
+guest-only work first (for example with `coop pull`); the replacement also
+discards any guest keyring and cached account login.
 
 ### GitHub auth
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -834,7 +834,7 @@ Kept across the wipe, because coop persists them host-side:
 | Port forwards, including a devcontainer's `forwardPorts` | `forwards.json` |
 | Guest env, including a devcontainer's `containerEnv` | `guest_env.json` |
 | Model mode and proxy settings | `model.json` / `proxy.json` |
-| GitHub PATs and provider credentials | host secret store (never on the guest disk) |
+| Credentials saved in the host secret store | unchanged; guest forwarding depends on the configured auth mode |
 
 **Not replayed**, because coop does not persist them:
 
@@ -842,7 +842,11 @@ Kept across the wipe, because coop persists them host-side:
 - `--exclude-git`. A workspace originally pushed without `.git/` is re-synced with it.
 - A devcontainer's `postStartCommand`, which reaches the guest only during `coop up`. Its `features` are baked into the image and so do survive. (`postCreateCommand` is unaffected because coop does not implement it — it is reported as an unrecognised `devcontainer.json` key.)
 
-Everything that can fail cheaply is checked while the instance is still intact — the image exists, the state files parse, the recorded workspace directory is still there, and no host port for a forward is taken. Only then is the disk replaced. A failure after that point leaves the instance in place with a partly provisioned guest, and re-running the same command finishes the job.
+Before replacing the disk, coop checks that the image exists, the state files
+parse, the recorded workspace directory is still there, and host ports for
+forwards are available. A later failure leaves the instance in place with a
+partly provisioned guest. Re-running the command replaces the disk again and
+restarts provisioning; save any guest-only work before retrying.
 
 Compared with the neighbouring commands:
 

--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -32,6 +32,11 @@ for the lifetime of the VM:
   closes). Codex subscription is therefore out of scope in proxy mode; use an
   OpenAI API key.
 
+When agent bootstrap runs with an OpenAI proxy, coop also removes any existing
+`~/.codex/auth.json` left by a previous direct-auth boot. If removal fails,
+proxy bootstrap aborts and tears down the proxy. `--no-agents` skips this
+cleanup along with the rest of agent bootstrap.
+
 For Codex account or workspace access without API billing, use
 `[codex] auth = "chatgpt"` instead of `[proxy.openai]`. That mode stores Codex
 credentials in the guest Linux keyring and is rejected when an OpenAI proxy is
@@ -145,19 +150,24 @@ disk. It does **not**:
 The proxy itself is new attack surface, mitigated by a fixed per-route upstream
 (the guest controls only the path, never the host — closing SSRF), TLS
 verification against a pinned root set, a required capability token, and
-resource limits. The listener binds only host loopback and is reverse-tunnelled
+resource limits. Each proxy allows at most 256 accepted guest TCP connections
+and 256 concurrent requests; excess connections are closed immediately, so
+idle sockets cannot bypass the request limit. The listener binds only host
+loopback and is reverse-tunnelled
 to exactly one guest — never a non-loopback interface, never the LAN.
 
-It is also **jailed** to bound the blast radius of a proxy exploit: `coop-proxy`
-runs confined so it cannot write files, execute programs, or reach any host
-beyond the upstream `:443` and DNS `:53`. On Linux this is Landlock (self-applied
-before serving); on macOS it is a Seatbelt profile applied via `sandbox-exec`.
-The confinement is **fail-closed** — if it cannot be established the VM start
-aborts rather than running the credential-holding proxy unconfined. The jail is
-port-scoped, not host-scoped (the two upstreams' identity is enforced by the
-proxy's TLS verification, not the jail), and does not restrict UDP on Linux; see
-[`trust-model.md`](trust-model.md) for the full threat model and the accepted
-limitations.
+It is also **jailed** to bound the blast radius of a proxy exploit. On Linux,
+Landlock denies filesystem writes and program execution as a required floor;
+additional filesystem restrictions apply where the kernel supports them. TCP
+egress is limited to `:443` and `:53` on kernels ≥6.7. On kernels 5.13–6.6,
+the proxy can start with that TCP restriction absent. On macOS, `sandbox-exec`
+applies a Seatbelt profile that denies filesystem writes and program execution
+and limits egress to those ports.
+
+Startup fails closed if the required filesystem/exec floor cannot be applied.
+The network rules are port-scoped, not host-scoped, and Landlock does not
+restrict UDP. See [`trust-model.md`](trust-model.md) for the full threat model
+and accepted limitations.
 
 ## Platform support
 
@@ -165,5 +175,5 @@ limitations.
 host and is exposed into the guest with a per-instance `ssh -R` reverse tunnel,
 so it works identically on both backends (each already keeps an SSH channel to
 its guest). The host-side proxy process is jailed on both — Landlock on Linux
-(host kernel ≥6.7), Seatbelt via `sandbox-exec` on macOS. Not yet built:
-GitHub.
+(enabled on the host; kernel ≥5.13, with TCP scoping from ≥6.7), Seatbelt via
+`sandbox-exec` on macOS. GitHub credentials are not supported.

--- a/docs/design/issue-411-injecting-proxy.md
+++ b/docs/design/issue-411-injecting-proxy.md
@@ -402,18 +402,21 @@ Ordered, independently shippable:
    Delivers Claude↔Codex parity at the API-key tier. Codex subscription is out of
    scope by vendor design (§7).
 3. **Jailing (shipped).** Bound a proxy-exploit blast radius by confining
-   `coop-proxy`. **Implemented with Landlock (ABI v4), not the uid+netns jailer
+   `coop-proxy`. **Implemented with tiered Landlock, not the uid+netns jailer
    sketched in §3/§11.3.** The settled architecture binds the listener on host
    `127.0.0.1` reached via `ssh -R`, and an isolated network namespace gets its
    own loopback the host-side tunnel could not reach — so instead of moving the
    bind, the proxy self-confines with Landlock (filesystem-write + `exec`
-   denied; TCP egress limited to `:443`/`:53`) applied before it binds. macOS,
-   which has no in-process sandbox, is confined externally with a Seatbelt
+   denied; TCP egress limited to `:443`/`:53` where supported) applied before
+   it binds. macOS, which has no in-process sandbox, is confined externally
+   with a Seatbelt
    profile via `sandbox-exec` — so this slice covers **both** backends, not just
    Firecracker. Fail-closed on both. See [`../trust-model.md`](../trust-model.md)
    and [`../credential-proxy.md`](../credential-proxy.md) for the shipped
    mechanism and its accepted limitations (port-scoped not host-scoped; UDP
-   unrestricted on Linux; host kernel ≥6.7).
+   unrestricted on Linux; enabled Landlock on host kernel ≥5.13, TCP scoping
+   from ≥6.7). The [tiered-jail design](proxy-jail-graceful-degradation.md)
+   describes the required floor and best-effort restrictions.
 4. **GitHub (separate, later).** No base-URL override exists for `gh`/`git`, and
    #73 already documented that URL/path filtering cannot constrain `gh api
    graphql`. Injection (token never crosses to the guest) is still worthwhile as

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -117,7 +117,9 @@ The SSH config block supplies the hostname, port, user, key, and host-key verifi
 
 ## Port forwarding
 
-coop does not manage port forwarding. Use SSH directly:
+Use `--forward-port` with [`coop up`](commands.md#up) or
+[`coop start`](commands.md#start) for forwards managed for the VM lifetime.
+For a temporary forward while an editor is connected, use SSH directly:
 
 ```bash
 ssh -L 3000:localhost:3000 coop-my-instance

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,15 +45,30 @@ instead, which it will only do when `gh` is logged in. `install.sh` and `coop
 update` use that API path themselves for releases published without a usable
 bundle.
 
+## Upgrading from v0.5.4
+
+Rerun the installer above when upgrading from v0.5.4 to a release that includes
+credential proxy support. The v0.5.4 updater replaces only `coop`; it does not
+install the new `coop-proxy` companion. Proxy mode requires both binaries in
+the same directory. If you installed into a custom directory, pass the same
+`INSTALL_DIR` to the installer.
+
+The published v0.5.4 Linux ARM64 binary reports
+`coop 0.5.4-dev (8e24729+dirty)` and refuses `coop update` because it identifies
+itself as a development build. Rerunning the installer also bypasses that old
+updater.
+
 ## Build from source
 
-coop is a Rust project. Install [Rust](https://rustup.rs/), then:
+Install [Rust](https://rustup.rs/) and CMake, then:
 
 ```
-cargo build --release
+cargo build --workspace --release
 ```
 
-The binary lands at `target/release/coop`.
+The binaries land at `target/release/coop` and `target/release/coop-proxy`.
+Keep them in the same directory when installing: proxy mode looks for its
+companion next to `coop`.
 
 ## Configuration
 
@@ -114,7 +129,8 @@ For Codex account or workspace access without OpenAI API billing, set
 `[codex] auth = "chatgpt"` and rebuild any old image with `coop setup
 --rebuild`. An existing VM keeps its own guest disk across a restart, so also
 run `coop restore <vm> --image <image> --reprovision` (see
-[Codex integration](codex-integration.md)) to pick up the rebuilt image. Then
+[Codex integration](codex-integration.md)) to pick up the rebuilt image.
+Reprovisioning replaces the guest disk, so save guest-only work first. Then
 run `coop codex -- login --device-auth` once.
 
 ## First run

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -76,6 +76,24 @@ Firecracker `--full` phase checks actual VM TAP flags and both direct and routed
 traffic; it also detects removal of the helper call from `setup_tap`. This
 host-only gate does not replace Firecracker or Lima VM integration.
 
+## Host-only proxy reverse-forward test
+
+Run `./tests/integration-proxy-forward.sh` on Linux to exercise the production
+reverse-tunnel startup against real OpenSSH. It authenticates with throwaway
+keys, witnesses traffic through an accepted forward, then occupies the guest
+loopback port and requires startup to return an error without publishing a PID
+or leaving the SSH master alive. Separate host and guest network namespaces
+allow the destination and reverse listener to use the same port.
+
+The runner requires Rust/Cargo, Python 3, passwordless sudo, iproute2,
+util-linux, coreutils, hostname, and OpenSSH client/server tools. It builds
+unprivileged, then confines the fixture to disposable mount, network, UTS, and
+PID namespaces. No user SSH configuration or keys are used. Namespace teardown
+removes all children and temporary files on success, failure, or timeout.
+Linux CI and release preflight run this gate explicitly; ordinary unit tests
+mark it ignored, and macOS preflight reports it as unrun. This host test does
+not replace the Firecracker and Lima VM integration gates.
+
 ## Mutation testing
 
 Mutation testing finds unit tests that pass even when the code is broken — real

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -87,7 +87,7 @@ step() {
 }
 
 cargo_toml_version() {
-  awk -F'"' '/^\[package\]/{p=1} p && /^version *=/{print $2; exit}' Cargo.toml
+  awk -F'"' '/^\[workspace\.package\]$/{p=1; next} /^\[/{p=0} p && /^version *=/{print $2; exit}' Cargo.toml
 }
 
 check_worktree() {
@@ -104,7 +104,7 @@ check_worktree() {
 }
 
 check_versions() {
-  local v tag lockv
+  local v tag lockv package
   v="$(cargo_toml_version)"
   if [[ -z "$v" ]]; then
     echo "Could not read version from Cargo.toml" >&2
@@ -113,11 +113,13 @@ check_versions() {
   tag="v$v"
   printf 'Cargo.toml version: %s  (release tag: %s)\n' "$v" "$tag"
 
-  lockv="$(awk '/^name = "coop"$/{getline; gsub(/version = "|"/, ""); print; exit}' Cargo.lock)"
-  if [[ "$lockv" != "$v" ]]; then
-    printf 'Cargo.lock coop version (%s) != Cargo.toml (%s) — run cargo build to refresh the lockfile\n' "$lockv" "$v"
-    return 1
-  fi
+  for package in coop coop-proxy; do
+    lockv="$(awk -v package="$package" '$0 == "name = \"" package "\"" {getline; gsub(/version = \"|\"/, ""); print; exit}' Cargo.lock)"
+    if [[ "$lockv" != "$v" ]]; then
+      printf 'Cargo.lock %s version (%s) != workspace version (%s) — run cargo build --workspace to refresh the lockfile\n' "$package" "$lockv" "$v"
+      return 1
+    fi
+  done
 
   # release.yml extracts notes with an exact whole-line match ($0 == "## vX.Y.Z"),
   # so the header must match exactly — a trailing date would pass a looser check
@@ -140,7 +142,23 @@ run_deny() {
     warn "cargo-deny not installed — supply-chain check skipped (CI still runs it; cargo install cargo-deny --locked)"
     return 0
   fi
-  cargo deny check
+  cargo deny --workspace check
+}
+
+run_bridge_isolation() {
+  if [[ "$(uname -s)" != Linux ]]; then
+    warn "Bridge isolation requires Linux — run tests/integration-network.sh on a Linux host before tagging"
+    return 0
+  fi
+  ./tests/integration-network.sh
+}
+
+run_taplo() {
+  if ! have taplo; then
+    warn "taplo not installed — TOML formatting skipped (CI still runs it; use scripts/install-dev-tools.sh)"
+    return 0
+  fi
+  taplo format --check
 }
 
 run_zizmor() {
@@ -208,8 +226,8 @@ handle_missing_targets() {
   printf '\nMissing rustup targets for the release build: %s\n' "${targets[*]}"
   printf 'Install the standard libraries with:\n'
   printf '  rustup target add %s\n' "${targets[*]}"
-  printf 'Cross-LINKING also needs platform tools (musl-cross on macOS; musl-tools\n'
-  printf '+ gcc-aarch64-linux-gnu on Linux) — see .github/workflows/release.yml.\n'
+  printf 'Building coop-proxy also needs cmake and a target C compiler/linker.\n'
+  printf 'Release CI uses native runners with musl-gcc on Linux; see RELEASING.md.\n'
   if [[ "$RUN_INSTALL_TARGETS" == 1 ]]; then
     rustup target add "${targets[@]}" || warn "rustup target add failed for: ${targets[*]}"
   else
@@ -237,14 +255,14 @@ build_release_targets() {
   for target in "${RELEASE_TARGETS[@]}"; do
     if grep -qx "$target" <<<"$installed"; then
       printf 'Building %s...\n' "$target"
-      cargo build --release --target "$target" || return 1
+      cargo build --release --workspace --target "$target" || return 1
       built=$((built + 1))
     else
       warn "release target $target not built locally (toolchain absent) — release.yml builds it on the tag, uncaught here."
     fi
   done
   if [[ "$built" -eq 0 ]]; then
-    warn "no release targets built locally — cross-compile breakage won't surface until the tag is pushed. Run the preflight from a host that can cross-compile all three (macOS + musl-cross)."
+    warn "no release targets built locally — cross-compile breakage won't surface until the tag is pushed. Build each target on a matching host or configure its C compiler and linker (see RELEASING.md)."
   fi
   return 0
 }
@@ -269,11 +287,15 @@ prompt_for_remote() {
 step "Working tree clean" check_worktree
 step "Version consistency" check_versions
 step "Format (cargo fmt --check)" cargo fmt -- --check
-step "Clippy" cargo clippy --all-targets --all-features -- -D warnings
-step "Unit tests" cargo test
+step "Clippy" cargo clippy --workspace --all-targets --all-features -- -D warnings
+step "Unit tests" cargo test --workspace
 step "Release target builds" build_release_targets
 step "Supply chain (cargo deny)" run_deny
 step "Workflow audit (zizmor)" run_zizmor
+step "TOML formatting" run_taplo
+step "Integration probe regression tests" python3 tests/test-integration-probes.py
+step "Release preflight regression tests" python3 tests/test-preflight-release.py
+step "Integration — bridge isolation" run_bridge_isolation
 step "Integration — installer provenance" ./tests/integration-install.sh
 step "Integration — coop update" ./tests/integration-update.sh
 step "Integration — coop uninstall" ./tests/integration-uninstall.sh
@@ -317,5 +339,9 @@ if [[ ${#FAILURES[@]} -gt 0 ]]; then
   exit 1
 fi
 version="$(cargo_toml_version)"
+if [[ ${#WARNINGS[@]} -gt 0 ]]; then
+  printf 'Completed checks passed for v%s; resolve the warnings and unrun gates before tagging.\n' "$version"
+  exit 0
+fi
 printf 'All required checks passed for v%s.\n' "$version"
 printf 'Next: tag v%s on the merge commit and push to trigger release.yml.\n' "$version"

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -153,6 +153,14 @@ run_bridge_isolation() {
   ./tests/integration-network.sh
 }
 
+run_proxy_forward() {
+  if [[ "$(uname -s)" != Linux ]]; then
+    warn "Proxy reverse forwarding requires Linux — run tests/integration-proxy-forward.sh on a Linux host before tagging"
+    return 0
+  fi
+  ./tests/integration-proxy-forward.sh
+}
+
 run_taplo() {
   if ! have taplo; then
     warn "taplo not installed — TOML formatting skipped (CI still runs it; use scripts/install-dev-tools.sh)"
@@ -296,6 +304,7 @@ step "TOML formatting" run_taplo
 step "Integration probe regression tests" python3 tests/test-integration-probes.py
 step "Release preflight regression tests" python3 tests/test-preflight-release.py
 step "Integration — bridge isolation" run_bridge_isolation
+step "Integration — proxy reverse forwarding" run_proxy_forward
 step "Integration — installer provenance" ./tests/integration-install.sh
 step "Integration — coop update" ./tests/integration-update.sh
 step "Integration — coop uninstall" ./tests/integration-uninstall.sh

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1714,8 +1714,17 @@ fn bootstrap_codex(
             model_state.save(inst)?;
         }
 
-        if wants_keyring {
-            remove_guest_codex_auth_json(&session.target);
+        if proxy.is_some() {
+            // The guest must not retain a direct credential when the proxy
+            // promises to keep that credential on the host. The outer guard
+            // tears down the proxy if cleanup fails.
+            remove_guest_codex_auth_json(&session.target)?;
+        } else if wants_keyring && let Err(e) = remove_guest_codex_auth_json(&session.target) {
+            tracing::warn!(
+                "Could not remove a possible stale plaintext ~/.codex/auth.json from the \
+                 guest; Codex account auth stores credentials in the guest keyring, so any \
+                 such file is unused but still readable: {e:#}"
+            );
         }
 
         // Marketplaces and plugins are persisted in the guest's config.toml and
@@ -1789,20 +1798,15 @@ pub fn ensure_codex_remote_auth_consistent(
 ///
 /// Dropping `auth.json` from the staged file set only stops coop *copying* a
 /// new one — `copy_staged_to_guest` is additive and deletes nothing — so a VM
-/// switched from `api_key` to `chatgpt` would keep a plaintext refresh token
-/// on its guest disk, which is precisely what this mode exists to avoid.
+/// switched from direct credentials to `chatgpt` or proxy mode would keep a
+/// plaintext refresh token on its guest disk despite no longer needing it.
 ///
-/// Best-effort: the credential store is already the keyring by this point, so
-/// a failure here leaves a stale file rather than breaking the boot. It is
-/// loud about it, because the file is a credential.
-fn remove_guest_codex_auth_json(target: &SshTarget) {
-    if let Err(e) = target.exec(RemoteCommand::new().literal("rm -f ~/.codex/auth.json")) {
-        tracing::warn!(
-            "Could not remove a possible stale plaintext ~/.codex/auth.json from the \
-             guest; Codex account auth stores credentials in the guest keyring, so any \
-             such file is unused but still readable: {e:#}"
-        );
-    }
+/// The caller fails proxy bootstrap closed on an error; account-auth mode
+/// preserves its existing best-effort cleanup with a warning.
+fn remove_guest_codex_auth_json(target: &SshTarget) -> Result<()> {
+    target
+        .exec(RemoteCommand::new().literal("rm -f ~/.codex/auth.json"))
+        .context("Failed to remove stale guest ~/.codex/auth.json")
 }
 
 pub fn codex_keyring_not_configured_message() -> &'static str {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4641,6 +4641,14 @@ skip = ["not-a-slug"]
     }
 
     #[test]
+    fn vm_memory_display_preserves_the_mib_quantity() {
+        for (input, expected) in [(128, "128"), (4096, "4096")] {
+            let memory = VmMemory::new(MiB::new(input).unwrap()).unwrap();
+            assert_eq!(memory.to_string(), expected);
+        }
+    }
+
+    #[test]
     fn vm_memory_parse_cli_enforces_floor() {
         assert!(VmMemory::parse_cli("16").is_err());
         assert!(VmMemory::parse_cli("0").is_err());
@@ -4757,6 +4765,18 @@ skip = ["not-a-slug"]
             mp.contains("/codex-plugins"),
             "should preserve path suffix, got: {mp}"
         );
+    }
+
+    #[test]
+    fn validate_and_warn_preserves_validation_errors() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = CoopConfig::default();
+        cfg.claude.config_dir =
+            ConfigDir::Custom(ConfigPath::new(tmp.path().join("missing-config")));
+
+        let expected = cfg.validate().unwrap_err().to_string();
+        assert!(expected.contains("claude.config_dir"));
+        assert_eq!(cfg.validate_and_warn().unwrap_err().to_string(), expected);
     }
 
     #[test]

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -737,6 +737,27 @@ mod tests {
     }
 
     #[test]
+    fn collect_baked_lists_merges_global_and_profile_entries() {
+        let mut cfg = CoopConfig::default();
+        cfg.claude.marketplaces = vec!["z".into(), "a".into(), "a".into()];
+        cfg.claude.plugins = vec!["p2@z".into(), "p1@a".into()];
+        cfg.codex.marketplaces = vec!["codex-only".into()];
+        cfg.codex.plugins = vec!["codex-only-plugin".into()];
+        let profile = ProfileDef {
+            name: "custom".into(),
+            apt_packages: vec![],
+            pre_install: None,
+            post_install: None,
+            marketplaces: vec!["b".into(), "a".into()],
+            plugins: vec!["p3@b".into(), "p1@a".into()],
+        };
+
+        let (marketplaces, plugins) = collect_baked_lists(&cfg, &[profile]);
+        assert_eq!(marketplaces, ["a", "b", "z"]);
+        assert_eq!(plugins, ["p1@a", "p2@z", "p3@b"]);
+    }
+
+    #[test]
     fn collect_codex_baked_lists_sorts_and_dedups() {
         let mut cfg = CoopConfig::default();
         cfg.codex.marketplaces = vec!["b".into(), "a".into(), "a".into()];
@@ -760,7 +781,13 @@ mod tests {
     #[test]
     fn unknown_profile_fails() {
         let custom = HashMap::new();
-        assert!(lookup_profile("nonexistent", &custom).is_err());
+        let message = lookup_profile("nonexistent", &custom)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            message.contains("Available profiles: python, node, c, fuzz, rust, go"),
+            "{message}"
+        );
     }
 
     #[test]
@@ -841,6 +868,26 @@ mod tests {
             let u = GuestUser::new(s).unwrap_or_else(|e| panic!("rejected {s:?}: {e}"));
             assert_eq!(u.as_str(), s);
         }
+    }
+
+    #[test]
+    fn guest_user_cli_parser_preserves_names_and_rejects_root() {
+        assert_eq!(GuestUser::parse("vscode").unwrap().as_str(), "vscode");
+        assert!(GuestUser::parse("root").is_err());
+    }
+
+    #[test]
+    fn guest_user_accepts_the_maximum_length() {
+        let name = "a".repeat(32);
+        assert_eq!(GuestUser::new(&name).unwrap().as_str(), name);
+    }
+
+    #[test]
+    fn guest_user_errors_distinguish_initial_and_later_characters() {
+        let initial = GuestUser::new("0user").unwrap_err().to_string();
+        assert!(initial.contains("must start with [a-z_]"), "{initial}");
+        let later = GuestUser::new("user.name").unwrap_err().to_string();
+        assert!(later.contains("contains invalid character"), "{later}");
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -804,6 +804,108 @@ mod tests {
         assert!(!fwd_pid_path(&inst, "test").exists());
     }
 
+    // The runner supplies real OpenSSH in disposable network/PID namespaces:
+    // the host destination and guest reverse listener use the same port.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "requires tests/integration-proxy-forward.sh"]
+    fn reverse_forward_requires_authenticated_bind_acknowledgment() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let fixture = PathBuf::from(std::env::var("COOP_FORWARD_TEST_DIR").unwrap());
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut inst = inst_with_index(0);
+        inst.dir = tmp.path().to_path_buf();
+        let target = SshTarget {
+            host: crate::backend::Hostname::new("192.0.2.2").unwrap(),
+            port: std::num::NonZeroU16::new(2222).unwrap(),
+            user: crate::backend::SshUser::new("root").unwrap(),
+            key_path: fixture.join("client"),
+        };
+        let master_pid = || -> i32 {
+            fs::read_to_string(fixture.join("master.pid"))
+                .unwrap()
+                .trim()
+                .parse()
+                .unwrap()
+        };
+        let destination = TcpListener::bind("127.0.0.1:0").unwrap();
+        destination.set_nonblocking(true).unwrap();
+        let port = destination.local_addr().unwrap().port();
+        spawn_reverse_forward(&inst, "test", &target, port).unwrap();
+        let pid = master_pid();
+        assert_eq!(
+            fs::read_to_string(fwd_pid_path(&inst, "test")).unwrap(),
+            pid.to_string()
+        );
+        assert_eq!(unsafe { libc::kill(pid, 0) }, 0);
+
+        // Send through the guest listener and receive at the host destination.
+        // This also proves the authenticated master survives socket removal.
+        let mut sender = Command::new("ip")
+            .args(["netns", "exec", "guest", "python3", "-c"])
+            .arg("import socket,sys; s=socket.create_connection(('127.0.0.1',int(sys.argv[1])),timeout=5); s.sendall(b'forwarded'); assert s.recv(2)==b'ok'")
+            .arg(port.to_string())
+            .spawn()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut connection = loop {
+            match destination.accept() {
+                Ok((connection, _)) => break Ok(connection),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(Instant::now() < deadline, "forwarded traffic never arrived");
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => break Err(error),
+            }
+        }
+        .unwrap();
+        connection
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut payload = [0; 9];
+        connection.read_exact(&mut payload).unwrap();
+        assert_eq!(&payload, b"forwarded");
+        connection.write_all(b"ok").unwrap();
+        assert!(sender.wait().unwrap().success());
+        kill_pid_file(&fwd_pid_path(&inst, "test"), "test tunnel");
+        assert_eq!(unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) }, pid);
+
+        // Occupy exactly the guest loopback port. Authentication still works;
+        // only the subsequent reverse-forward bind must be refused.
+        let ready = fixture.join("occupied");
+        let mut blocker = Command::new("ip")
+            .args(["netns", "exec", "guest", "python3", "-c"])
+            .arg("import socket,sys,pathlib,time; s=socket.socket(); s.bind(('127.0.0.1',int(sys.argv[1]))); s.listen(); pathlib.Path(sys.argv[2]).touch(); time.sleep(30)")
+            .arg(port.to_string())
+            .arg(&ready)
+            .spawn()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !ready.exists() {
+            assert!(blocker.try_wait().unwrap().is_none(), "bind blocker exited");
+            assert!(Instant::now() < deadline, "bind blocker never became ready");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let result = spawn_reverse_forward(&inst, "test", &target, port);
+        let rejected_pid = master_pid();
+        assert!(
+            result.is_err(),
+            "authenticated reverse bind refusal must fail startup"
+        );
+        let error = result.unwrap_err();
+        assert!(format!("{error:#}").contains("request failed"), "{error:#}");
+        assert!(!fwd_pid_path(&inst, "test").exists());
+        assert_eq!(unsafe { libc::kill(rejected_pid, 0) }, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
+        blocker.kill().unwrap();
+        blocker.wait().unwrap();
+    }
+
     #[test]
     fn token_file_round_trips_and_clears() {
         let tmp = tempfile::TempDir::new().unwrap();

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -23,6 +23,7 @@
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -37,11 +38,8 @@ use crate::config::{Instance, ProxyAuthScheme, ProxyUpstream, Secret, resolve_cm
 /// The proxy binary name, expected next to the `coop` binary.
 const PROXY_BIN_NAME: &str = "coop-proxy";
 
-/// How long to watch the reverse-tunnel `ssh` after spawn before treating it
-/// as established. With `ExitOnForwardFailure`, a refused `-R` bind makes `ssh`
-/// exit well within this window (the guest is already reachable — bootstrap
-/// SSH'd in moments earlier), so surviving it means the forward is bound.
-const TUNNEL_READY_GRACE: Duration = Duration::from_secs(2);
+/// Maximum time for SSH authentication and the guest's forwarding acknowledgment.
+const TUNNEL_READY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How long to wait for the freshly spawned proxy to accept a connection on
 /// its host-loopback listener before treating the launch as failed. This
@@ -364,23 +362,32 @@ const SEATBELT_PROFILE: &str = include_str!("seatbelt-proxy.sb");
 /// Establish a per-instance reverse SSH tunnel so the guest reaches the
 /// host-loopback proxy at `127.0.0.1:{port}` (`ssh -R guest → host`). Detached
 /// and tracked by a PID file like the proxy process, so teardown needs no SSH
-/// target. `ExitOnForwardFailure` makes a bind clash on the guest a loud
-/// failure rather than a silently dead tunnel.
+/// target. An acknowledged forwarding request makes a bind clash on the guest
+/// a startup failure rather than a silently dead tunnel.
 fn spawn_reverse_forward(inst: &Instance, name: &str, target: &SshTarget, port: u16) -> Result<()> {
     kill_pid_file(&fwd_pid_path(inst, name), "stale proxy tunnel");
 
+    let control_dir = create_tunnel_control_dir()?;
+    let control_path = control_dir.path().join("ssh.sock");
     let log_path = inst.dir.join(format!("proxy-{name}-fwd.log"));
     let log = File::create(&log_path)
         .with_context(|| format!("Failed to create proxy tunnel log {}", log_path.display()))?;
+    let forward_log = log
+        .try_clone()
+        .context("Failed to clone proxy tunnel log")?;
 
     let mut args = target.ssh_opts();
     args.extend([
         "-N".into(),
         "-T".into(),
         "-o".into(),
-        "ExitOnForwardFailure=yes".into(),
-        "-R".into(),
-        format!("127.0.0.1:{port}:127.0.0.1:{port}"),
+        "ControlMaster=yes".into(),
+        "-o".into(),
+        "ControlPersist=no".into(),
+        "-o".into(),
+        "ForkAfterAuthentication=no".into(),
+        "-S".into(),
+        control_path.display().to_string(),
     ]);
     args.push(target.addr());
 
@@ -394,36 +401,100 @@ fn spawn_reverse_forward(inst: &Instance, name: &str, target: &SshTarget, port: 
         .spawn()
         .context("Failed to spawn the reverse SSH tunnel for the credential proxy")?;
 
-    // Confirm the tunnel actually came up before returning Ok — otherwise the
-    // guest boots pointed at a dead endpoint. `ssh` was not given `-f`, so this
-    // child *is* the tunnel; with `ExitOnForwardFailure=yes` it exits promptly
-    // when the guest refuses the `-R` bind. If it survives the grace window the
-    // forward is bound; if it exits first, fail closed with the ssh log.
-    let deadline = Instant::now() + TUNNEL_READY_GRACE;
-    while Instant::now() < deadline {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let log = fs::read_to_string(&log_path).unwrap_or_default();
+    let setup = (|| -> Result<()> {
+        let deadline = Instant::now() + TUNNEL_READY_TIMEOUT;
+        loop {
+            crate::signal::check_shutdown()?;
+            if let Some(status) = child.try_wait().context("Failed to poll proxy tunnel")? {
                 bail!(
-                    "reverse SSH tunnel for the credential proxy exited before it was \
-                     established ({status}) — the guest may forbid TCP forwarding.\n{}",
-                    log.trim()
+                    "reverse SSH tunnel exited before its control socket became ready ({status})"
                 );
             }
-            Ok(None) => std::thread::sleep(Duration::from_millis(100)),
-            Err(e) => return Err(e).context("Failed to poll the reverse SSH tunnel process"),
+            if control_path.exists() {
+                break;
+            }
+            if Instant::now() >= deadline {
+                bail!("Timed out waiting for proxy tunnel authentication");
+            }
+            std::thread::sleep(Duration::from_millis(100));
         }
-    }
 
-    let pid = child.id();
-    let path = fwd_pid_path(inst, name);
-    if let Err(e) = fs::write(&path, pid.to_string()) {
+        // A live SSH process or control socket does not prove the guest has
+        // accepted a reverse forward. -O forward waits for that acknowledgment
+        // and returns nonzero for a rejected bind. The master stays the direct
+        // child, so its existing PID-file teardown remains authoritative.
+        let mut forward_args = target.ssh_opts();
+        forward_args.extend([
+            "-S".into(),
+            control_path.display().to_string(),
+            "-O".into(),
+            "forward".into(),
+            "-R".into(),
+            format!("127.0.0.1:{port}:127.0.0.1:{port}"),
+        ]);
+        forward_args.push(target.addr());
+        let request = Command::new("ssh")
+            .args(&forward_args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(forward_log))
+            .spawn()
+            .context("Failed to request the credential proxy's reverse forward")?;
+        await_forwarding_ack(request, deadline)?;
+
+        let path = fwd_pid_path(inst, name);
+        fs::write(&path, child.id().to_string())
+            .with_context(|| format!("Failed to write proxy tunnel pid file {}", path.display()))?;
+        Ok(())
+    })();
+    if let Err(e) = setup {
         let _ = child.kill();
         let _ = child.wait();
-        return Err(e)
-            .with_context(|| format!("Failed to write proxy tunnel pid file {}", path.display()));
+        let log = fs::read_to_string(&log_path).unwrap_or_default();
+        return Err(e).context(format!(
+            "Failed to establish the credential proxy's reverse SSH tunnel.\n{}",
+            log.trim()
+        ));
     }
+    // The master no longer needs a control socket: later teardown uses its PID.
     Ok(())
+}
+
+/// Use a short, private path even when TMPDIR or the instance path is long.
+fn create_tunnel_control_dir() -> Result<tempfile::TempDir> {
+    tempfile::Builder::new()
+        .prefix("coop-proxy-")
+        .permissions(fs::Permissions::from_mode(0o700))
+        .tempdir_in("/tmp")
+        .context("Failed to create proxy tunnel control directory")
+}
+
+/// Reap the setup client on every path, including a guest that never replies.
+fn await_forwarding_ack(mut request: std::process::Child, deadline: Instant) -> Result<()> {
+    let result = (|| -> Result<()> {
+        loop {
+            crate::signal::check_shutdown()?;
+            if let Some(status) = request
+                .try_wait()
+                .context("Failed to poll forwarding request")?
+            {
+                anyhow::ensure!(
+                    status.success(),
+                    "Proxy reverse forwarding request failed ({status})"
+                );
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                bail!("Timed out waiting for proxy reverse forwarding acknowledgment");
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    })();
+    if result.is_err() {
+        let _ = request.kill();
+        let _ = request.wait();
+    }
+    result
 }
 
 /// SIGTERM the process named by a PID file and remove the file. Best-effort;
@@ -646,6 +717,91 @@ mod tests {
             "unexpected error: {msg}"
         );
         let _ = child.wait();
+    }
+
+    #[test]
+    fn tunnel_control_directory_is_owner_only() {
+        let dir = create_tunnel_control_dir().unwrap();
+        assert_eq!(
+            fs::metadata(dir.path()).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[test]
+    fn forwarding_ack_waits_for_success_and_rejects_failure() {
+        let start = Instant::now();
+        let success = Command::new("sh")
+            .args(["-c", "sleep 0.2; exit 0"])
+            .spawn()
+            .unwrap();
+        await_forwarding_ack(success, start + Duration::from_secs(5)).unwrap();
+        assert!(start.elapsed() >= Duration::from_millis(200));
+
+        let failure = Command::new("sh").args(["-c", "exit 7"]).spawn().unwrap();
+        let error =
+            await_forwarding_ack(failure, Instant::now() + Duration::from_secs(5)).unwrap_err();
+        assert!(error.to_string().contains("request failed"));
+    }
+
+    #[test]
+    fn forwarding_ack_timeout_reaps_setup_client() {
+        let request = Command::new("sleep").arg("30").spawn().unwrap();
+        let pid = i32::try_from(request.id()).unwrap();
+        let error =
+            await_forwarding_ack(request, Instant::now() + Duration::from_millis(200)).unwrap_err();
+        assert!(error.to_string().contains("Timed out"));
+        // The setup client is gone, not merely dropped and left running.
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
+    }
+
+    #[test]
+    fn reverse_forward_rejects_a_live_ssh_without_an_established_connection() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut inst = inst_with_index(0);
+        inst.dir = tmp.path().to_path_buf();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        listener.set_nonblocking(true).unwrap();
+        let peer = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                match listener.accept() {
+                    Ok((connection, _)) => {
+                        // Outlive the old two-second readiness grace, then fail
+                        // the handshake without ever acknowledging a forward.
+                        std::thread::sleep(Duration::from_millis(2300));
+                        drop(connection);
+                        return Ok(true);
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return Ok(false);
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        });
+        let target = SshTarget {
+            host: crate::backend::Hostname::new("127.0.0.1").unwrap(),
+            port: std::num::NonZeroU16::new(port).unwrap(),
+            user: crate::backend::SshUser::new("coop").unwrap(),
+            key_path: tmp.path().join("unused-key"),
+        };
+        let result = spawn_reverse_forward(&inst, "test", &target, 8788);
+        let accepted = peer.join().unwrap().unwrap();
+        // Also clean up the old implementation when deliberately regressed.
+        kill_pid_file(&fwd_pid_path(&inst, "test"), "test tunnel");
+        assert!(accepted, "SSH must have reached the stalled peer");
+        let error = result.unwrap_err();
+        assert!(format!("{error:#}").contains("before its control socket became ready"));
+        assert!(!fwd_pid_path(&inst, "test").exists());
     }
 
     #[test]

--- a/src/proxy_state.rs
+++ b/src/proxy_state.rs
@@ -152,6 +152,41 @@ mod tests {
     }
 
     #[test]
+    fn slot_mut_updates_each_provider_independently() {
+        let mut state = ProxyState::default();
+        *state.slot_mut(Provider::Anthropic) =
+            Some(upstream("cmd:anthropic", ProxyAuthScheme::ApiKey));
+        *state.slot_mut(Provider::Openai) = Some(upstream("cmd:openai", ProxyAuthScheme::Bearer));
+
+        assert_eq!(
+            state.anthropic.as_ref().unwrap().credential.expose(),
+            "cmd:anthropic"
+        );
+        assert_eq!(
+            state.openai.as_ref().unwrap().credential.expose(),
+            "cmd:openai"
+        );
+        *state.slot_mut(Provider::Anthropic) = None;
+        assert!(state.anthropic.is_none());
+        assert_eq!(state.openai.unwrap().credential.expose(), "cmd:openai");
+    }
+
+    #[test]
+    fn unreadable_state_does_not_fall_back_to_config_defaults() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let inst = inst(tmp.path().to_path_buf());
+        fs::create_dir(inst.proxy_state_path()).unwrap();
+        let error = ProxyState::try_load(&inst).unwrap_err();
+        assert!(error.to_string().contains("Failed to read"));
+
+        let cfg = ProxyConfig {
+            openai: Some(upstream("cmd:default", ProxyAuthScheme::Bearer)),
+            ..Default::default()
+        };
+        assert!(effective_upstream(&inst, Provider::Openai, &cfg).is_err());
+    }
+
+    #[test]
     fn override_wins_over_default() {
         let cfg = ProxyConfig {
             anthropic: Some(upstream("cmd:default", ProxyAuthScheme::Bearer)),

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -753,6 +753,25 @@ mod tests {
     }
 
     #[test]
+    fn file_backend_separates_services_for_the_same_account() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let account = AccountName::new("same-account").unwrap();
+        let services = [
+            (SERVICE, "github-pat", "github-token"),
+            (ANTHROPIC_SERVICE, "anthropic", "anthropic-token"),
+            (OPENAI_SERVICE, "openai", "openai-token"),
+            ("coop-openai-dev", "openai-dev", "vm-token"),
+        ];
+        for (service, _, token) in services {
+            store_file(service, &account, token, tmp.path()).unwrap();
+        }
+        for (_, directory, token) in services {
+            let path = tmp.path().join(directory).join("same-account.txt");
+            assert_eq!(std::fs::read_to_string(path).unwrap(), format!("{token}\n"));
+        }
+    }
+
+    #[test]
     fn file_backend_round_trip() {
         let tmp = tempfile::TempDir::new().unwrap();
         let acc = account("trailofbits/coop");

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -574,10 +574,13 @@ fn kill_process_on_socket(socket_path: &std::path::Path) {
 /// PAM/`login.defs`, not ours: under a hardened `UMASK` (027 in the CIS
 /// baseline) the file would land unreadable to every unprivileged reader
 /// of it — `stop`, `status`, `check_alive` and `Instance::is_running`.
+/// Set the creation mask before publishing the file: chmod afterwards leaves
+/// a window where the unprivileged startup poll fails with `PermissionDenied`.
+/// The subshell preserves the VMM's inherited umask; POSIX `$$` still names
+/// the parent shell that execs Firecracker.
 const PID_TRAMPOLINE: &str = concat!(
     r#"rm -f "$1" || exit 1; "#,
-    r#"echo $$ > "$1" || exit 1; "#,
-    r#"chmod 644 "$1" || exit 1; "#,
+    r#"(umask 022; echo $$ > "$1") || exit 1; "#,
     r#"shift; exec "$@""#,
 );
 
@@ -695,6 +698,37 @@ mod tests {
         let back: MachineConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(back.vcpu_count, 4);
         assert_eq!(back.mem_size_mib, 3072);
+    }
+
+    #[test]
+    fn pid_trampoline_publishes_readable_pid_under_hardened_umask() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("firecracker.pid");
+        // Pause any post-publication chmod in the shell itself. This makes the
+        // old create-then-chmod window deterministic without sudo or a VM.
+        // The replacement process also stays alive until the test reaps it.
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "umask 077; chmod() {{ kill -STOP $$; command chmod \"$@\"; }}; {}",
+                crate::vm::PID_TRAMPOLINE,
+            ))
+            .arg("sh")
+            .arg(&path)
+            .args(["sleep", "30"])
+            .spawn()
+            .unwrap();
+        let published = wait_for_pid_file(&path, Duration::from_secs(5));
+        let mode = std::fs::metadata(&path).map(|m| m.permissions().mode() & 0o777);
+        let expected_pid = child.id();
+        // Reap even when an assertion below fails, including the stopped shell.
+        child.kill().unwrap();
+        child.wait().unwrap();
+
+        assert_eq!(published.unwrap(), expected_pid);
+        assert_eq!(mode.unwrap(), 0o644);
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -570,17 +570,19 @@ fn kill_process_on_socket(socket_path: &std::path::Path) {
 /// the VM running. This shell records its own PID and execs in place, so
 /// the PID file names the process SIGKILL must reach.
 ///
-/// The mode is pinned because root's umask here comes from the host's
-/// PAM/`login.defs`, not ours: under a hardened `UMASK` (027 in the CIS
-/// baseline) the file would land unreadable to every unprivileged reader
-/// of it — `stop`, `status`, `check_alive` and `Instance::is_running`.
-/// Set the creation mask before publishing the file: chmod afterwards leaves
-/// a window where the unprivileged startup poll fails with `PermissionDenied`.
-/// The subshell preserves the VMM's inherited umask; POSIX `$$` still names
-/// the parent shell that execs Firecracker.
+/// A root-owned PID file must be readable by the unprivileged caller despite
+/// root's umask or the instance directory's default ACL. Set the mode before
+/// atomically publishing it, so startup never observes an unreadable file.
+/// Staging beside the destination keeps the rename on the same filesystem.
 const PID_TRAMPOLINE: &str = concat!(
-    r#"rm -f "$1" || exit 1; "#,
-    r#"(umask 022; echo $$ > "$1") || exit 1; "#,
+    r#"rm -f -- "$1" || exit 1; "#,
+    r#"pid_tmp=$(mktemp -- "$1.XXXXXX") || exit 1; "#,
+    r#"trap 'rm -f -- "$pid_tmp"' EXIT; "#,
+    r#"trap 'exit 1' HUP INT TERM; "#,
+    r#"echo $$ > "$pid_tmp" || exit 1; "#,
+    r#"chmod 644 "$pid_tmp" || exit 1; "#,
+    r#"mv -f -- "$pid_tmp" "$1" || exit 1; "#,
+    r#"trap - EXIT HUP INT TERM; "#,
     r#"shift; exec "$@""#,
 );
 
@@ -712,7 +714,7 @@ mod tests {
         let mut child = std::process::Command::new("sh")
             .arg("-c")
             .arg(format!(
-                "umask 077; chmod() {{ kill -STOP $$; command chmod \"$@\"; }}; {}",
+                "published=$1; umask 077; chmod() {{ if [ \"$2\" = \"$published\" ]; then kill -STOP $$; fi; command chmod \"$@\"; }}; {}",
                 crate::vm::PID_TRAMPOLINE,
             ))
             .arg("sh")
@@ -729,6 +731,97 @@ mod tests {
 
         assert_eq!(published.unwrap(), expected_pid);
         assert_eq!(mode.unwrap(), 0o644);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn pid_trampoline_normalizes_inherited_default_acl() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let directory = std::ffi::CString::new(dir.path().as_os_str().as_bytes()).unwrap();
+        // Linux POSIX default ACL u::rwx,g::---,o::---. Such an ACL replaces
+        // the umask during file creation; changing the umask cannot grant read.
+        let mut acl = 2_u32.to_le_bytes().to_vec();
+        for (tag, permissions) in [(1_u16, 7_u16), (4, 0), (32, 0)] {
+            acl.extend(tag.to_le_bytes());
+            acl.extend(permissions.to_le_bytes());
+            acl.extend(u32::MAX.to_le_bytes());
+        }
+        // SAFETY: both C strings and the ACL buffer live through setxattr;
+        // the buffer length describes its complete initialized contents.
+        let status = unsafe {
+            libc::setxattr(
+                directory.as_ptr(),
+                c"system.posix_acl_default".as_ptr(),
+                acl.as_ptr().cast(),
+                acl.len(),
+                0,
+            )
+        };
+        assert_eq!(
+            status,
+            0,
+            "set default ACL: {}",
+            std::io::Error::last_os_error()
+        );
+
+        // Positive witness that this filesystem applies the restrictive ACL.
+        let witness = dir.path().join("inherited");
+        std::fs::write(&witness, "fixture").unwrap();
+        assert_eq!(
+            std::fs::metadata(&witness).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        let path = dir.path().join("firecracker.pid");
+        let result = std::process::Command::new("sh")
+            .args(["-c", crate::vm::PID_TRAMPOLINE, "sh"])
+            .arg(&path)
+            .arg("true")
+            .output()
+            .unwrap();
+        assert!(
+            result.status.success(),
+            "{}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .trim()
+                .parse::<u32>()
+                .unwrap()
+                > 0
+        );
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+    }
+
+    #[test]
+    fn pid_trampoline_cleans_staging_file_when_chmod_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("firecracker.pid");
+        let result = std::process::Command::new("sh")
+            .args([
+                "-c",
+                &format!(
+                    "chmod() {{ echo chmod-refused >&2; return 1; }}; {}",
+                    crate::vm::PID_TRAMPOLINE
+                ),
+                "sh",
+            ])
+            .arg(&path)
+            .arg("true")
+            .output()
+            .unwrap();
+        assert!(!result.status.success());
+        assert!(String::from_utf8_lossy(&result.stderr).contains("chmod-refused"));
+        assert!(!path.exists());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
     }
 
     #[test]

--- a/tests/integration-install.sh
+++ b/tests/integration-install.sh
@@ -173,14 +173,18 @@ fi
 
 echo "==> Test 2: bundle verification failure is fail-closed"
 printf '%s\n' 'keep-existing-install' >"$INSTALL_DIR/coop"
+printf '%s\n' 'keep-existing-proxy' >"$INSTALL_DIR/coop-proxy"
 COOP_TEST_GH_VERIFY_FAIL=1
 export COOP_TEST_GH_VERIFY_FAIL
 if run_installer >"$TEST_ROOT/t2.log" 2>&1; then
     fail "failed bundle verification aborts installation" "installer exited 0"
-elif [[ "$(cat "$INSTALL_DIR/coop")" == "keep-existing-install" ]]; then
-    pass "failed bundle verification leaves the installed binary unchanged"
+elif grep -q "Attestation verification failed" "$TEST_ROOT/t2.log" \
+    && [[ "$(cat "$INSTALL_DIR/coop")" == "keep-existing-install" \
+       && "$(cat "$INSTALL_DIR/coop-proxy")" == "keep-existing-proxy" ]]; then
+    pass "failed bundle verification leaves both installed binaries unchanged"
 else
-    fail "failed bundle verification leaves the installed binary unchanged"
+    fail "failed bundle verification leaves both installed binaries unchanged" \
+        "$(tail -10 "$TEST_ROOT/t2.log")"
 fi
 unset COOP_TEST_GH_VERIFY_FAIL
 
@@ -201,6 +205,55 @@ if grep -q 'attestation verify .* --repo trailofbits/coop$' "$GH_LOG" \
     pass "legacy fallback verifies through the attestations API"
 else
     fail "legacy fallback verifies through the attestations API" "gh calls: $(cat "$GH_LOG")"
+fi
+
+echo "==> Test 4: checksum rejection preserves both binaries"
+printf '%s\n' 'keep-existing-install' >"$INSTALL_DIR/coop"
+printf '%s\n' 'keep-existing-proxy' >"$INSTALL_DIR/coop-proxy"
+printf '%064d  %s\n' 0 "$TARBALL" >"$FIXTURE/SHA256SUMS"
+if run_installer >"$TEST_ROOT/t4.log" 2>&1; then
+    fail "checksum mismatch aborts installation" "installer exited 0"
+elif grep -q "Checksum mismatch" "$TEST_ROOT/t4.log" \
+    && [[ "$(cat "$INSTALL_DIR/coop")" == "keep-existing-install" \
+       && "$(cat "$INSTALL_DIR/coop-proxy")" == "keep-existing-proxy" ]]; then
+    pass "checksum mismatch leaves both installed binaries unchanged"
+else
+    fail "checksum mismatch leaves both installed binaries unchanged" \
+        "$(tail -10 "$TEST_ROOT/t4.log")"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$FIXTURE" && sha256sum "$TARBALL" > SHA256SUMS)
+else
+    (cd "$FIXTURE" && shasum -a 256 "$TARBALL" > SHA256SUMS)
+fi
+
+echo "==> Test 5: reinstall replaces both existing binaries"
+if run_installer >"$TEST_ROOT/t5.log" 2>&1 \
+    && [[ "$("$INSTALL_DIR/coop")" == "installed-coop" \
+       && "$("$INSTALL_DIR/coop-proxy")" == "installed-coop-proxy" ]]; then
+    pass "reinstall replaces both binaries with verified release contents"
+else
+    fail "reinstall replaces both binaries with verified release contents" \
+        "$(tail -10 "$TEST_ROOT/t5.log")"
+fi
+
+echo "==> Test 6: legacy package without companion remains installable"
+rm "$FIXTURE/$ARCHIVE_DIR/coop-proxy"
+(cd "$FIXTURE" && tar -czf "$TARBALL" "$ARCHIVE_DIR")
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$FIXTURE" && sha256sum "$TARBALL" > SHA256SUMS)
+else
+    (cd "$FIXTURE" && shasum -a 256 "$TARBALL" > SHA256SUMS)
+fi
+printf '%s\n' 'old-coop' >"$INSTALL_DIR/coop"
+if run_installer >"$TEST_ROOT/t6.log" 2>&1 \
+    && [[ "$("$INSTALL_DIR/coop")" == "installed-coop" \
+       && "$("$INSTALL_DIR/coop-proxy")" == "installed-coop-proxy" ]]; then
+    pass "legacy install replaces coop and preserves the existing companion"
+else
+    fail "legacy install replaces coop and preserves the existing companion" \
+        "$(tail -10 "$TEST_ROOT/t6.log")"
 fi
 
 echo

--- a/tests/integration-proxy-forward.sh
+++ b/tests/integration-proxy-forward.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Real OpenSSH, no VM: a disposable guest network namespace separates the
+# reverse listener from the host destination on the same loopback port.
+if [[ "$(uname -s)" != Linux ]]; then
+    echo "SKIP: proxy reverse-forward test requires Linux namespaces"
+    exit 0
+fi
+for tool in cargo python3 sudo unshare timeout mount ip ssh sshd ssh-keygen hostname cp chmod mkdir grep; do
+    command -v "$tool" >/dev/null || { echo "Missing prerequisite: $tool" >&2; exit 1; }
+done
+cd "$(dirname "$0")/.."
+artifacts=$(mktemp)
+trap 'rm -f "$artifacts"' EXIT
+cargo test --locked --lib --no-run --message-format=json >"$artifacts"
+binary=$(python3 - "$artifacts" <<'PY'
+import json
+import sys
+with open(sys.argv[1]) as source:
+    tests = [item["executable"] for line in source
+             if (item := json.loads(line)).get("reason") == "compiler-artifact"
+             and item.get("executable") and item["target"]["name"] == "coop"
+             and item["profile"]["test"]]
+if len(tests) != 1:
+    raise SystemExit(f"Expected one coop library test executable, found {tests!r}")
+print(tests[0])
+PY
+)
+test_name=proxy::tests::reverse_forward_requires_authenticated_bind_acknowledgment
+"$binary" --list --ignored --exact "$test_name" | grep -Fx "$test_name: test"
+sudo -n timeout --kill-after=5s 60s \
+    unshare --mount --net --uts --pid --fork --mount-proc --kill-child \
+    bash -s -- "$binary" "$test_name" "$(command -v ssh)" "$(command -v sshd)" <<'INNER'
+set -euo pipefail
+mount --make-rprivate /
+hostname localhost
+mount -t tmpfs -o mode=755 tmpfs /run
+# Preserve the executable before covering /tmp (Cargo targets may live there).
+cp "$1" /run/coop-test
+mount -t tmpfs tmpfs /tmp
+mkdir -p /run/netns /run/sshd /run/coop-forward/bin
+export COOP_FORWARD_TEST_DIR=/run/coop-forward
+chmod 700 "$COOP_FORWARD_TEST_DIR"
+ip link set lo up
+ip netns add guest
+ip link add host0 type veth peer name guest0 netns guest
+ip addr add 192.0.2.1/24 dev host0
+ip link set host0 up
+ip -n guest addr add 192.0.2.2/24 dev guest0
+ip -n guest link set guest0 up
+ip -n guest link set lo up
+for key in host client; do
+    ssh-keygen -q -t ed25519 -N '' -f "$COOP_FORWARD_TEST_DIR/$key"
+done
+cat >"$COOP_FORWARD_TEST_DIR/sshd_config" <<CONFIG
+ListenAddress 192.0.2.2
+Port 2222
+HostKey $COOP_FORWARD_TEST_DIR/host
+AuthorizedKeysFile $COOP_FORWARD_TEST_DIR/client.pub
+StrictModes yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin prohibit-password
+UsePAM yes
+AllowUsers root
+AllowTcpForwarding remote
+PidFile $COOP_FORWARD_TEST_DIR/sshd.pid
+LogLevel ERROR
+CONFIG
+# Exec the real client, suppress all user/system config, and record the direct
+# master PID independently of the production pidfile under test.
+export COOP_FORWARD_TEST_SSH="$3"
+cat >"$COOP_FORWARD_TEST_DIR/bin/ssh" <<'WRAPPER'
+#!/bin/sh
+case " $* " in *' -N '*) echo $$ >"$COOP_FORWARD_TEST_DIR/master.pid" ;; esac
+exec "$COOP_FORWARD_TEST_SSH" -F /dev/null "$@"
+WRAPPER
+chmod 700 "$COOP_FORWARD_TEST_DIR/bin/ssh"
+export PATH="$COOP_FORWARD_TEST_DIR/bin:$PATH"
+ip netns exec guest "$4" -D -e -f "$COOP_FORWARD_TEST_DIR/sshd_config" &
+# Readiness probes only the isolated fixture, never a host SSH daemon.
+python3 - <<'PY'
+import socket,time
+end = time.monotonic() + 5
+while True:
+    try:
+        with socket.create_connection(('192.0.2.2', 2222), timeout=.2):
+            break
+    except OSError:
+        if time.monotonic() >= end:
+            raise
+        time.sleep(.02)
+PY
+# Namespace init exit kills every descendant, including on test panic/timeout.
+/run/coop-test --ignored --exact "$2" --nocapture
+INNER

--- a/tests/integration-update.sh
+++ b/tests/integration-update.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 #
 # Serves a synthetic GitHub-shaped fixture from a local HTTP server and
 # verifies that the update flow downloads, checksums, and atomically
-# replaces the running binary. Also verifies checksum rollback,
-# `--check` behaviour, and dev-build refusal.
+# replaces the running binary and its proxy companion. Also verifies checksum
+# rollback, `--check` behaviour, and dev-build refusal.
 #
 # Run manually:   ./tests/integration-update.sh
 # Run in CI:      same (fast — no VM, no external network)
@@ -168,7 +168,11 @@ cat > "$TMPDIR/build/${FAKE_DIR}/coop" << 'EOF'
 #!/bin/sh
 echo "MARKER: fake-replacement-binary"
 EOF
-chmod +x "$TMPDIR/build/${FAKE_DIR}/coop"
+cat > "$TMPDIR/build/${FAKE_DIR}/coop-proxy" << 'EOF'
+#!/bin/sh
+echo "MARKER: fake-proxy-binary"
+EOF
+chmod +x "$TMPDIR/build/${FAKE_DIR}/coop" "$TMPDIR/build/${FAKE_DIR}/coop-proxy"
 (cd "$TMPDIR/build" && tar -czf "$FIXTURE/${FAKE_TARBALL}" "$FAKE_DIR")
 (cd "$FIXTURE" && sha256sums_line "${FAKE_TARBALL}" > SHA256SUMS)
 
@@ -213,6 +217,13 @@ else
     fail "update --yes returned non-zero" "$(tail -5 "$TMPDIR/t1.log")"
 fi
 
+if [[ -x "$TMPDIR/bin/coop-proxy" ]] \
+    && [[ "$("$TMPDIR/bin/coop-proxy")" == "MARKER: fake-proxy-binary" ]]; then
+    pass "update installs the missing proxy companion"
+else
+    fail "update installs the missing proxy companion" "expected release proxy contents"
+fi
+
 # Confirm the update-check state file landed inside the test's tempdir,
 # not somewhere under the developer's real home. Searching $TMPDIR (not
 # $HOME) is deliberate: if a future edit accidentally drops the HOME
@@ -252,6 +263,8 @@ fi
 
 cp "$RELEASE_BIN" "$COOP_BIN"
 ORIG_SHA="$(sha_of "$COOP_BIN")"
+printf '%s\n' 'keep-existing-proxy' > "$TMPDIR/bin/coop-proxy"
+ORIG_PROXY_SHA="$(sha_of "$TMPDIR/bin/coop-proxy")"
 
 # Restore the newer-release fixture but corrupt SHA256SUMS.
 write_release_json \
@@ -266,14 +279,16 @@ if "$COOP_BIN" update --yes > "$TMPDIR/t3.log" 2>&1; then
     fail "update --yes should have failed on checksum mismatch"
 else
     new_sha="$(sha_of "$COOP_BIN")"
-    if [[ "$new_sha" == "$ORIG_SHA" ]]; then
-        pass "checksum mismatch leaves binary unchanged"
+    if grep -q "SHA-256 mismatch" "$TMPDIR/t3.log" \
+        && [[ "$new_sha" == "$ORIG_SHA" \
+           && "$(sha_of "$TMPDIR/bin/coop-proxy")" == "$ORIG_PROXY_SHA" ]]; then
+        pass "checksum mismatch leaves both binaries unchanged"
     else
-        fail "binary replaced despite checksum mismatch"
+        fail "checksum rejection must preserve both binaries" "$(tail -5 "$TMPDIR/t3.log")"
     fi
 fi
 
-# Restore valid SHA256SUMS for subsequent tests (not needed here — test 4 rebuilds).
+# Restore valid SHA256SUMS for subsequent tests.
 (cd "$FIXTURE" && sha256sums_line "${FAKE_TARBALL}" > SHA256SUMS)
 
 # ── Test 4: dev build refuses to self-update ─────────────────────────────────
@@ -287,6 +302,34 @@ else
     else
         fail "dev-build refusal message missing" "$(cat "$TMPDIR/t4.log")"
     fi
+fi
+
+# ── Test 5: update replaces an existing companion ───────────────────────────
+
+echo "==> Test 5: update replaces both existing binaries"
+cp "$RELEASE_BIN" "$COOP_BIN"
+if "$COOP_BIN" update --yes > "$TMPDIR/t5.log" 2>&1 \
+    && [[ "$("$COOP_BIN")" == "MARKER: fake-replacement-binary" \
+       && "$("$TMPDIR/bin/coop-proxy")" == "MARKER: fake-proxy-binary" ]]; then
+    pass "update replaces the existing coop and coop-proxy"
+else
+    fail "update replaces the existing coop and coop-proxy" "$(tail -5 "$TMPDIR/t5.log")"
+fi
+
+# ── Test 6: older packages without a companion remain supported ──────────────
+
+echo "==> Test 6: legacy update without a proxy"
+cp "$RELEASE_BIN" "$COOP_BIN"
+rm "$TMPDIR/build/${FAKE_DIR}/coop-proxy"
+(cd "$TMPDIR/build" && tar -czf "$FIXTURE/${FAKE_TARBALL}" "$FAKE_DIR")
+(cd "$FIXTURE" && sha256sums_line "${FAKE_TARBALL}" > SHA256SUMS)
+ORIG_PROXY_SHA="$(sha_of "$TMPDIR/bin/coop-proxy")"
+if "$COOP_BIN" update --yes > "$TMPDIR/t6.log" 2>&1 \
+    && [[ "$("$COOP_BIN")" == "MARKER: fake-replacement-binary" \
+       && "$(sha_of "$TMPDIR/bin/coop-proxy")" == "$ORIG_PROXY_SHA" ]]; then
+    pass "legacy update replaces coop and preserves the existing companion"
+else
+    fail "legacy update replaces coop and preserves the existing companion" "$(tail -5 "$TMPDIR/t6.log")"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -5438,6 +5438,41 @@ CFGEOF
         return
     fi
 
+    # A directory at the credential path makes rm -f fail even for guest root.
+    # Proxy startup must refuse to continue.
+    if px_exec mkdir ./.codex/auth.json && px stop "$inst_name"; then
+        if px start "$inst_name"; then
+            fail "proxy restart fails closed when auth cleanup fails" "start unexpectedly succeeded"
+        elif [[ "$HARNESS_ERR" == *"Failed to remove stale guest ~/.codex/auth.json"* ]]; then
+            pass "proxy restart fails closed when auth cleanup fails"
+        else
+            fail "proxy restart fails closed when auth cleanup fails" "unexpected failure: $HARNESS_ERR"
+        fi
+        # Start without bootstrap to remove the deliberate obstruction, then
+        # the normal restart below tests successful stale-file cleanup.
+        px stop "$inst_name" || true
+        if ! px start "$inst_name" --no-agents \
+            || ! px_exec rmdir ./.codex/auth.json; then
+            fail "recover proxy VM after auth cleanup refusal" "stderr: $HARNESS_ERR"
+        fi
+    else
+        fail "prepare auth cleanup refusal" "stderr: $HARNESS_ERR"
+    fi
+
+    # Existing direct-auth VMs (and committed images) can already contain this
+    # file. Excluding it from the host copy alone does not remove guest state.
+    if px_exec sh -c 'mkdir -p ~/.codex && printf stale > ~/.codex/auth.json' \
+        && px_exec test -f ./.codex/auth.json; then
+        pass "seed stale Codex auth.json before proxy restart"
+    else
+        fail "seed stale Codex auth.json before proxy restart" "stderr: $(guest_stderr)"
+    fi
+    if px stop "$inst_name" && px start "$inst_name"; then
+        pass "restart proxy VM with stale direct credentials exits 0"
+    else
+        fail "restart proxy VM with stale direct credentials exits 0" "stderr: $HARNESS_ERR"
+    fi
+
     # Pin the user-facing status contract against the same running instance.
     # Literal credentials are deliberately used above, so this also proves the
     # command redacts them rather than leaking either value to stdout.
@@ -5501,11 +5536,11 @@ STATEEOF
         fail "codex config.toml readable" "cat failed; stderr: $(guest_stderr)"
     fi
 
-    # auth.json must not be staged in proxy mode (issue #411 §7).
-    if px_exec test -f ./.codex/auth.json; then
-        fail "codex auth.json not staged in proxy mode" "auth.json present in guest"
+    # The seeded auth.json must be actively removed, not only excluded from staging.
+    if px_exec test ! -e ./.codex/auth.json; then
+        pass "codex proxy restart removes stale auth.json"
     else
-        pass "codex auth.json not staged in proxy mode"
+        fail "codex proxy restart removes stale auth.json" "auth.json remains or guest check failed: $(guest_stderr)"
     fi
 
     # ── Crown jewel: raw keys never enter the guest env ──

--- a/tests/test-preflight-release.py
+++ b/tests/test-preflight-release.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Exercise release preflight dispatch and version gates without building VMs."""
+import os
+import re
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class PreflightTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        for directory in ('scripts', 'tests', 'bin'):
+            (self.root / directory).mkdir()
+        (self.root / 'scripts/preflight-release.sh').write_text(
+            (ROOT / 'scripts/preflight-release.sh').read_text())
+        (self.root / 'Cargo.toml').write_text(
+            '[workspace.package]\nversion = "9.8.7"\n'
+            '[package]\nname = "coop"\nversion.workspace = true\n')
+        self.lock()
+        (self.root / 'CHANGELOG.md').write_text('## v9.8.7\n\nRelease notes.\n')
+        self.log = self.root / 'calls'
+        for name in ('cargo', 'cargo-deny', 'taplo', 'zizmor', 'cargo-kani'):
+            self.executable('bin/' + name, '''#!/bin/bash
+printf '%s %s\n' "${0##*/}" "$*" >> "$PREFLIGHT_CALLS"
+if [[ "${0##*/} $*" == "${PREFLIGHT_FAIL:-}" ]]; then exit 1; fi
+''')
+        self.executable('bin/rustup', '#!/bin/bash\necho aarch64-unknown-linux-gnu\necho aarch64-unknown-linux-musl\n')
+        self.executable('bin/uname', '#!/bin/bash\necho Linux\n')
+        self.executable('bin/git', '''#!/bin/bash
+if [[ "$1" == rev-parse ]]; then exit 1; fi
+''')
+        for name in ('integration-install.sh', 'integration-update.sh',
+                     'integration-uninstall.sh', 'integration-network.sh'):
+            self.executable('tests/' + name, '''#!/bin/bash
+printf '%s\n' "${0##*/}" >> "$PREFLIGHT_CALLS"
+''')
+        for name in ('test-integration-probes.py', 'test-preflight-release.py'):
+            (self.root / 'tests' / name).write_text(
+                'import os\nwith open(os.environ["PREFLIGHT_CALLS"], "a") as f:\n'
+                f'    f.write("{name}\\n")\n')
+
+    def executable(self, name, contents):
+        path = self.root / name
+        path.write_text(contents)
+        path.chmod(0o755)
+
+    def lock(self, proxy='9.8.7'):
+        (self.root / 'Cargo.lock').write_text(
+            '[[package]]\nname = "coop"\nversion = "9.8.7"\n'
+            f'[[package]]\nname = "coop-proxy"\nversion = "{proxy}"\n')
+
+    def run_preflight(self, fail=''):
+        return subprocess.run(
+            ['bash', str(self.root / 'scripts/preflight-release.sh'), '--quick'],
+            env={**os.environ, 'PATH': str(self.root / 'bin') + ':' + os.environ['PATH'],
+                 'PREFLIGHT_CALLS': str(self.log), 'PREFLIGHT_FAIL': fail},
+            capture_output=True, text=True, timeout=20)
+
+    def test_workspace_version_and_gates(self):
+        result = self.run_preflight()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn('Version sources agree; tag v9.8.7 is free.', result.stdout)
+        calls = self.log.read_text().splitlines()
+        for call in ('cargo clippy --workspace --all-targets --all-features -- -D warnings',
+                     'cargo test --workspace', 'cargo deny --workspace check',
+                     'cargo build --release --workspace --target aarch64-unknown-linux-musl',
+                     'taplo format --check', 'test-integration-probes.py',
+                     'test-preflight-release.py', 'integration-network.sh'):
+            self.assertIn(call, calls)
+        self.assertNotIn('Next: tag', result.stdout)
+        self.assertIn('unrun gates before tagging', result.stdout)
+
+    def test_non_linux_bridge_gate_is_reported_as_unrun(self):
+        self.executable('bin/uname', '#!/bin/bash\necho Darwin\n')
+        result = self.run_preflight()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn('Bridge isolation requires Linux', result.stdout)
+        self.assertNotIn('integration-network.sh', self.log.read_text().splitlines())
+        self.assertNotIn('Next: tag', result.stdout)
+
+    def test_proxy_lock_mismatch_fails(self):
+        self.lock(proxy='9.8.6')
+        result = self.run_preflight()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('Cargo.lock coop-proxy version (9.8.6)', result.stdout)
+
+    def test_workspace_test_failure_is_fatal(self):
+        result = self.run_preflight(fail='cargo test --workspace')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('FAIL: Unit tests', result.stdout)
+
+
+class ReleaseBinaryTests(unittest.TestCase):
+    def test_packaging_requires_release_identity_and_companion(self):
+        workflow = (ROOT / '.github/workflows/release.yml').read_text()
+        block = re.search(
+            r"      - name: Verify release binaries\n.*?        run: \|\n(.*?)\n      - name:",
+            workflow, re.S)[1]
+        script = "\n".join(line[10:] for line in block.splitlines())
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            binary_dir = root / 'target/test-target/release'
+            binary_dir.mkdir(parents=True)
+            (root / 'bin').mkdir()
+            git = root / 'bin/git'
+            git.write_text('#!/bin/sh\necho abc1234\n')
+            git.chmod(0o755)
+            proxy = binary_dir / 'coop-proxy'
+            proxy.write_text('#!/bin/sh\nexit 0\n')
+            proxy.chmod(0o755)
+            coop = binary_dir / 'coop'
+            for version, companion, expected in [('coop 9.8.7 (abc1234)', True, 0),
+                                                 ('coop 9.8.7-dev (abc1234+dirty)', True, 1),
+                                                 ('coop 9.8.6 (abc1234)', True, 1),
+                                                 ('coop 9.8.7 (abc1234)', False, 1)]:
+                with self.subTest(version=version, companion=companion):
+                    if not companion:
+                        proxy.unlink()
+                    coop.write_text(f"#!/bin/sh\nprintf '%s\\n' '{version}'\n")
+                    coop.chmod(0o755)
+                    result = subprocess.run(
+                        ['bash', '-euc', script], cwd=root,
+                        env={**os.environ, 'PATH': str(root / 'bin') + ':' + os.environ['PATH'],
+                             'TAG': 'v9.8.7', 'TARGET': 'test-target'},
+                        capture_output=True, text=True, timeout=10)
+                    self.assertEqual(result.returncode, expected, result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test-preflight-release.py
+++ b/tests/test-preflight-release.py
@@ -36,9 +36,11 @@ if [[ "${0##*/} $*" == "${PREFLIGHT_FAIL:-}" ]]; then exit 1; fi
 if [[ "$1" == rev-parse ]]; then exit 1; fi
 ''')
         for name in ('integration-install.sh', 'integration-update.sh',
-                     'integration-uninstall.sh', 'integration-network.sh'):
+                     'integration-uninstall.sh', 'integration-network.sh',
+                     'integration-proxy-forward.sh'):
             self.executable('tests/' + name, '''#!/bin/bash
 printf '%s\n' "${0##*/}" >> "$PREFLIGHT_CALLS"
+if [[ "${0##*/}" == "${PREFLIGHT_FAIL:-}" ]]; then exit 1; fi
 ''')
         for name in ('test-integration-probes.py', 'test-preflight-release.py'):
             (self.root / 'tests' / name).write_text(
@@ -71,16 +73,19 @@ printf '%s\n' "${0##*/}" >> "$PREFLIGHT_CALLS"
                      'cargo test --workspace', 'cargo deny --workspace check',
                      'cargo build --release --workspace --target aarch64-unknown-linux-musl',
                      'taplo format --check', 'test-integration-probes.py',
-                     'test-preflight-release.py', 'integration-network.sh'):
+                     'test-preflight-release.py', 'integration-network.sh',
+                     'integration-proxy-forward.sh'):
             self.assertIn(call, calls)
         self.assertNotIn('Next: tag', result.stdout)
         self.assertIn('unrun gates before tagging', result.stdout)
 
-    def test_non_linux_bridge_gate_is_reported_as_unrun(self):
+    def test_non_linux_namespace_gates_are_reported_as_unrun(self):
         self.executable('bin/uname', '#!/bin/bash\necho Darwin\n')
         result = self.run_preflight()
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn('Bridge isolation requires Linux', result.stdout)
+        self.assertIn('Proxy reverse forwarding requires Linux', result.stdout)
+        self.assertNotIn('integration-proxy-forward.sh', self.log.read_text().splitlines())
         self.assertNotIn('integration-network.sh', self.log.read_text().splitlines())
         self.assertNotIn('Next: tag', result.stdout)
 
@@ -89,6 +94,11 @@ printf '%s\n' "${0##*/}" >> "$PREFLIGHT_CALLS"
         result = self.run_preflight()
         self.assertNotEqual(result.returncode, 0)
         self.assertIn('Cargo.lock coop-proxy version (9.8.6)', result.stdout)
+
+    def test_proxy_forward_failure_is_fatal(self):
+        result = self.run_preflight(fail='integration-proxy-forward.sh')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('FAIL: Integration — proxy reverse forwarding', result.stdout)
 
     def test_workspace_test_failure_is_fatal(self):
         result = self.run_preflight(fail='cargo test --workspace')


### PR DESCRIPTION
Release preparation exposed proxy resource exhaustion, stale guest credentials after an auth-mode change, startup races, and release checks that omitted the new companion binary. This PR contains the audited fixes and migration guidance for users upgrading from v0.5.4.

- Bound proxy connections independently of requests, back off on accept errors, and remove stale Codex auth.json during proxy bootstrap. Cleanup failure aborts bootstrap.
- Normalize Firecracker PID permissions on a temporary file before atomic publication, including directories with inherited default ACLs. Require an acknowledged SSH reverse forward, with bounded setup, cancellation cleanup, and private control sockets.
- Check both workspace packages during release preflight, validate built release identity before packaging, and test installation/replacement and rejection preservation of both binaries.
- Correct documentation for workspace builds, proxy confinement, reprovisioning, and upgrades. The old updater does not install coop-proxy; the published v0.5.4 Linux ARM64 binary identifies itself as a dev build and refuses self-update, so the guidance directs users to rerun the installer.

Validation completed on Linux ARM64:

- 1,214 Rust tests; strict workspace clippy; Rust/TOML formatting; dependency audit; shell syntax and diff checks.
- Installer 10/10, updater 8/8, uninstall 12/12; preflight/artifact tests 6/6; integration-probe tests 6/6; isolated Linux bridge test.
- Both Linux ARM64 musl release binaries built; native proxy jail self-test passed.
- Retained real OpenSSH integration test proves authenticated forwarding traffic, rejected-bind startup failure, no published PID, and master cleanup. Linux CI and preflight run it explicitly. Deliberate regressions to acknowledgment propagation, PID permission normalization/publication, staging cleanup, and companion installation/replacement are caught.
- Fresh independent full-branch subagent review after the fixes, plus documentation/convention/comment review; pre-commit hooks passed.

Additional release validation completed:

- Full VM integration at e6c70e7: macOS ARM64/Lima 438 passed, 0 failed, 13 skipped; Linux/Firecracker 451 passed, 0 failed, 8 skipped, as reported by the integration runner's operator.
- Linux x86_64 musl: both release binaries cross-built, with tagged CLI identity verified under QEMU. The macOS integration runner builds both binaries in release mode.
- Kani: all three harnesses verified. Three fuzz targets processed approximately 7.2 million inputs without crashes (60-second budgets).
- Full-file mutation sweeps assessed 675 unique mutations, plus four targeted network-helper mutations. Twenty-one survivors were addressed with nine new tests and one strengthened assertion; focused mutation reruns or deliberate regressions confirmed every fix.
- Final workspace tests: 1,214 passed, three ignored; strict workspace clippy and formatting passed. An existing ephemeral-port availability test failed once during concurrent mutation workers and passed in the final serial run; no mutation result was affected.
- Independent closeout review of the test-only follow-up was clean; pre-commit hooks passed.

No version bump or release tag is included. The updater still replaces the two binaries sequentially; transactional installation is outside this change.
