### PR TITLE
feat: add --no-github to up and start

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,6 +59,7 @@ Use `--git-repo <url>` instead of `DIR` to clone a remote repository into
 | `--mem <MiB>` | Memory in MiB when creating a new instance |
 | `--disk <GiB>` | Instance disk size when creating a new instance |
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
+| `--no-github` | Use `github = "off"` for this invocation and suppress the PAT setup prompt. See [scope and limitations](configuration.md#github-auth). |
 | `--image <name>` | Named image to use when creating a new instance (default: `default`) |
 | `--profile <list>` | Build or reuse a profile-derived image when creating a new instance, named from the sorted profiles (for example `node-python`) |
 | `--exclude-git` | Skip `.git/` when copying/syncing local directories; does not strip `.git` from a `--git-repo` clone |
@@ -245,6 +246,7 @@ instances, pass the instance name.
 | `NAME` | Stopped instance name (optional only when exactly one stopped instance exists) |
 | `--workspace <dir>` | Restart the stopped instance associated with this project path |
 | `--no-agents` | Skip injecting Claude Code and Codex credentials/config into the VM |
+| `--no-github` | Use `github = "off"` for this invocation and suppress the PAT setup prompt. See [scope and limitations](configuration.md#github-auth). |
 | `--forward-port <spec>` | Forward a guest port to the host (`GUEST[:HOST]`, repeatable). Lives for the lifetime of the VM; torn down on `coop stop`. |
 | `--no-prompt` | Suppress the interactive prompt to set up a scoped GitHub PAT when one is missing for the resolved repo (see [`coop github setup-pat`](#github)). |
 | `--post-start <cmd>` | Shell command to run inside the guest after boot. Overrides the `post_start` field in `config.toml`. Failure is logged but does not fail the start. |
@@ -264,6 +266,7 @@ rules, and recreate guidance.
 coop start
 coop start my-project
 coop start my-project --no-agents
+coop start my-project --no-github
 coop start --env RUST_LOG=info --env MY_FLAG=1
 coop start --forward-port 3000 --forward-port 8080:18080
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,19 @@ The `github` field determines how coop obtains a `GITHUB_TOKEN` for the guest:
 
 When a token is present, coop runs `gh auth setup-git` inside the guest to wire up git credential helpers.
 
+`coop up --no-github` and `coop start --no-github` force `github = "off"`
+for that invocation, regardless of the configured strategy, and suppress the
+PAT setup prompt. Configured PAT retrieval commands are not evaluated. Model
+credentials and other configuration remain in effect, and the config file is
+not changed. `coop up` rejects this flag for an already-running instance;
+stop it first, then repeat `up` with the flag.
+
+This has the same scope as `github = "off"`: it disables strategy-based token
+forwarding, but does not block explicit `env_forward`, `guest_env`, or `--env`
+entries, or the one-shot host-token fallback used for `--git-repo` clones.
+It does not erase credentials already stored in the guest. Later invocations
+(including `shell` and `exec`) use the configured strategy again.
+
 ### Fine-grained PAT (`github = "pat"`)
 
 In pat mode coop forwards a *per-repo* fine-grained personal access token: the resolved `owner/repo` at VM startup selects the matching entry in `[github.pat]`. Compared with `"auto"` / `"env"`, the effective reach of a leaked token is bounded by the repos and permissions GitHub recorded when it was created — GitHub rejects out-of-scope operations (REST and GraphQL) server-side, not in coop.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,6 +38,11 @@ guest environment → docker → stop → destroy). CI additionally runs the fas
 host-only `tests/integration-install.sh`, `tests/integration-update.sh`, and
 `tests/integration-uninstall.sh` suites.
 
+The `--full` suite includes a dedicated `--no-github` phase. It captures the
+boot session through `post_start` for fresh `up`, `start`, and a stopped-project
+`up`, checks that model credentials still arrive, and witnesses normal GitHub
+forwarding on an intervening invocation without the flag.
+
 When adding new features, consider whether they should be covered here. New
 commands or guest-visible changes are good candidates for a new test phase.
 

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -93,7 +93,10 @@ user `env_forward` entries, and the VM SSH key. The invariants:
   forwarded, `bootstrap_agents` runs `gh auth setup-git`, which makes the token
   **persistent guest state** (a git credential helper any guest process can
   read). A change that forwards it by default, or makes it persistent where it
-  wasn't, is a finding.
+  wasn't, is a finding. `up --no-github` / `start --no-github` override the
+  strategy to Off and disable the PAT wizard for that invocation. This does
+  not scrub existing guest credentials or block explicit environment entries
+  or one-shot clone authentication; see [GitHub auth](configuration.md#github-auth).
 - **Secret files stay `0600`, dirs `0700`.** File-backend PATs live at
   `<state_dir>/github-pat/<account>.txt` (`secret_store.rs:store_file`); all
   managed writes go through `fs_util::atomic_write_with_mode` / `atomic_write_ssh`,

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -47,8 +47,13 @@ impl UpOpts<'_> {
     }
 }
 
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "independent CLI switches, not mutually exclusive lifecycle states"
+)]
 pub(crate) struct UpRuntimeOpts {
     pub(crate) no_agents: bool,
+    pub(crate) no_github: bool,
     pub(crate) exclude_git: bool,
     pub(crate) no_prompt: bool,
     pub(crate) forward_ports: Vec<config::PortForward>,
@@ -713,6 +718,7 @@ fn ensure_up_git_repo_name_matches(
 
 fn up_has_restart_only_inputs(opts: &UpOpts<'_>) -> bool {
     opts.runtime.no_agents
+        || opts.runtime.no_github
         || !opts.runtime.forward_ports.is_empty()
         || opts.runtime.post_start.is_some()
         || !opts.runtime.guest_env.is_empty()
@@ -722,7 +728,7 @@ fn reject_running_up_restart_inputs(inst: &config::Instance, opts: &UpOpts<'_>) 
     if up_has_restart_only_inputs(opts) {
         bail!(
             "Instance '{}' is already running for this project. \
-             --no-agents, --forward-port, --post-start, and --env only take \
+             --no-agents, --no-github, --forward-port, --post-start, and --env only take \
              effect during start or restart.\n\
              Run `coop stop {}` first, then repeat `coop up` with those options.",
             inst.name,
@@ -2554,6 +2560,7 @@ mod tests {
             profile_target: None,
             runtime: super::UpRuntimeOpts {
                 no_agents: false,
+                no_github: false,
                 exclude_git: false,
                 no_prompt: true,
                 forward_ports: Vec::new(),
@@ -3505,11 +3512,11 @@ mod tests {
             .allocate_instance(None, &img, Some(&project))
             .expect("inst");
         let mut opts = up_opts_for_tests(project.to_str());
-        opts.runtime.post_start = Some("echo hi".to_string());
+        opts.runtime.no_github = true;
 
         let err = super::reject_running_up_restart_inputs(&inst, &opts)
             .expect_err("expected restart-only rejection");
-        assert!(format!("{err}").contains("--post-start"));
+        assert!(format!("{err}").contains("--no-github"));
     }
 
     #[test]
@@ -3863,6 +3870,10 @@ mod tests {
         let mut no_agents = up_opts_for_tests(None);
         no_agents.runtime.no_agents = true;
         assert!(super::up_has_restart_only_inputs(&no_agents));
+
+        let mut no_github = up_opts_for_tests(None);
+        no_github.runtime.no_github = true;
+        assert!(super::up_has_restart_only_inputs(&no_github));
 
         let mut ports = up_opts_for_tests(None);
         ports.runtime.forward_ports = vec![super::config::PortForward::parse("3000").unwrap()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,9 @@ enum Commands {
         /// Skip injecting Claude Code and Codex credentials/config into the VM
         #[arg(long, alias = "no-claude")]
         no_agents: bool,
+        /// Use github = "off" for this invocation and skip the GitHub PAT prompt
+        #[arg(long)]
+        no_github: bool,
         /// Named image to use when creating a new instance (default: "default")
         #[arg(
             long,
@@ -289,6 +292,9 @@ enum Commands {
         /// Skip injecting Claude Code and Codex credentials/config into the VM
         #[arg(long, alias = "no-claude")]
         no_agents: bool,
+        /// Use github = "off" for this invocation and skip the GitHub PAT prompt
+        #[arg(long)]
+        no_github: bool,
         /// Forward a guest port to the host (`GUEST[:HOST]`, repeatable).
         /// `--forward-port 3000` forwards guest 3000 to host 3000;
         /// `--forward-port 3000:3001` forwards guest 3000 to host 3001.
@@ -885,6 +891,26 @@ enum DevcontainerCheckStage {
     Both,
 }
 
+impl Commands {
+    fn apply_github_override(&self, cfg: &mut config::CoopConfig) {
+        if matches!(
+            self,
+            Self::Up {
+                no_github: true,
+                ..
+            } | Self::Start {
+                no_github: true,
+                ..
+            }
+        ) {
+            cfg.github = Some(config::GitHubAuth::Off);
+            // Off alone is eligible for the PAT wizard, which can replace
+            // cfg.github after writing a new credential to the config file.
+            cfg.setup.prompt_for_pat = false;
+        }
+    }
+}
+
 fn init_tracing(verbosity: u8) {
     let filter = match verbosity {
         0 => "coop=info",
@@ -1007,6 +1033,7 @@ pub fn run() -> Result<()> {
     }
 
     let mut cfg = config::CoopConfig::load(&cli.config)?;
+    cli.command.apply_github_override(&mut cfg);
     update::maybe_print_notify(&cfg.updates);
     update::maybe_run_background_check(&cfg.updates);
     let be: backend::PlatformBackend = backend::PlatformBackend::new();
@@ -1028,6 +1055,7 @@ pub fn run() -> Result<()> {
             mem,
             disk,
             no_agents,
+            no_github,
             image,
             profile,
             exclude_git,
@@ -1071,6 +1099,7 @@ pub fn run() -> Result<()> {
                 profile_target,
                 runtime: UpRuntimeOpts {
                     no_agents,
+                    no_github,
                     exclude_git,
                     no_prompt,
                     forward_ports: forward_port,
@@ -1184,6 +1213,7 @@ pub fn run() -> Result<()> {
             name,
             workspace,
             no_agents,
+            no_github: _,
             no_prompt,
             post_start,
             guest_env,
@@ -1512,6 +1542,85 @@ mod tests {
         match Cli::try_parse_from(std::iter::once("coop").chain(args.iter().copied())) {
             Err(e) => e,
             Ok(_) => panic!("expected parse failure"),
+        }
+    }
+
+    #[test]
+    fn no_github_overrides_each_mode_without_changing_other_settings() {
+        use crate::config::{CoopConfig, GitHubAuth};
+        use crate::pat_prompt::{Decision, PromptContext};
+
+        let repo = crate::github_repo::RepoSlug::new("owner/repo").unwrap();
+        for command in ["up", "start"] {
+            for github in [
+                "",
+                "github = \"off\"",
+                "github = \"auto\"",
+                "github = \"env\"",
+                "[github]\nmode = \"pat\"\n[github.pat.\"owner/repo\"]\ntoken = \"cmd:exit 42\"",
+            ] {
+                let mut cfg: CoopConfig = toml::from_str(github).unwrap();
+                cfg.claude.api_key =
+                    Some(crate::config::Secret::new("test-claude-key".to_string()));
+                cfg.codex.api_key = Some(crate::config::Secret::new("test-codex-key".to_string()));
+                cfg.setup.prompt_for_pat = true;
+                let original = serde_json::to_value(&cfg).unwrap();
+
+                parse(&[command]).command.apply_github_override(&mut cfg);
+                assert_eq!(serde_json::to_value(&cfg).unwrap(), original);
+
+                let cli = parse(&[command, "--no-github"]);
+                match &cli.command {
+                    crate::Commands::Up { no_agents, .. }
+                    | crate::Commands::Start { no_agents, .. } => assert!(!no_agents),
+                    _ => panic!("expected a boot command"),
+                }
+                cli.command.apply_github_override(&mut cfg);
+                assert!(matches!(cfg.github, Some(GitHubAuth::Off)));
+                assert_eq!(
+                    Decision::resolve(
+                        &cfg,
+                        Some(&repo),
+                        PromptContext {
+                            is_tty: true,
+                            is_ci: false,
+                            no_prompt_flag: false,
+                        },
+                    ),
+                    Decision::Skip,
+                );
+                // The failing PAT command must never be evaluated. Model
+                // credentials still reach the same forwarding builder.
+                let env = crate::backend::prepare_env_forwarding(&cfg, Some(&repo), false, false)
+                    .unwrap();
+                assert!(!env.contains("GITHUB_TOKEN"));
+                assert!(env.contains("ANTHROPIC_API_KEY"));
+                assert!(env.contains("OPENAI_API_KEY"));
+
+                let mut expected = original;
+                expected["github"] = serde_json::to_value(GitHubAuth::Off).unwrap();
+                expected["setup"]["prompt_for_pat"] = false.into();
+                assert_eq!(serde_json::to_value(&cfg).unwrap(), expected);
+            }
+        }
+    }
+
+    #[test]
+    fn no_github_preserves_pat_forwarding_without_the_flag() {
+        let mut cfg: crate::config::CoopConfig = toml::from_str(
+            r#"[github]
+mode = "pat"
+[github.pat."owner/repo"]
+token = "test-pat"
+"#,
+        )
+        .unwrap();
+        let repo = crate::github_repo::RepoSlug::new("owner/repo").unwrap();
+        for command in ["up", "start", "list"] {
+            parse(&[command]).command.apply_github_override(&mut cfg);
+            let env =
+                crate::backend::prepare_env_forwarding(&cfg, Some(&repo), false, false).unwrap();
+            assert!(env.contains("GITHUB_TOKEN"));
         }
     }
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1816,6 +1816,117 @@ CFGEOF
     env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" destroy "$pat_instance" 2>/dev/null || true
 }
 
+# Capture the boot session in post_start: a later `exec printenv` resolves
+# credentials again and would not test the invocation-only boot override.
+test_no_github() {
+    echo ""
+    echo "=== Phase: --no-github invocation override ==="
+
+    local inst_name="${INSTANCE}-no-gh"
+    local cfg_file="$tmpdir/no-github.toml"
+    local ws_dir="$tmpdir/no-github-workspace"
+    local observe_cfg="$tmpdir/no-github-observe.toml"
+    printf 'github = "off"\n' > "$observe_cfg"
+    mkdir -p "$ws_dir"
+    if ! (cd "$ws_dir" && git init --quiet &&
+        git remote add origin https://github.com/trailofbits/coop.git); then
+        fail "no-github: create workspace with matching PAT origin"
+        return
+    fi
+
+    ng() {
+        local rc=0
+        HARNESS_OUT=$(env -u CLAUDE_CODE_OAUTH_TOKEN \
+            GITHUB_TOKEN=coop-test-github ANTHROPIC_API_KEY=coop-test-claude \
+            OPENAI_API_KEY=coop-test-codex \
+            "$BINARY" --config "$cfg_file" "$@" 2>"$tmpdir/stderr") || rc=$?
+        HARNESS_ERR=$(cat "$tmpdir/stderr")
+        return "$rc"
+    }
+
+    STARTED_INSTANCES+=("$inst_name")
+    local stage expected probe
+    local boot_args=()
+    for stage in fresh-up plain-start flagged-start pat-up; do
+        cat > "$cfg_file" <<'CFGEOF'
+github = "env"
+[claude]
+config_dir = false
+[codex]
+config_dir = false
+CFGEOF
+        expected=absent
+        case "$stage" in
+            fresh-up)
+                boot_args=(up "$ws_dir" --name "$inst_name" --no-devcontainer --no-github)
+                ;;
+            plain-start)
+                boot_args=(start "$inst_name")
+                expected=coop-test-github
+                ;;
+            flagged-start)
+                boot_args=(start "$inst_name" --no-github)
+                ;;
+            pat-up)
+                cat > "$cfg_file" <<'CFGEOF'
+[github]
+mode = "pat"
+[github.pat."trailofbits/coop"]
+token = "cmd:exit 42"
+[claude]
+config_dir = false
+[codex]
+config_dir = false
+CFGEOF
+                boot_args=(up "$ws_dir" --no-github)
+                ;;
+        esac
+        cp "$cfg_file" "$cfg_file.before"
+        # Each boot writes its own stage name, so a stale probe cannot pass.
+        local hook="umask 077; printf '%s\\n' '$stage'"
+        hook+=' "${GITHUB_TOKEN-absent}" "$ANTHROPIC_API_KEY" "$OPENAI_API_KEY" > ~/.coop-no-github-probe'
+        if ! ng "${boot_args[@]}" --post-start "$hook"; then
+            fail "no-github: $stage boots" "$HARNESS_ERR"
+            break
+        fi
+        if HARNESS_OUT=$(env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY -u OPENAI_API_KEY \
+            -u CLAUDE_CODE_OAUTH_TOKEN "$BINARY" --config "$observe_cfg" \
+            exec "$inst_name" -- cat .coop-no-github-probe 2>"$tmpdir/stderr"); then
+            probe=$(printf '%s\n' "$stage" "$expected" coop-test-claude coop-test-codex)
+            if [[ "$HARNESS_OUT" == "$probe" ]]; then
+                pass "no-github: $stage captures expected GitHub and model credentials"
+            else
+                fail "no-github: $stage captures expected GitHub and model credentials"
+            fi
+        else
+            fail "no-github: $stage reads boot-session probe" "$(cat "$tmpdir/stderr")"
+        fi
+        if cmp -s "$cfg_file" "$cfg_file.before"; then
+            pass "no-github: $stage leaves config unchanged"
+        else
+            fail "no-github: $stage leaves config unchanged"
+        fi
+        if [[ "$stage" == fresh-up ]]; then
+            if ng up "$ws_dir" --no-github; then
+                fail "no-github: running up rejects the override"
+            elif [[ "$HARNESS_ERR" == *"already running"* && "$HARNESS_ERR" == *"--no-github"* ]]; then
+                pass "no-github: running up rejects the override"
+            else
+                fail "no-github: running up rejects the override" "$HARNESS_ERR"
+            fi
+        fi
+        if ! ng stop "$inst_name"; then
+            fail "no-github: $stage stops" "$HARNESS_ERR"
+            break
+        fi
+    done
+    if ng destroy "$inst_name"; then
+        untrack_instance "$inst_name"
+    else
+        fail "no-github: destroy test instance" "$HARNESS_ERR"
+    fi
+}
+
 test_term_handling() {
     echo ""
     echo "=== Phase: TERM handling ==="
@@ -6560,6 +6671,7 @@ main() {
 
         # github = "pat" mode + per-repo token forwarding (uses a stub image)
         test_github_pat_forwarding
+        test_no_github
 
         # Config sources: CLAUDE.md + rules copy
         test_config_dir


### PR DESCRIPTION
Scripts can disable model credential injection per invocation, but disabling configured GitHub token forwarding requires a separate config file. Add `--no-github` to `coop up` and `coop start` to force `github = "off"` for that invocation and suppress the PAT setup prompt. Other configuration and model credentials remain in effect; the config file is not changed. `up` rejects the flag when the project VM is already running.

The flag has the same scope as `github = "off"`: explicit environment entries, one-shot clone authentication, existing guest credentials, and later invocations retain their existing behavior. Document these limits and add a dedicated `--full` integration phase covering fresh up, restart, normal forwarding without the flag, PAT retrieval suppression, and config preservation.

Closes #428.

Validation:

- Workspace build, Clippy with zero warnings, and tests passed (1,217 tests).
- Rust/TOML formatting, cargo-deny, pre-commit hooks, shell syntax, and diff checks passed.
- Deliberately removing the Off override, prompt suppression, and running-instance guard each failed its regression test.
- Independent review and closeout review completed; all findings fixed.
- Lima and Firecracker VM integration have not been run. The author will run them separately, including the new phase with `./tests/run-integration.sh --full` (or `--remote user@host --full`).
