### PR TITLE
ci: use self-repository reference for release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   ci:
     permissions:
       contents: read
-    uses: ./.github/workflows/ci.yml
+    uses: $/.github/workflows/ci.yml
 
   build:
     needs: ci


### PR DESCRIPTION
The zizmor 1.30.0 update in #465 flags the release workflow's existing `./.github/workflows/ci.yml` reference. Use GitHub's `$/` self-repository syntax so the release still calls CI at the running commit and passes the new `self-repository` audit.

This is a separate prerequisite for #465; rebase that dependency PR after this lands.

Validation:
- Reproduced the original exit-12 finding with zizmor 1.30.0; the updated tree passes its full online audit and offline audits with 1.30.0 and 1.30.1.
- `cargo fmt -- --check`, workspace clippy with `-D warnings`, `cargo test --workspace`, `cargo deny --workspace check`, and `taplo format --check` passed.
- YAML/pre-commit checks and `git diff --check` passed.
- Closeout review: clean (correctness, design, conventions, and GitHub syntax compatibility).
- VM integration suites and a tag-triggered release were not run; this changes only a reusable-workflow reference.
