### PR TITLE
fix: explain missing host tools when apt is unavailable

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -60,7 +60,7 @@ The Firecracker backend runs [Firecracker microVMs](https://firecracker-microvm.
 - **KVM access**: `/dev/kvm` must exist and be readable/writable by the current user. Setup checks this and offers to fix permissions via `setfacl` or by adding the user to the `kvm` group.
 - **x86_64 or arm64 architecture**: The Firecracker backend supports both. x86_64 is the primary test target; arm64 builds are produced but less exercised.
 - **curl**: Required for downloading the Firecracker binary and kernel.
-- **System packages**: Setup installs `squashfs-tools` and `e2fsprogs` (for rootfs manipulation) via `apt-get` if they are missing.
+- **System packages**: Setup checks for `setfacl`, `unsquashfs`, `mkfs.ext4`, `ssh`, and `rsync`. If tools are missing, it offers to install their Debian/Ubuntu packages (`acl`, `squashfs-tools`, `e2fsprogs`, `openssh-client`, and `rsync`) using `apt-get`. If `apt-get` is unavailable, setup lists the missing tools; install the packages providing them with your host's package manager and rerun `coop setup`. No package manager is needed for this check when all these tools are already on `PATH`. The guest remains Ubuntu regardless of the host distribution.
 
 ### Setup process
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,6 +17,7 @@ coop runs Claude Code and Codex inside isolated virtual machines. On Linux, it s
 - x86_64 or arm64 architecture (x86_64 is the primary test target; arm64 builds are available but untested)
 - `sudo` privileges (Firecracker uses jailer and TAP networking)
 - `curl`, `tar`, `e2fsprogs` (for `mkfs.ext4`, `resize2fs`)
+- Setup also checks for `setfacl`, `unsquashfs`, `ssh`, and `rsync`. Automatic installation of missing tools requires `apt-get`; on other hosts, install the packages providing the reported tools manually and rerun `coop setup`. See [backend prerequisites](backends.md#prerequisites-1).
 
 ## Install
 

--- a/docs/images-and-profiles.md
+++ b/docs/images-and-profiles.md
@@ -7,7 +7,7 @@ coop builds **golden images** (templates) once and copies them to create VM inst
 A template is a fully provisioned ext4 root filesystem. The build process:
 
 1. Creates an ext4 disk image (default 8 GiB, configurable with `--template-size`)
-2. Provisions a base Ubuntu system (debootstrap on Firecracker, Ubuntu 24.04 cloud image on Lima)
+2. Provisions a base Ubuntu system (a downloaded Firecracker CI squashfs on Firecracker, Ubuntu 24.04 cloud image on Lima)
 3. Installs base packages, Docker, GitHub CLI, Claude Code, and Codex
 4. Applies requested profiles and extra packages
 5. Runs post-install scripts if provided

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1018,24 +1018,19 @@ fn fix_kvm_access(skip_confirm: bool) -> Result<()> {
 
 fn install_system_packages(skip_confirm: bool) -> Result<()> {
     let mut missing = Vec::new();
+    let mut missing_tools = Vec::new();
 
-    if !command_exists("setfacl") {
-        missing.push("acl");
-    }
-    if !command_exists("debootstrap") {
-        missing.push("debootstrap");
-    }
-    if !command_exists("unsquashfs") {
-        missing.push("squashfs-tools");
-    }
-    if !command_exists("mkfs.ext4") {
-        missing.push("e2fsprogs");
-    }
-    if !command_exists("ssh") {
-        missing.push("openssh-client");
-    }
-    if !command_exists("rsync") {
-        missing.push("rsync");
+    for (tool, package) in [
+        ("setfacl", "acl"),
+        ("unsquashfs", "squashfs-tools"),
+        ("mkfs.ext4", "e2fsprogs"),
+        ("ssh", "openssh-client"),
+        ("rsync", "rsync"),
+    ] {
+        if !command_exists(tool) {
+            missing.push(package);
+            missing_tools.push(tool);
+        }
     }
 
     if missing.is_empty() {
@@ -1044,6 +1039,16 @@ fn install_system_packages(skip_confirm: bool) -> Result<()> {
     }
 
     step("Missing system packages");
+    if !command_exists("apt-get") {
+        bail!(
+            "Missing host tools: {}.\n\
+             Automatic host package installation requires apt-get, which was not found on PATH.\n\
+             Install the packages providing these tools with your host's package manager, \
+             then rerun `coop setup`.",
+            missing_tools.join(", "),
+        );
+    }
+
     let pkg_list = missing.join(" ");
     eprintln!("  Need to install: {pkg_list}");
 
@@ -1699,6 +1704,52 @@ fn confirm(action: &str, skip: bool) -> Result<bool> {
 #[expect(clippy::unwrap_used, clippy::panic, reason = "tests")]
 mod tests {
     use super::*;
+
+    #[test]
+    fn system_packages_without_apt() {
+        const CHILD: &str = "COOP_TEST_SYSTEM_PACKAGES";
+        if let Ok(scenario) = std::env::var(CHILD) {
+            let result = install_system_packages(true);
+            if scenario == "present" {
+                result.unwrap();
+            } else {
+                let error = result.unwrap_err().to_string();
+                assert!(error.contains("Missing host tools: unsquashfs, ssh, rsync."));
+                assert!(error.contains("apt-get, which was not found on PATH"));
+                assert!(error.contains("host's package manager"));
+                assert!(error.contains("rerun `coop setup`"));
+            }
+            return;
+        }
+
+        // Isolate PATH in child processes instead of mutating the test runner's
+        // environment. No fixture can invoke a real package manager or sudo.
+        for scenario in ["present", "missing"] {
+            let bin = tempfile::tempdir().unwrap();
+            std::os::unix::fs::symlink("/bin/sh", bin.path().join("sh")).unwrap();
+            for tool in ["setfacl", "unsquashfs", "mkfs.ext4", "ssh", "rsync"] {
+                if scenario == "present" || matches!(tool, "setfacl" | "mkfs.ext4") {
+                    std::os::unix::fs::symlink("/bin/sh", bin.path().join(tool)).unwrap();
+                }
+            }
+            let output = Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "setup::tests::system_packages_without_apt",
+                    "--nocapture",
+                ])
+                .env("PATH", bin.path())
+                .env(CHILD, scenario)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{scenario}: {}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
+    }
 
     fn profile(name: &str, apt: &[&str], pre: Option<&str>, post: Option<&str>) -> ProfileDef {
         ProfileDef {


### PR DESCRIPTION
When `coop setup` finds missing host tools on a machine without `apt-get`, it now lists the missing executable names and explains how to install them manually before retrying. Fully provisioned hosts still proceed without a package manager. The unused `debootstrap` requirement is removed, and the prerequisite and rootfs documentation is corrected.

This implements step 1 of the incremental plan in #456. The broader prerequisite audit and native package-manager support remain follow-ups.

Refs #456.

Validation:
- Workspace build, tests, and clippy with all targets/features and `-D warnings` passed.
- Cargo formatting, tracked-file TOML formatting, dependency checks, and pre-commit hooks passed. Dependency checks emitted existing duplicate-version warnings; the broad TOML scan encountered unrelated nested checkouts, so tracked repository TOML files were checked explicitly.
- The isolated-PATH regression test covers missing tools without apt and the all-tools-present path without apt or debootstrap. It fails when the apt guard is removed or the obsolete dependency is restored.
- Independent correctness/design/conventions and tests/docs/comments reviews found no issues.
- Firecracker and Lima VM integration tests were not run. This change affects host prerequisite checks, not guest provisioning or VM lifecycle operations.
