### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.0
+
 ### Upgrading from v0.5.4
 
 - Rerun the [installer](docs/getting-started.md#install) to install both `coop`
@@ -12,6 +14,9 @@
 - The published v0.5.4 Linux ARM64 binary reports
   `coop 0.5.4-dev (8e24729+dirty)` and refuses self-update as a development
   build. Use the installer to upgrade it.
+- Restart all running Linux VMs after upgrading to apply guest-to-guest
+  network isolation. Every VM on the shared bridge needs the restart; a
+  pre-upgrade VM leaves peers reachable. macOS is unaffected.
 - Save guest-only work before `restore --reprovision`: it replaces the guest
   disk, including any guest keyring and cached account login. Rebuilding an
   image alone does not update existing VM disks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coop"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "coop-proxy"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["coop-proxy"]
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.5.4"
+version = "0.6.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/trailofbits/coop"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -172,7 +172,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coop"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -182,6 +182,7 @@ dependencies = [
  "indexmap",
  "libc",
  "mutants",
+ "percent-encoding",
  "semver",
  "serde",
  "serde_json",


### PR DESCRIPTION
Prepare v0.6.0 with the account-authentication, credential-proxy, reprovisioning, editor, and instance-management features already merged into main.

Update both workspace package versions and lockfile entries, refresh the fuzz workspace's stale coop entry, and promote the changelog. The upgrade section highlights reinstalling from v0.5.4, restarting all Linux VMs for network isolation, and preserving guest-only work before reprovisioning.

Validation:

- `scripts/preflight-release.sh --quick`: format, strict workspace clippy, unit tests, both Linux musl release builds, dependency/workflow audits, host integration and regression suites, and all three Kani harnesses passed.
- The local platform warnings are covered by the previously reported macOS ARM64/Lima and Linux/Firecracker full suites at e6c70e7 (438 and 451 passed, zero failures), plus the prior macOS release build performed by the integration runner. Since then, source changes have been test-only and release metadata.
- Release-wide mutation/fuzz validation was completed in #455: 675 mutations plus four network checks, all 21 survivors addressed and confirmed, and approximately 7.2 million fuzz inputs without crashes.
- Independent closeout review is clean. Both root package versions and the fuzz dependency agree with the v0.6.0 changelog heading; registry dependency versions are unchanged.

The local workflow audit uses zizmor 1.29.0, matching the observed CI run. Zizmor 1.30.1 additionally recommends replacing the existing reusable-workflow `./` reference with the new self-repository syntax; this pre-existing low-severity modernization is a follow-up outside the version bump.
