### PR TITLE
Allow VMs to select existing GitHub PAT entries

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -52,6 +52,8 @@ exclude_globs = [
 # operator/value mutants inside that function, without catching longer names
 # that share a prefix (e.g. \bprobe_user\b leaves probe_user_login alone).
 exclude_re = [
+  # VM status discovers repository state through git; view formatting remains tested.
+  "\\bbuild_vm_status\\b",
   # cfg(kani) proofs (config.rs `mod proofs`): never compiled in a normal
   # build, so every mutation is a silent no-op and always "missed". The
   # proofs are exercised by `cargo kani`, not by mutation testing.

--- a/config.example.toml
+++ b/config.example.toml
@@ -14,6 +14,9 @@
 #
 # Form B — table, required when you want per-repo PAT entries.
 # Run `coop github setup-pat --repo owner/name` to populate it via wizard.
+# Select an existing entry for a VM with:
+#   coop github assign-pat --vm projects --repo owner/name
+# The VM stores only the entry key; it overrides workspace-based selection.
 # Form B `mode = "pat"` is equivalent to form A `github = "pat"`.
 #
 # [github]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,7 @@ coop/
 │   ├── model_state.rs      # per-instance local/remote model routing
 │   ├── secret_store.rs     # pluggable secret backends (keychain/op/secret-tool/file)
 │   ├── github_pat.rs       # `coop github` PAT wizard (setup/rotate/status/forget)
+│   ├── github_assignment.rs # persistent VM selection of an existing PAT entry
 │   ├── github_repo.rs      # RepoSlug + repo-URL parsing
 │   ├── github_submodules.rs# submodule discovery for PAT scoping
 │   ├── pat_prompt.rs       # interactive pre-start PAT prompt

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -94,7 +94,9 @@ The `github` field controls how coop obtains a `GITHUB_TOKEN` for the guest. Thi
 | `"auto"` | Check the `GITHUB_TOKEN` env var first. If unset, run `gh auth token` on the host to extract a token from the GitHub CLI. |
 | `"env"`  | Require `GITHUB_TOKEN` in the host environment. Warns if missing. |
 | `"off"`  | Skip GitHub token forwarding entirely. This is the default when `github` is unset. |
-| `"pat"`  | Use a per-repo fine-grained PAT from `[github.pat]`. Scope is server-enforced to one repo. Run `coop github setup-pat --repo owner/name` to add an entry; see [configuration.md](configuration.md#fine-grained-pat-github--pat) for the full reference. |
+| `"pat"`  | Use a per-repo fine-grained PAT from `[github.pat]`. GitHub enforces the permissions and repositories selected for that token. Run `coop github setup-pat --repo owner/name` to add an entry; see [configuration.md](configuration.md#fine-grained-pat-github--pat) for the full reference. |
+
+A [VM PAT assignment](configuration.md#assign-an-existing-pat-to-a-vm) selects an existing entry independently of workspace detection.
 
 When a token is available, coop runs `gh auth setup-git` in the guest during bootstrap. This configures the git credential helper so `git clone` works against private repositories without further setup.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -966,9 +966,11 @@ coop github <subcommand>
 
 | Subcommand | Effect |
 |------------|--------|
+| `assign-pat --vm NAME --repo owner/name` | Persist selection of an existing stored entry for this VM; `--repo` is the entry key, not its full permission scope. Works while stopped. |
+| `unassign-pat --vm NAME` | Remove only the VM association; leave the shared credential intact. |
 | `setup-pat [--repo owner/name]` | Run the wizard end-to-end: open the GitHub PAT-creation form, validate the pasted token against `api.github.com`, store it in a chosen secret manager (Keychain / Secret Service / 1Password / file), and write a `[github.pat."owner/repo"]` entry. The repo is auto-detected from `git remote get-url origin` when `--repo` is omitted. |
 | `rotate-pat --repo owner/name` | Re-run the wizard for an existing entry (FGPATs expire — max 1 year). |
-| `status [--probe] [--json]` | List configured entries and their storage backend. By default the cmd-invocation is *not* resolved (so Keychain / 1Password prompts don't fire). Pass `--probe` to also resolve each entry and report whether the secret store still serves it. Pass `--json` for machine-readable output. |
+| `status [--vm NAME] [--probe] [--json]` | List configured entries and their storage backend. By default the cmd-invocation is *not* resolved (so Keychain / 1Password prompts don't fire). Pass `--probe` to also resolve each entry and report whether the secret store still serves it. Pass `--json` for machine-readable output. |
 | `forget-pat --repo owner/name` | Delete the stored secret from its backend and drop the `[github.pat."owner/repo"]` entry. Does **not** add a skip marker — use the auto-prompt's `never` answer if you want coop to stop asking about this repo. Does **not** revoke the PAT on GitHub. |
 
 ```
@@ -985,6 +987,14 @@ coop github forget-pat --repo trailofbits/coop
 `storage` a stable token (`macos_keychain`/`linux_secret_service`/`one_password`/
 `file`, or `null` when unparseable) and `probe` (`ok`/`unexpected_format`/
 `resolve_failed`, or `null` unless `--probe`). The token value is never emitted.
+
+With `--vm NAME`, status also includes `vm: { "name", "assigned_entry", "source" }`.
+`assigned_entry` is a stored entry key or `null`; `source` is `assignment`,
+`missing_assignment`, `repository`, `auto`, `env`, `off`, or `no_matching_entry`.
+The configured entry list remains present. `missing_assignment` means restore
+the entry or unassign it; malformed state produces an error. `--probe` tests
+retrieval, not GitHub permissions. See [VM PAT assignments](configuration.md#assign-an-existing-pat-to-a-vm)
+for precedence, opt-out, conflicts, rotation, and bootstrap timing.
 
 ### `proxy`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ The `github` field determines how coop obtains a `GITHUB_TOKEN` for the guest:
 | `"auto"` | Checks `$GITHUB_TOKEN` first. Falls back to `gh auth token` if unset. |
 | `"env"` | Reads `$GITHUB_TOKEN` from the environment only. Warns if unset. |
 | `"off"` | No GitHub token forwarding. |
-| `"pat"` | Uses a per-repo fine-grained PAT recorded under `[github.pat]`. Scope is **server-enforced** to one repository. |
+| `"pat"` | Uses a per-repo fine-grained PAT recorded under `[github.pat]`. GitHub enforces the permissions and repositories selected for that token. |
 
 When a token is present, coop runs `gh auth setup-git` inside the guest to wire up git credential helpers.
 
@@ -105,10 +105,53 @@ Other subcommands:
 
 | Command | Effect |
 |---------|--------|
-| `coop github status` | List configured entries, storage backend, and whether each token still resolves. Never prints token material. |
+| `coop github status` | List configured entries and storage backend; add `--probe` to test retrieval. Never prints token material. |
 | `coop github rotate-pat --repo X/Y` | Re-run the wizard against an existing entry (PATs expire — max 1 year). |
 | `coop github forget-pat --repo X/Y` | Remove the stored secret and the `[github.pat."X/Y"]` entry. Does **not** add a skip marker; the token may still be live on GitHub. |
 | `coop validate --probe` | Resolves each entry and probes `GET /user` against api.github.com. May trigger Keychain authorization or a 1Password Touch-ID prompt the first time per session. |
+
+#### Assign an existing PAT to a VM
+
+```sh
+coop github assign-pat --vm projects --repo myorg/frontend
+coop github status --vm projects
+coop github unassign-pat --vm projects
+```
+
+`--repo` selects the **stored entry key**, not the workspace repository or the
+PAT's permission scope. For example, a token stored under `myorg/frontend`
+may also authorize `myorg/backend`; assigning it to a VM whose workspace is a
+plain parent directory works without detecting either child repository.
+Different VMs can select different entries for the same workspace.
+
+Assignment is explicit opt-in and takes precedence over workspace detection.
+Only the validated key is saved in owner-only, atomically written
+`<instance>/github_pat.json`; the shared secret is resolved again for each
+subsequent session or clone. Assignment works while the VM is stopped.
+Restart/bootstrap, shell, exec, agent sessions, and restore/reprovision use it.
+Existing shells, agents, and background processes are not updated. Restart
+without `--no-agents` to establish the git credential helper on a guest that
+has never had GitHub authentication bootstrapped.
+
+`up --no-github` and `start --no-github` suppress assignment use and the PAT
+setup prompt for that invocation, without removing the saved association.
+The existing separate clone fallback remains: under opt-out, a GitHub HTTPS
+clone may still use host credentials. Without an assignment, normal auth-mode
+and repository selection are unchanged.
+
+Missing entries, unreadable or malformed assignment state, and failed secret
+retrieval fail instead of falling back. Restore a forgotten entry with
+`setup-pat`, or remove the association with `unassign-pat`. Rotation affects
+subsequent resolutions. Unassigning restores normal selection and neither
+deletes the shared secret nor revokes it on GitHub. Destroying the VM removes
+its association with the VM state, leaving the shared PAT intact.
+
+An active assignment rejects managed `GITHUB_TOKEN` **and** `GH_TOKEN` entries
+in `[guest_env]`, either agent's `env_forward`, or persisted `--env` /
+`containerEnv` overrides. Remove these conflicting entries, including saved
+keys in `<instance>/guest_env.json`, or unassign the PAT. This controls coop's
+delivery; the guest can still change its own environment. The VM receives the
+token's actual authority over every repository it covers.
 
 #### Auto-prompt at VM startup
 

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -88,7 +88,11 @@ user `env_forward` entries, and the VM SSH key. The invariants:
   `ps`/`/proc`. Known exceptions are the macOS `security` and 1Password `op`
   backends, which take the secret on argv because their CLIs offer no stdin
   path; this is documented at the call sites and limited to the store step.
-- **`GITHUB_TOKEN` defaults to Off.** It is only forwarded with an explicit
+- **`GITHUB_TOKEN` defaults to Off.** A saved VM PAT assignment is also explicit
+  opt-in; it stores only a validated existing entry key. Invocation-level
+  `--no-github` suppresses the assignment before loading it. Active assignments
+  reject both managed `GITHUB_TOKEN` and `GH_TOKEN` overrides and fail closed
+  on missing references or failed retrieval. It is only forwarded with an explicit
   `github = auto|env|pat` opt-in (`backend.rs:resolve_github_token`). When
   forwarded, `bootstrap_agents` runs `gh auth setup-git`, which makes the token
   **persistent guest state** (a git credential helper any guest process can

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1985,7 +1985,7 @@ fn resolve_github_token(
 
 /// Look up a `[github.pat."repo"]` entry and resolve its `token` via
 /// the `cmd:` indirection.
-fn resolve_pat_token(
+pub(crate) fn resolve_pat_token(
     strategy: Option<&GitHubAuth>,
     repo: &crate::github_repo::RepoSlug,
 ) -> Result<String> {
@@ -3076,8 +3076,10 @@ fn register_mcp_servers(
 ///
 /// For GitHub HTTPS URLs, resolves a token on the host and forwards it to
 /// git in the guest via stdin and a one-shot credential helper. Token
-/// resolution honours the configured GitHub strategy:
+/// resolution honours VM assignment before the configured GitHub strategy:
 ///
+/// - An active VM assignment selects its stored entry independently of the
+///   clone URL. Missing entries and retrieval failures return an error.
 /// - `github = "pat"` with a matching `[github.pat."owner/repo"]` entry
 ///   uses the configured PAT. This is the user's explicit per-repo intent,
 ///   so it takes precedence over the host-side fallback. If the entry's
@@ -3095,12 +3097,13 @@ pub fn clone_git_repo(
     target: &SshTarget,
     github: Option<&GitHubAuth>,
     repo_url: &str,
+    assigned: Option<&crate::github_repo::RepoSlug>,
 ) -> Result<()> {
     tracing::info!("Cloning {repo_url} into guest /workspace");
 
     let is_github = is_github_https_url(repo_url);
     let token = if is_github {
-        resolve_clone_token(github, repo_url)?
+        resolve_clone_token(github, repo_url, assigned)?
     } else {
         None
     };
@@ -3133,7 +3136,7 @@ pub fn clone_git_repo(
 /// If `strategy` is `Pat` mode and a `[github.pat."owner/repo"]` entry
 /// exists for `repo_url`, return the matching slug. Otherwise `None`.
 ///
-/// This is the sole "should the clone path use a configured PAT?" check.
+/// Without a VM assignment, this selects a configured PAT for cloning.
 /// Returning `None` directs [`resolve_clone_token`] to fall through to
 /// [`host_github_token`] — preserving the pre-PAT behaviour for `Auto`,
 /// `Env`, `Off`, and `Pat`-without-a-matching-entry.
@@ -3151,11 +3154,19 @@ fn clone_pat_slug(
 
 /// Resolve the token to use for `git clone` of `repo_url`.
 ///
-/// PAT mode with a matching entry wins — the user's per-repo intent
+/// An active VM assignment wins and fails closed on lookup/retrieval errors.
+/// Otherwise PAT mode with a matching entry wins — the user's per-repo intent
 /// overrides the opportunistic host lookup. Every other configuration
 /// (including `Pat` mode without a matching entry) falls back to
 /// [`host_github_token`].
-fn resolve_clone_token(strategy: Option<&GitHubAuth>, repo_url: &str) -> Result<Option<String>> {
+fn resolve_clone_token(
+    strategy: Option<&GitHubAuth>,
+    repo_url: &str,
+    assigned: Option<&crate::github_repo::RepoSlug>,
+) -> Result<Option<String>> {
+    if let Some(repo) = assigned {
+        return resolve_pat_token(strategy, repo).map(Some);
+    }
     if let Some(slug) = clone_pat_slug(strategy, repo_url) {
         return resolve_pat_token(strategy, &slug).map(Some);
     }
@@ -4791,8 +4802,32 @@ url = "https://example.com/m"
         // exists — the test for "PAT bypassed" is that it survives
         // independently of the host's environment.
         let auth = pat_auth_with(&[("owner/repo", "github_pat_literal")]);
-        let token = resolve_clone_token(Some(&auth), "https://github.com/owner/repo.git").unwrap();
+        let token =
+            resolve_clone_token(Some(&auth), "https://github.com/owner/repo.git", None).unwrap();
         assert_eq!(token.as_deref(), Some("github_pat_literal"));
+    }
+
+    #[test]
+    fn assigned_clone_selection_never_falls_back() {
+        let assigned = crate::github_repo::RepoSlug::new("owner/assigned").unwrap();
+        let url = "https://github.com/owner/repo.git";
+        let auth = pat_auth_with(&[
+            ("owner/repo", "github_pat_default"),
+            ("owner/assigned", "github_pat_selected"),
+        ]);
+        assert_eq!(
+            resolve_clone_token(Some(&auth), url, Some(&assigned))
+                .unwrap()
+                .as_deref(),
+            Some("github_pat_selected")
+        );
+        let missing = pat_auth_with(&[("owner/repo", "github_pat_default")]);
+        assert!(resolve_clone_token(Some(&missing), url, Some(&assigned)).is_err());
+        let failed = pat_auth_with(&[
+            ("owner/repo", "github_pat_default"),
+            ("owner/assigned", "cmd:exit 42"),
+        ]);
+        assert!(resolve_clone_token(Some(&failed), url, Some(&assigned)).is_err());
     }
 
     // ── EnvForward Debug redaction ──────────────────────────

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -23,7 +23,21 @@ pub(crate) fn cmd_github(
             };
             github_pat::run_rotate_pat(cfg, &opts)
         }
-        GithubAction::Status { probe, json } => github_pat::run_status(cfg, probe, json),
+        GithubAction::AssignPat { vm, repo } => {
+            let inst = cfg.resolve_instance(Some(&vm))?;
+            crate::github_assignment::Assignment { repo }.save(cfg, &inst)
+        }
+        GithubAction::UnassignPat { vm } => {
+            let inst = cfg.resolve_instance(Some(&vm))?;
+            crate::github_assignment::Assignment::remove(&inst)
+        }
+        GithubAction::Status { probe, json, vm } => {
+            let inst = vm
+                .as_ref()
+                .map(|name| cfg.resolve_instance(Some(name)))
+                .transpose()?;
+            github_pat::run_status(cfg, probe, json, inst.as_ref())
+        }
         GithubAction::ForgetPat { repo } => github_pat::run_forget_pat(cfg, &repo, config_path),
     }
 }

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -1090,7 +1090,9 @@ fn restart_instance(
     // Pre-flight: same auto-prompt as a fresh start. Uses the instance's
     // recorded workspace-state to recover the repo slug.
     let repo = backend::detect_instance_repo(inst);
-    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_ref(), opts.no_prompt)?;
+    if crate::github_assignment::active(cfg, inst)?.is_none() {
+        pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_ref(), opts.no_prompt)?;
+    }
 
     // Re-apply the forward set the instance was last started with.
     // CLI `--forward-port` on a restart appends/overrides; otherwise the
@@ -1116,6 +1118,7 @@ fn restart_instance(
         cfg.guest_env.insert(key.clone(), value.clone());
     }
 
+    crate::github_assignment::active(cfg, inst)?;
     be.start_existing(cfg, inst)?;
 
     signal::check_shutdown()?;
@@ -1205,7 +1208,9 @@ fn start_instance(
     // can fire before any VM cost is incurred, and so pat-mode token
     // forwarding works at bootstrap time.
     let repo = resolve_start_repo(opts)?;
-    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_ref(), opts.no_prompt)?;
+    if crate::github_assignment::active(cfg, inst)?.is_none() {
+        pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_ref(), opts.no_prompt)?;
+    }
 
     // Forwards are checked up-front so an in-use host port fails fast,
     // before any VM cost is incurred. The actual `-L` tunnels are
@@ -1322,7 +1327,13 @@ fn provision_first_boot(
         state.save(inst)?;
         Some(state)
     } else if let Some(repo_url) = opts.git_repo {
-        backend::clone_git_repo(&target, cfg.github.as_ref(), repo_url)?;
+        let assignment = crate::github_assignment::active(cfg, inst)?;
+        backend::clone_git_repo(
+            &target,
+            cfg.github.as_ref(),
+            repo_url,
+            assignment.as_ref().map(|a| &a.repo),
+        )?;
 
         let state = workspace::WorkspaceState {
             guest_path: workspace::default_workspace_path(),
@@ -1597,6 +1608,9 @@ fn bootstrap_and_post_start(
         tracing::warn!("{}", NO_AGENTS_CHATGPT_WARNING);
     }
     if opts.no_agents && post_start.is_none() {
+        if let Some(assignment) = crate::github_assignment::active(cfg, inst)? {
+            backend::resolve_pat_token(cfg.github.as_ref(), &assignment.repo)?;
+        }
         tracing::info!("Skipping guest agent bootstrap (--no-agents)");
         return Ok(());
     }
@@ -1699,6 +1713,11 @@ pub(crate) fn prepare_session_from_target(
         tracing::warn!("{}", backend::codex_chatgpt_proxy_conflict_message());
     }
 
+    let assignment = inst
+        .map(|inst| crate::github_assignment::active(cfg, inst))
+        .transpose()?
+        .flatten();
+    let repo = assignment.as_ref().map(|a| &a.repo).or(repo);
     let mut env = backend::prepare_env_forwarding(cfg, repo, proxy_anthropic, suppress_openai_key)?;
     if let Some(inst) = inst {
         if let Some(state) = guest_env_state::GuestEnvState::try_load(inst)? {
@@ -2187,7 +2206,9 @@ fn reprovision_instance(
     // reason `start_instance` fires it before any VM cost: an interactive
     // wizard should not appear with the guest already wiped.
     let repo = backend::detect_instance_repo(&inst);
-    pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_ref(), opts.no_prompt)?;
+    if crate::github_assignment::active(cfg, &inst)?.is_none() {
+        pat_prompt::maybe_prompt(cfg, opts.config_path, repo.as_ref(), opts.no_prompt)?;
+    }
 
     // Installed before the stop, so a Ctrl-C during it is handled too.
     let _guard = signal::install_handlers();

--- a/src/config.rs
+++ b/src/config.rs
@@ -685,6 +685,10 @@ impl<'de> Deserialize<'de> for ConfigPath {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CoopConfig {
+    /// Invocation-only opt-out; never persisted.
+    #[serde(skip)]
+    pub github_disabled: bool,
+
     /// Directory for storing VM artifacts (images, sockets, logs)
     #[serde(default = "default_data_dir")]
     pub data_dir: ConfigPath,
@@ -2360,6 +2364,7 @@ impl Default for CoopConfig {
             ssh_port: default_ssh_port(),
             firecracker_bin: default_firecracker_bin(),
             github: None,
+            github_disabled: false,
             setup: SetupConfig::default(),
             claude: ClaudeConfig::default(),
             codex: CodexConfig::default(),

--- a/src/github_assignment.rs
+++ b/src/github_assignment.rs
@@ -292,6 +292,22 @@ mod tests {
         assert!(active(&cfg, &inst).is_err());
         Assignment::remove(&inst).unwrap();
         assert!(Assignment::load(&inst).unwrap().is_none());
+
+        let target = inst.dir.join("valid-assignment.json");
+        std::fs::write(&target, r#"{"repo":"org/assigned"}"#).unwrap();
+        std::os::unix::fs::symlink(&target, inst.dir.join("github_pat.json")).unwrap();
+        assert!(Assignment::load(&inst).is_err());
+        Assignment::remove(&inst).unwrap();
+        assert!(
+            target.is_file(),
+            "removal must unlink the association, not its target"
+        );
+
+        let regular_file = inst.dir.join("not-a-directory");
+        std::fs::write(&regular_file, "file").unwrap();
+        let mut invalid_parent = inst.clone();
+        invalid_parent.dir = regular_file.join("child");
+        assert!(Assignment::load(&invalid_parent).is_err());
     }
 
     #[test]

--- a/src/github_assignment.rs
+++ b/src/github_assignment.rs
@@ -1,0 +1,325 @@
+//! A VM stores an entry key, never a resolved PAT or a duplicate secret.
+use std::fs;
+use std::io::ErrorKind;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::config::{CoopConfig, Instance};
+use crate::github_repo::RepoSlug;
+use crate::guest_env_state::GuestEnvState;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Assignment {
+    pub repo: RepoSlug,
+}
+
+impl Assignment {
+    pub fn load(inst: &Instance) -> Result<Option<Self>> {
+        let path = inst.dir.join("github_pat.json");
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => bail!(
+                "github_pat.json must be a regular file; use coop github unassign-pat --vm <name> to remove it"
+            ),
+            Err(e) if e.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e).context("Cannot inspect github_pat.json"),
+        }
+        let bytes = fs::read(path).context("Cannot read github_pat.json")?;
+        serde_json::from_slice::<Self>(&bytes).map(Some).context(
+            "Invalid github_pat.json; use coop github unassign-pat --vm <name> to remove it",
+        )
+    }
+
+    pub fn save(&self, cfg: &CoopConfig, inst: &Instance) -> Result<()> {
+        self.validate(cfg)?;
+        crate::fs_util::atomic_write_with_mode(
+            &inst.dir.join("github_pat.json"),
+            &serde_json::to_string(self)?,
+            0o600,
+        )
+    }
+
+    pub fn remove(inst: &Instance) -> Result<()> {
+        match fs::remove_file(inst.dir.join("github_pat.json")) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).context("Cannot remove github_pat.json"),
+        }
+    }
+
+    pub fn validate(&self, cfg: &CoopConfig) -> Result<()> {
+        if !self.available(cfg) {
+            bail!(
+                "Assigned PAT entry '{}' is unavailable; restore it with coop github setup-pat --repo {}, or use coop github unassign-pat --vm <name>",
+                self.repo,
+                self.repo
+            );
+        }
+        Ok(())
+    }
+
+    pub fn available(&self, cfg: &CoopConfig) -> bool {
+        cfg.github
+            .as_ref()
+            .and_then(|auth| auth.pat_entry(&self.repo))
+            .is_some()
+    }
+}
+
+/// Opt-out precedes even reading the sidecar. A bad reference never falls back.
+pub fn active(cfg: &CoopConfig, inst: &Instance) -> Result<Option<Assignment>> {
+    if cfg.github_disabled {
+        return Ok(None);
+    }
+    let assignment = Assignment::load(inst)?;
+    if let Some(assignment) = &assignment {
+        assignment.validate(cfg)?;
+        reject_overrides(cfg.guest_env.keys().map(AsRef::as_ref))?;
+        reject_overrides(
+            cfg.claude
+                .env_forward
+                .iter()
+                .chain(&cfg.codex.env_forward)
+                .map(AsRef::as_ref),
+        )?;
+        if let Some(state) = GuestEnvState::try_load(inst)? {
+            reject_overrides(state.entries.keys().map(AsRef::as_ref))?;
+        }
+    }
+    Ok(assignment)
+}
+
+pub fn reject_overrides<'a>(names: impl IntoIterator<Item = &'a str>) -> Result<()> {
+    for name in names {
+        if matches!(name, "GITHUB_TOKEN" | "GH_TOKEN") {
+            bail!(
+                "VM PAT assignment conflicts with managed {name}; remove it from guest_env, env_forward, and persisted guest_env.json (including --env/containerEnv), or unassign the PAT"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, clippy::panic, reason = "tests")]
+mod tests {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    use crate::backend::{Hostname, SshTarget, SshUser};
+    use crate::config::{ConfigPath, CoopConfig, Instance, InstanceName};
+    use crate::github_assignment::{Assignment, active, reject_overrides};
+    use crate::github_repo::RepoSlug;
+    use crate::guest_env_state::{EnvVarName, GuestEnvState};
+
+    fn fixture() -> (tempfile::TempDir, CoopConfig, Instance) {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg: CoopConfig = toml::from_str(
+            r#"
+            [github]
+            mode = "pat"
+            [github.pat."org/assigned"]
+            token = "github_pat_assigned"
+            [github.pat."org/workspace"]
+            token = "github_pat_default"
+        "#,
+        )
+        .unwrap();
+        cfg.data_dir = ConfigPath::new(tmp.path());
+        let inst = cfg
+            .allocate_instance(
+                Some(&InstanceName::new("projects").unwrap()),
+                &crate::config::ImageName::new("default").unwrap(),
+                None,
+            )
+            .unwrap();
+        (tmp, cfg, inst)
+    }
+
+    fn assign(cfg: &CoopConfig, inst: &Instance) {
+        Assignment {
+            repo: RepoSlug::new("org/assigned").unwrap(),
+        }
+        .save(cfg, inst)
+        .unwrap();
+    }
+
+    fn session_token(
+        cfg: &CoopConfig,
+        inst: &Instance,
+        repo: Option<&RepoSlug>,
+    ) -> anyhow::Result<Option<String>> {
+        let target = SshTarget {
+            host: Hostname::new("127.0.0.1").unwrap(),
+            port: std::num::NonZeroU16::new(22).unwrap(),
+            user: SshUser::new("ubuntu").unwrap(),
+            key_path: inst.dir.join("unused"),
+        };
+        let session = crate::commands::prepare_session_from_target(cfg, Some(inst), target, repo)?;
+        Ok(session.env.as_envs().get("GITHUB_TOKEN").cloned())
+    }
+
+    #[test]
+    fn assignment_selection_rotation_unassignment_and_vm_independence() {
+        let (_tmp, mut cfg, inst) = fixture();
+        let repo = RepoSlug::new("org/workspace").unwrap();
+        let other = cfg
+            .allocate_instance(
+                Some(&InstanceName::new("other").unwrap()),
+                &crate::config::ImageName::new("default").unwrap(),
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            session_token(&cfg, &inst, Some(&repo)).unwrap().as_deref(),
+            Some("github_pat_default")
+        );
+        assign(&cfg, &inst);
+        for context in [None, Some(&repo)] {
+            assert_eq!(
+                session_token(&cfg, &inst, context).unwrap().as_deref(),
+                Some("github_pat_assigned")
+            );
+        }
+        assert_eq!(
+            session_token(&cfg, &other, Some(&repo)).unwrap().as_deref(),
+            Some("github_pat_default")
+        );
+        let crate::config::GitHubAuth::Pat(auth) = cfg.github.as_mut().unwrap() else {
+            panic!()
+        };
+        auth.entries
+            .get_mut(&RepoSlug::new("org/assigned").unwrap())
+            .unwrap()
+            .token = crate::config::Secret::new("github_pat_rotated".into());
+        assert_eq!(
+            session_token(&cfg, &inst, None).unwrap().as_deref(),
+            Some("github_pat_rotated")
+        );
+        let saved = std::fs::read_to_string(inst.dir.join("github_pat.json")).unwrap();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&saved).unwrap(),
+            serde_json::json!({"repo": "org/assigned"})
+        );
+        assert_eq!(
+            std::fs::metadata(inst.dir.join("github_pat.json"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        Assignment::remove(&inst).unwrap();
+        Assignment::remove(&inst).unwrap();
+        assert!(Assignment::load(&inst).unwrap().is_none());
+        assert_eq!(
+            session_token(&cfg, &inst, Some(&repo)).unwrap().as_deref(),
+            Some("github_pat_default")
+        );
+        assert!(
+            cfg.github
+                .as_ref()
+                .unwrap()
+                .pat_entry(&RepoSlug::new("org/assigned").unwrap())
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn assignment_missing_failed_and_malformed_fail_closed_except_opt_out() {
+        let (_tmp, mut cfg, inst) = fixture();
+        let bad = Assignment {
+            repo: RepoSlug::new("org/missing").unwrap(),
+        };
+        assert!(bad.save(&cfg, &inst).is_err());
+        assert!(Assignment::load(&inst).unwrap().is_none());
+        assign(&cfg, &inst);
+        let crate::config::GitHubAuth::Pat(auth) = cfg.github.as_mut().unwrap() else {
+            panic!()
+        };
+        auth.entries.remove(&RepoSlug::new("org/assigned").unwrap());
+        assert!(
+            session_token(&cfg, &inst, None)
+                .unwrap_err()
+                .to_string()
+                .contains("unavailable")
+        );
+        cfg.github_disabled = true;
+        cfg.github = Some(crate::config::GitHubAuth::Off);
+        assert!(session_token(&cfg, &inst, None).unwrap().is_none());
+        for state in [
+            "null",
+            "{}",
+            "{",
+            r#"{"repo":"bad"}"#,
+            r#"{"repo":"org/assigned","token":"unexpected"}"#,
+        ] {
+            std::fs::write(inst.dir.join("github_pat.json"), state).unwrap();
+            assert!(active(&cfg, &inst).unwrap().is_none());
+            cfg.github_disabled = false;
+            assert!(active(&cfg, &inst).is_err(), "{state}");
+            cfg.github_disabled = true;
+        }
+        let (_tmp2, mut cfg2, inst2) = fixture();
+        assign(&cfg2, &inst2);
+        let crate::config::GitHubAuth::Pat(auth) = cfg2.github.as_mut().unwrap() else {
+            panic!()
+        };
+        auth.entries
+            .get_mut(&RepoSlug::new("org/assigned").unwrap())
+            .unwrap()
+            .token = crate::config::Secret::new("cmd:exit 42".into());
+        assert!(
+            session_token(
+                &cfg2,
+                &inst2,
+                Some(&RepoSlug::new("org/workspace").unwrap())
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn assignment_state_io_errors_are_not_absence() {
+        let (_tmp, cfg, inst) = fixture();
+        std::fs::create_dir(inst.dir.join("github_pat.json")).unwrap();
+        assert!(Assignment::load(&inst).is_err());
+        assert!(Assignment::remove(&inst).is_err());
+        assert!(active(&cfg, &inst).is_err());
+        std::fs::remove_dir(inst.dir.join("github_pat.json")).unwrap();
+        std::os::unix::fs::symlink("missing-target", inst.dir.join("github_pat.json")).unwrap();
+        assert!(active(&cfg, &inst).is_err());
+        Assignment::remove(&inst).unwrap();
+        assert!(Assignment::load(&inst).unwrap().is_none());
+    }
+
+    #[test]
+    fn assignment_rejects_each_managed_override_source() {
+        for name in ["GITHUB_TOKEN", "GH_TOKEN"] {
+            for source in 0..4 {
+                let (_tmp, mut cfg, inst) = fixture();
+                assign(&cfg, &inst);
+                let key = EnvVarName::new(name).unwrap();
+                match source {
+                    0 => {
+                        cfg.guest_env.insert(key, "not-printed".into());
+                    }
+                    1 => cfg.claude.env_forward.push(key),
+                    2 => cfg.codex.env_forward.push(key),
+                    _ => {
+                        let mut state = GuestEnvState::default();
+                        state.entries.insert(key, "not-printed".into());
+                        state.save(&inst).unwrap();
+                    }
+                }
+                let err = session_token(&cfg, &inst, None).unwrap_err().to_string();
+                assert!(err.contains(name), "{err}");
+                assert!(!err.contains("not-printed"));
+                Assignment::remove(&inst).unwrap();
+                assert!(active(&cfg, &inst).unwrap().is_none());
+            }
+        }
+        reject_overrides(["GH_TOKEN_OTHER", "OTHER_GITHUB_TOKEN", "NORMAL"]).unwrap();
+    }
+}

--- a/src/github_pat.rs
+++ b/src/github_pat.rs
@@ -104,8 +104,14 @@ pub fn run_rotate_pat(cfg: &CoopConfig, opts: &SetupOpts<'_>) -> Result<()> {
 /// printed. When `probe` is true, each `cmd:` invocation is resolved to
 /// confirm the secret store still serves it — this may trigger a
 /// Keychain dialog / `op` Touch-ID prompt per entry, so it is opt-in.
-pub fn run_status(cfg: &CoopConfig, probe: bool, json_out: bool) -> Result<()> {
-    let view = build_status(cfg, probe);
+pub fn run_status(
+    cfg: &CoopConfig,
+    probe: bool,
+    json_out: bool,
+    inst: Option<&crate::config::Instance>,
+) -> Result<()> {
+    let mut view = build_status(cfg, probe);
+    view.vm = inst.map(|inst| build_vm_status(cfg, inst)).transpose()?;
     if json_out {
         return json::render_json(&view);
     }
@@ -180,6 +186,8 @@ impl ProbeStatus {
 /// repo, storage backend, and (opt-in) probe result.
 #[derive(serde::Serialize)]
 pub(crate) struct GithubStatus<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vm: Option<VmPatStatus>,
     pub mode: GithubMode,
     pub entries: Vec<PatEntryView<'a>>,
     pub skip: Vec<&'a RepoSlug>,
@@ -222,6 +230,7 @@ fn build_status(cfg: &CoopConfig, probe: bool) -> GithubStatus<'_> {
         _ => (Vec::new(), Vec::new()),
     };
     GithubStatus {
+        vm: None,
         mode,
         entries,
         skip,
@@ -232,6 +241,22 @@ fn build_status(cfg: &CoopConfig, probe: bool) -> GithubStatus<'_> {
 fn format_status(view: &GithubStatus<'_>) -> String {
     use std::fmt::Write as _;
     let mut s = String::new();
+    if let Some(vm) = &view.vm {
+        let _ = writeln!(
+            s,
+            "VM {}: selection {:?}; assigned entry: {}",
+            vm.name,
+            vm.source,
+            vm.assigned_entry.as_ref().map_or("none", RepoSlug::as_str)
+        );
+        if vm.source == SelectionSource::MissingAssignment {
+            let _ = writeln!(
+                s,
+                "  Assigned entry unavailable: restore it with setup-pat or use unassign-pat --vm {}",
+                vm.name
+            );
+        }
+    }
     if view.mode != GithubMode::Pat {
         let _ = writeln!(s, "github mode: {} (no PAT entries)", view.mode.label());
         return s;
@@ -258,6 +283,66 @@ fn format_status(view: &GithubStatus<'_>) -> String {
         }
     }
     s
+}
+
+#[derive(Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SelectionSource {
+    Assignment,
+    MissingAssignment,
+    Repository,
+    Auto,
+    Env,
+    Off,
+    NoMatchingEntry,
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct VmPatStatus {
+    name: String,
+    assigned_entry: Option<RepoSlug>,
+    source: SelectionSource,
+}
+
+fn build_vm_status(cfg: &CoopConfig, inst: &crate::config::Instance) -> Result<VmPatStatus> {
+    let assignment = crate::github_assignment::Assignment::load(inst)?;
+    let repo = if assignment.is_none() {
+        crate::backend::detect_instance_repo(inst)
+    } else {
+        None
+    };
+    let source = selection_source(cfg, assignment.as_ref(), repo.as_ref());
+    Ok(VmPatStatus {
+        name: inst.name.to_string(),
+        assigned_entry: assignment.map(|a| a.repo),
+        source,
+    })
+}
+
+fn selection_source(
+    cfg: &CoopConfig,
+    assignment: Option<&crate::github_assignment::Assignment>,
+    repo: Option<&RepoSlug>,
+) -> SelectionSource {
+    if let Some(assignment) = assignment {
+        return if assignment.available(cfg) {
+            SelectionSource::Assignment
+        } else {
+            SelectionSource::MissingAssignment
+        };
+    }
+    match cfg.github.as_ref() {
+        Some(GitHubAuth::Auto) => SelectionSource::Auto,
+        Some(GitHubAuth::Env) => SelectionSource::Env,
+        Some(GitHubAuth::Pat(auth)) => {
+            if repo.is_some_and(|repo| auth.entries.contains_key(repo)) {
+                SelectionSource::Repository
+            } else {
+                SelectionSource::NoMatchingEntry
+            }
+        }
+        _ => SelectionSource::Off,
+    }
 }
 
 /// `coop github forget-pat --repo owner/name` — remove the secret and
@@ -1139,6 +1224,86 @@ mod tests {
 
     fn slug(s: &str) -> RepoSlug {
         RepoSlug::new(s).unwrap()
+    }
+
+    #[test]
+    fn vm_assignment_status_keeps_entry_listing_and_reports_missing_reference() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg: CoopConfig = toml::from_str(
+            r#"
+            [github]
+            mode = "pat"
+            [github.pat."org/entry"]
+            token = "github_pat_never_print"
+        "#,
+        )
+        .unwrap();
+        cfg.data_dir = crate::config::ConfigPath::new(tmp.path());
+        let inst = cfg
+            .allocate_instance(
+                Some(&crate::config::InstanceName::new("projects").unwrap()),
+                &crate::config::ImageName::new("default").unwrap(),
+                None,
+            )
+            .unwrap();
+        let assignment = crate::github_assignment::Assignment {
+            repo: RepoSlug::new("org/entry").unwrap(),
+        };
+        assignment.save(&cfg, &inst).unwrap();
+        assert_eq!(
+            selection_source(&cfg, None, Some(&assignment.repo)),
+            SelectionSource::Repository
+        );
+        assert_eq!(
+            selection_source(&cfg, None, Some(&RepoSlug::new("org/unknown").unwrap())),
+            SelectionSource::NoMatchingEntry
+        );
+        assert_eq!(
+            selection_source(
+                &cfg,
+                Some(&assignment),
+                Some(&RepoSlug::new("org/unknown").unwrap())
+            ),
+            SelectionSource::Assignment
+        );
+
+        let mut view = build_status(&cfg, false);
+        view.vm = Some(build_vm_status(&cfg, &inst).unwrap());
+        let json = serde_json::to_value(&view).unwrap();
+        assert_eq!(
+            json["vm"],
+            serde_json::json!({"name":"projects", "assigned_entry":"org/entry", "source":"assignment"})
+        );
+        assert_eq!(json["entries"][0]["repo"], "org/entry");
+        assert!(!json.to_string().contains("never_print"));
+        let text = format_status(&view);
+        assert!(
+            text.contains("projects") && text.contains("org/entry") && text.contains("Assignment")
+        );
+        cfg.github = None;
+        let mut view = build_status(&cfg, false);
+        view.vm = Some(build_vm_status(&cfg, &inst).unwrap());
+        assert_eq!(
+            serde_json::to_value(&view).unwrap()["vm"]["source"],
+            "missing_assignment"
+        );
+        assert!(format_status(&view).contains("unassign-pat --vm projects"));
+        crate::github_assignment::Assignment::remove(&inst).unwrap();
+        assert_eq!(
+            build_vm_status(&cfg, &inst).unwrap().source,
+            SelectionSource::Off
+        );
+        for (auth, source) in [
+            (GitHubAuth::Auto, SelectionSource::Auto),
+            (GitHubAuth::Env, SelectionSource::Env),
+            (
+                GitHubAuth::Pat(crate::config::PatConfig::default()),
+                SelectionSource::NoMatchingEntry,
+            ),
+        ] {
+            cfg.github = Some(auth);
+            assert_eq!(build_vm_status(&cfg, &inst).unwrap().source, source);
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod devcontainer;
 mod devcontainer_oci;
 mod fs_util;
 mod git_repo_devcontainer;
+mod github_assignment;
 mod github_pat;
 pub mod github_repo;
 mod github_submodules;
@@ -644,7 +645,7 @@ enum Commands {
         #[command(subcommand)]
         action: Option<ProfilesAction>,
     },
-    /// Manage GitHub authentication (fine-grained PAT wizard, status, rotate, forget)
+    /// Manage GitHub PAT entries and VM assignments
     Github {
         #[command(subcommand)]
         action: GithubAction,
@@ -782,6 +783,29 @@ enum ProfilesAction {
 
 #[derive(Subcommand)]
 enum GithubAction {
+    /// Select an existing stored PAT entry for subsequent VM sessions
+    AssignPat {
+        #[arg(
+            long,
+            value_name = "NAME",
+            value_parser = config::InstanceName::new,
+            add = ArgValueCandidates::new(completions::instance_candidates)
+        )]
+        vm: config::InstanceName,
+        /// Stored entry key, not the workspace or the token's permission scope
+        #[arg(long, value_parser = github_repo::RepoSlug::parse_cli)]
+        repo: github_repo::RepoSlug,
+    },
+    /// Remove only the VM association; keep the shared stored credential
+    UnassignPat {
+        #[arg(
+            long,
+            value_name = "NAME",
+            value_parser = config::InstanceName::new,
+            add = ArgValueCandidates::new(completions::instance_candidates)
+        )]
+        vm: config::InstanceName,
+    },
     /// Run the fine-grained PAT wizard for a repo
     SetupPat {
         /// Repo slug to scope to (auto-detected if omitted)
@@ -796,6 +820,14 @@ enum GithubAction {
     },
     /// Print configured PAT entries and their validation state
     Status {
+        /// Also show this VM's assigned entry and effective selection source
+        #[arg(
+            long,
+            value_name = "NAME",
+            value_parser = config::InstanceName::new,
+            add = ArgValueCandidates::new(completions::instance_candidates)
+        )]
+        vm: Option<config::InstanceName>,
         /// Resolve each entry's `cmd:` invocation (may trigger Keychain /
         /// 1Password prompts) to confirm the secret store still serves it.
         #[arg(long)]
@@ -903,6 +935,7 @@ impl Commands {
                 ..
             }
         ) {
+            cfg.github_disabled = true;
             cfg.github = Some(config::GitHubAuth::Off);
             // Off alone is eligible for the PAT wizard, which can replace
             // cfg.github after writing a new credential to the config file.
@@ -1546,6 +1579,51 @@ mod tests {
     }
 
     #[test]
+    fn github_assignment_cli_requires_valid_vm_and_entry() {
+        let cli = parse(&[
+            "github",
+            "assign-pat",
+            "--vm",
+            "projects",
+            "--repo",
+            "org/entry",
+        ]);
+        let crate::Commands::Github {
+            action: crate::GithubAction::AssignPat { vm, repo },
+        } = cli.command
+        else {
+            panic!("expected assignment")
+        };
+        assert_eq!(vm.as_str(), "projects");
+        assert_eq!(repo.as_str(), "org/entry");
+        for args in [
+            vec!["coop", "github", "assign-pat", "--repo", "org/entry"],
+            vec!["coop", "github", "assign-pat", "--vm", "projects"],
+            vec![
+                "coop",
+                "github",
+                "assign-pat",
+                "--vm",
+                "../escape",
+                "--repo",
+                "org/entry",
+            ],
+            vec![
+                "coop",
+                "github",
+                "assign-pat",
+                "--vm",
+                "projects",
+                "--repo",
+                "bad",
+            ],
+            vec!["coop", "github", "unassign-pat"],
+        ] {
+            assert!(Cli::try_parse_from(args).is_err());
+        }
+    }
+
+    #[test]
     fn no_github_overrides_each_mode_without_changing_other_settings() {
         use crate::config::{CoopConfig, GitHubAuth};
         use crate::pat_prompt::{Decision, PromptContext};
@@ -1577,6 +1655,7 @@ mod tests {
                 }
                 cli.command.apply_github_override(&mut cfg);
                 assert!(matches!(cfg.github, Some(GitHubAuth::Off)));
+                assert!(cfg.github_disabled);
                 assert_eq!(
                     Decision::resolve(
                         &cfg,

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1812,6 +1812,91 @@ CFGEOF
         fail "pat: configured token forwarded to guest" "got: ${pat_token_out:-empty}"
     fi
 
+    # Select a different existing entry, independent of the workspace origin.
+    cat >> "$cfg_file" <<CFGEOF
+
+[github.pat."myorg/assigned"]
+token = "cmd:cat $tmpdir/assigned-pat.txt"
+CFGEOF
+    printf '%s' 'github_pat_ASSIGNED' > "$tmpdir/assigned-pat.txt"
+    chmod 0600 "$tmpdir/assigned-pat.txt"
+    pat_cmd() {
+        env GITHUB_TOKEN=github_pat_HOST GH_TOKEN=github_pat_OTHER_HOST \
+            "$BINARY" --config "$cfg_file" "$@"
+    }
+    if pat_cmd stop "$pat_instance" &&
+        pat_cmd github assign-pat --vm "$pat_instance" --repo myorg/assigned &&
+        pat_cmd start "$pat_instance" --no-agents --no-prompt \
+            --post-start 'printf "%s" "$GITHUB_TOKEN" > /tmp/pat-at-boot'; then
+        pat_token_out=$(pat_cmd exec "$pat_instance" -- cat /tmp/pat-at-boot) || pat_token_out=failed
+        if [[ "$pat_token_out" == github_pat_ASSIGNED ]]; then
+            pass "pat: startup session receives assigned credential"
+        else
+            fail "pat: startup session receives assigned credential"
+        fi
+        pass "pat: assign existing entry while stopped and restart"
+    else
+        fail "pat: assign existing entry while stopped and restart"
+    fi
+    local stage expected
+    for stage in assigned parent-workspace rotated unassigned; do
+        expected=github_pat_ASSIGNED
+        case "$stage" in
+            parent-workspace)
+                # Remove only the fixture's root repo; child repositories remain.
+                mkdir -p "$ws_dir/frontend" "$ws_dir/backend"
+                mv "$ws_dir/.git" "$ws_dir/frontend/.git"
+                git -C "$ws_dir/backend" init --quiet
+                ;;
+            rotated)
+                expected=github_pat_ROTATED
+                printf '%s' "$expected" > "$tmpdir/assigned-pat.txt"
+                ;;
+            unassigned)
+                expected=absent
+                pat_cmd github unassign-pat --vm "$pat_instance" || fail "pat: unassign"
+                ;;
+        esac
+        pat_token_out=$(pat_cmd exec "$pat_instance" -- sh -c 'printf "%s" "${GITHUB_TOKEN:-absent}"') || pat_token_out=failed
+        if [[ "$pat_token_out" == "$expected" ]]; then
+            pass "pat: $stage selects expected credential"
+        else
+            fail "pat: $stage selects expected credential" "unexpected selection"
+        fi
+    done
+    # Observe the boot session itself: a later exec would resolve again.
+    pat_cmd github assign-pat --vm "$pat_instance" --repo myorg/assigned || fail "pat: reassign"
+    if pat_cmd stop "$pat_instance" && pat_cmd start "$pat_instance" --no-github --no-agents \
+        --post-start 'printf "%s" "${GITHUB_TOKEN:-absent}" > /tmp/pat-opt-out'; then
+        pat_token_out=$(pat_cmd exec "$pat_instance" -- cat /tmp/pat-opt-out) || pat_token_out=failed
+        if [[ "$pat_token_out" == absent ]]; then
+            pass "pat: no-github suppresses saved assignment at boot"
+        else
+            fail "pat: no-github suppresses saved assignment at boot"
+        fi
+    else
+        fail "pat: no-github restart"
+    fi
+    # Restore/reprovision must preserve the association across a disk replacement.
+    # Configure a post_start witness because reprovision has no CLI override.
+    {
+        cat <<'CFGEOF'
+post_start = 'printf %s "$GITHUB_TOKEN" > /tmp/pat-at-boot'
+CFGEOF
+        cat "$cfg_file"
+    } > "$tmpdir/pat-reprovision.toml"
+    cp "$tmpdir/pat-reprovision.toml" "$cfg_file"
+    if pat_cmd restore "$pat_instance" --reprovision --no-agents --no-prompt -y; then
+        pat_token_out=$(pat_cmd exec "$pat_instance" -- cat /tmp/pat-at-boot) || pat_token_out=failed
+        if [[ "$pat_token_out" == github_pat_ROTATED ]]; then
+            pass "pat: reprovision preserves assignment"
+        else
+            fail "pat: reprovision preserves assignment"
+        fi
+    else
+        fail "pat: assigned reprovision"
+    fi
+
     # Cleanup.
     env -u GITHUB_TOKEN -u ANTHROPIC_API_KEY "$BINARY" --config "$cfg_file" destroy "$pat_instance" 2>/dev/null || true
 }


### PR DESCRIPTION
Allow an existing VM to select a stored repository-keyed PAT independently of its workspace. `coop github assign-pat --vm projects --repo myorg/frontend` saves only the entry key; subsequent sessions and GitHub HTTPS clones resolve the shared entry again, so rotation takes effect without changing the assignment.

Assignments fail on missing entries, malformed state, failed retrieval, or managed `GITHUB_TOKEN`/`GH_TOKEN` overrides. `--no-github` suppresses the assignment for that invocation while retaining the existing separate clone fallback. Unassignment and VM destruction leave the shared credential intact. Status retains the entry list and adds optional VM selection details, including missing references.

Includes CLI/configuration/trust documentation and VM integration coverage for stopped assignment, startup delivery, parent workspaces, rotation, opt-out, and reprovisioning.

Validation:
- Workspace build, clippy with zero warnings, tests, cargo-deny, Rust/TOML formatting, shell syntax, pre-commit hooks, and real CLI state/status probes passed.
- Independent review completed; fixed clone precedence documentation, VM completion, boot-time test witnesses, and mutation scoping.
- Deliberately bypassing session and clone assignment selection makes the corresponding tests fail.
- Full-file mutation sweep covered `github_assignment.rs`, `github_pat.rs`, `config.rs`, `lib.rs`, and the GitHub/lifecycle command modules: 448 mutants, initially 2 survivors. Added discriminating filesystem tests; the complete assignment-module rerun caught 17 mutants with 2 unbuildable and zero survivors. Both initial survivors are caught.
- Firecracker and Lima `--full` integration gates **not run**: this environment has no `/dev/kvm` or macOS backend, and no remote integration hosts were supplied. This draft is not ready to merge until both gates run. Real GitHub token authorization was not tested; fixtures use distinct fake credentials.

Closes #468.
